### PR TITLE
Add minimal README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# confusio
+
+*confusio linguarum* — the confusion of tongues.
+
+A REST API shim that implements a subset of GitHub's remote API, translating requests to other providers under the hood.
+
+## What it is
+
+GitHub's API is the lingua franca of git hosting tools. Other providers speak their own dialects. Confusio stands in the middle, translating.
+
+Built with [Redbean](https://redbean.dev) — a single-file web server containing a Lua interpreter, distributed as a self-extracting zip.
+
+## Initially targeted providers
+
+- GitLab
+- Bitbucket
+- Gitea
+- Forgejo
+- Sourcehut
+
+## How it works
+
+Confusio runs as a local proxy. Point your tools at it and Confusio translates GitHub API calls to the target provider's native API.
+
+Auth is currently PAT-based: provide a token for the target provider and Confusio passes it through, translated to the right format. OAuth is out of scope for now.
+
+## Compatibility
+
+Not every provider supports every GitHub API concept. Confusio maintains a compatibility matrix — each GitHub API endpoint mapped against each provider, showing whether it's fully supported, partially supported, or unsupported. Think of it as a support table you can scan to see what works before you try it.
+
+The matrix will be published to GitHub Pages.
+
+## Status
+
+Early design stage.


### PR DESCRIPTION
Adds a minimal README capturing the spirit of Confusio: a REST API translation layer implementing a subset of GitHub's remote API, routing to other providers. Tech stack: Redbean.

---

## Work queue

<!-- WORK_QUEUE_START -->
<details><summary>Completed (12)</summary>

- [x] Write and commit README.md
- [x] ASK: Target providers priority
- [x] Add target providers to README
- [x] ASK: Deployment model
- [x] Add deployment model to README
- [x] ASK: API surface scope
- [x] Add compatibility table note to README
- [x] PR comment: Reword description to focus on API subset
- [x] PR comment: Rename to "Initially targeted providers"
- [x] PR comment: Remove gh reference from How it works
- [x] PR comment: Reword auth to "currently PAT-based"
- [x] PR comment: Expand caniuse description

</details>
<!-- WORK_QUEUE_END -->