### PR TITLE
Implement segment-based radix trie router with startup-time handler resolution

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -1,61 +1,115 @@
--- Config defaults
-local config = {
+-- Config defaults (global: backends/<name>.lua can read at startup)
+config = {
   backend  = "",
   base_url = "https://gitea.com",
 }
 
--- Config keys that can be set via .confusio.lua or SCRIPTARGS (after --).
--- Parity is structural: every key works the same way in both mechanisms.
--- CLI:         sh ./confusio.com -- backend=gitea base_url=https://gitea.com
--- Config file: confusio = { backend="gitea", base_url="https://gitea.com" }
+-- Config keys accepted by both .confusio.lua and SCRIPTARGS.
 local CONFIG_KEYS = { "backend", "base_url" }
 
--- Load .confusio.lua if present. Runs with full Lua global access so it
--- can call functions (e.g. secrets backends) during init.
+-- Load .confusio.lua if present.
 if pcall(dofile, ".confusio.lua") then
   if type(confusio) == "table" then
     for k, v in pairs(confusio) do
       if config[k] ~= nil then config[k] = v end
     end
   end
-  confusio = nil  -- clean up global
+  confusio = nil
 end
 
--- SCRIPTARGS (key=value after --) override config file (highest precedence).
+-- SCRIPTARGS (key=value after --) override config file.
 for _, a in ipairs(arg or {}) do
   local k, v = a:match("^([%w_]+)=(.+)$")
   if k and config[k] ~= nil then config[k] = v end
 end
 
--- Strip trailing slash for uniform concatenation.
 config.base_url = config.base_url:gsub("/$", "")
 
-local function respond_json(status, reason, body)
+-- respond_json is global: backends/<name>.lua uses it.
+function respond_json(status, reason, body)
   SetStatus(status, reason)
   SetHeader("Content-Type", "application/json; charset=utf-8")
   Write(EncodeJson(body))
 end
 
-local function handle_root_gitea()
-  local ok, status = pcall(Fetch, config.base_url .. "/api/v1/version")
-  if ok and status == 200 then
-    respond_json(200, "OK", {})
-  else
-    respond_json(503, "Service Unavailable", {})
-  end
+-- backend_impl is global: set by backends/<name>.lua at startup.
+backend_impl = {}
+if config.backend ~= "" then
+  assert(config.backend:match("^[%a][%w_]*$"),
+    "invalid backend name: " .. config.backend)
+  dofile("/zip/backends/" .. config.backend .. ".lua")
 end
+
+-- Default handlers. Add an entry here for every endpoint confusio exposes.
+-- Override in backends/<name>.lua only when the backend behaves differently.
+local defaults = {
+  root = function() respond_json(200, "OK", {}) end,
+}
+
+-- Resolve handlers once at startup: backend overrides shadow defaults via __index.
+-- The backend is fixed for the program's lifetime — no per-request dispatch needed.
+local handle = setmetatable(backend_impl, { __index = defaults })
+
+-- ---------------------------------------------------------------------------
+-- Segment-based radix trie router
+--
+-- Each node: { static = {[segment]→node}, param = node|nil, handler = name|nil }
+--
+-- route_add builds the trie at startup. {param} segments become param edges;
+-- all other segments become static edges. Static edges are preferred over param
+-- edges during matching, so /repos/search beats /repos/{owner} for that path.
+-- ---------------------------------------------------------------------------
+
+local function new_node() return { static = {}, param = nil, handler = nil } end
+local trie = new_node()
+
+local function route_add(path, handler_name)
+  local node = trie
+  for seg in path:gmatch("[^/]+") do
+    if seg:sub(1, 1) == "{" then
+      node.param = node.param or new_node()
+      node = node.param
+    else
+      node.static[seg] = node.static[seg] or new_node()
+      node = node.static[seg]
+    end
+  end
+  node.handler = handler_name
+end
+
+local function route_match(path)
+  local node = trie
+  local caps = {}
+  for seg in path:gmatch("[^/]+") do
+    if node.static[seg] then
+      node = node.static[seg]
+    elseif node.param then
+      caps[#caps + 1] = seg
+      node = node.param
+    else
+      return nil, nil
+    end
+  end
+  return node.handler, caps
+end
+
+-- ---------------------------------------------------------------------------
+-- Route registry
+--
+-- Exact:      route_add("/emojis",               "emojis")
+-- Parametric: route_add("/repos/{owner}/{repo}",  "repo")
+--
+-- Each handler_name must have an entry in defaults above (and optionally an
+-- override in backends/<name>.lua). Parametric captures are passed positionally:
+--   repo = function(owner, repo) ... end
+-- ---------------------------------------------------------------------------
+
+route_add("/", "root")
 
 function OnHttpRequest()
   local method = GetMethod()
   local path   = GetPath()
-
-  if (method == "GET" or method == "HEAD") and path == "/" then
-    if config.backend == "gitea" then
-      handle_root_gitea()
-    else
-      respond_json(200, "OK", {})
-    end
-  else
-    Route()
-  end
+  if method ~= "GET" and method ~= "HEAD" then Route(); return end
+  local ep, caps = route_match(path)
+  if ep then handle[ep](table.unpack(caps)) else Route() end
 end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,17 +83,22 @@ When implementing a new endpoint, check the spec for:
 ## Adding a new endpoint
 
 1. Check `vendor/github-rest-api-description/api.github.com.yaml` for the endpoint's contract.
-2. Add a `handle_<path>_<backend>()` function in `.init.lua`.
-3. Route to it in `OnHttpRequest()`.
-4. Add a hurl assertion file in `test/` and wire it into `test/test-unit.sh` (mock) and `test/test-integration.sh` (live).
-5. Update the compatibility matrix in `README.md`.
+2. Add a `route_add(...)` call in `.init.lua`:
+   - Exact path: `route_add("/emojis", "emojis")`
+   - Parametric path: `route_add("/repos/{owner}/{repo}", "repo")`
+3. Add a default handler to the `defaults` table in `.init.lua`.
+4. If any backend behaves differently, add an override in `backends/<name>.lua`.
+   Parametric captures are passed positionally: `repo = function(owner, repo) ... end`
+5. Add a hurl assertion file in `test/` and wire it into `test/test-unit.sh` (mock) and `test/test-integration.sh` (live).
+6. Update the compatibility matrix in `README.md`.
 
 ## Adding a new backend
 
-1. Add the backend name to config validation in `.init.lua` (or leave open — currently no validation).
-2. Implement `handle_<endpoint>_<newbackend>()` functions.
-3. Add mock server as `test/mock-<newbackend>.lua` and build it in the `Makefile` (copy pattern from `mock-gitea.com`).
-4. Add a `test/test-mock-validate.sh`-equivalent for the new backend if its spec differs meaningfully.
+1. Create `backends/<name>.lua`. Set `backend_impl = { endpoint = function, ... }` with only
+   the endpoints that differ from the defaults. The file is loaded automatically when
+   `config.backend == "<name>"` — no changes to `.init.lua` needed.
+2. Add mock server as `test/mock-<newbackend>.lua` and build it in the `Makefile` (copy pattern from `mock-gitea.com`).
+3. Add a `test/test-mock-validate.sh`-equivalent for the new backend if its spec differs meaningfully.
 
 ## Redbean API notes
 
@@ -139,6 +144,19 @@ Hard-won insights from building this project. **Keep this section current**: whe
 ### GitHub Actions composite actions
 
 - **A local composite action (`uses: ./.github/actions/setup`) cannot contain `actions/checkout`.** The workflow runner needs to find the action file before checkout has run — chicken-and-egg. Always put `actions/checkout@v4` as an explicit first step in each job; the composite action handles everything after.
+
+### Routing
+
+- **Segment-based radix trie** (`route_add` / `route_match` in `.init.lua`): O(k) lookup where
+  k = path depth. Static edges are preferred over param edges at each node, so `/repos/search`
+  beats `/repos/{owner}` when both are registered. Captures from `{param}` segments are passed
+  as positional arguments to the handler.
+- **Startup-time handler resolution**: `setmetatable(backend_impl, { __index = defaults })` is
+  built once after config loads. The backend is fixed for the program's lifetime — no per-request
+  dispatch needed. Backend files set `backend_impl = { ... }` globally; `dofile` runs in global
+  scope so locals from `.init.lua` are not visible to backend files.
+- **`/zip/` prefix for dofile**: Redbean's `dofile` resolves paths on the real filesystem by
+  default. Files inside the zip must be accessed as `dofile("/zip/backends/gitea.lua")`.
 
 ### Mock server design
 

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ else
 	chmod +x hurl
 endif
 
-confusio.com: redbean.com .init.lua
+confusio.com: redbean.com .init.lua $(wildcard backends/*.lua)
 	cp redbean.com confusio.com
-	zip confusio.com .init.lua
+	zip confusio.com .init.lua $(wildcard backends/*.lua)
 
 mock-gitea.com: redbean.com test/mock-gitea.lua
 	cp redbean.com mock-gitea.com

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -1,0 +1,10 @@
+-- Gitea backend handler overrides.
+-- Loaded by .init.lua when config.backend == "gitea".
+-- Only endpoints that behave differently from the default need to be listed here.
+backend_impl = {
+  root = function()
+    local ok, status = pcall(Fetch, config.base_url .. "/api/v1/version")
+    if ok and status == 200 then respond_json(200, "OK", {})
+    else respond_json(503, "Service Unavailable", {}) end
+  end,
+}


### PR DESCRIPTION
Replaces the flat `if/else` + per-request backend dispatch with an architecture that scales to the full GitHub REST API surface (~900 endpoints).

**What changed:**
- **Radix trie router** (`route_add` / `route_match`): O(k) segment-based lookup. Static edges beat param edges at each node, so `/repos/search` correctly wins over `/repos/{owner}`. Parametric captures passed positionally to handlers.
- **Startup-time handler resolution**: `setmetatable(backend_impl, { __index = defaults })` built once after config loads — no per-request backend dispatch.
- **`backends/gitea.lua`** split out: adding a backend is now a single new file. Backend-specific overrides only need to list endpoints that differ from the defaults.
- **`compile_path`-style registration**: routes read like the GitHub API docs — `route_add("/repos/{owner}/{repo}", "repo")`.

**Research basis:** Express/Fastify/Gin all use radix tries for the same reason. Lapis (Lua) uses sequential pattern scan — fine at small scale but O(n) at lookup time. For hundreds of endpoints the trie wins.

---

## Work queue

<!-- WORK_QUEUE_START -->
<details><summary>Completed (1)</summary>

- [x] Implement segment-based radix trie router with startup-time handler resolution

</details>
<!-- WORK_QUEUE_END -->