### PR TITLE
Add repos API endpoints to compat matrix

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -207,32 +207,189 @@
         </tr>
         <tr>
           <td>GET /emojis</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
-          <td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/{owner}/{repo}</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+        </tr>
+        <tr>
+          <td>PATCH /repos/{owner}/{repo}</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+        </tr>
+        <tr>
+          <td>DELETE /repos/{owner}/{repo}</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+        </tr>
+        <tr>
+          <td>GET/POST /user/repos</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+        </tr>
+        <tr>
+          <td>GET/POST /orgs/{org}/repos</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /users/{username}/repos</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/topics</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/languages</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/branches</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/commits</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET/PUT/DELETE /repos/…/contents/…</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/collaborators</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET/POST /repos/…/forks</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/releases</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/keys</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/hooks</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+        </tr>
+        <tr>
+          <td>GET /repos/…/tags</td>
+          <td class="no">&#x274C;</td><td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="yes">&#x2705;</td><td class="no">&#x274C;</td><td class="no">&#x274C;</td>
+          <td class="yes">&#x2705;</td><td class="yes">&#x2705;</td><td class="yes">&#x2705;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td><td class="no">&#x274C;</td>
+          <td class="no">&#x274C;</td><td class="yes">&#x2705;</td>
         </tr>
       </tbody>
     </table>
   </div>
   <p style="margin-top:0.75rem; color:var(--text-muted); font-size:0.85rem;">
-    &#x2705; Supported &middot; &#x274C; Unsupported (returns 404)
+    &#x2705; Supported &middot; &#x26A0;&#xFE0F; Partial &middot; &#x274C; Unsupported (returns 404 or 501)
   </p>
 </section>
 


### PR DESCRIPTION
The compat matrix in site/index.html was missing 17 rows for the repos API endpoints that shipped in PR #10. GitHub Pages serves from main so the table was nearly empty. Adds all missing rows.