### PR TITLE
Parallelize tests: make -j across providers, hurl --jobs within

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 REDBEAN_VERSION := $(shell cat .redbean-version)
 REDBEAN_URL      = https://redbean.dev/redbean-$(REDBEAN_VERSION).com
 
-MOCKS = mock-gitea.com mock-gitlab.com mock-gitbucket.com mock-bitbucket.com \
-        mock-harness.com mock-pagure.com mock-onedev.com mock-sourcehut.com \
-        mock-radicle.com mock-bitbucket_datacenter.com
-
 HURL_VERSION  := $(shell cat .hurl-version)
 HURL_OS       := $(shell uname -s)
 HURL_RAW_ARCH := $(shell uname -m)
@@ -47,14 +43,45 @@ mock-%.com: redbean.com test/mock-%.lua
 	(cd .tmp-mock && zip -u ../$@ .init.lua)
 	rm -rf .tmp-mock
 
-.PHONY: build test test-unit test-integration validate-mock clean
+# Backend test configuration.
+# To add a backend: append to BACKENDS (ports auto-assigned from 18080).
+# Each backend needs test/mock-<name>.lua (symlink ok) and
+# test/<name>-repos.hurl + test/<name>-users.hurl (symlinks ok).
+BACKENDS = bitbucket bitbucket_datacenter codeberg forgejo gitbucket gitea gitlab gogs \
+           harness kallithea launchpad notabug onedev pagure phabricator radicle \
+           rhodecode sourceforge sourcehut
+MOCKS    = $(addprefix mock-,$(addsuffix .com,$(BACKENDS)))
+
+gitea_HURL = test/gitea-root-auth.hurl test/gitea-repos.hurl \
+             test/gitea-repos-ext.hurl test/gitea-users.hurl
+
+$(eval _p := 18080)
+$(foreach b,$(BACKENDS),$(eval $(b)_CPORT := $(_p))$(eval $(b)_MPORT := $(shell expr $(_p) + 1))$(eval _p := $(shell expr $(_p) + 2)))
+
+define BACKEND_RULE
+.PHONY: test-unit-$(1)
+test-unit-$(1): confusio.com mock-$(1).com hurl
+	bash test/run-backend.sh mock-$(1).com \
+	  $($(1)_CPORT) $($(1)_MPORT) \
+	  "-- backend=$(1) base_url=http://127.0.0.1:$($(1)_MPORT)" \
+	  $(or $($(1)_HURL),test/$(1)-repos.hurl test/$(1)-users.hurl)
+endef
+
+$(foreach b,$(BACKENDS),$(eval $(call BACKEND_RULE,$(b))))
+
+.PHONY: build test test-unit test-unit-backends test-integration validate-mock clean
 
 build: confusio.com
 
 test: test-unit test-integration
 
+# Sequential preamble (boot-path checks), then all backends in parallel
 test-unit: confusio.com $(MOCKS) hurl
 	bash test/test-unit.sh
+	$(MAKE) -j$$(nproc) test-unit-backends
+
+# Aggregate target — Make runs all prerequisites in parallel under -j
+test-unit-backends: $(addprefix test-unit-,$(BACKENDS))
 
 test-integration: confusio.com hurl
 	bash test/test-integration.sh

--- a/test/codeberg-repos-ext.hurl
+++ b/test/codeberg-repos-ext.hurl
@@ -1,0 +1,1 @@
+gitea-repos-ext.hurl

--- a/test/codeberg-repos.hurl
+++ b/test/codeberg-repos.hurl
@@ -1,0 +1,1 @@
+gitea-repos.hurl

--- a/test/codeberg-users.hurl
+++ b/test/codeberg-users.hurl
@@ -1,0 +1,1 @@
+gitea-users.hurl

--- a/test/forgejo-repos-ext.hurl
+++ b/test/forgejo-repos-ext.hurl
@@ -1,0 +1,1 @@
+gitea-repos-ext.hurl

--- a/test/forgejo-repos.hurl
+++ b/test/forgejo-repos.hurl
@@ -1,0 +1,1 @@
+gitea-repos.hurl

--- a/test/forgejo-users.hurl
+++ b/test/forgejo-users.hurl
@@ -1,0 +1,1 @@
+gitea-users.hurl

--- a/test/gogs-repos-ext.hurl
+++ b/test/gogs-repos-ext.hurl
@@ -1,0 +1,1 @@
+gitea-repos-ext.hurl

--- a/test/gogs-repos.hurl
+++ b/test/gogs-repos.hurl
@@ -1,0 +1,1 @@
+gitea-repos.hurl

--- a/test/gogs-users.hurl
+++ b/test/gogs-users.hurl
@@ -1,0 +1,1 @@
+gitea-users.hurl

--- a/test/kallithea-repos.hurl
+++ b/test/kallithea-repos.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/kallithea-users.hurl
+++ b/test/kallithea-users.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/launchpad-repos.hurl
+++ b/test/launchpad-repos.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/launchpad-users.hurl
+++ b/test/launchpad-users.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/mock-codeberg.lua
+++ b/test/mock-codeberg.lua
@@ -1,0 +1,1 @@
+mock-gitea.lua

--- a/test/mock-forgejo.lua
+++ b/test/mock-forgejo.lua
@@ -1,0 +1,1 @@
+mock-gitea.lua

--- a/test/mock-gogs.lua
+++ b/test/mock-gogs.lua
@@ -1,0 +1,1 @@
+mock-gitea.lua

--- a/test/mock-kallithea.lua
+++ b/test/mock-kallithea.lua
@@ -1,0 +1,1 @@
+mock-stub.lua

--- a/test/mock-launchpad.lua
+++ b/test/mock-launchpad.lua
@@ -1,0 +1,1 @@
+mock-stub.lua

--- a/test/mock-notabug.lua
+++ b/test/mock-notabug.lua
@@ -1,0 +1,1 @@
+mock-gitea.lua

--- a/test/mock-phabricator.lua
+++ b/test/mock-phabricator.lua
@@ -1,0 +1,1 @@
+mock-stub.lua

--- a/test/mock-rhodecode.lua
+++ b/test/mock-rhodecode.lua
@@ -1,0 +1,1 @@
+mock-stub.lua

--- a/test/mock-sourceforge.lua
+++ b/test/mock-sourceforge.lua
@@ -1,0 +1,1 @@
+mock-stub.lua

--- a/test/mock-stub.lua
+++ b/test/mock-stub.lua
@@ -1,0 +1,6 @@
+-- Stub mock for backends that only need a reachable health-check endpoint.
+-- Returns 200 for all requests; the confusio backend checks a path-specific
+-- URL, but we don't need to validate auth or path here.
+function OnHttpRequest()
+  SetStatus(200, "OK")
+end

--- a/test/notabug-repos-ext.hurl
+++ b/test/notabug-repos-ext.hurl
@@ -1,0 +1,1 @@
+gitea-repos-ext.hurl

--- a/test/notabug-repos.hurl
+++ b/test/notabug-repos.hurl
@@ -1,0 +1,1 @@
+gitea-repos.hurl

--- a/test/notabug-users.hurl
+++ b/test/notabug-users.hurl
@@ -1,0 +1,1 @@
+gitea-users.hurl

--- a/test/phabricator-repos.hurl
+++ b/test/phabricator-repos.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/phabricator-users.hurl
+++ b/test/phabricator-users.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/phase-01-root.sh
+++ b/test/phase-01-root.sh
@@ -1,1 +1,0 @@
-run_phase test/root.hurl

--- a/test/phase-02-gitea-root.sh
+++ b/test/phase-02-gitea-root.sh
@@ -1,1 +1,0 @@
-run_mock_phase test/gitea-root.hurl $MOCK_ARGS

--- a/test/phase-03-gitea-config-file.sh
+++ b/test/phase-03-gitea-config-file.sh
@@ -1,2 +1,0 @@
-CONFUSIO_CONFIG="confusio = { backend=\"gitea\", base_url=\"http://127.0.0.1:$MOCK_PORT\" }"
-run_mock_phase test/gitea-root.hurl

--- a/test/phase-04-gitea-auth.sh
+++ b/test/phase-04-gitea-auth.sh
@@ -1,1 +1,0 @@
-run_mock_phase test/gitea-root-auth.hurl $MOCK_ARGS

--- a/test/phase-05-gitea-repos.sh
+++ b/test/phase-05-gitea-repos.sh
@@ -1,1 +1,0 @@
-run_mock_phase test/gitea-repos.hurl $MOCK_ARGS

--- a/test/phase-06-gitea-repos-ext.sh
+++ b/test/phase-06-gitea-repos-ext.sh
@@ -1,1 +1,0 @@
-run_mock_phase test/gitea-repos-ext.hurl $MOCK_ARGS

--- a/test/phase-07-gitlab-repos.sh
+++ b/test/phase-07-gitlab-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_GITLAB_BIN
-run_mock_phase test/gitlab-repos.hurl -- backend=gitlab base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-08-gitbucket-repos.sh
+++ b/test/phase-08-gitbucket-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_GITBUCKET_BIN
-run_mock_phase test/gitbucket-repos.hurl -- backend=gitbucket base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-09-bitbucket-repos.sh
+++ b/test/phase-09-bitbucket-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_BITBUCKET_BIN
-run_mock_phase test/bitbucket-repos.hurl -- backend=bitbucket base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-10-harness-repos.sh
+++ b/test/phase-10-harness-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_HARNESS_BIN
-run_mock_phase test/harness-repos.hurl -- backend=harness base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-11-pagure-repos.sh
+++ b/test/phase-11-pagure-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_PAGURE_BIN
-run_mock_phase test/pagure-repos.hurl -- backend=pagure base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-12-onedev-repos.sh
+++ b/test/phase-12-onedev-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_ONEDEV_BIN
-run_mock_phase test/onedev-repos.hurl -- backend=onedev base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-13-sourcehut-repos.sh
+++ b/test/phase-13-sourcehut-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_SOURCEHUT_BIN
-run_mock_phase test/sourcehut-repos.hurl -- backend=sourcehut base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-14-radicle-repos.sh
+++ b/test/phase-14-radicle-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_RADICLE_BIN
-run_mock_phase test/radicle-repos.hurl -- backend=radicle base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-15-bitbucket_datacenter-repos.sh
+++ b/test/phase-15-bitbucket_datacenter-repos.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_BITBUCKET_DATACENTER_BIN
-run_mock_phase test/bitbucket_datacenter-repos.hurl -- backend=bitbucket_datacenter base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-16-gitea-users.sh
+++ b/test/phase-16-gitea-users.sh
@@ -1,1 +1,0 @@
-run_mock_phase test/gitea-users.hurl $MOCK_ARGS

--- a/test/phase-17-gitlab-users.sh
+++ b/test/phase-17-gitlab-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_GITLAB_BIN
-run_mock_phase test/gitlab-users.hurl -- backend=gitlab base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-18-gitbucket-users.sh
+++ b/test/phase-18-gitbucket-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_GITBUCKET_BIN
-run_mock_phase test/gitbucket-users.hurl -- backend=gitbucket base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-19-bitbucket-users.sh
+++ b/test/phase-19-bitbucket-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_BITBUCKET_BIN
-run_mock_phase test/bitbucket-users.hurl -- backend=bitbucket base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-20-bitbucket_datacenter-users.sh
+++ b/test/phase-20-bitbucket_datacenter-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_BITBUCKET_DATACENTER_BIN
-run_mock_phase test/bitbucket_datacenter-users.hurl -- backend=bitbucket_datacenter base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-21-harness-users.sh
+++ b/test/phase-21-harness-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_HARNESS_BIN
-run_mock_phase test/harness-users.hurl -- backend=harness base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-22-pagure-users.sh
+++ b/test/phase-22-pagure-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_PAGURE_BIN
-run_mock_phase test/pagure-users.hurl -- backend=pagure base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-23-onedev-users.sh
+++ b/test/phase-23-onedev-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_ONEDEV_BIN
-run_mock_phase test/onedev-users.hurl -- backend=onedev base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/phase-24-sourcehut-users.sh
+++ b/test/phase-24-sourcehut-users.sh
@@ -1,2 +1,0 @@
-MOCK_BIN=$MOCK_SOURCEHUT_BIN
-run_mock_phase test/sourcehut-users.hurl -- backend=sourcehut base_url=http://127.0.0.1:$MOCK_PORT

--- a/test/radicle-users.hurl
+++ b/test/radicle-users.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/rhodecode-repos.hurl
+++ b/test/rhodecode-repos.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/rhodecode-users.hurl
+++ b/test/rhodecode-users.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/run-backend.sh
+++ b/test/run-backend.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run one backend's hurl test files in parallel against a dedicated server pair.
+# Usage: run-backend.sh <mock_bin> <confusio_port> <mock_port> <confusio_args> [hurl_files...]
+#
+# confusio_args is a single string passed as-is to confusio (e.g. "-- backend=gitea base_url=...")
+# hurl_files are passed together to hurl --jobs so they run in parallel.
+set -euo pipefail
+
+case "$1" in /*) MOCK_BIN="$1" ;; *) MOCK_BIN="$(pwd)/$1" ;; esac
+CPORT="$2"
+MPORT="$3"
+CONF_ARGS="$4"
+shift 4
+HURL_FILES=("$@")
+
+CONFUSIO_BIN="$(pwd)/confusio.com"
+HURL="$(pwd)/hurl"
+
+start_isolated() {
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$@" &
+  else
+    "$@" &
+  fi
+}
+
+tmpdir=$(mktemp -d)
+# Kill entire process groups (setsid makes each server a group leader; redbean forks workers)
+cleanup() {
+  kill -- -"$CPID" 2>/dev/null || kill "$CPID" 2>/dev/null || true
+  kill -- -"$MPID" 2>/dev/null || kill "$MPID" 2>/dev/null || true
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+# Start mock backend
+start_isolated sh "$MOCK_BIN" -p "$MPORT"
+MPID=$!
+
+# Start confusio (with optional confusio_args)
+if [ -n "${CONFUSIO_CONFIG:-}" ]; then
+  printf '%s\n' "$CONFUSIO_CONFIG" > "$tmpdir/.confusio.lua"
+fi
+if command -v setsid >/dev/null 2>&1; then
+  # shellcheck disable=SC2086
+  (cd "$tmpdir" && setsid sh "$CONFUSIO_BIN" -p "$CPORT" $CONF_ARGS) &
+else
+  # shellcheck disable=SC2086
+  (cd "$tmpdir" && sh "$CONFUSIO_BIN" -p "$CPORT" $CONF_ARGS) &
+fi
+CPID=$!
+
+# Run all hurl files in parallel
+"$HURL" --retry 20 --retry-interval 300 --connect-timeout 1 --max-time 10 \
+  --variable "host=localhost:$CPORT" \
+  --jobs "$(nproc)" \
+  "${HURL_FILES[@]}"

--- a/test/sourceforge-repos.hurl
+++ b/test/sourceforge-repos.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/sourceforge-users.hurl
+++ b/test/sourceforge-users.hurl
@@ -1,0 +1,1 @@
+stub-root.hurl

--- a/test/stub-root.hurl
+++ b/test/stub-root.hurl
@@ -1,0 +1,6 @@
+GET http://{{host}}/
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "{}"

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -1,36 +1,25 @@
 #!/usr/bin/env bash
-# Unit tests — no real network access required.
+# Unit test preamble — sequential boot-path checks.
+# Backend tests (phases 4+) run in parallel via: $(MAKE) -j test-unit-backends
 set -euo pipefail
 
 CONFUSIO_PORT=18080
 MOCK_PORT=18081
 CONFUSIO_BIN=$(pwd)/confusio.com
 MOCK_GITEA_BIN=$(pwd)/mock-gitea.com
-MOCK_GITLAB_BIN=$(pwd)/mock-gitlab.com
-MOCK_GITBUCKET_BIN=$(pwd)/mock-gitbucket.com
-MOCK_BITBUCKET_BIN=$(pwd)/mock-bitbucket.com
-MOCK_HARNESS_BIN=$(pwd)/mock-harness.com
-MOCK_PAGURE_BIN=$(pwd)/mock-pagure.com
-MOCK_ONEDEV_BIN=$(pwd)/mock-onedev.com
-MOCK_SOURCEHUT_BIN=$(pwd)/mock-sourcehut.com
-MOCK_RADICLE_BIN=$(pwd)/mock-radicle.com
-MOCK_BITBUCKET_DATACENTER_BIN=$(pwd)/mock-bitbucket_datacenter.com
 HURL=$(pwd)/hurl
 
-MOCK_ARGS="-- backend=gitea base_url=http://127.0.0.1:$MOCK_PORT"
-
 start_isolated() {
-  local cmd="$*"
   if command -v setsid >/dev/null 2>&1; then
-    setsid $cmd &
+    setsid "$@" &
   else
-    $cmd &
+    "$@" &
   fi
 }
 
 start_confusio() {
-  local dir="$1"; shift   # working directory
-  local args="${*:-}"     # remaining args passed to binary
+  local dir="$1"; shift
+  local args="${*:-}"
   local cmd="sh $CONFUSIO_BIN -p $CONFUSIO_PORT $args"
   if command -v setsid >/dev/null 2>&1; then
     (cd "$dir" && setsid $cmd) &
@@ -39,49 +28,42 @@ start_confusio() {
   fi
 }
 
-start_mock() {
-  start_isolated sh "$MOCK_BIN" -p "$MOCK_PORT"
-}
-
 run_hurl() {
   $HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
     --variable host=localhost:$CONFUSIO_PORT "$1"
 }
 
-# run_phase <hurl_file> [confusio_args...]
-# Starts confusio in a temp dir, runs the hurl assertion, then cleans up.
 run_phase() {
   local hurl_file="$1"; shift
-  local tmpdir
-  tmpdir=$(mktemp -d)
-  start_confusio "$tmpdir" "$@"
-  PID=$!
+  local tmpdir; tmpdir=$(mktemp -d)
+  start_confusio "$tmpdir" "$@"; PID=$!
   trap "kill $PID 2>/dev/null || true; rm -rf $tmpdir" EXIT
   run_hurl "$hurl_file"
   kill $PID 2>/dev/null || true; sleep 0.3
 }
 
-# run_mock_phase <hurl_file> [confusio_args...]
-# Like run_phase but also starts the mock backend server.
-# Set CONFUSIO_CONFIG before calling to write a .confusio.lua config file.
 run_mock_phase() {
   local hurl_file="$1"; shift
-  local tmpdir
-  tmpdir=$(mktemp -d)
+  local tmpdir; tmpdir=$(mktemp -d)
   if [ -n "${CONFUSIO_CONFIG:-}" ]; then
     printf '%s\n' "$CONFUSIO_CONFIG" > "$tmpdir/.confusio.lua"
   fi
-  start_mock; MOCK_PID=$!
-  start_confusio "$tmpdir" "$@"
-  PID=$!
+  start_isolated sh "$MOCK_GITEA_BIN" -p "$MOCK_PORT"; MOCK_PID=$!
+  start_confusio "$tmpdir" "$@"; PID=$!
   trap "kill $PID 2>/dev/null || true; kill $MOCK_PID 2>/dev/null || true; rm -rf $tmpdir" EXIT
   run_hurl "$hurl_file"
   kill $PID 2>/dev/null || true; kill $MOCK_PID 2>/dev/null || true; sleep 0.3
 }
 
-for phase_file in test/phase-*.sh; do
-  MOCK_BIN=$MOCK_GITEA_BIN
-  unset CONFUSIO_CONFIG
-  # shellcheck source=/dev/null
-  source "$phase_file"
-done
+MOCK_ARGS="-- backend=gitea base_url=http://127.0.0.1:$MOCK_PORT"
+
+# Phase 1: no config
+run_phase test/root.hurl
+
+# Phase 2: Gitea via CLI flags
+run_mock_phase test/gitea-root.hurl $MOCK_ARGS
+
+# Phase 3: Gitea via .confusio.lua config file
+CONFUSIO_CONFIG="confusio = { backend=\"gitea\", base_url=\"http://127.0.0.1:$MOCK_PORT\" }"
+run_mock_phase test/gitea-root.hurl
+unset CONFUSIO_CONFIG


### PR DESCRIPTION
Replaces 24 sequential phase-files with two levels of parallelism:

- **Across providers**: `$(MAKE) -j$(nproc) test-unit-backends` — Make runs all 19 backend groups simultaneously
- **Within each provider**: `hurl --jobs $(nproc)` — repos + users test files run in parallel against one server pair

Backend config collapsed to 2 data lines: `BACKENDS` + `gitea_HURL` override. Each backend has its own mock + hurl files (symlinks for shared-implementation backends). Adding a backend is one list edit + two symlinks.

`test/run-backend.sh` is the self-contained per-backend runner: starts mock+confusio, runs hurl, cleans up by killing the entire process group.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (8)</summary>

- [x] PR comment: DRY up test-unit-backend Makefile targets
- [x] ASK: clarify "12 of the 22 backends"
- [x] PR comment: add mocks for 9 backends lacking test coverage
- [x] PR comment: DRY up repeated _MOCK/_HURL values in Makefile
- [x] PR comment: sort BACKENDS list alphabetically
- [x] PR comment: collapse per-backend vars to BACKENDS+family lists with auto-ports
- [x] ASK: eliminate GITEA_BACKENDS/STUB_BACKENDS — awaiting decision
- [x] PR comment: replace GITEA_BACKENDS/STUB_BACKENDS with per-backend symlinks

</details>
<!-- WORK_QUEUE_END -->