### PR TITLE
Add mock server and unit tests for azuredevops backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ mock-%.com: redbean.com test/mock-%.lua
 # To add a backend: append to BACKENDS (ports auto-assigned from 18080).
 # Each backend needs test/mock-<name>.lua (symlink ok) and
 # test/<name>-repos.hurl + test/<name>-users.hurl (symlinks ok).
-BACKENDS = bitbucket bitbucket_datacenter codeberg forgejo gitbucket gitea gitlab gogs \
+BACKENDS = azuredevops bitbucket bitbucket_datacenter codeberg forgejo gitbucket gitea gitlab gogs \
            harness kallithea launchpad notabug onedev pagure phabricator radicle \
            rhodecode sourceforge sourcehut
 MOCKS    = $(addprefix mock-,$(addsuffix .com,$(BACKENDS)))

--- a/test/azuredevops-repos.hurl
+++ b/test/azuredevops-repos.hurl
@@ -1,0 +1,153 @@
+# Azure DevOps backend repos API assertions.
+# ADO project = GitHub owner; ADO repository = GitHub repo name.
+
+# GET /repos/{owner}/{repo}
+GET http://{{host}}/repos/octocat/hello-world
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" == "hello-world"
+jsonpath "$.full_name" == "octocat/hello-world"
+jsonpath "$.owner.login" isString
+jsonpath "$.default_branch" isString
+jsonpath "$.private" isBoolean
+jsonpath "$.visibility" isString
+
+# GET /user/repos — lists across all ADO projects
+GET http://{{host}}/user/repos
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].name" isString
+
+# GET /orgs/{org}/repos — maps to ADO project repos
+GET http://{{host}}/orgs/testorg/repos
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].name" == "org-repo"
+
+# GET /repos/{owner}/{repo}/tags
+GET http://{{host}}/repos/octocat/hello-world/tags
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].name" == "v1.0"
+jsonpath "$[0].commit.sha" isString
+
+# GET /repos/{owner}/{repo}/branches
+GET http://{{host}}/repos/octocat/hello-world/branches
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].name" == "main"
+jsonpath "$[0].commit.sha" isString
+
+# GET /repos/{owner}/{repo}/branches/{branch}
+GET http://{{host}}/repos/octocat/hello-world/branches/main
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" == "main"
+jsonpath "$.commit.sha" isString
+
+# GET /repos/{owner}/{repo}/commits
+GET http://{{host}}/repos/octocat/hello-world/commits
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].sha" isString
+jsonpath "$[0].commit.message" isString
+
+# GET /repos/{owner}/{repo}/commits/{ref}
+GET http://{{host}}/repos/octocat/hello-world/commits/abc123
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.sha" isString
+jsonpath "$.commit.message" isString
+
+# GET /repos/{owner}/{repo}/readme — fetches items?path=/README.md
+GET http://{{host}}/repos/octocat/hello-world/readme
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.type" == "file"
+jsonpath "$.encoding" == "base64"
+jsonpath "$.name" isString
+jsonpath "$.content" isString
+
+# GET /repos/{owner}/{repo}/contents/{path}
+GET http://{{host}}/repos/octocat/hello-world/contents/README.md
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.type" == "file"
+jsonpath "$.encoding" == "base64"
+jsonpath "$.content" isString
+
+# GET /repos/{owner}/{repo}/tarball/{ref} — redirects to ADO items download
+GET http://{{host}}/repos/octocat/hello-world/tarball/main
+[Options]
+location: false
+
+HTTP 302
+[Asserts]
+header "Location" contains "/_apis/git/repositories/hello-world/items"
+
+# GET /repos/{owner}/{repo}/zipball/{ref}
+GET http://{{host}}/repos/octocat/hello-world/zipball/main
+[Options]
+location: false
+
+HTTP 302
+[Asserts]
+header "Location" contains "/_apis/git/repositories/hello-world/items"
+
+# GET /repos/{owner}/{repo}/forks
+GET http://{{host}}/repos/octocat/hello-world/forks
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+
+# GET /repos/{owner}/{repo}/hooks — resolves repo ID then fetches subscriptions
+GET http://{{host}}/repos/octocat/hello-world/hooks
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].id" isInteger
+jsonpath "$[0].active" isBoolean
+jsonpath "$[0].config.url" isString
+
+# GET /users/{username}/repos — treats username as ADO project
+GET http://{{host}}/users/octocat/repos
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].name" isString
+
+# Repo not found → 404
+GET http://{{host}}/repos/nonexist/notareal
+
+HTTP 404

--- a/test/azuredevops-users.hurl
+++ b/test/azuredevops-users.hurl
@@ -1,0 +1,10 @@
+# Azure DevOps backend users API.
+# azuredevops.lua does not implement user endpoints; all return 404.
+
+# GET /user — not implemented
+GET http://{{host}}/user
+HTTP 404
+
+# GET /users/octocat — not implemented
+GET http://{{host}}/users/octocat
+HTTP 404

--- a/test/mock-azuredevops.lua
+++ b/test/mock-azuredevops.lua
@@ -1,0 +1,122 @@
+-- Mock Azure DevOps server.
+-- Responds to ADO Git REST API paths used by backends/azuredevops.lua.
+-- config.base_url = http://localhost:{port}
+-- GitHub {owner}/{repo} maps to ADO project/repository.
+function OnHttpRequest()
+  local path   = GetPath()
+  local method = GetMethod()
+
+  local function json(body)
+    SetHeader("Content-Type", "application/json")
+    Write(body)
+  end
+
+  -- ADO-format repository object.
+  -- id is a GUID used by delete_repo and get_repo_hooks to resolve the repo.
+  local REPO_ID = "repo-abc123"
+  local REPO =
+    '{"id":"' .. REPO_ID .. '","name":"hello-world",' ..
+    '"defaultBranch":"refs/heads/main",' ..
+    '"remoteUrl":"http://localhost/octocat/hello-world.git",' ..
+    '"isPrivate":false,"isDisabled":false,"size":1024,' ..
+    '"project":{"id":"proj-abc123","name":"octocat","description":"Test project"}}'
+
+  local ORG_REPO =
+    '{"id":"repo-org-123","name":"org-repo",' ..
+    '"defaultBranch":"refs/heads/main",' ..
+    '"remoteUrl":"http://localhost/testorg/org-repo.git",' ..
+    '"isPrivate":false,"isDisabled":false,"size":0,' ..
+    '"project":{"id":"proj-testorg","name":"testorg","description":""}}'
+
+  -- ADO-format commit object.
+  local COMMIT =
+    '{"commitId":"abc123def456","comment":"Initial commit",' ..
+    '"author":{"name":"Octocat","email":"octocat@github.com","date":"2011-01-26T19:01:12Z"},' ..
+    '"committer":{"name":"Octocat","email":"octocat@github.com","date":"2011-01-26T19:01:12Z"}}'
+
+  local rb = "/octocat/_apis/git/repositories/hello-world"
+
+  -- Connection health check ---------------------------------------------------
+  if path == "/_apis/connectionData" then
+    SetStatus(200, "OK")
+    json('{"locationServiceData":{}}')
+
+  -- All repos (get_user_repos: GET /_apis/git/repositories) ------------------
+  elseif path == "/_apis/git/repositories" then
+    SetStatus(200, "OK")
+    json('{"count":1,"value":[' .. REPO .. ']}')
+
+  -- Project repos (get_org_repos / get_users_repos) --------------------------
+  elseif path == "/octocat/_apis/git/repositories" and method == "GET" then
+    SetStatus(200, "OK")
+    json('{"count":1,"value":[' .. REPO .. ']}')
+
+  elseif path == "/testorg/_apis/git/repositories" and method == "GET" then
+    SetStatus(200, "OK")
+    json('{"count":1,"value":[' .. ORG_REPO .. ']}')
+
+  -- POST new repo (post_org_repos / post_user_repos) -------------------------
+  elseif path == "/octocat/_apis/git/repositories" or
+         path == "/default/_apis/git/repositories" then
+    SetStatus(201, "Created")
+    json(REPO)
+
+  -- Single repo (get_repo / patch_repo) --------------------------------------
+  elseif path == rb and (method == "GET" or method == "PATCH") then
+    SetStatus(200, "OK")
+    json(REPO)
+
+  -- Delete repo by resolved ID (delete_repo second step) --------------------
+  elseif path == "/octocat/_apis/git/repositories/" .. REPO_ID and method == "DELETE" then
+    SetStatus(204, "No Content")
+
+  -- Refs — branches and tags (filter param distinguishes) -------------------
+  elseif path == rb .. "/refs" then
+    local filter = GetParam("filter") or ""
+    if filter:find("^heads") then
+      SetStatus(200, "OK")
+      json('{"count":1,"value":[{"name":"refs/heads/main","objectId":"abc123def456"}]}')
+    elseif filter == "tags" then
+      SetStatus(200, "OK")
+      json('{"count":1,"value":[{"name":"refs/tags/v1.0","objectId":"abc123def456"}]}')
+    else
+      SetStatus(200, "OK")
+      json('{"count":0,"value":[]}')
+    end
+
+  -- Commits ------------------------------------------------------------------
+  elseif path == rb .. "/commits" then
+    SetStatus(200, "OK")
+    json('{"count":1,"value":[' .. COMMIT .. ']}')
+
+  elseif path == rb .. "/commits/abc123" then
+    SetStatus(200, "OK")
+    json(COMMIT)
+
+  -- File contents (readme + arbitrary paths) --------------------------------
+  elseif path == rb .. "/items" then
+    SetStatus(200, "OK")
+    Write("Hello World\n")
+
+  -- Forks -------------------------------------------------------------------
+  elseif path == rb .. "/forks/octocat" then
+    SetStatus(200, "OK")
+    json('{"count":1,"value":[' .. REPO .. ']}')
+
+  elseif path == rb .. "/forks" and method == "POST" then
+    SetStatus(201, "Created")
+    json(REPO)
+
+  -- Webhooks subscriptions (get_repo_hooks second step) --------------------
+  elseif path == "/_apis/hooks/subscriptions" then
+    SetStatus(200, "OK")
+    json('{"count":1,"value":[' ..
+      '{"id":1,"status":"enabled","eventType":"git.push",' ..
+      '"consumerInputs":{"url":"https://example.com/hook"},' ..
+      '"createdDate":"2020-01-01T00:00:00Z","modifiedDate":"2020-01-01T00:00:00Z"}' ..
+      ']}')
+
+  else
+    SetStatus(404, "Not Found")
+  end
+end


### PR DESCRIPTION
Brings the \`azuredevops\` backend into \`make test-unit\` by adding a mock server (\`test/mock-azuredevops.lua\`) that serves Azure DevOps Git REST API responses, plus hurl assertion files that verify confusio's GitHub-format translations. Wires \`azuredevops\` into the \`BACKENDS\` list in the Makefile.

Closes #15

---

## Work queue

<!-- WORK_QUEUE_START -->
<details><summary>Completed (1)</summary>

- [x] Add mock server, hurl tests, and Makefile wiring for azuredevops backend

</details>
<!-- WORK_QUEUE_END -->