### PR TITLE
Add .git-blame-ignore-revs for StyLua mass-reformat commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# StyLua mass-reformat (Linting/formatting #58)
+451f9e04be1d58e4a587f4008115767174ec1ac1


### PR DESCRIPTION
Adds a `.git-blame-ignore-revs` file so that `git blame` automatically skips over the StyLua mass-reformat commit from #58, keeping blame output focused on meaningful changes.

---

## Work queue

<!-- WORK_QUEUE_START -->
<details><summary>Completed (1)</summary>

- [x] Add .git-blame-ignore-revs listing the StyLua mass-reformat commit

</details>
<!-- WORK_QUEUE_END -->