### PR TITLE
Fix compat matrix on mobile

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -94,6 +94,12 @@
   }
   @media (max-width: 768px) {
     .table-scroll-hint { display: block; }
+    th:first-child,
+    td:first-child {
+      max-width: 40vw;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   table {
     border-collapse: separate;


### PR DESCRIPTION
Adds iOS Safari \`-webkit-sticky\` prefixes to all sticky table elements, switches the scroll container to explicit \`overflow-x: auto; overflow-y: auto\` with \`-webkit-overflow-scrolling: touch\` for momentum scrolling, shows a "Scroll →" hint below the table on narrow screens, and truncates the endpoint column at 40vw on narrow screens.

---

## Work queue

<!-- WORK_QUEUE_START -->
<details><summary>Completed (2)</summary>

- [x] Fix sticky headers/columns on iOS Safari and add mobile scroll hint
- [x] Reduce endpoint column width on narrow screens with text truncation or wrapping

</details>
<!-- WORK_QUEUE_END -->