### PR TITLE
Implement GitHub REST API for Migrations (closes #43)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -373,6 +373,17 @@ local function code_scanning_list_empty()
   respond_json(200, {})
 end
 
+-- Default handlers for migration endpoints: no backend has a native migration API.
+-- Organization and user migration exports return 501 for single-resource endpoints.
+-- Source imports (deprecated) also return 501.
+local function migrations_not_supported()
+  respond_json(501, { message = "Migrations are not supported by this backend." })
+end
+
+local function source_imports_not_supported()
+  respond_json(501, { message = "Source imports are not supported by this backend." })
+end
+
 -- Default handlers for GET /zen, GET /octocat, GET /versions, GET /meta.
 -- These endpoints are fully self-contained and do not call any backend.
 local ZEN_QUOTES = {
@@ -1115,6 +1126,85 @@ local routes = {
   ["DELETE /user/interaction-limits"] = {
     "delete_user_interaction_limits",
     interaction_limits_delete,
+  },
+
+  -- Migrations — Organization (https://docs.github.com/en/rest/migrations/orgs)
+  ["GET /orgs/{org}/migrations"] = { "get_org_migrations", empty_list },
+  ["POST /orgs/{org}/migrations"] = { "post_org_migrations", migrations_not_supported },
+  ["GET /orgs/{org}/migrations/{migration_id}"] = {
+    "get_org_migration",
+    migrations_not_supported,
+  },
+  ["GET /orgs/{org}/migrations/{migration_id}/archive"] = {
+    "get_org_migration_archive",
+    migrations_not_supported,
+  },
+  ["DELETE /orgs/{org}/migrations/{migration_id}/archive"] = {
+    "delete_org_migration_archive",
+    migrations_not_supported,
+  },
+  ["DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock"] = {
+    "delete_org_migration_repo_lock",
+    migrations_not_supported,
+  },
+  ["GET /orgs/{org}/migrations/{migration_id}/repositories"] = {
+    "get_org_migration_repos",
+    empty_list,
+  },
+
+  -- Migrations — Source imports (https://docs.github.com/en/rest/migrations/source-imports)
+  ["GET /repos/{owner}/{repo}/import"] = {
+    "get_repo_import",
+    source_imports_not_supported,
+  },
+  ["PUT /repos/{owner}/{repo}/import"] = {
+    "put_repo_import",
+    source_imports_not_supported,
+  },
+  ["PATCH /repos/{owner}/{repo}/import"] = {
+    "patch_repo_import",
+    source_imports_not_supported,
+  },
+  ["DELETE /repos/{owner}/{repo}/import"] = {
+    "delete_repo_import",
+    source_imports_not_supported,
+  },
+  ["GET /repos/{owner}/{repo}/import/authors"] = { "get_repo_import_authors", empty_list },
+  ["PATCH /repos/{owner}/{repo}/import/authors/{author_id}"] = {
+    "patch_repo_import_author",
+    source_imports_not_supported,
+  },
+  ["GET /repos/{owner}/{repo}/import/large_files"] = {
+    "get_repo_import_large_files",
+    empty_list,
+  },
+  ["PATCH /repos/{owner}/{repo}/import/lfs"] = {
+    "patch_repo_import_lfs",
+    source_imports_not_supported,
+  },
+
+  -- Migrations — User (https://docs.github.com/en/rest/migrations/users)
+  ["GET /user/migrations"] = { "get_user_migrations", empty_list },
+  ["POST /user/migrations"] = { "post_user_migrations", migrations_not_supported },
+  ["GET /user/migrations/{migration_id}"] = {
+    "get_user_migration",
+    migrations_not_supported,
+  },
+  ["GET /user/migrations/{migration_id}/archive"] = {
+    "get_user_migration_archive",
+    migrations_not_supported,
+  },
+  ["DELETE /user/migrations/{migration_id}/archive"] = {
+    "delete_user_migration_archive",
+    migrations_not_supported,
+  },
+  ["DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock"] = {
+    "delete_user_migration_repo_lock",
+    migrations_not_supported,
+  },
+  ["GET /user/migrations/{migration_id}/repositories"] = {
+    "get_user_migration_repos",
+    empty_list,
   },
 }
 for spec, v in pairs(routes) do

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -199,3 +199,26 @@ GET /user/installations/{installation_id}/repositories,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /user/installations/{installation_id}/repositories/{repository_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /user/installations/{installation_id}/repositories/{repository_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /users/{username}/installation,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+Migrations,,,,,,,,,,,,,,,,,,,,,,,,
+GET /orgs/{org}/migrations,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+POST /orgs/{org}/migrations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /orgs/{org}/migrations/{migration_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /orgs/{org}/migrations/{migration_id}/archive,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /orgs/{org}/migrations/{migration_id}/archive,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /orgs/{org}/migrations/{migration_id}/repositories,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/import,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /repos/{owner}/{repo}/import,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/import,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /repos/{owner}/{repo}/import,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/import/authors,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+PATCH /repos/{owner}/{repo}/import/authors/{author_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/import/large_files,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+PATCH /repos/{owner}/{repo}/import/lfs,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /user/migrations,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+POST /user/migrations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /user/migrations/{migration_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /user/migrations/{migration_id}/archive,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /user/migrations/{migration_id}/archive,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /user/migrations/{migration_id}/repositories,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list

--- a/test/azuredevops-migrations.hurl
+++ b/test/azuredevops-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/bitbucket-migrations.hurl
+++ b/test/bitbucket-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/bitbucket_datacenter-migrations.hurl
+++ b/test/bitbucket_datacenter-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/codeberg-migrations.hurl
+++ b/test/codeberg-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/codecommit-migrations.hurl
+++ b/test/codecommit-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/forgejo-migrations.hurl
+++ b/test/forgejo-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/gerrit-migrations.hurl
+++ b/test/gerrit-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/gitblit-migrations.hurl
+++ b/test/gitblit-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/gitbucket-migrations.hurl
+++ b/test/gitbucket-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/gitea-migrations.hurl
+++ b/test/gitea-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/gitlab-migrations.hurl
+++ b/test/gitlab-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/gogs-migrations.hurl
+++ b/test/gogs-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/harness-migrations.hurl
+++ b/test/harness-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/kallithea-migrations.hurl
+++ b/test/kallithea-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/launchpad-migrations.hurl
+++ b/test/launchpad-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/notabug-migrations.hurl
+++ b/test/notabug-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/onedev-migrations.hurl
+++ b/test/onedev-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/pagure-migrations.hurl
+++ b/test/pagure-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/phabricator-migrations.hurl
+++ b/test/phabricator-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/radicle-migrations.hurl
+++ b/test/radicle-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/rhodecode-migrations.hurl
+++ b/test/rhodecode-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/sourceforge-migrations.hurl
+++ b/test/sourceforge-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/sourcehut-migrations.hurl
+++ b/test/sourcehut-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl

--- a/test/stub-migrations.hurl
+++ b/test/stub-migrations.hurl
@@ -1,0 +1,218 @@
+# Migrations API — default stubs for backends without native migration support.
+# List endpoints return empty arrays (200); single-resource endpoints return 501.
+
+# --- Organization migrations ---
+
+# GET /orgs/{org}/migrations — empty list
+GET http://{{host}}/orgs/testorg/migrations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /orgs/{org}/migrations — not supported
+POST http://{{host}}/orgs/testorg/migrations
+Authorization: token testtoken
+Content-Type: application/json
+{"repositories": ["testorg/hello-world"]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/migrations/{migration_id} — not supported
+GET http://{{host}}/orgs/testorg/migrations/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/migrations/{migration_id}/archive — not supported
+GET http://{{host}}/orgs/testorg/migrations/1/archive
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/migrations/{migration_id}/archive — not supported
+DELETE http://{{host}}/orgs/testorg/migrations/1/archive
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock — not supported
+DELETE http://{{host}}/orgs/testorg/migrations/1/repos/hello-world/lock
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/migrations/{migration_id}/repositories — empty list
+GET http://{{host}}/orgs/testorg/migrations/1/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# --- Source imports (deprecated) ---
+
+# GET /repos/{owner}/{repo}/import — not supported
+GET http://{{host}}/repos/octocat/hello-world/import
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/import — not supported
+PUT http://{{host}}/repos/octocat/hello-world/import
+Authorization: token testtoken
+Content-Type: application/json
+{"vcs_url": "https://example.com/repo.git"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/import — not supported
+PATCH http://{{host}}/repos/octocat/hello-world/import
+Authorization: token testtoken
+Content-Type: application/json
+{"vcs_username": "user", "vcs_password": "pass"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/import — not supported
+DELETE http://{{host}}/repos/octocat/hello-world/import
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/import/authors — empty list
+GET http://{{host}}/repos/octocat/hello-world/import/authors
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# PATCH /repos/{owner}/{repo}/import/authors/{author_id} — not supported
+PATCH http://{{host}}/repos/octocat/hello-world/import/authors/1
+Authorization: token testtoken
+Content-Type: application/json
+{"email": "user@example.com", "name": "User"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/import/large_files — empty list
+GET http://{{host}}/repos/octocat/hello-world/import/large_files
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# PATCH /repos/{owner}/{repo}/import/lfs — not supported
+PATCH http://{{host}}/repos/octocat/hello-world/import/lfs
+Authorization: token testtoken
+Content-Type: application/json
+{"use_lfs": "opt_in"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# --- User migrations ---
+
+# GET /user/migrations — empty list
+GET http://{{host}}/user/migrations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /user/migrations — not supported
+POST http://{{host}}/user/migrations
+Authorization: token testtoken
+Content-Type: application/json
+{"repositories": ["octocat/hello-world"]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /user/migrations/{migration_id} — not supported
+GET http://{{host}}/user/migrations/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /user/migrations/{migration_id}/archive — not supported
+GET http://{{host}}/user/migrations/1/archive
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /user/migrations/{migration_id}/archive — not supported
+DELETE http://{{host}}/user/migrations/1/archive
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock — not supported
+DELETE http://{{host}}/user/migrations/1/repos/hello-world/lock
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /user/migrations/{migration_id}/repositories — empty list
+GET http://{{host}}/user/migrations/1/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/tuleap-migrations.hurl
+++ b/test/tuleap-migrations.hurl
@@ -1,0 +1,1 @@
+stub-migrations.hurl


### PR DESCRIPTION
## Summary

Woof woof! 🐕 Fetched all 22 migration endpoints and dropped them right at your feet:

- **Organization migrations** (7 endpoints): list, start, get status, download/delete archive, unlock repo, list repos
- **Source imports** (8 endpoints, deprecated): get/start/update/cancel import, commit authors, large files, LFS preference
- **User migrations** (7 endpoints): list, start, get status, download/delete archive, unlock repo, list repos

No backend has a native migration API that maps to GitHub's export/import model, so all providers get sensible defaults — list endpoints return empty arrays (200), single-resource and mutating endpoints return 501. Every provider has a test file and compatibility matrix entry.

## Test plan

- [x] `make -j test` passes (unit + integration + format + lint)
- [x] All 24 providers have migration test files (symlinked to shared stub)
- [x] All 22 endpoints tested: correct status codes + response shapes
- [x] `site/compatibility.csv` updated with 22 new migration rows
- [x] `make -j site` generates valid matrix page

🐾 Generated with [Claude Code](https://claude.com/claude-code)