### PR TITLE
Implement GitHub REST API for Licenses (closes #39)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -492,6 +492,12 @@ local function git_not_implemented()
   respond_json(501, { message = "Git database API is not supported by this backend." })
 end
 
+-- Default handler for Licenses endpoints: backends that have a native license
+-- template API override these. Falls back to 501 Not Implemented.
+local function licenses_not_implemented()
+  respond_json(501, { message = "Licenses API is not supported by this backend." })
+end
+
 -- Default handlers for GET /zen, GET /octocat, GET /versions, GET /meta.
 -- These endpoints are fully self-contained and do not call any backend.
 local ZEN_QUOTES = {
@@ -676,6 +682,9 @@ local routes = {
   -- Gitignore templates (https://docs.github.com/en/rest/gitignore)
   ["GET /gitignore/templates"] = "get_gitignore_templates",
   ["GET /gitignore/templates/{name}"] = "get_gitignore_template",
+  -- Licenses (https://docs.github.com/en/rest/licenses)
+  ["GET /licenses"] = { "get_licenses", licenses_not_implemented },
+  ["GET /licenses/{license}"] = { "get_license", licenses_not_implemented },
   -- Rate Limits (https://docs.github.com/en/rest/rate-limit)
   ["GET /rate_limit"] = { "get_rate_limit", rate_limit_response },
 
@@ -727,6 +736,8 @@ local routes = {
   ["DELETE /repos/{owner}/{repo}/contents/{path}"] = "delete_repo_content",
   ["GET /repos/{owner}/{repo}/tarball/{ref}"] = "get_repo_tarball",
   ["GET /repos/{owner}/{repo}/zipball/{ref}"] = "get_repo_zipball",
+  -- Repo license (https://docs.github.com/en/rest/licenses)
+  ["GET /repos/{owner}/{repo}/license"] = { "get_repo_license", licenses_not_implemented },
 
   -- Compare
   ["GET /repos/{owner}/{repo}/compare/{basehead}"] = "get_repo_compare",

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -576,6 +576,30 @@ backend_impl = {
     respond_json(404, { message = "Not Found" })
   end,
 
+  -- GET /repos/{owner}/{repo}/license
+  -- ADO has no license template API; fetch the LICENSE file via the items endpoint.
+  get_repo_license = function(owner, repo_name)
+    local candidates = { "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }
+    for _, fname in ipairs(candidates) do
+      local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/items?path=/" .. fname)
+      local ok, status, _, body = fetch_json(url)
+      if ok and status == 200 then
+        respond_json(200, {
+          type = "file",
+          name = fname,
+          path = fname,
+          sha = "",
+          size = #body,
+          encoding = "base64",
+          content = EncodeBase64(body),
+          license = nil,
+        })
+        return
+      end
+    end
+    respond_json(404, { message = "License file not found" })
+  end,
+
   get_repo_content = function(owner, repo_name, path)
     local ref = GetParam("ref") or ""
     local url = ado_url(

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -846,6 +846,36 @@ backend_impl = {
     end
   end,
 
+  -- GET /repos/{owner}/{repo}/license
+  -- Bitbucket has no license template API; fetch the LICENSE file via src endpoint.
+  get_repo_license = function(owner, repo_name)
+    local repo_url = base() .. "/repositories/" .. owner .. "/" .. repo_name
+    local ok, status, _, body = fetch_json(repo_url)
+    if not ok or status ~= 200 then
+      respond_json(404, {})
+      return
+    end
+    local repo = DecodeJson(body or "{}")
+    local ref = (repo.mainbranch and repo.mainbranch.name) or "HEAD"
+    for _, name in ipairs({ "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }) do
+      local ok2, status2, _, body2 = fetch_json(repo_url .. "/src/" .. ref .. "/" .. name)
+      if ok2 and status2 == 200 then
+        respond_json(200, {
+          type = "file",
+          encoding = "base64",
+          content = EncodeBase64(body2 or ""),
+          name = name,
+          path = name,
+          sha = "",
+          size = #(body2 or ""),
+          license = nil,
+        })
+        return
+      end
+    end
+    respond_json(404, { message = "License file not found" })
+  end,
+
   -- Forks ---------------------------------------------------------------------
 
   get_repo_forks = function(owner, repo_name)

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -561,6 +561,29 @@ backend_impl = {
     respond_json(404, { message = "Not Found" })
   end,
 
+  -- GET /repos/{owner}/{repo}/license
+  -- BBS has no license template API; fetch the LICENSE file via raw endpoint.
+  get_repo_license = function(owner, repo_name)
+    local candidates = { "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }
+    for _, fname in ipairs(candidates) do
+      local ok, status, _, body = fetch_json(repo_path(owner, repo_name) .. "/raw/" .. fname)
+      if ok and status == 200 then
+        respond_json(200, {
+          type = "file",
+          name = fname,
+          path = fname,
+          sha = "",
+          size = #body,
+          encoding = "base64",
+          content = EncodeBase64(body),
+          license = nil,
+        })
+        return
+      end
+    end
+    respond_json(404, { message = "License file not found" })
+  end,
+
   get_repo_content = function(owner, repo_name, path)
     local ref = GetParam("ref") or ""
     local url = repo_path(owner, repo_name) .. "/raw/" .. path

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -385,6 +385,19 @@ backend_impl = {
     respond_json(200, { total_count = 0, check_suites = {} })
   end,
 
+  -- Licenses ------------------------------------------------------------------
+  get_licenses = proxy_handler(nil, function()
+    return base() .. "/licenses"
+  end),
+
+  get_license = proxy_handler(nil, function(license_name)
+    return base() .. "/licenses/" .. license_name
+  end),
+
+  get_repo_license = proxy_handler(nil, function(o, r)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/license"
+  end),
+
   -- Contents ------------------------------------------------------------------
   get_repo_readme = proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/readme"

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -830,6 +830,37 @@ backend_impl = {
     proxy_json(nil, fetch_json(base() .. "/gitignores/" .. name))
   end,
 
+  -- GET /licenses
+  get_licenses = function()
+    proxy_json(nil, fetch_json(base() .. "/licenses"))
+  end,
+
+  -- GET /licenses/{license}
+  get_license = function(license_name)
+    proxy_json(nil, fetch_json(base() .. "/licenses/" .. license_name))
+  end,
+
+  -- GET /repos/{owner}/{repo}/license
+  -- Gitea has no dedicated endpoint; combine contents/LICENSE with repo license metadata.
+  get_repo_license = function(owner, repo_name)
+    local ok, status, _, body =
+      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/LICENSE")
+    if not ok then
+      respond_json(503, {})
+      return
+    end
+    if status ~= 200 then
+      respond_json(status, {})
+      return
+    end
+    local content = DecodeJson(body) or {}
+    local rok, rstatus, _, rbody = fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name)
+    if rok and rstatus == 200 then
+      content.license = (DecodeJson(rbody) or {}).license
+    end
+    respond_json(200, content)
+  end,
+
   -- GET /repos/{owner}/{repo}
   get_repo = function(owner, repo_name)
     proxy_json(translate_repo, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name))

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -3001,6 +3001,76 @@ backend_impl = {
     end, fetch_json(base() .. "/templates/gitignores/" .. name))
   end,
 
+  -- Licenses -----------------------------------------------------------------
+
+  -- GET /licenses → GitLab GET /api/v4/templates/licenses
+  -- GitLab returns [{key,name,...}]; GitHub returns [{key,name,...}] (license-simple)
+  get_licenses = function()
+    proxy_json(function(list)
+      local result = {}
+      for i, t in ipairs(list or {}) do
+        result[i] = { key = t.key, name = t.name }
+      end
+      return result
+    end, fetch_json(base() .. "/templates/licenses"))
+  end,
+
+  -- GET /licenses/{license} → GitLab GET /api/v4/templates/licenses/{key}
+  -- GitLab returns {key,name,content,description,conditions,permissions,limitations,html_url}
+  -- GitHub returns {key,name,body,description,conditions,permissions,limitations,html_url,...}
+  get_license = function(license_name)
+    proxy_json(function(t)
+      if not t then
+        return {}
+      end
+      return {
+        key = t.key,
+        name = t.name,
+        html_url = t.html_url,
+        description = t.description,
+        body = t.content,
+        permissions = t.permissions or {},
+        conditions = t.conditions or {},
+        limitations = t.limitations or {},
+      }
+    end, fetch_json(base() .. "/templates/licenses/" .. license_name))
+  end,
+
+  -- GET /repos/{owner}/{repo}/license
+  -- Combines /repository/files/LICENSE content with project license metadata.
+  get_repo_license = function(owner, repo_name)
+    local pid = project_id(owner, repo_name)
+    local ok, status, _, body =
+      fetch_json(base() .. "/projects/" .. pid .. "/repository/files/LICENSE?ref=HEAD")
+    if not ok then
+      respond_json(503, {})
+      return
+    end
+    if status ~= 200 then
+      respond_json(status, {})
+      return
+    end
+    local f = DecodeJson(body) or {}
+    local rok, rstatus, _, rbody = fetch_json(base() .. "/projects/" .. pid)
+    local license_meta = nil
+    if rok and rstatus == 200 then
+      local lic = (DecodeJson(rbody) or {}).license
+      if lic then
+        license_meta = { key = lic.key, name = lic.name }
+      end
+    end
+    respond_json(200, {
+      name = f.file_name,
+      path = f.file_path,
+      sha = f.blob_id,
+      size = f.size,
+      type = "file",
+      content = f.content,
+      encoding = f.encoding,
+      license = license_meta,
+    })
+  end,
+
   -- Checks (via GitLab commit statuses and pipelines) -------------------------
   --
   -- GitHub Check Runs map onto GitLab commit statuses.  GitLab has no concept

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,y,y,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,y,y,y,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,y,y,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,y,y,y,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,y,y,y,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -153,8 +153,8 @@ Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 Licenses,,,,,,,,,,,,,,,,,,,,,,,,
-GET /licenses,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /licenses,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /licenses/{license},n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,n,n,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -153,8 +153,8 @@ Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 Licenses,,,,,,,,,,,,,,,,,,,,,,,,
-GET /licenses,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /licenses/{license},n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses,n,n,n,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses/{license},n,n,n,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,6 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -151,6 +152,9 @@ GET /search/topics,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
+Licenses,,,,,,,,,,,,,,,,,,,,,,,,
+GET /licenses,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses/{license},n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -153,8 +153,8 @@ Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 Licenses,,,,,,,,,,,,,,,,,,,,,,,,
-GET /licenses,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
 Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -153,8 +153,8 @@ Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 Licenses,,,,,,,,,,,,,,,,,,,,,,,,
-GET /licenses,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
-GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -153,8 +153,8 @@ Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 Licenses,,,,,,,,,,,,,,,,,,,,,,,,
-GET /licenses,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /licenses,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -19,7 +19,7 @@ GET /repos/{owner}/{repo}/commits,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/contents/{path},n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/license,n,n,n,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/license,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -153,8 +153,8 @@ Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 Licenses,,,,,,,,,,,,,,,,,,,,,,,,
-GET /licenses,n,n,n,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /licenses/{license},n,n,n,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /licenses/{license},n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y

--- a/test/azuredevops-licenses.hurl
+++ b/test/azuredevops-licenses.hurl
@@ -1,0 +1,22 @@
+# Licenses API assertions — Azure DevOps backend.
+# ADO has no license template API — GET /licenses and GET /licenses/{license} return 501.
+
+# GET /licenses
+GET http://{{host}}/licenses
+
+HTTP 501
+
+# GET /licenses/{license}
+GET http://{{host}}/licenses/mit
+
+HTTP 501
+
+# GET /repos/{owner}/{repo}/license — fetched via ADO items endpoint
+GET http://{{host}}/repos/octocat/hello-world/license
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" isString
+jsonpath "$.content" isString
+jsonpath "$.encoding" == "base64"

--- a/test/bitbucket-licenses.hurl
+++ b/test/bitbucket-licenses.hurl
@@ -1,0 +1,22 @@
+# Licenses API assertions — Bitbucket Cloud backend.
+# Bitbucket has no license template API — GET /licenses and GET /licenses/{license} return 501.
+
+# GET /licenses
+GET http://{{host}}/licenses
+
+HTTP 501
+
+# GET /licenses/{license}
+GET http://{{host}}/licenses/mit
+
+HTTP 501
+
+# GET /repos/{owner}/{repo}/license — fetched via Bitbucket src endpoint
+GET http://{{host}}/repos/octocat/hello-world/license
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" isString
+jsonpath "$.content" isString
+jsonpath "$.encoding" == "base64"

--- a/test/bitbucket_datacenter-licenses.hurl
+++ b/test/bitbucket_datacenter-licenses.hurl
@@ -1,0 +1,22 @@
+# Licenses API assertions — Bitbucket Data Center backend.
+# BBS has no license template API — GET /licenses and GET /licenses/{license} return 501.
+
+# GET /licenses
+GET http://{{host}}/licenses
+
+HTTP 501
+
+# GET /licenses/{license}
+GET http://{{host}}/licenses/mit
+
+HTTP 501
+
+# GET /repos/{owner}/{repo}/license — fetched via BBS raw endpoint
+GET http://{{host}}/repos/octocat/hello-world/license
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" isString
+jsonpath "$.content" isString
+jsonpath "$.encoding" == "base64"

--- a/test/codeberg-licenses.hurl
+++ b/test/codeberg-licenses.hurl
@@ -1,0 +1,1 @@
+gitea-licenses.hurl

--- a/test/codecommit-licenses.hurl
+++ b/test/codecommit-licenses.hurl
@@ -1,0 +1,19 @@
+# Licenses API assertions — CodeCommit backend.
+# CodeCommit, Gerrit, Gitblit, Harness, Kallithea, Launchpad, OneDev, Pagure,
+# Phabricator, Radicle, RhodeCode, SourceForge, Sourcehut, and Tuleap have no
+# license template API and no accessible license file endpoint — all return 501.
+
+# GET /licenses — not supported
+GET http://{{host}}/licenses
+
+HTTP 501
+
+# GET /licenses/{license} — not supported
+GET http://{{host}}/licenses/mit
+
+HTTP 501
+
+# GET /repos/{owner}/{repo}/license — not supported
+GET http://{{host}}/repos/octocat/hello-world/license
+
+HTTP 501

--- a/test/forgejo-licenses.hurl
+++ b/test/forgejo-licenses.hurl
@@ -1,0 +1,1 @@
+gitea-licenses.hurl

--- a/test/gerrit-licenses.hurl
+++ b/test/gerrit-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/gitblit-licenses.hurl
+++ b/test/gitblit-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/gitbucket-licenses.hurl
+++ b/test/gitbucket-licenses.hurl
@@ -1,0 +1,31 @@
+# Licenses API assertions — GitBucket backend.
+
+# GET /licenses
+GET http://{{host}}/licenses
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].key" isString
+jsonpath "$[0].name" isString
+
+# GET /licenses/{license}
+GET http://{{host}}/licenses/mit
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.key" == "mit"
+jsonpath "$.name" == "MIT License"
+jsonpath "$.body" isString
+
+# GET /repos/{owner}/{repo}/license
+GET http://{{host}}/repos/octocat/hello-world/license
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" isString
+jsonpath "$.content" isString
+jsonpath "$.license.key" == "mit"

--- a/test/gitea-licenses.hurl
+++ b/test/gitea-licenses.hurl
@@ -1,0 +1,37 @@
+# Licenses API assertions — Gitea backend.
+
+# GET /licenses
+GET http://{{host}}/licenses
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].key" isString
+jsonpath "$[0].name" isString
+
+# GET /licenses/{license}
+GET http://{{host}}/licenses/mit
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.key" == "mit"
+jsonpath "$.name" == "MIT License"
+jsonpath "$.body" isString
+
+# Unknown license returns 404
+GET http://{{host}}/licenses/nonexistent
+
+HTTP 404
+
+# GET /repos/{owner}/{repo}/license
+GET http://{{host}}/repos/octocat/hello-world/license
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" isString
+jsonpath "$.content" isString
+jsonpath "$.license.key" == "mit"
+jsonpath "$.license.name" == "MIT License"

--- a/test/gitlab-licenses.hurl
+++ b/test/gitlab-licenses.hurl
@@ -1,0 +1,37 @@
+# Licenses API assertions — GitLab backend.
+
+# GET /licenses
+GET http://{{host}}/licenses
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].key" isString
+jsonpath "$[0].name" isString
+
+# GET /licenses/{license}
+GET http://{{host}}/licenses/mit
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.key" == "mit"
+jsonpath "$.name" == "MIT License"
+jsonpath "$.body" isString
+
+# Unknown license returns 404
+GET http://{{host}}/licenses/Nonexistent
+
+HTTP 404
+
+# GET /repos/{owner}/{repo}/license
+GET http://{{host}}/repos/octocat/hello-world/license
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.name" isString
+jsonpath "$.content" isString
+jsonpath "$.license.key" == "mit"
+jsonpath "$.license.name" == "MIT License"

--- a/test/gogs-licenses.hurl
+++ b/test/gogs-licenses.hurl
@@ -1,0 +1,1 @@
+gitea-licenses.hurl

--- a/test/harness-licenses.hurl
+++ b/test/harness-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/kallithea-licenses.hurl
+++ b/test/kallithea-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/launchpad-licenses.hurl
+++ b/test/launchpad-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/mock-gitbucket.lua
+++ b/test/mock-gitbucket.lua
@@ -638,6 +638,34 @@ function OnHttpRequest()
         .. '"sha":"3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15","size":19,"url":""}]}'
     )
 
+  -- License templates ---------------------------------------------------------
+  elseif path == "/api/v3/licenses" then
+    SetStatus(200, "OK")
+    json(
+      '[{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZW1pdA=="}]'
+    )
+  elseif path == "/api/v3/licenses/mit" then
+    SetStatus(200, "OK")
+    json(
+      '{"key":"mit","name":"MIT License","spdx_id":"MIT",'
+        .. '"url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZW1pdA==",'
+        .. '"html_url":"http://choosealicense.com/licenses/mit/",'
+        .. '"description":"A permissive license.",'
+        .. '"implementation":"Create a LICENSE file.",'
+        .. '"body":"MIT License\\n\\nCopyright (c) [year] [fullname]",'
+        .. '"permissions":["commercial-use","modifications","distribution","private-use"],'
+        .. '"conditions":["include-copyright"],'
+        .. '"limitations":["liability","warranty"]}'
+    )
+  elseif path == rb .. "/license" then
+    SetStatus(200, "OK")
+    json(
+      '{"name":"LICENSE","path":"LICENSE","sha":"abc123","size":100,'
+        .. '"type":"file","encoding":"base64","content":"SGVsbG8gV29ybGQ=",'
+        .. '"license":{"key":"mit","name":"MIT License","spdx_id":"MIT",'
+        .. '"url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZW1pdA=="}}'
+    )
+
   -- Migrations ----------------------------------------------------------------
   -- GitBucket has no GitHub-style org/user migration API; confusio
   -- returns fixed responses without proxying. Routes documented here for reference.

--- a/test/mock-gitea.lua
+++ b/test/mock-gitea.lua
@@ -23,7 +23,8 @@ function OnHttpRequest()
     .. '"open_issues_count":0,"default_branch":"main","visibility":"public",'
     .. '"forks":9,"open_issues":0,"watchers":80,'
     .. '"created_at":"2011-01-26T19:01:12Z","updated_at":"2011-01-26T19:14:43Z",'
-    .. '"pushed_at":"2011-01-26T19:06:43Z"}'
+    .. '"pushed_at":"2011-01-26T19:06:43Z",'
+    .. '"license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit"}}'
 
   local USER = '{"login":"octocat","id":1,"avatar_url":"","html_url":"http://localhost/octocat",'
     .. '"full_name":"The Octocat","email":"octocat@github.com","is_admin":false,'
@@ -403,6 +404,24 @@ function OnHttpRequest()
     ["/api/v1/gitignores/C"] = {
       200,
       '{"name":"C","source":"# Object files\\n*.o\\n\\n# Libraries\\n*.a\\n"}',
+    },
+
+    -- License templates
+    ["/api/v1/licenses"] = {
+      200,
+      '[{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit"}]',
+    },
+    ["/api/v1/licenses/mit"] = {
+      200,
+      '{"key":"mit","name":"MIT License","spdx_id":"MIT",'
+        .. '"url":"https://api.github.com/licenses/mit",'
+        .. '"html_url":"http://choosealicense.com/licenses/mit/",'
+        .. '"description":"A permissive license.",'
+        .. '"implementation":"Create a LICENSE file.",'
+        .. '"body":"MIT License\\n\\nCopyright (c) [year] [fullname]",'
+        .. '"permissions":["commercial-use","modifications","distribution","private-use"],'
+        .. '"conditions":["include-copyright"],'
+        .. '"limitations":["liability","warranty"]}',
     },
 
     -- Apps: Gitea has no GitHub Apps API; confusio returns 404 directly.

--- a/test/mock-gitlab.lua
+++ b/test/mock-gitlab.lua
@@ -21,7 +21,8 @@ function OnHttpRequest()
     .. '"open_issues_count":0,"issues_enabled":true,"wiki_enabled":false,'
     .. '"archived":false,"default_branch":"main",'
     .. '"created_at":"2011-01-26T19:01:12Z","last_activity_at":"2011-01-26T19:14:43Z",'
-    .. '"topics":["lua","api"]}'
+    .. '"topics":["lua","api"],'
+    .. '"license":{"key":"mit","name":"MIT License"}}'
 
   if path == "/api/v4/version" then
     SetStatus(200, "OK")
@@ -539,6 +540,33 @@ function OnHttpRequest()
   elseif path == "/api/v4/templates/gitignores/Nonexistent" then
     SetStatus(404, "Not Found")
     json('{"message":"404 Not Found"}')
+
+  -- License templates ----------------------------------------------------------
+  elseif path == "/api/v4/templates/licenses" then
+    SetStatus(200, "OK")
+    json('[{"key":"mit","name":"MIT License"},{"key":"apache-2.0","name":"Apache License 2.0"}]')
+  elseif path == "/api/v4/templates/licenses/mit" then
+    SetStatus(200, "OK")
+    json(
+      '{"key":"mit","name":"MIT License",'
+        .. '"html_url":"http://choosealicense.com/licenses/mit/",'
+        .. '"description":"A permissive license.",'
+        .. '"content":"MIT License\\n\\nCopyright (c) [year] [fullname]",'
+        .. '"permissions":["commercial-use","modifications","distribution","private-use"],'
+        .. '"conditions":["include-copyright"],'
+        .. '"limitations":["liability","warranty"]}'
+    )
+  elseif path == "/api/v4/templates/licenses/Nonexistent" then
+    SetStatus(404, "Not Found")
+    json('{"message":"404 Not Found"}')
+
+  -- Repo license file ----------------------------------------------------------
+  elseif path == pb .. "/repository/files/LICENSE" then
+    SetStatus(200, "OK")
+    json(
+      '{"file_name":"LICENSE","file_path":"LICENSE","blob_id":"abc123",'
+        .. '"size":100,"encoding":"base64","content":"SGVsbG8gV29ybGQ="}'
+    )
 
   -- Migrations: GitLab has per-project export, not GitHub-style org/user migrations.
   -- confusio returns fixed responses without proxying, but routes are documented here.

--- a/test/notabug-licenses.hurl
+++ b/test/notabug-licenses.hurl
@@ -1,0 +1,1 @@
+gitea-licenses.hurl

--- a/test/onedev-licenses.hurl
+++ b/test/onedev-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/pagure-licenses.hurl
+++ b/test/pagure-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/phabricator-licenses.hurl
+++ b/test/phabricator-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/radicle-licenses.hurl
+++ b/test/radicle-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/rhodecode-licenses.hurl
+++ b/test/rhodecode-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/sourceforge-licenses.hurl
+++ b/test/sourceforge-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/sourcehut-licenses.hurl
+++ b/test/sourcehut-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/tuleap-licenses.hurl
+++ b/test/tuleap-licenses.hurl
@@ -1,0 +1,1 @@
+codecommit-licenses.hurl

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -927,6 +927,28 @@ ok(
   "OnHttpRequest: GET /repos/{owner}/{repo}/actions/workflows → body contains workflows"
 )
 
+-- licenses_not_implemented: GET /licenses → 501
+reset_response()
+reset_request({ method = "GET", path = "/licenses" })
+OnHttpRequest()
+eq(_last_status, 501, "OnHttpRequest: GET /licenses → 501 (licenses not implemented)")
+
+-- licenses_not_implemented: GET /licenses/{license} → 501
+reset_response()
+reset_request({ method = "GET", path = "/licenses/mit" })
+OnHttpRequest()
+eq(_last_status, 501, "OnHttpRequest: GET /licenses/{license} → 501 (licenses not implemented)")
+
+-- licenses_not_implemented: GET /repos/{owner}/{repo}/license → 501
+reset_response()
+reset_request({ method = "GET", path = "/repos/alice/myrepo/license" })
+OnHttpRequest()
+eq(
+  _last_status,
+  501,
+  "OnHttpRequest: GET /repos/{owner}/{repo}/license → 501 (licenses not implemented)"
+)
+
 -- git_not_implemented: any git database route → 501
 reset_response()
 reset_request({ method = "GET", path = "/repos/alice/myrepo/git/blobs/abc123" })


### PR DESCRIPTION
Implement GitHub REST API for Licenses (closes #39)

Fixes #39.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (12)</summary>

- [x] Add license endpoint routes and default handlers <!-- type:spec -->
- [x] Gitea: implement license endpoints, mock routes, tests, and CSV <!-- type:spec -->
- [x] Codeberg: license endpoint tests and CSV (inherits gitea) <!-- type:spec -->
- [x] Forgejo: license endpoint tests and CSV (inherits gitea) <!-- type:spec -->
- [x] Gogs: license endpoint tests and CSV (inherits gitea) <!-- type:spec -->
- [x] Notabug: license endpoint tests and CSV (inherits gitea) <!-- type:spec -->
- [x] GitLab: implement license endpoints, tests, and CSV <!-- type:spec -->
- [x] Bitbucket Cloud: implement license endpoints, tests, and CSV <!-- type:spec -->
- [x] Bitbucket Data Center: implement license endpoints, tests, and CSV <!-- type:spec -->
- [x] Azure DevOps: implement license endpoints, tests, and CSV <!-- type:spec -->
- [x] Gitbucket: implement license endpoints, tests, and CSV <!-- type:spec -->
- [x] Remaining backends: license endpoint tests (all 501) <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->