### PR TITLE
Implement GitHub REST API for Dependabot (closes #34)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -422,6 +422,17 @@ local function code_scanning_list_empty()
   respond_json(200, {})
 end
 
+-- Default handlers for Dependabot endpoints: most backends have no native Dependabot API.
+-- Alert list endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+-- Secrets list endpoints use make_empty_collection (defined below) for proper envelope format.
+local function dependabot_not_implemented()
+  respond_json(501, { message = "Dependabot is not supported by this backend." })
+end
+
+local function dependabot_list_empty()
+  respond_json(200, {})
+end
+
 -- Default handler for Pages endpoints: no backend has a native GitHub Pages API.
 -- Returns 501 Not Implemented with a descriptive message.
 local function pages_not_implemented()
@@ -728,6 +739,29 @@ local route_defaults = {
   update_code_scanning_default_setup = code_scanning_not_implemented,
   upload_code_scanning_sarif = code_scanning_not_implemented,
   get_code_scanning_sarif = code_scanning_not_implemented,
+  -- Dependabot
+  list_enterprise_dependabot_alerts = dependabot_list_empty,
+  list_org_dependabot_alerts = dependabot_list_empty,
+  list_repo_dependabot_alerts = dependabot_list_empty,
+  get_repo_dependabot_alert = dependabot_not_implemented,
+  update_repo_dependabot_alert = dependabot_not_implemented,
+  list_org_dependabot_secrets = make_empty_collection("secrets"),
+  get_org_dependabot_public_key = dependabot_not_implemented,
+  get_org_dependabot_secret = dependabot_not_implemented,
+  put_org_dependabot_secret = dependabot_not_implemented,
+  delete_org_dependabot_secret = dependabot_not_implemented,
+  list_org_dependabot_secret_repos = make_empty_collection("repositories"),
+  put_org_dependabot_secret_repos = dependabot_not_implemented,
+  add_org_dependabot_secret_repo = dependabot_not_implemented,
+  remove_org_dependabot_secret_repo = dependabot_not_implemented,
+  list_repo_dependabot_secrets = make_empty_collection("secrets"),
+  get_repo_dependabot_public_key = dependabot_not_implemented,
+  get_repo_dependabot_secret = dependabot_not_implemented,
+  put_repo_dependabot_secret = dependabot_not_implemented,
+  delete_repo_dependabot_secret = dependabot_not_implemented,
+  get_org_dependabot_repo_access = dependabot_not_implemented,
+  update_org_dependabot_repo_access = dependabot_not_implemented,
+  set_org_dependabot_repo_access_default_level = dependabot_not_implemented,
   -- Packages
   get_org_packages = empty_list,
   get_org_package_versions = empty_list,
@@ -1553,6 +1587,30 @@ local routes = {
   ["PATCH /repos/{owner}/{repo}/code-scanning/default-setup"] = "update_code_scanning_default_setup",
   ["POST /repos/{owner}/{repo}/code-scanning/sarifs"] = "upload_code_scanning_sarif",
   ["GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}"] = "get_code_scanning_sarif",
+
+  -- Dependabot (https://docs.github.com/en/rest/dependabot)
+  ["GET /enterprises/{enterprise}/dependabot/alerts"] = "list_enterprise_dependabot_alerts",
+  ["GET /orgs/{org}/dependabot/alerts"] = "list_org_dependabot_alerts",
+  ["GET /orgs/{org}/dependabot/secrets"] = "list_org_dependabot_secrets",
+  ["GET /orgs/{org}/dependabot/secrets/public-key"] = "get_org_dependabot_public_key",
+  ["GET /orgs/{org}/dependabot/secrets/{secret_name}"] = "get_org_dependabot_secret",
+  ["PUT /orgs/{org}/dependabot/secrets/{secret_name}"] = "put_org_dependabot_secret",
+  ["DELETE /orgs/{org}/dependabot/secrets/{secret_name}"] = "delete_org_dependabot_secret",
+  ["GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories"] = "list_org_dependabot_secret_repos",
+  ["PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories"] = "put_org_dependabot_secret_repos",
+  ["PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}"] = "add_org_dependabot_secret_repo",
+  ["DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}"] = "remove_org_dependabot_secret_repo",
+  ["GET /organizations/{org}/dependabot/repository-access"] = "get_org_dependabot_repo_access",
+  ["PATCH /organizations/{org}/dependabot/repository-access"] = "update_org_dependabot_repo_access",
+  ["PUT /organizations/{org}/dependabot/repository-access/default-level"] = "set_org_dependabot_repo_access_default_level",
+  ["GET /repos/{owner}/{repo}/dependabot/alerts"] = "list_repo_dependabot_alerts",
+  ["GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"] = "get_repo_dependabot_alert",
+  ["PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"] = "update_repo_dependabot_alert",
+  ["GET /repos/{owner}/{repo}/dependabot/secrets"] = "list_repo_dependabot_secrets",
+  ["GET /repos/{owner}/{repo}/dependabot/secrets/public-key"] = "get_repo_dependabot_public_key",
+  ["GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}"] = "get_repo_dependabot_secret",
+  ["PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}"] = "put_repo_dependabot_secret",
+  ["DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}"] = "delete_repo_dependabot_secret",
 
   -- Dependency Graph (https://docs.github.com/en/rest/dependency-graph)
   ["GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}"] = "get_repo_dependency_graph_compare",

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -1635,6 +1635,142 @@ _b.upload_code_scanning_sarif = function(owner, repo_name)
   end
 end
 
+-- Dependabot alerts via ADO Advanced Security dependency scanning -----------------
+--
+-- Uses the same /_apis/advancedsecurity/alerts/{repo} endpoint as code scanning
+-- but with alertType=dependency. Secrets and repository-access have no ADO
+-- equivalent and fall back to defaults (501 / empty list).
+--
+-- ADO dependency alert fields used:
+--   alertId, state, severity, firstSeenDate, dismissedDate, dismissal,
+--   dependency.{componentName, componentVersion, packageManager}, title, cve
+
+local ADO_PACKAGE_MANAGER_TO_ECOSYSTEM = {
+  npm = "npm",
+  nuget = "nuget",
+  pypi = "pip",
+  maven = "maven",
+  cargo = "cargo",
+  rubygems = "rubygems",
+  composer = "composer",
+  go = "go",
+}
+
+local GH_DEPENDABOT_DISMISS_REASON_TO_ADO = {
+  inaccurate = "falsePositive",
+  ["fix_started"] = "wontFix",
+  ["no_bandwidth"] = "wontFix",
+  ["not_used"] = "wontFix",
+  ["tolerable_risk"] = "wontFix",
+}
+
+local function translate_ado_dependency_alert(a)
+  if not a then
+    return {}
+  end
+  local state = ADO_STATE_TO_GH[a.state or ""] or "open"
+  local dismissal = a.dismissal or {}
+  local dismissed_reason = ADO_DISMISS_REASON_TO_GH[dismissal.dismissalType or ""]
+  local dep = a.dependency or {}
+  local pm = (dep.packageManager or ""):lower()
+  local ecosystem = ADO_PACKAGE_MANAGER_TO_ECOSYSTEM[pm] or pm
+  local package = { ecosystem = ecosystem, name = dep.componentName or "" }
+  return {
+    number = a.alertId or 0,
+    state = state,
+    dependency = {
+      package = package,
+      manifest_path = "",
+      scope = "runtime",
+    },
+    security_advisory = {
+      ghsa_id = "",
+      cve_id = a.cve or nil,
+      summary = a.title or "",
+      description = a.title or "",
+      severity = (a.severity or ""):lower(),
+      identifiers = {},
+      references = {},
+      published_at = a.firstSeenDate or "",
+      updated_at = a.firstSeenDate or "",
+      withdrawn_at = nil,
+      vulnerabilities = {},
+    },
+    security_vulnerability = {
+      package = package,
+      severity = (a.severity or ""):lower(),
+      vulnerable_version_range = dep.componentVersion and ("= " .. dep.componentVersion) or "",
+      first_patched_version = nil,
+    },
+    url = "",
+    html_url = "",
+    created_at = a.firstSeenDate or "",
+    updated_at = a.firstSeenDate or "",
+    dismissed_at = a.dismissedDate,
+    dismissed_by = nil,
+    dismissed_reason = dismissed_reason,
+    dismissed_comment = dismissal.message or nil,
+    fixed_at = nil,
+    auto_dismissed_at = nil,
+  }
+end
+
+_b.list_repo_dependabot_alerts = function(owner, repo_name)
+  local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "?alertType=dependency")
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local result = {}
+  for _, a in ipairs(data.value or {}) do
+    result[#result + 1] = translate_ado_dependency_alert(a)
+  end
+  respond_json(200, result)
+end
+
+_b.get_repo_dependabot_alert = function(owner, repo_name, alert_number)
+  local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "/" .. alert_number)
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, translate_ado_dependency_alert(DecodeJson(body) or {}))
+end
+
+_b.update_repo_dependabot_alert = function(owner, repo_name, alert_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local ado_state = GH_STATE_TO_ADO[req.state or ""] or "active"
+  local patch = { state = ado_state }
+  if req.dismissed_reason then
+    patch.dismissal = {
+      dismissalType = GH_DEPENDABOT_DISMISS_REASON_TO_ADO[req.dismissed_reason] or "wontFix",
+      message = req.dismissed_comment or "",
+    }
+  end
+  local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "/" .. alert_number)
+  local ok, status, _, body = fetch_json(url, "PATCH", EncodeJson(patch))
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, translate_ado_dependency_alert(DecodeJson(body) or {}))
+end
+
 -- Git database (refs only; blobs/commits/tag-objects/trees have no ADO equivalent) ----
 
 local ZERO_SHA = "0000000000000000000000000000000000000000"

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -3450,3 +3450,138 @@ backend_impl = {
     Write(parsed.html or "")
   end,
 }
+
+-- Dependabot alerts via GitLab Vulnerabilities API (requires Ultimate tier).
+--
+-- Endpoint mapping:
+--   GET  /repos/{owner}/{repo}/dependabot/alerts       → GET  /projects/:id/vulnerabilities
+--   GET  /repos/{owner}/{repo}/dependabot/alerts/{n}   → GET  /projects/:id/vulnerabilities/:n
+--   PATCH /repos/{owner}/{repo}/dependabot/alerts/{n}  → POST /vulnerabilities/:n/dismiss|revert-to-detected
+--   GET  /orgs/{org}/dependabot/alerts                 → GET  /groups/:org/vulnerabilities
+--
+-- GitLab state mapping:
+--   detected / confirmed → open
+--   dismissed            → dismissed
+--   resolved             → fixed
+--
+-- Secrets and repository-access have no GitLab equivalent; those handlers
+-- remain at their defaults (501 Not Implemented).
+
+local GL_VULN_STATE_TO_GH = {
+  detected = "open",
+  confirmed = "open",
+  dismissed = "dismissed",
+  resolved = "fixed",
+}
+
+local GH_STATE_TO_GL_ACTION = {
+  open = "revert-to-detected",
+  dismissed = "dismiss",
+}
+
+local function translate_gl_vulnerability(v)
+  if not v then
+    return {}
+  end
+  local loc = v.location or {}
+  local dep = loc.dependency or {}
+  local pkg = dep.package or {}
+  local identifiers = v.identifiers or {}
+  local cve_id = nil
+  for _, id in ipairs(identifiers) do
+    if id.type == "cve" then
+      cve_id = id.value
+      break
+    end
+  end
+  local package = { ecosystem = "unknown", name = pkg.name or "" }
+  return {
+    number = v.id or 0,
+    state = GL_VULN_STATE_TO_GH[v.state or ""] or "open",
+    dependency = {
+      package = package,
+      manifest_path = loc.file or "",
+      scope = "runtime",
+    },
+    security_advisory = {
+      ghsa_id = "",
+      cve_id = cve_id,
+      summary = v.title or "",
+      description = v.description or "",
+      severity = v.severity or "unknown",
+      identifiers = identifiers,
+      references = {},
+      published_at = v.created_at or "",
+      updated_at = v.updated_at or "",
+      withdrawn_at = nil,
+      vulnerabilities = {},
+    },
+    security_vulnerability = {
+      package = package,
+      severity = v.severity or "unknown",
+      vulnerable_version_range = dep.version and ("= " .. dep.version) or "",
+      first_patched_version = nil,
+    },
+    url = "",
+    html_url = "",
+    created_at = v.created_at or "",
+    updated_at = v.updated_at or "",
+    dismissed_at = v.dismissed_at,
+    dismissed_by = nil,
+    dismissed_reason = v.dismissed_reason,
+    dismissed_comment = nil,
+    fixed_at = nil,
+    auto_dismissed_at = nil,
+  }
+end
+
+local function translate_gl_vuln_list(arr)
+  local result = {}
+  for _, v in ipairs(arr) do
+    result[#result + 1] = translate_gl_vulnerability(v)
+  end
+  return result
+end
+
+local _b = backend_impl
+
+_b.list_repo_dependabot_alerts = function(owner, repo_name)
+  proxy_json_paged(
+    translate_gl_vuln_list,
+    PAGES,
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities")
+  )
+end
+
+_b.get_repo_dependabot_alert = function(owner, repo_name, alert_number)
+  proxy_json(
+    translate_gl_vulnerability,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
+    )
+  )
+end
+
+_b.update_repo_dependabot_alert = function(_owner, _repo_name, alert_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local action = GH_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
+  local gl_url = base() .. "/vulnerabilities/" .. alert_number .. "/" .. action
+  local ok, status, _, body = fetch_json(gl_url, "POST", EncodeJson({}))
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, translate_gl_vulnerability(DecodeJson(body) or {}))
+end
+
+_b.list_org_dependabot_alerts = function(org)
+  proxy_json_paged(
+    translate_gl_vuln_list,
+    PAGES,
+    fetch_json(base() .. "/groups/" .. org .. "/vulnerabilities")
+  )
+end

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -370,3 +370,26 @@ Dependency Graph,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/dependency-graph/sbom,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/dependency-graph/snapshots,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+Dependabot,,,,,,,,,,,,,,,,,,,,,,,,
+GET /enterprises/{enterprise}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /orgs/{org}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /orgs/{org}/dependabot/secrets,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /orgs/{org}/dependabot/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /orgs/{org}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /orgs/{org}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /orgs/{org}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /organizations/{org}/dependabot/repository-access,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /organizations/{org}/dependabot/repository-access,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /organizations/{org}/dependabot/repository-access/default-level,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/dependabot/secrets,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/dependabot/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -385,9 +385,9 @@ DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
 GET /organizations/{org}/dependabot/repository-access,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PATCH /organizations/{org}/dependabot/repository-access,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /organizations/{org}/dependabot/repository-access/default-level,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/dependabot/alerts,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/dependabot/secrets,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /repos/{owner}/{repo}/dependabot/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -372,7 +372,7 @@ GET /repos/{owner}/{repo}/dependency-graph/sbom,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,
 POST /repos/{owner}/{repo}/dependency-graph/snapshots,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Dependabot,,,,,,,,,,,,,,,,,,,,,,,,
 GET /enterprises/{enterprise}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-GET /orgs/{org}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /orgs/{org}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/dependabot/secrets,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/dependabot/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -385,9 +385,9 @@ DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
 GET /organizations/{org}/dependabot/repository-access,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PATCH /organizations/{org}/dependabot/repository-access,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /organizations/{org}/dependabot/repository-access/default-level,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/dependabot/secrets,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /repos/{owner}/{repo}/dependabot/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/test/azuredevops-dependabot.hurl
+++ b/test/azuredevops-dependabot.hurl
@@ -1,0 +1,226 @@
+# Dependabot API — Azure DevOps Advanced Security backend.
+# Dependency alerts proxy to ADO Advanced Security API (alertType=dependency).
+# Secrets and repository-access have no ADO equivalent and return 501.
+
+# GET /enterprises/{enterprise}/dependabot/alerts — no ADO equivalent; returns empty list
+GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/alerts — no ADO equivalent; returns empty list
+GET http://{{host}}/orgs/testorg/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts → GET /{owner}/_apis/advancedsecurity/alerts/{repo}?alertType=dependency
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].number" == 2
+jsonpath "$[0].state" == "open"
+jsonpath "$[0].security_advisory.cve_id" == "CVE-2019-10744"
+jsonpath "$[0].security_advisory.severity" == "high"
+jsonpath "$[0].security_advisory.summary" isString
+jsonpath "$[0].dependency.package.name" == "lodash"
+jsonpath "$[0].dependency.package.ecosystem" == "npm"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} → GET /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/2
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 2
+jsonpath "$.state" == "open"
+jsonpath "$.security_advisory.cve_id" == "CVE-2019-10744"
+jsonpath "$.dependency.package.name" == "lodash"
+
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number} → PATCH /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
+PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/2
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed", "dismissed_reason": "tolerable_risk"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 2
+jsonpath "$.state" == "dismissed"
+jsonpath "$.dismissed_at" isString
+
+# GET /orgs/{org}/dependabot/secrets — no ADO equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /orgs/{org}/dependabot/secrets/public-key — no ADO equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name} — no ADO equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name} — no ADO equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name} — no ADO equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no ADO equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.repositories" isCollection
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no ADO equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+Content-Type: application/json
+{"selected_repository_ids": [1]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no ADO equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no ADO equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /organizations/{org}/dependabot/repository-access — no ADO equivalent
+GET http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /organizations/{org}/dependabot/repository-access — no ADO equivalent
+PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /organizations/{org}/dependabot/repository-access/default-level — no ADO equivalent
+PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
+Authorization: token testtoken
+Content-Type: application/json
+{"default_level": "public"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets — no ADO equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key — no ADO equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no ADO equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no ADO equivalent
+PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no ADO equivalent
+DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/bitbucket-dependabot.hurl
+++ b/test/bitbucket-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/bitbucket_datacenter-dependabot.hurl
+++ b/test/bitbucket_datacenter-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/codeberg-dependabot.hurl
+++ b/test/codeberg-dependabot.hurl
@@ -1,0 +1,214 @@
+# Dependabot API — Codeberg (Forgejo) backend.
+# Forgejo has no native Dependabot API.
+# Alert and secret list endpoints return empty collections; per-resource endpoints return 501.
+
+# GET /enterprises/{enterprise}/dependabot/alerts — no Forgejo equivalent; returns empty list
+GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/alerts — no Forgejo equivalent; returns empty list
+GET http://{{host}}/orgs/testorg/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/secrets — no Forgejo equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /orgs/{org}/dependabot/secrets/public-key — no Forgejo equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Forgejo equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.repositories" isCollection
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Forgejo equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+Content-Type: application/json
+{"selected_repository_ids": [1]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Forgejo equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Forgejo equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /organizations/{org}/dependabot/repository-access — no Forgejo equivalent
+GET http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /organizations/{org}/dependabot/repository-access — no Forgejo equivalent
+PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /organizations/{org}/dependabot/repository-access/default-level — no Forgejo equivalent
+PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
+Authorization: token testtoken
+Content-Type: application/json
+{"default_level": "public"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/alerts — no Forgejo equivalent; returns empty list
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Forgejo equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Forgejo equivalent
+PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets — no Forgejo equivalent; returns empty envelope
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key — no Forgejo equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/codecommit-dependabot.hurl
+++ b/test/codecommit-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/forgejo-dependabot.hurl
+++ b/test/forgejo-dependabot.hurl
@@ -1,0 +1,214 @@
+# Dependabot API — Forgejo backend.
+# Forgejo has no native Dependabot API.
+# Alert and secret list endpoints return empty collections; per-resource endpoints return 501.
+
+# GET /enterprises/{enterprise}/dependabot/alerts — no Forgejo equivalent; returns empty list
+GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/alerts — no Forgejo equivalent; returns empty list
+GET http://{{host}}/orgs/testorg/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/secrets — no Forgejo equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /orgs/{org}/dependabot/secrets/public-key — no Forgejo equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Forgejo equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.repositories" isCollection
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Forgejo equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+Content-Type: application/json
+{"selected_repository_ids": [1]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Forgejo equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Forgejo equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /organizations/{org}/dependabot/repository-access — no Forgejo equivalent
+GET http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /organizations/{org}/dependabot/repository-access — no Forgejo equivalent
+PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /organizations/{org}/dependabot/repository-access/default-level — no Forgejo equivalent
+PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
+Authorization: token testtoken
+Content-Type: application/json
+{"default_level": "public"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/alerts — no Forgejo equivalent; returns empty list
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Forgejo equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Forgejo equivalent
+PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets — no Forgejo equivalent; returns empty envelope
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key — no Forgejo equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Forgejo equivalent
+DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gerrit-dependabot.hurl
+++ b/test/gerrit-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/gitblit-dependabot.hurl
+++ b/test/gitblit-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/gitbucket-dependabot.hurl
+++ b/test/gitbucket-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/gitea-dependabot.hurl
+++ b/test/gitea-dependabot.hurl
@@ -1,8 +1,8 @@
-# Dependabot API — minimal stubs for backends without native Dependabot support.
-# Alert list endpoints return empty arrays (200); per-resource endpoints return 501.
-# Secrets list endpoints return empty envelopes (200); mutation endpoints return 501.
+# Dependabot API — Gitea backend.
+# Gitea has no native Dependabot API.
+# Alert and secret list endpoints return empty collections; per-resource endpoints return 501.
 
-# GET /enterprises/{enterprise}/dependabot/alerts
+# GET /enterprises/{enterprise}/dependabot/alerts — no Gitea equivalent; returns empty list
 GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
 Authorization: token testtoken
 
@@ -10,7 +10,7 @@ HTTP 200
 [Asserts]
 header "Content-Type" == "application/json; charset=utf-8"
 
-# GET /orgs/{org}/dependabot/alerts
+# GET /orgs/{org}/dependabot/alerts — no Gitea equivalent; returns empty list
 GET http://{{host}}/orgs/testorg/dependabot/alerts
 Authorization: token testtoken
 
@@ -18,7 +18,7 @@ HTTP 200
 [Asserts]
 header "Content-Type" == "application/json; charset=utf-8"
 
-# GET /orgs/{org}/dependabot/secrets
+# GET /orgs/{org}/dependabot/secrets — no Gitea equivalent; returns empty envelope
 GET http://{{host}}/orgs/testorg/dependabot/secrets
 Authorization: token testtoken
 
@@ -28,7 +28,7 @@ header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.total_count" == 0
 jsonpath "$.secrets" isCollection
 
-# GET /orgs/{org}/dependabot/secrets/public-key
+# GET /orgs/{org}/dependabot/secrets/public-key — no Gitea equivalent
 GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
 Authorization: token testtoken
 
@@ -37,7 +37,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# GET /orgs/{org}/dependabot/secrets/{secret_name}
+# GET /orgs/{org}/dependabot/secrets/{secret_name} — no Gitea equivalent
 GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
 Authorization: token testtoken
 
@@ -46,7 +46,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# PUT /orgs/{org}/dependabot/secrets/{secret_name}
+# PUT /orgs/{org}/dependabot/secrets/{secret_name} — no Gitea equivalent
 PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
 Authorization: token testtoken
 Content-Type: application/json
@@ -57,7 +57,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# DELETE /orgs/{org}/dependabot/secrets/{secret_name}
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name} — no Gitea equivalent
 DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
 Authorization: token testtoken
 
@@ -66,7 +66,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Gitea equivalent; returns empty envelope
 GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
 Authorization: token testtoken
 
@@ -76,7 +76,7 @@ header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.total_count" == 0
 jsonpath "$.repositories" isCollection
 
-# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Gitea equivalent
 PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
 Authorization: token testtoken
 Content-Type: application/json
@@ -87,7 +87,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Gitea equivalent
 PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
 Authorization: token testtoken
 Content-Length: 0
@@ -97,7 +97,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Gitea equivalent
 DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
 Authorization: token testtoken
 
@@ -106,7 +106,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# GET /organizations/{org}/dependabot/repository-access
+# GET /organizations/{org}/dependabot/repository-access — no Gitea equivalent
 GET http://{{host}}/organizations/testorg/dependabot/repository-access
 Authorization: token testtoken
 
@@ -115,7 +115,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# PATCH /organizations/{org}/dependabot/repository-access
+# PATCH /organizations/{org}/dependabot/repository-access — no Gitea equivalent
 PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
 Authorization: token testtoken
 Content-Type: application/json
@@ -126,7 +126,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# PUT /organizations/{org}/dependabot/repository-access/default-level
+# PUT /organizations/{org}/dependabot/repository-access/default-level — no Gitea equivalent
 PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
 Authorization: token testtoken
 Content-Type: application/json
@@ -137,7 +137,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# GET /repos/{owner}/{repo}/dependabot/alerts
+# GET /repos/{owner}/{repo}/dependabot/alerts — no Gitea equivalent; returns empty list
 GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
 Authorization: token testtoken
 
@@ -145,7 +145,7 @@ HTTP 200
 [Asserts]
 header "Content-Type" == "application/json; charset=utf-8"
 
-# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Gitea equivalent
 GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
 Authorization: token testtoken
 
@@ -154,7 +154,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Gitea equivalent
 PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
 Authorization: token testtoken
 Content-Type: application/json
@@ -165,7 +165,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# GET /repos/{owner}/{repo}/dependabot/secrets
+# GET /repos/{owner}/{repo}/dependabot/secrets — no Gitea equivalent; returns empty envelope
 GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
 Authorization: token testtoken
 
@@ -175,7 +175,7 @@ header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.total_count" == 0
 jsonpath "$.secrets" isCollection
 
-# GET /repos/{owner}/{repo}/dependabot/secrets/public-key
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key — no Gitea equivalent
 GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
 Authorization: token testtoken
 
@@ -184,7 +184,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Gitea equivalent
 GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
 Authorization: token testtoken
 
@@ -193,7 +193,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Gitea equivalent
 PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
 Authorization: token testtoken
 Content-Type: application/json
@@ -204,7 +204,7 @@ HTTP 501
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.message" isString
 
-# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Gitea equivalent
 DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
 Authorization: token testtoken
 

--- a/test/gitlab-dependabot.hurl
+++ b/test/gitlab-dependabot.hurl
@@ -1,0 +1,229 @@
+# Dependabot API — GitLab backend.
+# Alerts proxy to GitLab Vulnerabilities API (requires Ultimate tier).
+# Secrets and repository-access have no GitLab equivalent and return 501.
+
+# GET /repos/{owner}/{repo}/dependabot/alerts → GET /projects/:id/vulnerabilities
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].number" == 1
+jsonpath "$[0].state" == "open"
+jsonpath "$[0].security_advisory.cve_id" == "CVE-2019-10744"
+jsonpath "$[0].security_advisory.severity" == "high"
+jsonpath "$[0].security_advisory.summary" isString
+jsonpath "$[0].dependency.package.name" == "lodash"
+jsonpath "$[0].dependency.manifest_path" == "package-lock.json"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} → GET /projects/:id/vulnerabilities/:id
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 1
+jsonpath "$.state" == "open"
+jsonpath "$.security_advisory.cve_id" == "CVE-2019-10744"
+jsonpath "$.security_advisory.severity" == "high"
+jsonpath "$.dependency.package.name" == "lodash"
+
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number} → POST /vulnerabilities/:id/dismiss
+PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed", "dismissed_reason": "tolerable_risk"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 1
+jsonpath "$.state" == "dismissed"
+jsonpath "$.dismissed_at" isString
+
+# GET /orgs/{org}/dependabot/alerts → GET /groups/:org/vulnerabilities
+GET http://{{host}}/orgs/testorg/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].number" == 1
+jsonpath "$[0].state" == "open"
+
+# GET /enterprises/{enterprise}/dependabot/alerts — no GitLab equivalent; returns empty list
+GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/secrets — no GitLab equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /orgs/{org}/dependabot/secrets/public-key — no GitLab equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name} — no GitLab equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name} — no GitLab equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name} — no GitLab equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no GitLab equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.repositories" isCollection
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no GitLab equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+Content-Type: application/json
+{"selected_repository_ids": [1]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no GitLab equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no GitLab equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /organizations/{org}/dependabot/repository-access — no GitLab equivalent
+GET http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /organizations/{org}/dependabot/repository-access — no GitLab equivalent
+PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /organizations/{org}/dependabot/repository-access/default-level — no GitLab equivalent
+PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
+Authorization: token testtoken
+Content-Type: application/json
+{"default_level": "public"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets — no GitLab equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key — no GitLab equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no GitLab equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no GitLab equivalent
+PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no GitLab equivalent
+DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gogs-dependabot.hurl
+++ b/test/gogs-dependabot.hurl
@@ -1,0 +1,214 @@
+# Dependabot API — Gogs backend.
+# Gogs has no native Dependabot API.
+# Alert and secret list endpoints return empty collections; per-resource endpoints return 501.
+
+# GET /enterprises/{enterprise}/dependabot/alerts — no Gogs equivalent; returns empty list
+GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/alerts — no Gogs equivalent; returns empty list
+GET http://{{host}}/orgs/testorg/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/secrets — no Gogs equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /orgs/{org}/dependabot/secrets/public-key — no Gogs equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name} — no Gogs equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name} — no Gogs equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name} — no Gogs equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Gogs equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.repositories" isCollection
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no Gogs equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+Content-Type: application/json
+{"selected_repository_ids": [1]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Gogs equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no Gogs equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /organizations/{org}/dependabot/repository-access — no Gogs equivalent
+GET http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /organizations/{org}/dependabot/repository-access — no Gogs equivalent
+PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /organizations/{org}/dependabot/repository-access/default-level — no Gogs equivalent
+PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
+Authorization: token testtoken
+Content-Type: application/json
+{"default_level": "public"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/alerts — no Gogs equivalent; returns empty list
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Gogs equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no Gogs equivalent
+PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets — no Gogs equivalent; returns empty envelope
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key — no Gogs equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Gogs equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Gogs equivalent
+PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no Gogs equivalent
+DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/harness-dependabot.hurl
+++ b/test/harness-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/kallithea-dependabot.hurl
+++ b/test/kallithea-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/launchpad-dependabot.hurl
+++ b/test/launchpad-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/mock-azuredevops.lua
+++ b/test/mock-azuredevops.lua
@@ -267,18 +267,29 @@ function OnHttpRequest()
         .. "]}"
     )
 
-  -- Advanced Security — alert list (list_repo_code_scanning_alerts) ----------
+  -- Advanced Security — alert list (code scanning or dependency) -------------
   elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world" and method == "GET" then
     SetStatus(200, "OK")
-    json(
-      '{"count":1,"value":[{"alertId":1,"alertType":"code","state":"active",'
-        .. '"severity":"high","firstSeenDate":"2024-01-01T00:00:00Z",'
-        .. '"rule":{"id":"CS001","name":"SQL Injection","description":"Untrusted input"},'
-        .. '"physicalLocations":[{"physicalLocation":{"artifactLocation":{"uri":"src/app.js"}},'
-        .. '"region":{"startLine":42,"endLine":42,"startColumn":5,"endColumn":20}}]}]}'
-    )
+    local alert_type = GetParam("alertType") or "code"
+    if alert_type == "dependency" then
+      json(
+        '{"count":1,"value":[{"alertId":2,"alertType":"dependency","state":"active",'
+          .. '"severity":"high","firstSeenDate":"2024-02-01T00:00:00Z",'
+          .. '"title":"Prototype Pollution in lodash",'
+          .. '"cve":"CVE-2019-10744",'
+          .. '"dependency":{"componentName":"lodash","componentVersion":"4.17.11","packageManager":"npm"}}]}'
+      )
+    else
+      json(
+        '{"count":1,"value":[{"alertId":1,"alertType":"code","state":"active",'
+          .. '"severity":"high","firstSeenDate":"2024-01-01T00:00:00Z",'
+          .. '"rule":{"id":"CS001","name":"SQL Injection","description":"Untrusted input"},'
+          .. '"physicalLocations":[{"physicalLocation":{"artifactLocation":{"uri":"src/app.js"}},'
+          .. '"region":{"startLine":42,"endLine":42,"startColumn":5,"endColumn":20}}]}]}'
+      )
+    end
 
-  -- Advanced Security — single alert (get_code_scanning_alert) ---------------
+  -- Advanced Security — single alert (code scanning alert 1) -----------------
   elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world/1" and method == "GET" then
     SetStatus(200, "OK")
     json(
@@ -289,7 +300,7 @@ function OnHttpRequest()
         .. '"region":{"startLine":42,"endLine":42,"startColumn":5,"endColumn":20}}]}'
     )
 
-  -- Advanced Security — update alert (update_code_scanning_alert) ------------
+  -- Advanced Security — update alert (code scanning alert 1) -----------------
   elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world/1" and method == "PATCH" then
     SetStatus(200, "OK")
     json(
@@ -299,6 +310,30 @@ function OnHttpRequest()
         .. '"dismissal":{"dismissalType":"wontFix","message":"Not exploitable"},'
         .. '"rule":{"id":"CS001","name":"SQL Injection","description":"Untrusted input"},'
         .. '"physicalLocations":[]}'
+    )
+
+  -- Advanced Security — single dependency alert 2 ----------------------------
+  elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world/2" and method == "GET" then
+    SetStatus(200, "OK")
+    json(
+      '{"alertId":2,"alertType":"dependency","state":"active",'
+        .. '"severity":"high","firstSeenDate":"2024-02-01T00:00:00Z",'
+        .. '"title":"Prototype Pollution in lodash",'
+        .. '"cve":"CVE-2019-10744",'
+        .. '"dependency":{"componentName":"lodash","componentVersion":"4.17.11","packageManager":"npm"}}'
+    )
+
+  -- Advanced Security — update dependency alert 2 ----------------------------
+  elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world/2" and method == "PATCH" then
+    SetStatus(200, "OK")
+    json(
+      '{"alertId":2,"alertType":"dependency","state":"dismissed",'
+        .. '"severity":"high","firstSeenDate":"2024-02-01T00:00:00Z",'
+        .. '"dismissedDate":"2024-02-02T00:00:00Z",'
+        .. '"dismissal":{"dismissalType":"wontFix","message":""},'
+        .. '"title":"Prototype Pollution in lodash",'
+        .. '"cve":"CVE-2019-10744",'
+        .. '"dependency":{"componentName":"lodash","componentVersion":"4.17.11","packageManager":"npm"}}'
     )
 
   -- Advanced Security — analyses list (list_code_scanning_analyses) -----------

--- a/test/mock-gitlab.lua
+++ b/test/mock-gitlab.lua
@@ -568,6 +568,65 @@ function OnHttpRequest()
         .. '"size":100,"encoding":"base64","content":"SGVsbG8gV29ybGQ="}'
     )
 
+  -- Vulnerabilities (Dependabot alerts) -----------------------------------------
+  -- Requires GitLab Ultimate; returns dependency_scanning vulnerabilities.
+  elseif path == pb .. "/vulnerabilities" then
+    SetStatus(200, "OK")
+    json(
+      '[{"id":1,"title":"Prototype Pollution in lodash",'
+        .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
+        .. '"state":"detected","severity":"high","confidence":"high",'
+        .. '"report_type":"dependency_scanning",'
+        .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-01T00:00:00Z",'
+        .. '"dismissed_at":null,"dismissed_reason":null,'
+        .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
+        .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
+        .. '"location":{"file":"package-lock.json",'
+        .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}]'
+    )
+  elseif path == pb .. "/vulnerabilities/1" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":1,"title":"Prototype Pollution in lodash",'
+        .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
+        .. '"state":"detected","severity":"high","confidence":"high",'
+        .. '"report_type":"dependency_scanning",'
+        .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-01T00:00:00Z",'
+        .. '"dismissed_at":null,"dismissed_reason":null,'
+        .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
+        .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
+        .. '"location":{"file":"package-lock.json",'
+        .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}'
+    )
+  elseif path == "/api/v4/vulnerabilities/1/dismiss" and GetMethod() == "POST" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":1,"title":"Prototype Pollution in lodash",'
+        .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
+        .. '"state":"dismissed","severity":"high","confidence":"high",'
+        .. '"report_type":"dependency_scanning",'
+        .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-02T00:00:00Z",'
+        .. '"dismissed_at":"2021-01-02T00:00:00Z","dismissed_reason":"acceptable_risk",'
+        .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
+        .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
+        .. '"location":{"file":"package-lock.json",'
+        .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}'
+    )
+  elseif path == "/api/v4/groups/testorg/vulnerabilities" then
+    SetStatus(200, "OK")
+    json(
+      '[{"id":1,"title":"Prototype Pollution in lodash",'
+        .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
+        .. '"state":"detected","severity":"high","confidence":"high",'
+        .. '"report_type":"dependency_scanning",'
+        .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-01T00:00:00Z",'
+        .. '"dismissed_at":null,"dismissed_reason":null,'
+        .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
+        .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
+        .. '"location":{"file":"package-lock.json",'
+        .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}]'
+    )
+
   -- Migrations: GitLab has per-project export, not GitHub-style org/user migrations.
   -- confusio returns fixed responses without proxying, but routes are documented here.
   -- POST /projects/:id/export → 202 Accepted (starts export asynchronously)

--- a/test/notabug-dependabot.hurl
+++ b/test/notabug-dependabot.hurl
@@ -1,0 +1,214 @@
+# Dependabot API — NotABug backend.
+# NotABug (Gogs-based) has no native Dependabot API.
+# Alert and secret list endpoints return empty collections; per-resource endpoints return 501.
+
+# GET /enterprises/{enterprise}/dependabot/alerts — no NotABug equivalent; returns empty list
+GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/alerts — no NotABug equivalent; returns empty list
+GET http://{{host}}/orgs/testorg/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/secrets — no NotABug equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /orgs/{org}/dependabot/secrets/public-key — no NotABug equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name} — no NotABug equivalent
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name} — no NotABug equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name} — no NotABug equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no NotABug equivalent; returns empty envelope
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.repositories" isCollection
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories — no NotABug equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+Content-Type: application/json
+{"selected_repository_ids": [1]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no NotABug equivalent
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id} — no NotABug equivalent
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /organizations/{org}/dependabot/repository-access — no NotABug equivalent
+GET http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /organizations/{org}/dependabot/repository-access — no NotABug equivalent
+PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /organizations/{org}/dependabot/repository-access/default-level — no NotABug equivalent
+PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
+Authorization: token testtoken
+Content-Type: application/json
+{"default_level": "public"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/alerts — no NotABug equivalent; returns empty list
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no NotABug equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — no NotABug equivalent
+PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets — no NotABug equivalent; returns empty envelope
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key — no NotABug equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no NotABug equivalent
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no NotABug equivalent
+PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name} — no NotABug equivalent
+DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/onedev-dependabot.hurl
+++ b/test/onedev-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/pagure-dependabot.hurl
+++ b/test/pagure-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/phabricator-dependabot.hurl
+++ b/test/phabricator-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/radicle-dependabot.hurl
+++ b/test/radicle-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/rhodecode-dependabot.hurl
+++ b/test/rhodecode-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/sourceforge-dependabot.hurl
+++ b/test/sourceforge-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/sourcehut-dependabot.hurl
+++ b/test/sourcehut-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/stub-dependabot.hurl
+++ b/test/stub-dependabot.hurl
@@ -1,0 +1,213 @@
+# Dependabot API — minimal stubs for backends without native Dependabot support.
+# Alert list endpoints return empty arrays (200); per-resource endpoints return 501.
+# Secrets list endpoints return empty envelopes (200); mutation endpoints return 501.
+
+# GET /enterprises/{enterprise}/dependabot/alerts
+GET http://{{host}}/enterprises/testenterprise/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/alerts
+GET http://{{host}}/orgs/testorg/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/dependabot/secrets
+GET http://{{host}}/orgs/testorg/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /orgs/{org}/dependabot/secrets/public-key
+GET http://{{host}}/orgs/testorg/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories
+GET http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.repositories" isCollection
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories
+Authorization: token testtoken
+Content-Type: application/json
+{"selected_repository_ids": [1]}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
+PUT http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
+DELETE http://{{host}}/orgs/testorg/dependabot/secrets/MY_SECRET/repositories/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /organizations/{org}/dependabot/repository-access
+GET http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /organizations/{org}/dependabot/repository-access
+PATCH http://{{host}}/organizations/testorg/dependabot/repository-access
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /organizations/{org}/dependabot/repository-access/default-level
+PUT http://{{host}}/organizations/testorg/dependabot/repository-access/default-level
+Authorization: token testtoken
+Content-Type: application/json
+{"default_level": "public"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/alerts
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/dependabot/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.total_count" == 0
+jsonpath "$.secrets" isCollection
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/public-key
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/public-key
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
+GET http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
+PUT http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+Content-Type: application/json
+{"encrypted_value": "abc", "key_id": "1"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
+DELETE http://{{host}}/repos/octocat/hello-world/dependabot/secrets/MY_SECRET
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/tuleap-dependabot.hurl
+++ b/test/tuleap-dependabot.hurl
@@ -1,0 +1,1 @@
+stub-dependabot.hurl

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1151,6 +1151,22 @@ ok(
   "OnHttpRequest: GET /repos/{owner}/{repo}/commits/{ref}/check-suites → body has check_suites"
 )
 
+-- GET /orgs/{org}/dependabot/alerts — dependabot_list_empty default → 200
+reset_response()
+reset_request({ method = "GET", path = "/orgs/myorg/dependabot/alerts" })
+OnHttpRequest()
+eq(_last_status, 200, "OnHttpRequest: GET /orgs/{org}/dependabot/alerts → 200 (empty list)")
+
+-- GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} — dependabot_not_implemented default → 501
+reset_response()
+reset_request({ method = "GET", path = "/repos/alice/myrepo/dependabot/alerts/1" })
+OnHttpRequest()
+eq(
+  _last_status,
+  501,
+  "OnHttpRequest: GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number} → 501 (dependabot not implemented)"
+)
+
 -- ============================================================
 -- Summary
 -- ============================================================


### PR DESCRIPTION
Implement GitHub REST API for Dependabot (closes #34)

Fixes #34.

All 25 Dependabot endpoint tasks are complete and committed. The work queue below is empty to prevent redundant re-seeding on worker restart.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (26)</summary>

- [x] Add Dependabot routes and default handlers <!-- type:spec -->
- [x] Add unit tests for dependabot default handlers <!-- type:spec -->
- [x] Dependabot endpoints for Gitea backend <!-- type:spec -->
- [x] Dependabot endpoints for Codeberg backend <!-- type:spec -->
- [x] Dependabot endpoints for Forgejo backend <!-- type:spec -->
- [x] Dependabot endpoints for Gogs backend <!-- type:spec -->
- [x] Dependabot endpoints for NotABug backend <!-- type:spec -->
- [x] Dependabot endpoints for GitLab backend <!-- type:spec -->
- [x] Dependabot endpoints for Azure DevOps backend <!-- type:spec -->
- [x] Dependabot endpoints for Bitbucket Cloud backend <!-- type:spec -->
- [x] Dependabot endpoints for Bitbucket Data Center backend <!-- type:spec -->
- [x] Dependabot endpoints for CodeCommit backend <!-- type:spec -->
- [x] Dependabot endpoints for Gerrit backend <!-- type:spec -->
- [x] Dependabot endpoints for Gitblit backend <!-- type:spec -->
- [x] Dependabot endpoints for GitBucket backend <!-- type:spec -->
- [x] Dependabot endpoints for Harness backend <!-- type:spec -->
- [x] Dependabot endpoints for Kallithea backend <!-- type:spec -->
- [x] Dependabot endpoints for Launchpad backend <!-- type:spec -->
- [x] Dependabot endpoints for OneDev backend <!-- type:spec -->
- [x] Dependabot endpoints for Pagure backend <!-- type:spec -->
- [x] Dependabot endpoints for Phabricator backend <!-- type:spec -->
- [x] Dependabot endpoints for Radicle backend <!-- type:spec -->
- [x] Dependabot endpoints for RhodeCode backend <!-- type:spec -->
- [x] Dependabot endpoints for SourceForge backend <!-- type:spec -->
- [x] Dependabot endpoints for Sourcehut backend <!-- type:spec -->
- [x] Dependabot endpoints for Tuleap backend <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->