### PR TITLE
Implement GitHub REST API for Activity (closes #33)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -25,6 +25,7 @@ local HTTP_STATUS_TEXT = {
   [200] = "OK",
   [201] = "Created",
   [204] = "No Content",
+  [205] = "Reset Content",
   [302] = "Found",
   [401] = "Unauthorized",
   [404] = "Not Found",
@@ -489,6 +490,28 @@ local function projects_list_empty()
   respond_json(200, {})
 end
 
+-- Default handlers for Activity endpoints (https://docs.github.com/en/rest/activity).
+-- Events and list endpoints return empty arrays (200).
+-- Star/watch/subscription mutation endpoints return 204 No Content (acknowledged, not tracked).
+-- Mark-as-read endpoints return 205 Reset Content (standard GitHub response).
+-- Per-resource GET endpoints (thread, subscription) return 404 (not found / not watching).
+-- Feeds and subscription set endpoints return 501 (no backend exposes these natively).
+local function activity_not_implemented()
+  respond_json(501, { message = "This activity endpoint is not supported by this backend." })
+end
+
+local function activity_no_content()
+  set_preamble(204)
+end
+
+local function activity_reset_content()
+  set_preamble(205)
+end
+
+local function activity_not_found()
+  respond_json(404, { message = "Not Found" })
+end
+
 -- Default handlers for GET /zen, GET /octocat, GET /versions, GET /meta.
 -- These endpoints are fully self-contained and do not call any backend.
 local ZEN_QUOTES = {
@@ -799,6 +822,43 @@ local route_defaults = {
   projects_update_item_for_user = projects_not_implemented,
   projects_delete_item_for_user = projects_not_implemented,
   projects_list_view_items_for_user = projects_list_empty,
+  -- Activity (https://docs.github.com/en/rest/activity)
+  -- Events
+  list_public_events = empty_list,
+  get_feeds = activity_not_implemented,
+  list_network_repo_events = empty_list,
+  list_org_events = empty_list,
+  list_repo_events = empty_list,
+  list_user_events = empty_list,
+  list_user_org_events = empty_list,
+  list_user_public_events = empty_list,
+  list_received_events_for_user = empty_list,
+  list_received_public_events_for_user = empty_list,
+  -- Notifications
+  list_notifications = empty_list,
+  mark_notifications_as_read = activity_reset_content,
+  get_notification_thread = activity_not_found,
+  mark_thread_as_read = activity_reset_content,
+  mark_thread_as_done = activity_no_content,
+  get_thread_subscription = activity_not_found,
+  set_thread_subscription = activity_not_implemented,
+  delete_thread_subscription = activity_no_content,
+  list_repo_notifications = empty_list,
+  mark_repo_notifications_as_read = activity_reset_content,
+  -- Starring
+  list_repo_stargazers = empty_list,
+  list_starred_repos_for_auth_user = empty_list,
+  check_repo_starred_by_auth_user = activity_not_found,
+  star_repo = activity_no_content,
+  unstar_repo = activity_no_content,
+  list_repos_starred_by_user = empty_list,
+  -- Watching
+  list_repo_subscribers = empty_list,
+  get_repo_subscription = activity_not_found,
+  set_repo_subscription = activity_not_implemented,
+  delete_repo_subscription = activity_no_content,
+  list_watched_repos_for_auth_user = empty_list,
+  list_repos_watched_by_user = empty_list,
   -- Packages
   get_org_packages = empty_list,
   get_org_package_versions = empty_list,
@@ -1681,6 +1741,44 @@ local routes = {
   ["PATCH /users/{username}/projectsV2/{project_number}/items/{item_id}"] = "projects_update_item_for_user",
   ["DELETE /users/{username}/projectsV2/{project_number}/items/{item_id}"] = "projects_delete_item_for_user",
   ["GET /users/{username}/projectsV2/{project_number}/views/{view_number}/items"] = "projects_list_view_items_for_user",
+
+  -- Activity (https://docs.github.com/en/rest/activity)
+  -- Events
+  ["GET /events"] = "list_public_events",
+  ["GET /feeds"] = "get_feeds",
+  ["GET /networks/{owner}/{repo}/events"] = "list_network_repo_events",
+  ["GET /orgs/{org}/events"] = "list_org_events",
+  ["GET /repos/{owner}/{repo}/events"] = "list_repo_events",
+  ["GET /users/{username}/events"] = "list_user_events",
+  ["GET /users/{username}/events/orgs/{org}"] = "list_user_org_events",
+  ["GET /users/{username}/events/public"] = "list_user_public_events",
+  ["GET /users/{username}/received_events"] = "list_received_events_for_user",
+  ["GET /users/{username}/received_events/public"] = "list_received_public_events_for_user",
+  -- Notifications
+  ["GET /notifications"] = "list_notifications",
+  ["PUT /notifications"] = "mark_notifications_as_read",
+  ["GET /notifications/threads/{thread_id}"] = "get_notification_thread",
+  ["PATCH /notifications/threads/{thread_id}"] = "mark_thread_as_read",
+  ["DELETE /notifications/threads/{thread_id}"] = "mark_thread_as_done",
+  ["GET /notifications/threads/{thread_id}/subscription"] = "get_thread_subscription",
+  ["PUT /notifications/threads/{thread_id}/subscription"] = "set_thread_subscription",
+  ["DELETE /notifications/threads/{thread_id}/subscription"] = "delete_thread_subscription",
+  ["GET /repos/{owner}/{repo}/notifications"] = "list_repo_notifications",
+  ["PUT /repos/{owner}/{repo}/notifications"] = "mark_repo_notifications_as_read",
+  -- Starring
+  ["GET /repos/{owner}/{repo}/stargazers"] = "list_repo_stargazers",
+  ["GET /user/starred"] = "list_starred_repos_for_auth_user",
+  ["GET /user/starred/{owner}/{repo}"] = "check_repo_starred_by_auth_user",
+  ["PUT /user/starred/{owner}/{repo}"] = "star_repo",
+  ["DELETE /user/starred/{owner}/{repo}"] = "unstar_repo",
+  ["GET /users/{username}/starred"] = "list_repos_starred_by_user",
+  -- Watching
+  ["GET /repos/{owner}/{repo}/subscribers"] = "list_repo_subscribers",
+  ["GET /repos/{owner}/{repo}/subscription"] = "get_repo_subscription",
+  ["PUT /repos/{owner}/{repo}/subscription"] = "set_repo_subscription",
+  ["DELETE /repos/{owner}/{repo}/subscription"] = "delete_repo_subscription",
+  ["GET /user/subscriptions"] = "list_watched_repos_for_auth_user",
+  ["GET /users/{username}/subscriptions"] = "list_repos_watched_by_user",
 
   -- Packages (https://docs.github.com/en/rest/packages)
   ["GET /orgs/{org}/packages"] = "get_org_packages",

--- a/test/stub-activity.hurl
+++ b/test/stub-activity.hurl
@@ -1,0 +1,277 @@
+# Activity API — minimal stubs for backends without native Activity support.
+# List endpoints return empty arrays (200); mark-as-read endpoints return 205 Reset Content;
+# star/watch/unsubscribe mutation endpoints return 204 No Content;
+# per-resource GET endpoints (thread, subscription check) return 404 Not Found;
+# feeds and subscription set endpoints return 501 Not Implemented.
+
+# GET /events
+GET http://{{host}}/events
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /feeds
+GET http://{{host}}/feeds
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /networks/{owner}/{repo}/events
+GET http://{{host}}/networks/octocat/hello-world/events
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /notifications
+GET http://{{host}}/notifications
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# PUT /notifications
+PUT http://{{host}}/notifications
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 205
+
+# GET /notifications/threads/{thread_id}
+GET http://{{host}}/notifications/threads/1
+Authorization: token testtoken
+
+HTTP 404
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /notifications/threads/{thread_id}
+PATCH http://{{host}}/notifications/threads/1
+Authorization: token testtoken
+
+HTTP 205
+
+# DELETE /notifications/threads/{thread_id}
+DELETE http://{{host}}/notifications/threads/1
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /notifications/threads/{thread_id}/subscription
+GET http://{{host}}/notifications/threads/1/subscription
+Authorization: token testtoken
+
+HTTP 404
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /notifications/threads/{thread_id}/subscription
+PUT http://{{host}}/notifications/threads/1/subscription
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /notifications/threads/{thread_id}/subscription
+DELETE http://{{host}}/notifications/threads/1/subscription
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /orgs/{org}/events
+GET http://{{host}}/orgs/testorg/events
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /repos/{owner}/{repo}/events
+GET http://{{host}}/repos/octocat/hello-world/events
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /repos/{owner}/{repo}/notifications
+GET http://{{host}}/repos/octocat/hello-world/notifications
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# PUT /repos/{owner}/{repo}/notifications
+PUT http://{{host}}/repos/octocat/hello-world/notifications
+Authorization: token testtoken
+Content-Type: application/json
+{}
+
+HTTP 205
+
+# GET /repos/{owner}/{repo}/stargazers
+GET http://{{host}}/repos/octocat/hello-world/stargazers
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /repos/{owner}/{repo}/subscribers
+GET http://{{host}}/repos/octocat/hello-world/subscribers
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /repos/{owner}/{repo}/subscription
+GET http://{{host}}/repos/octocat/hello-world/subscription
+Authorization: token testtoken
+
+HTTP 404
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /repos/{owner}/{repo}/subscription
+PUT http://{{host}}/repos/octocat/hello-world/subscription
+Authorization: token testtoken
+Content-Type: application/json
+{"subscribed": true, "ignored": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /repos/{owner}/{repo}/subscription
+DELETE http://{{host}}/repos/octocat/hello-world/subscription
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /user/starred
+GET http://{{host}}/user/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /user/starred/{owner}/{repo}
+GET http://{{host}}/user/starred/octocat/hello-world
+Authorization: token testtoken
+
+HTTP 404
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /user/starred/{owner}/{repo}
+PUT http://{{host}}/user/starred/octocat/hello-world
+Authorization: token testtoken
+
+HTTP 204
+
+# DELETE /user/starred/{owner}/{repo}
+DELETE http://{{host}}/user/starred/octocat/hello-world
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /user/subscriptions
+GET http://{{host}}/user/subscriptions
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /users/{username}/events
+GET http://{{host}}/users/octocat/events
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /users/{username}/events/orgs/{org}
+GET http://{{host}}/users/octocat/events/orgs/testorg
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /users/{username}/events/public
+GET http://{{host}}/users/octocat/events/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /users/{username}/received_events
+GET http://{{host}}/users/octocat/received_events
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /users/{username}/received_events/public
+GET http://{{host}}/users/octocat/received_events/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /users/{username}/starred
+GET http://{{host}}/users/octocat/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /users/{username}/subscriptions
+GET http://{{host}}/users/octocat/subscriptions
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1183,6 +1183,38 @@ eq(
   "OnHttpRequest: GET /orgs/{org}/projectsV2/{project_number} → 501 (projects not implemented)"
 )
 
+-- activity_not_implemented: GET /feeds → 501
+reset_response()
+reset_request({ method = "GET", path = "/feeds" })
+OnHttpRequest()
+eq(_last_status, 501, "OnHttpRequest: GET /feeds → 501 (activity not implemented)")
+
+-- activity_no_content: DELETE /notifications/threads/{thread_id} → 204
+reset_response()
+reset_request({ method = "DELETE", path = "/notifications/threads/1" })
+OnHttpRequest()
+eq(
+  _last_status,
+  204,
+  "OnHttpRequest: DELETE /notifications/threads/{thread_id} → 204 (activity no content)"
+)
+
+-- activity_reset_content: PUT /notifications → 205
+reset_response()
+reset_request({ method = "PUT", path = "/notifications" })
+OnHttpRequest()
+eq(_last_status, 205, "OnHttpRequest: PUT /notifications → 205 (activity reset content)")
+
+-- activity_not_found: GET /notifications/threads/{thread_id} → 404
+reset_response()
+reset_request({ method = "GET", path = "/notifications/threads/1" })
+OnHttpRequest()
+eq(
+  _last_status,
+  404,
+  "OnHttpRequest: GET /notifications/threads/{thread_id} → 404 (activity not found)"
+)
+
 -- ============================================================
 -- Summary
 -- ============================================================


### PR DESCRIPTION
Implement GitHub REST API for Activity (closes #33)

Fixes #33.

---

## Work queue

<!-- WORK_QUEUE_START -->
- [ ] Add Activity routes and default handlers **→ next** <!-- type:spec -->
- [ ] Activity endpoints for Gitea backend <!-- type:spec -->
- [ ] Activity endpoints for Codeberg backend <!-- type:spec -->
- [ ] Activity endpoints for Forgejo backend <!-- type:spec -->
- [ ] Activity endpoints for Gogs backend <!-- type:spec -->
- [ ] Activity endpoints for NotABug backend <!-- type:spec -->
- [ ] Activity endpoints for GitLab backend <!-- type:spec -->
- [ ] Activity endpoints for Azure DevOps backend <!-- type:spec -->
- [ ] Activity endpoints for Bitbucket Cloud backend <!-- type:spec -->
- [ ] Activity endpoints for Bitbucket Data Center backend <!-- type:spec -->
- [ ] Activity endpoints for CodeCommit backend <!-- type:spec -->
- [ ] Activity endpoints for Gerrit backend <!-- type:spec -->
- [ ] Activity endpoints for Gitblit backend <!-- type:spec -->
- [ ] Activity endpoints for GitBucket backend <!-- type:spec -->
- [ ] Activity endpoints for Harness backend <!-- type:spec -->
- [ ] Activity endpoints for Kallithea backend <!-- type:spec -->
- [ ] Activity endpoints for Launchpad backend <!-- type:spec -->
- [ ] Activity endpoints for OneDev backend <!-- type:spec -->
- [ ] Activity endpoints for Pagure backend <!-- type:spec -->
- [ ] Activity endpoints for Phabricator backend <!-- type:spec -->
- [ ] Activity endpoints for Radicle backend <!-- type:spec -->
- [ ] Activity endpoints for RhodeCode backend <!-- type:spec -->
- [ ] Activity endpoints for SourceForge backend <!-- type:spec -->
- [ ] Activity endpoints for Sourcehut backend <!-- type:spec -->
- [ ] Activity endpoints for Tuleap backend <!-- type:spec -->
- [ ] test: cover activity default handlers <!-- type:spec -->
- [ ] consolidate activity hurl tests into shared file with symlinks <!-- type:spec -->
<!-- WORK_QUEUE_END -->