### PR TITLE
Implement GitHub REST API for Secret Scanning (closes #31)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -422,6 +422,18 @@ local function code_scanning_list_empty()
   respond_json(200, {})
 end
 
+-- Default handlers for secret-scanning endpoints: no backend has a native secret scanning API.
+-- Returns 501 Not Implemented with a descriptive message.
+local function secret_scanning_not_implemented()
+  respond_json(501, { message = "Secret scanning is not supported by this backend." })
+end
+
+-- Default handler for secret-scanning list endpoints: returns an empty collection (200).
+-- Per-resource and mutation endpoints use secret_scanning_not_implemented (501) as their default.
+local function secret_scanning_list_empty()
+  respond_json(200, {})
+end
+
 -- Default handlers for Dependabot endpoints: most backends have no native Dependabot API.
 -- Alert list endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
 -- Secrets list endpoints use make_empty_collection (defined below) for proper envelope format.
@@ -749,6 +761,16 @@ local route_defaults = {
   update_code_scanning_default_setup = code_scanning_not_implemented,
   upload_code_scanning_sarif = code_scanning_not_implemented,
   get_code_scanning_sarif = code_scanning_not_implemented,
+  -- Secret Scanning
+  list_org_secret_scanning_alerts = secret_scanning_list_empty,
+  get_org_secret_scanning_pattern_configs = secret_scanning_not_implemented,
+  update_org_secret_scanning_pattern_configs = secret_scanning_not_implemented,
+  list_repo_secret_scanning_alerts = secret_scanning_list_empty,
+  get_secret_scanning_alert = secret_scanning_not_implemented,
+  update_secret_scanning_alert = secret_scanning_not_implemented,
+  list_secret_scanning_alert_locations = secret_scanning_list_empty,
+  create_secret_scanning_push_protection_bypass = secret_scanning_not_implemented,
+  get_secret_scanning_scan_history = secret_scanning_not_implemented,
   -- Dependabot
   list_enterprise_dependabot_alerts = dependabot_list_empty,
   list_org_dependabot_alerts = dependabot_list_empty,
@@ -1624,6 +1646,17 @@ local routes = {
   ["PATCH /repos/{owner}/{repo}/code-scanning/default-setup"] = "update_code_scanning_default_setup",
   ["POST /repos/{owner}/{repo}/code-scanning/sarifs"] = "upload_code_scanning_sarif",
   ["GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}"] = "get_code_scanning_sarif",
+
+  -- Secret Scanning (https://docs.github.com/en/rest/secret-scanning)
+  ["GET /orgs/{org}/secret-scanning/alerts"] = "list_org_secret_scanning_alerts",
+  ["GET /orgs/{org}/secret-scanning/pattern-configurations"] = "get_org_secret_scanning_pattern_configs",
+  ["PATCH /orgs/{org}/secret-scanning/pattern-configurations"] = "update_org_secret_scanning_pattern_configs",
+  ["GET /repos/{owner}/{repo}/secret-scanning/alerts"] = "list_repo_secret_scanning_alerts",
+  ["GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"] = "get_secret_scanning_alert",
+  ["PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"] = "update_secret_scanning_alert",
+  ["GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations"] = "list_secret_scanning_alert_locations",
+  ["POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses"] = "create_secret_scanning_push_protection_bypass",
+  ["GET /repos/{owner}/{repo}/secret-scanning/scan-history"] = "get_secret_scanning_scan_history",
 
   -- Dependabot (https://docs.github.com/en/rest/dependabot)
   ["GET /enterprises/{enterprise}/dependabot/alerts"] = "list_enterprise_dependabot_alerts",

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -1771,6 +1771,143 @@ _b.update_repo_dependabot_alert = function(owner, repo_name, alert_number)
   respond_json(200, translate_ado_dependency_alert(DecodeJson(body) or {}))
 end
 
+-- Secret Scanning via ADO Advanced Security -----------------------------------------
+--
+-- Azure DevOps Advanced Security exposes secret scanning alerts at the
+-- repository level via the same /_apis/advancedsecurity/alerts/{repo} endpoint
+-- used by code scanning, selecting alertType=secret:
+--   GET  /{owner}/_apis/advancedsecurity/alerts/{repo}?alertType=secret
+--   GET  /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
+--   PATCH /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
+--
+-- Org-level listing, alert locations, push-protection bypasses, and scan
+-- history have no ADO equivalent and fall back to defaults.
+--
+-- ADO secret alert fields:
+--   alertId, state, severity, firstSeenDate, fixedDate, dismissedDate,
+--   dismissal.{dismissalType, message}, rule.{id, name},
+--   logicalLocations[0].fullyQualifiedName (secret value)
+--
+-- ADO dismissal type → GitHub resolution mapping for secrets:
+--   falsePositive  → false_positive
+--   wontFix        → wont_fix
+--   usedInTests    → used_in_tests
+--   revokedSecret  → revoked
+
+local ADO_SECRET_DISMISS_REASON_TO_GH = {
+  falsePositive = "false_positive",
+  wontFix = "wont_fix",
+  usedInTests = "used_in_tests",
+  revokedSecret = "revoked",
+}
+
+local GH_SECRET_DISMISS_REASON_TO_ADO = {
+  false_positive = "falsePositive",
+  wont_fix = "wontFix",
+  used_in_tests = "usedInTests",
+  revoked = "revokedSecret",
+  pattern_deleted = "wontFix",
+  pattern_edited = "wontFix",
+}
+
+local ADO_SECRET_STATE_TO_GH = {
+  active = "open",
+  dismissed = "dismissed",
+  fixed = "resolved",
+}
+
+local function translate_ado_secret_alert(a)
+  if not a then
+    return {}
+  end
+  local state = ADO_SECRET_STATE_TO_GH[a.state or ""] or "open"
+  local dismissal = a.dismissal or {}
+  local resolution = ADO_SECRET_DISMISS_REASON_TO_GH[dismissal.dismissalType or ""]
+  local rule = a.rule or {}
+  local locs = a.logicalLocations or {}
+  local secret = (locs[1] or {}).fullyQualifiedName or ""
+  local resolved_at = a.fixedDate or a.dismissedDate
+  return {
+    number = a.alertId or 0,
+    created_at = a.firstSeenDate or "",
+    updated_at = a.firstSeenDate or "",
+    url = "",
+    html_url = "",
+    locations_url = "",
+    state = state,
+    resolution = resolution,
+    resolved_by = nil,
+    resolved_at = resolved_at,
+    resolution_comment = dismissal.message or nil,
+    secret_type = rule.id or "",
+    secret_type_display_name = rule.name or "",
+    secret = secret,
+    push_protection_bypassed = nil,
+    push_protection_bypassed_by = nil,
+    push_protection_bypassed_at = nil,
+    validity = "unknown",
+    publicly_leaked = false,
+    multi_repo = false,
+    auto_dismissed_at = nil,
+  }
+end
+
+_b.list_repo_secret_scanning_alerts = function(owner, repo_name)
+  local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "?alertType=secret")
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local result = {}
+  for _, a in ipairs(data.value or {}) do
+    result[#result + 1] = translate_ado_secret_alert(a)
+  end
+  respond_json(200, result)
+end
+
+_b.get_secret_scanning_alert = function(owner, repo_name, alert_number)
+  local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "/" .. alert_number)
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, translate_ado_secret_alert(DecodeJson(body) or {}))
+end
+
+_b.update_secret_scanning_alert = function(owner, repo_name, alert_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local ado_state = GH_STATE_TO_ADO[req.state or ""] or "active"
+  local patch = { state = ado_state }
+  if req.resolution then
+    patch.dismissal = {
+      dismissalType = GH_SECRET_DISMISS_REASON_TO_ADO[req.resolution] or "wontFix",
+      message = req.resolution_comment or "",
+    }
+  end
+  local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "/" .. alert_number)
+  local ok, status, _, body = fetch_json(url, "PATCH", EncodeJson(patch))
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, translate_ado_secret_alert(DecodeJson(body) or {}))
+end
+
 -- Git database (refs only; blobs/commits/tag-objects/trees have no ADO equivalent) ----
 
 local ZERO_SHA = "0000000000000000000000000000000000000000"

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -3585,3 +3585,134 @@ _b.list_org_dependabot_alerts = function(org)
     fetch_json(base() .. "/groups/" .. org .. "/vulnerabilities")
   )
 end
+
+-- Secret Scanning via GitLab Secret Detection ----------------------------------
+--
+-- GitLab Secret Detection stores findings as vulnerabilities with
+-- report_type=secret_detection. Endpoint mapping:
+--   GET  /repos/{owner}/{repo}/secret-scanning/alerts       → GET  /projects/:id/vulnerabilities?report_type=secret_detection
+--   GET  /repos/{owner}/{repo}/secret-scanning/alerts/{n}   → GET  /projects/:id/vulnerabilities/:n
+--   PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{n}  → POST /vulnerabilities/:n/dismiss|revert-to-detected|resolve
+--   GET  /orgs/{org}/secret-scanning/alerts                 → GET  /groups/:org/vulnerabilities?report_type=secret_detection
+--
+-- Alert locations, push-protection bypasses, pattern configurations, and
+-- scan history have no GitLab equivalent and fall back to defaults.
+--
+-- GitLab dismissed_reason → GitHub resolution:
+--   false_positive   → false_positive
+--   acceptable_risk  → wont_fix
+--   used_in_tests    → used_in_tests
+--   mitigating_control / not_applicable → wont_fix
+
+local GL_SECRET_DISMISS_REASON_TO_GH = {
+  false_positive = "false_positive",
+  acceptable_risk = "wont_fix",
+  used_in_tests = "used_in_tests",
+  mitigating_control = "wont_fix",
+  not_applicable = "wont_fix",
+}
+
+local GH_SECRET_STATE_TO_GL_ACTION = {
+  open = "revert-to-detected",
+  dismissed = "dismiss",
+  resolved = "resolve",
+}
+
+local function translate_gl_secret_alert(v)
+  if not v then
+    return {}
+  end
+  local state = GL_VULN_STATE_TO_GH[v.state or ""] or "open"
+  if v.state == "resolved" then
+    state = "resolved"
+  end
+  local identifiers = v.identifiers or {}
+  local secret_type = ""
+  for _, id in ipairs(identifiers) do
+    if id.type == "secret_detection" then
+      secret_type = id.value or ""
+      break
+    end
+  end
+  local scanner = v.scanner or {}
+  if secret_type == "" then
+    secret_type = scanner.id or ""
+  end
+  return {
+    number = v.id or 0,
+    created_at = v.created_at or "",
+    updated_at = v.updated_at or "",
+    url = "",
+    html_url = "",
+    locations_url = "",
+    state = state,
+    resolution = GL_SECRET_DISMISS_REASON_TO_GH[v.dismissed_reason or ""],
+    resolved_by = nil,
+    resolved_at = v.dismissed_at,
+    resolution_comment = nil,
+    secret_type = secret_type,
+    secret_type_display_name = v.title or "",
+    secret = "",
+    push_protection_bypassed = nil,
+    push_protection_bypassed_by = nil,
+    push_protection_bypassed_at = nil,
+    validity = "unknown",
+    publicly_leaked = false,
+    multi_repo = false,
+    auto_dismissed_at = nil,
+  }
+end
+
+local function translate_gl_secret_list(arr)
+  local result = {}
+  for _, v in ipairs(arr) do
+    result[#result + 1] = translate_gl_secret_alert(v)
+  end
+  return result
+end
+
+_b.list_repo_secret_scanning_alerts = function(owner, repo_name)
+  proxy_json_paged(
+    translate_gl_secret_list,
+    PAGES,
+    fetch_json(
+      base()
+        .. "/projects/"
+        .. project_id(owner, repo_name)
+        .. "/vulnerabilities?report_type=secret_detection"
+    )
+  )
+end
+
+_b.list_org_secret_scanning_alerts = function(org)
+  proxy_json_paged(
+    translate_gl_secret_list,
+    PAGES,
+    fetch_json(base() .. "/groups/" .. org .. "/vulnerabilities?report_type=secret_detection")
+  )
+end
+
+_b.get_secret_scanning_alert = function(owner, repo_name, alert_number)
+  proxy_json(
+    translate_gl_secret_alert,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
+    )
+  )
+end
+
+_b.update_secret_scanning_alert = function(_owner, _repo_name, alert_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local action = GH_SECRET_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
+  local gl_url = base() .. "/vulnerabilities/" .. alert_number .. "/" .. action
+  local ok, status, _, body = fetch_json(gl_url, "POST", EncodeJson({}))
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, translate_gl_secret_alert(DecodeJson(body) or {}))
+end

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -209,12 +209,12 @@ PATCH /repos/{owner}/{repo}/code-scanning/default-setup,n,n,n,n,n,n,n,n,n,n,n,n,
 POST /repos/{owner}/{repo}/code-scanning/sarifs,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Secret Scanning,,,,,,,,,,,,,,,,,,,,,,,,
-GET /orgs/{org}/secret-scanning/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /orgs/{org}/secret-scanning/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PATCH /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/secret-scanning/alerts,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/secret-scanning/alerts,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/secret-scanning/scan-history,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -208,6 +208,16 @@ GET /repos/{owner}/{repo}/code-scanning/default-setup,n,n,n,n,n,n,n,n,n,n,n,n,n,
 PATCH /repos/{owner}/{repo}/code-scanning/default-setup,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/code-scanning/sarifs,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+Secret Scanning,,,,,,,,,,,,,,,,,,,,,,,,
+GET /orgs/{org}/secret-scanning/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/secret-scanning/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/secret-scanning/scan-history,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GitHub Apps,,,,,,,,,,,,,,,,,,,,,,,,
 GET /app,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /app/hook/config,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -212,9 +212,9 @@ Secret Scanning,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/secret-scanning/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PATCH /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/secret-scanning/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/secret-scanning/alerts,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/secret-scanning/scan-history,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/test/azuredevops-secret-scanning.hurl
+++ b/test/azuredevops-secret-scanning.hurl
@@ -1,0 +1,97 @@
+# Secret Scanning API — Azure DevOps Advanced Security (GHAzDO) backend.
+# Repo-level list/get/update proxy to ADO Advanced Security with alertType=secret.
+# Org-level list returns empty; locations, push-protection bypasses, and scan history
+# have no ADO equivalent and return 501 or empty list.
+
+# GET /orgs/{org}/secret-scanning/alerts — no ADO org-level endpoint; returns empty list
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations — no ADO equivalent
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations — no ADO equivalent
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].number" == 3
+jsonpath "$[0].state" == "open"
+jsonpath "$[0].secret_type" isString
+jsonpath "$[0].secret_type_display_name" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/3
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 3
+jsonpath "$.state" == "open"
+jsonpath "$.secret_type" == "github-personal-access-token"
+jsonpath "$.secret_type_display_name" == "GitHub Personal Access Token"
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/3
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed", "resolution": "revoked", "resolution_comment": "Token has been rotated"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 3
+jsonpath "$.state" == "dismissed"
+jsonpath "$.resolution" == "revoked"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations — no ADO equivalent; returns empty list
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/3/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses — no ADO equivalent
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history — no ADO equivalent
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/bitbucket-secret-scanning.hurl
+++ b/test/bitbucket-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Bitbucket backend.
+# Bitbucket has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/bitbucket_datacenter-secret-scanning.hurl
+++ b/test/bitbucket_datacenter-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Bitbucket Datacenter backend.
+# Bitbucket Datacenter has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/codeberg-secret-scanning.hurl
+++ b/test/codeberg-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Codeberg (Forgejo) backend.
+# Forgejo has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/codecommit-secret-scanning.hurl
+++ b/test/codecommit-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — CodeCommit backend.
+# CodeCommit has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/forgejo-secret-scanning.hurl
+++ b/test/forgejo-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Forgejo backend.
+# Forgejo has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gerrit-secret-scanning.hurl
+++ b/test/gerrit-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Gerrit backend.
+# Gerrit has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gitblit-secret-scanning.hurl
+++ b/test/gitblit-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Gitblit backend.
+# Gitblit has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gitbucket-secret-scanning.hurl
+++ b/test/gitbucket-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Gitbucket backend.
+# Gitbucket has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gitea-secret-scanning.hurl
+++ b/test/gitea-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Gitea backend.
+# Gitea has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gitlab-secret-scanning.hurl
+++ b/test/gitlab-secret-scanning.hurl
@@ -1,0 +1,102 @@
+# Secret Scanning API — GitLab backend.
+# GitLab Secret Detection stores findings as vulnerabilities with report_type=secret_detection.
+# List/get/update endpoints proxy to the GitLab vulnerabilities API.
+# Alert locations, push-protection bypasses, pattern configurations, and scan history
+# have no GitLab equivalent and fall back to defaults.
+
+# GET /orgs/{org}/secret-scanning/alerts — via GET /groups/:org/vulnerabilities?report_type=secret_detection
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].number" == 2
+jsonpath "$[0].state" == "open"
+jsonpath "$[0].secret_type" isString
+jsonpath "$[0].secret_type_display_name" isString
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations — no GitLab equivalent
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations — no GitLab equivalent
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts — via GET /projects/:id/vulnerabilities?report_type=secret_detection
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].number" == 2
+jsonpath "$[0].state" == "open"
+jsonpath "$[0].secret_type" == "gitlab_personal_access_token"
+jsonpath "$[0].secret_type_display_name" == "GitLab Personal Access Token"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number} — via GET /projects/:id/vulnerabilities/:n
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/2
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 2
+jsonpath "$.state" == "open"
+jsonpath "$.secret_type" == "gitlab_personal_access_token"
+jsonpath "$.secret_type_display_name" == "GitLab Personal Access Token"
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number} — via POST /vulnerabilities/:n/dismiss
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/2
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "dismissed", "resolution": "false_positive"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.number" == 2
+jsonpath "$.state" == "dismissed"
+jsonpath "$.resolution" == "false_positive"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations — no GitLab equivalent; returns empty list
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/2/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses — no GitLab equivalent
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history — no GitLab equivalent
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/gogs-secret-scanning.hurl
+++ b/test/gogs-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Gogs backend.
+# Gogs has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/harness-secret-scanning.hurl
+++ b/test/harness-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Harness backend.
+# Harness Code has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/kallithea-secret-scanning.hurl
+++ b/test/kallithea-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Kallithea backend.
+# Kallithea has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/launchpad-secret-scanning.hurl
+++ b/test/launchpad-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Launchpad backend.
+# Launchpad has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/mock-azuredevops.lua
+++ b/test/mock-azuredevops.lua
@@ -267,7 +267,7 @@ function OnHttpRequest()
         .. "]}"
     )
 
-  -- Advanced Security — alert list (code scanning or dependency) -------------
+  -- Advanced Security — alert list (code scanning, dependency, or secret) ------
   elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world" and method == "GET" then
     SetStatus(200, "OK")
     local alert_type = GetParam("alertType") or "code"
@@ -278,6 +278,13 @@ function OnHttpRequest()
           .. '"title":"Prototype Pollution in lodash",'
           .. '"cve":"CVE-2019-10744",'
           .. '"dependency":{"componentName":"lodash","componentVersion":"4.17.11","packageManager":"npm"}}]}'
+      )
+    elseif alert_type == "secret" then
+      json(
+        '{"count":1,"value":[{"alertId":3,"alertType":"secret","state":"active",'
+          .. '"severity":"critical","firstSeenDate":"2024-03-01T00:00:00Z",'
+          .. '"rule":{"id":"github-personal-access-token","name":"GitHub Personal Access Token"},'
+          .. '"logicalLocations":[{"fullyQualifiedName":"github_pat_EXAMPLE12345"}]}]}'
       )
     else
       json(
@@ -310,6 +317,28 @@ function OnHttpRequest()
         .. '"dismissal":{"dismissalType":"wontFix","message":"Not exploitable"},'
         .. '"rule":{"id":"CS001","name":"SQL Injection","description":"Untrusted input"},'
         .. '"physicalLocations":[]}'
+    )
+
+  -- Advanced Security — single secret alert 3 ----------------------------------
+  elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world/3" and method == "GET" then
+    SetStatus(200, "OK")
+    json(
+      '{"alertId":3,"alertType":"secret","state":"active",'
+        .. '"severity":"critical","firstSeenDate":"2024-03-01T00:00:00Z",'
+        .. '"rule":{"id":"github-personal-access-token","name":"GitHub Personal Access Token"},'
+        .. '"logicalLocations":[{"fullyQualifiedName":"github_pat_EXAMPLE12345"}]}'
+    )
+
+  -- Advanced Security — update secret alert 3 ----------------------------------
+  elseif path == "/octocat/_apis/advancedsecurity/alerts/hello-world/3" and method == "PATCH" then
+    SetStatus(200, "OK")
+    json(
+      '{"alertId":3,"alertType":"secret","state":"dismissed",'
+        .. '"severity":"critical","firstSeenDate":"2024-03-01T00:00:00Z",'
+        .. '"dismissedDate":"2024-03-02T00:00:00Z",'
+        .. '"dismissal":{"dismissalType":"revokedSecret","message":"Token has been rotated"},'
+        .. '"rule":{"id":"github-personal-access-token","name":"GitHub Personal Access Token"},'
+        .. '"logicalLocations":[{"fullyQualifiedName":"github_pat_EXAMPLE12345"}]}'
     )
 
   -- Advanced Security — single dependency alert 2 ----------------------------

--- a/test/mock-gitlab.lua
+++ b/test/mock-gitlab.lua
@@ -568,22 +568,38 @@ function OnHttpRequest()
         .. '"size":100,"encoding":"base64","content":"SGVsbG8gV29ybGQ="}'
     )
 
-  -- Vulnerabilities (Dependabot alerts) -----------------------------------------
-  -- Requires GitLab Ultimate; returns dependency_scanning vulnerabilities.
+  -- Vulnerabilities (Dependabot alerts + Secret Scanning) ----------------------
+  -- Requires GitLab Ultimate. Filters by report_type when provided.
   elseif path == pb .. "/vulnerabilities" then
     SetStatus(200, "OK")
-    json(
-      '[{"id":1,"title":"Prototype Pollution in lodash",'
-        .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
-        .. '"state":"detected","severity":"high","confidence":"high",'
-        .. '"report_type":"dependency_scanning",'
-        .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-01T00:00:00Z",'
-        .. '"dismissed_at":null,"dismissed_reason":null,'
-        .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
-        .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
-        .. '"location":{"file":"package-lock.json",'
-        .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}]'
-    )
+    local report_type = GetParam("report_type") or ""
+    if report_type == "secret_detection" then
+      json(
+        '[{"id":2,"title":"GitLab Personal Access Token",'
+          .. '"description":"A GitLab personal access token was detected.",'
+          .. '"state":"detected","severity":"critical","confidence":"high",'
+          .. '"report_type":"secret_detection",'
+          .. '"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z",'
+          .. '"dismissed_at":null,"dismissed_reason":null,'
+          .. '"scanner":{"id":"gitlab_pat_scanner","name":"GitLab Token Scanner"},'
+          .. '"identifiers":[{"type":"secret_detection","name":"GitLab Personal Access Token",'
+          .. '"value":"gitlab_personal_access_token"}],'
+          .. '"location":{"file":"config/database.yml"}}]'
+      )
+    else
+      json(
+        '[{"id":1,"title":"Prototype Pollution in lodash",'
+          .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
+          .. '"state":"detected","severity":"high","confidence":"high",'
+          .. '"report_type":"dependency_scanning",'
+          .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-01T00:00:00Z",'
+          .. '"dismissed_at":null,"dismissed_reason":null,'
+          .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
+          .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
+          .. '"location":{"file":"package-lock.json",'
+          .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}]'
+      )
+    end
   elseif path == pb .. "/vulnerabilities/1" then
     SetStatus(200, "OK")
     json(
@@ -612,20 +628,68 @@ function OnHttpRequest()
         .. '"location":{"file":"package-lock.json",'
         .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}'
     )
-  elseif path == "/api/v4/groups/testorg/vulnerabilities" then
+
+  -- Single secret scanning vulnerability (id=2) --------------------------------
+  elseif path == pb .. "/vulnerabilities/2" then
     SetStatus(200, "OK")
     json(
-      '[{"id":1,"title":"Prototype Pollution in lodash",'
-        .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
-        .. '"state":"detected","severity":"high","confidence":"high",'
-        .. '"report_type":"dependency_scanning",'
-        .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-01T00:00:00Z",'
+      '{"id":2,"title":"GitLab Personal Access Token",'
+        .. '"description":"A GitLab personal access token was detected.",'
+        .. '"state":"detected","severity":"critical","confidence":"high",'
+        .. '"report_type":"secret_detection",'
+        .. '"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z",'
         .. '"dismissed_at":null,"dismissed_reason":null,'
-        .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
-        .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
-        .. '"location":{"file":"package-lock.json",'
-        .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}]'
+        .. '"scanner":{"id":"gitlab_pat_scanner","name":"GitLab Token Scanner"},'
+        .. '"identifiers":[{"type":"secret_detection","name":"GitLab Personal Access Token",'
+        .. '"value":"gitlab_personal_access_token"}],'
+        .. '"location":{"file":"config/database.yml"}}'
     )
+
+  -- Dismiss secret scanning vulnerability (id=2) --------------------------------
+  elseif path == "/api/v4/vulnerabilities/2/dismiss" and GetMethod() == "POST" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":2,"title":"GitLab Personal Access Token",'
+        .. '"description":"A GitLab personal access token was detected.",'
+        .. '"state":"dismissed","severity":"critical","confidence":"high",'
+        .. '"report_type":"secret_detection",'
+        .. '"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-02T00:00:00Z",'
+        .. '"dismissed_at":"2024-01-02T00:00:00Z","dismissed_reason":"false_positive",'
+        .. '"scanner":{"id":"gitlab_pat_scanner","name":"GitLab Token Scanner"},'
+        .. '"identifiers":[{"type":"secret_detection","name":"GitLab Personal Access Token",'
+        .. '"value":"gitlab_personal_access_token"}],'
+        .. '"location":{"file":"config/database.yml"}}'
+    )
+  elseif path == "/api/v4/groups/testorg/vulnerabilities" then
+    SetStatus(200, "OK")
+    local report_type = GetParam("report_type") or ""
+    if report_type == "secret_detection" then
+      json(
+        '[{"id":2,"title":"GitLab Personal Access Token",'
+          .. '"description":"A GitLab personal access token was detected.",'
+          .. '"state":"detected","severity":"critical","confidence":"high",'
+          .. '"report_type":"secret_detection",'
+          .. '"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z",'
+          .. '"dismissed_at":null,"dismissed_reason":null,'
+          .. '"scanner":{"id":"gitlab_pat_scanner","name":"GitLab Token Scanner"},'
+          .. '"identifiers":[{"type":"secret_detection","name":"GitLab Personal Access Token",'
+          .. '"value":"gitlab_personal_access_token"}],'
+          .. '"location":{"file":"config/database.yml"}}]'
+      )
+    else
+      json(
+        '[{"id":1,"title":"Prototype Pollution in lodash",'
+          .. '"description":"lodash before 4.17.12 is vulnerable to Prototype Pollution in the function zipObjectDeep.",'
+          .. '"state":"detected","severity":"high","confidence":"high",'
+          .. '"report_type":"dependency_scanning",'
+          .. '"created_at":"2021-01-01T00:00:00Z","updated_at":"2021-01-01T00:00:00Z",'
+          .. '"dismissed_at":null,"dismissed_reason":null,'
+          .. '"identifiers":[{"type":"cve","name":"CVE-2019-10744","value":"CVE-2019-10744",'
+          .. '"url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744"}],'
+          .. '"location":{"file":"package-lock.json",'
+          .. '"dependency":{"package":{"name":"lodash"},"version":"4.17.11"}}}]'
+      )
+    end
 
   -- Migrations: GitLab has per-project export, not GitHub-style org/user migrations.
   -- confusio returns fixed responses without proxying, but routes are documented here.

--- a/test/notabug-secret-scanning.hurl
+++ b/test/notabug-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Notabug backend.
+# Notabug has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/onedev-secret-scanning.hurl
+++ b/test/onedev-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Onedev backend.
+# Onedev has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/pagure-secret-scanning.hurl
+++ b/test/pagure-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Pagure backend.
+# Pagure has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/phabricator-secret-scanning.hurl
+++ b/test/phabricator-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Phabricator backend.
+# Phabricator has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/radicle-secret-scanning.hurl
+++ b/test/radicle-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Radicle backend.
+# Radicle has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/rhodecode-secret-scanning.hurl
+++ b/test/rhodecode-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Rhodecode backend.
+# Rhodecode has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/sourceforge-secret-scanning.hurl
+++ b/test/sourceforge-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Sourceforge backend.
+# Sourceforge has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/sourcehut-secret-scanning.hurl
+++ b/test/sourcehut-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Sourcehut backend.
+# Sourcehut has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/stub-secret-scanning.hurl
+++ b/test/stub-secret-scanning.hurl
@@ -1,0 +1,86 @@
+# Secret Scanning API — minimal stubs for backends without native secret scanning.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/tuleap-secret-scanning.hurl
+++ b/test/tuleap-secret-scanning.hurl
@@ -1,0 +1,87 @@
+# Secret Scanning API — Tuleap backend.
+# Tuleap has no native secret scanning API.
+# List endpoints return empty collections (200); per-resource and mutation endpoints return 501.
+
+# GET /orgs/{org}/secret-scanning/alerts
+GET http://{{host}}/orgs/testorg/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /orgs/{org}/secret-scanning/pattern-configurations
+GET http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /orgs/{org}/secret-scanning/pattern-configurations
+PATCH http://{{host}}/orgs/testorg/secret-scanning/pattern-configurations
+Authorization: token testtoken
+Content-Type: application/json
+{"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
+PATCH http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1
+Authorization: token testtoken
+Content-Type: application/json
+{"state": "resolved", "resolution": "false_positive"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/alerts/1/locations
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+
+# POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses
+POST http://{{host}}/repos/octocat/hello-world/secret-scanning/push-protection-bypasses
+Authorization: token testtoken
+Content-Type: application/json
+{"reason": "will_fix_later", "placeholder_id": "2k4dM4tseyC5lPIsjl5emX9sPNk"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /repos/{owner}/{repo}/secret-scanning/scan-history
+GET http://{{host}}/repos/octocat/hello-world/secret-scanning/scan-history
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1183,6 +1183,22 @@ eq(
   "OnHttpRequest: GET /orgs/{org}/projectsV2/{project_number} → 501 (projects not implemented)"
 )
 
+-- GET /orgs/{org}/secret-scanning/alerts — secret_scanning_list_empty default → 200
+reset_response()
+reset_request({ method = "GET", path = "/orgs/myorg/secret-scanning/alerts" })
+OnHttpRequest()
+eq(_last_status, 200, "OnHttpRequest: GET /orgs/{org}/secret-scanning/alerts → 200 (empty list)")
+
+-- GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number} — secret_scanning_not_implemented default → 501
+reset_response()
+reset_request({ method = "GET", path = "/repos/alice/myrepo/secret-scanning/alerts/1" })
+OnHttpRequest()
+eq(
+  _last_status,
+  501,
+  "OnHttpRequest: GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number} → 501 (not implemented)"
+)
+
 -- ============================================================
 -- Summary
 -- ============================================================


### PR DESCRIPTION
Implement GitHub REST API for Secret Scanning (closes #31)

Fixes #31.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (25)</summary>

- [x] Add secret scanning routes and default handlers <!-- type:spec -->
- [x] Azuredevops: secret scanning endpoints and tests <!-- type:spec -->
- [x] Bitbucket: secret scanning endpoints and tests <!-- type:spec -->
- [x] Bitbucket Datacenter: secret scanning endpoints and tests <!-- type:spec -->
- [x] Codeberg: secret scanning endpoints and tests <!-- type:spec -->
- [x] Codecommit: secret scanning endpoints and tests <!-- type:spec -->
- [x] Forgejo: secret scanning endpoints and tests <!-- type:spec -->
- [x] Gerrit: secret scanning endpoints and tests <!-- type:spec -->
- [x] Gitblit: secret scanning endpoints and tests <!-- type:spec -->
- [x] Gitbucket: secret scanning endpoints and tests <!-- type:spec -->
- [x] Gitea: secret scanning endpoints and tests <!-- type:spec -->
- [x] Gitlab: secret scanning endpoints and tests <!-- type:spec -->
- [x] Gogs: secret scanning endpoints and tests <!-- type:spec -->
- [x] Harness: secret scanning endpoints and tests <!-- type:spec -->
- [x] Kallithea: secret scanning endpoints and tests <!-- type:spec -->
- [x] Launchpad: secret scanning endpoints and tests <!-- type:spec -->
- [x] Notabug: secret scanning endpoints and tests <!-- type:spec -->
- [x] Onedev: secret scanning endpoints and tests <!-- type:spec -->
- [x] Pagure: secret scanning endpoints and tests <!-- type:spec -->
- [x] Phabricator: secret scanning endpoints and tests <!-- type:spec -->
- [x] Radicle: secret scanning endpoints and tests <!-- type:spec -->
- [x] Rhodecode: secret scanning endpoints and tests <!-- type:spec -->
- [x] Sourceforge: secret scanning endpoints and tests <!-- type:spec -->
- [x] Sourcehut: secret scanning endpoints and tests <!-- type:spec -->
- [x] Tuleap: secret scanning endpoints and tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->