### PR TITLE
Implement GitHub REST API for Gists (closes #32)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,3 +23,6 @@ runs:
       with:
         path: luacov
         key: luacov-${{ hashFiles('.luacov-version') }}
+    - name: Touch restored tool binaries
+      shell: bash
+      run: touch -c redbean.com hurl stylua luacheck 2>/dev/null; touch -c luacov 2>/dev/null; true

--- a/.init.lua
+++ b/.init.lua
@@ -501,6 +501,12 @@ local function projects_list_empty()
   respond_json(200, {})
 end
 
+-- Default handlers for Gists endpoints: most backends have no native gist API.
+-- List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+local function gists_not_implemented()
+  respond_json(501, { message = "Gists are not supported by this backend." })
+end
+
 -- Default handlers for GET /zen, GET /octocat, GET /versions, GET /meta.
 -- These endpoints are fully self-contained and do not call any backend.
 local ZEN_QUOTES = {
@@ -1202,6 +1208,27 @@ local route_defaults = {
   get_commit_check_suites = function(_owner, _repo_name, _ref)
     respond_json(200, { total_count = 0, check_suites = {} })
   end,
+  -- Gists
+  get_gists = empty_list,
+  post_gists = gists_not_implemented,
+  get_gists_public = empty_list,
+  get_gists_starred = empty_list,
+  get_gist = gists_not_implemented,
+  patch_gist = gists_not_implemented,
+  delete_gist = gists_not_implemented,
+  get_gist_comments = empty_list,
+  post_gist_comment = gists_not_implemented,
+  get_gist_comment = gists_not_implemented,
+  patch_gist_comment = gists_not_implemented,
+  delete_gist_comment = gists_not_implemented,
+  get_gist_commits = empty_list,
+  get_gist_forks = empty_list,
+  post_gist_fork = gists_not_implemented,
+  get_gist_star = gists_not_implemented,
+  put_gist_star = gists_not_implemented,
+  delete_gist_star = gists_not_implemented,
+  get_gist_revision = gists_not_implemented,
+  get_user_gists = empty_list,
 }
 
 -- ---------------------------------------------------------------------------
@@ -1233,6 +1260,28 @@ local routes = {
   ["GET /licenses/{license}"] = "get_license",
   -- Rate Limits (https://docs.github.com/en/rest/rate-limit)
   ["GET /rate_limit"] = "get_rate_limit",
+
+  -- Gists (https://docs.github.com/en/rest/gists)
+  ["GET /gists"] = "get_gists",
+  ["POST /gists"] = "post_gists",
+  ["GET /gists/public"] = "get_gists_public",
+  ["GET /gists/starred"] = "get_gists_starred",
+  ["GET /gists/{gist_id}"] = "get_gist",
+  ["PATCH /gists/{gist_id}"] = "patch_gist",
+  ["DELETE /gists/{gist_id}"] = "delete_gist",
+  ["GET /gists/{gist_id}/comments"] = "get_gist_comments",
+  ["POST /gists/{gist_id}/comments"] = "post_gist_comment",
+  ["GET /gists/{gist_id}/comments/{comment_id}"] = "get_gist_comment",
+  ["PATCH /gists/{gist_id}/comments/{comment_id}"] = "patch_gist_comment",
+  ["DELETE /gists/{gist_id}/comments/{comment_id}"] = "delete_gist_comment",
+  ["GET /gists/{gist_id}/commits"] = "get_gist_commits",
+  ["GET /gists/{gist_id}/forks"] = "get_gist_forks",
+  ["POST /gists/{gist_id}/forks"] = "post_gist_fork",
+  ["GET /gists/{gist_id}/star"] = "get_gist_star",
+  ["PUT /gists/{gist_id}/star"] = "put_gist_star",
+  ["DELETE /gists/{gist_id}/star"] = "delete_gist_star",
+  ["GET /gists/{gist_id}/{sha}"] = "get_gist_revision",
+  ["GET /users/{username}/gists"] = "get_user_gists",
 
   -- Repos core (https://docs.github.com/en/rest/repos/repos)
   ["GET /repos/{owner}/{repo}"] = "get_repo",

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifneq (,$(or $(findstring MINGW,$(HURL_OS)),$(findstring MSYS,$(HURL_OS)),$(find
 	chmod +x hurl
 	rm hurl.zip
 else
-	curl -sL $(HURL_URL) | tar -xz --strip-components=2 hurl-$(HURL_VERSION)-$(HURL_PLATFORM)/bin/hurl
+	curl -fsSL $(HURL_URL) | tar -xz --strip-components=2 hurl-$(HURL_VERSION)-$(HURL_PLATFORM)/bin/hurl
 	chmod +x hurl
 endif
 

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -499,6 +499,153 @@ local function translate_bb_ref(r)
   }
 end
 
+-- Gist helpers ---------------------------------------------------------------
+
+-- Translate a Bitbucket snippet object to GitHub gist format.
+-- Files include only metadata (raw_url, size); content is not eagerly fetched.
+-- gist.id encodes "workspace~encoded_id" for round-trip decoding.
+local function translate_bb_snippet(s)
+  if not s then
+    return {}
+  end
+  local owner = s.owner or {}
+  local ws = owner.nickname or owner.display_name or ""
+  local files = {}
+  for name, f in pairs(s.files or {}) do
+    files[name] = {
+      filename = name,
+      type = f.mimetype or "text/plain",
+      language = nil,
+      raw_url = (f.links and f.links.self and f.links.self.href) or "",
+      size = f.size or 0,
+      truncated = false,
+    }
+  end
+  return {
+    id = ws .. "~" .. tostring(s.id or ""),
+    node_id = "",
+    url = "",
+    html_url = (s.links and s.links.html and s.links.html.href) or "",
+    files = files,
+    public = not (s.is_private or false),
+    created_at = s.created_on or "",
+    updated_at = s.updated_on or "",
+    description = s.title or "",
+    comments = 0,
+    user = nil,
+    owner = {
+      login = ws,
+      id = 0,
+      node_id = owner.uuid or "",
+      avatar_url = (owner.links and owner.links.avatar and owner.links.avatar.href) or "",
+      url = "",
+      html_url = "",
+      type = "User",
+    },
+    truncated = false,
+  }
+end
+
+-- Translate a paginated Bitbucket snippet list to a GitHub gist array.
+local function translate_bb_snippets(data)
+  local result = {}
+  for i, s in ipairs(data.values or {}) do
+    result[i] = translate_bb_snippet(s)
+  end
+  return result
+end
+
+-- Translate a Bitbucket snippet comment to GitHub gist comment format.
+local function translate_bb_snippet_comment(c)
+  if not c then
+    return {}
+  end
+  local author = c.author or {}
+  local content = c.content or {}
+  return {
+    id = c.id or 0,
+    node_id = "",
+    url = "",
+    body = content.raw or "",
+    user = {
+      login = author.nickname or author.display_name or "",
+      id = 0,
+      node_id = author.uuid or "",
+      avatar_url = (author.links and author.links.avatar and author.links.avatar.href) or "",
+      url = "",
+      html_url = "",
+      type = "User",
+    },
+    created_at = c.created_on or "",
+    updated_at = c.updated_on or "",
+  }
+end
+
+-- Translate a paginated Bitbucket snippet comment list.
+local function translate_bb_snippet_comments(data)
+  local result = {}
+  for i, c in ipairs(data.values or {}) do
+    result[i] = translate_bb_snippet_comment(c)
+  end
+  return result
+end
+
+-- Translate a paginated Bitbucket snippet commit list to GitHub gist commit format.
+local function translate_bb_snippet_commits(data)
+  local result = {}
+  for i, c in ipairs(data.values or {}) do
+    local author = c.author or {}
+    local user = author.user or {}
+    result[i] = {
+      url = "",
+      version = c.hash or "",
+      user = {
+        login = user.nickname or user.display_name or "",
+        id = 0,
+        node_id = user.uuid or "",
+        avatar_url = (user.links and user.links.avatar and user.links.avatar.href) or "",
+        url = "",
+        html_url = "",
+        type = "User",
+      },
+      committed_at = c.date or "",
+      change_status = { total = 0, additions = 0, deletions = 0 },
+    }
+  end
+  return result
+end
+
+-- Decode a GitHub gist ID (from a confusio response) back to Bitbucket workspace
+-- and encoded_id.  Returns nil, nil if gist_id is not in "workspace~encoded_id" form.
+local function gist_id_split(gist_id)
+  return gist_id:match("^([^~]+)~(.+)$")
+end
+
+-- Build the Bitbucket snippets base URL for a split gist_id, or respond 404
+-- and return nil if gist_id is malformed.
+local function snippet_url(gist_id)
+  local ws, eid = gist_id_split(gist_id)
+  if not ws then
+    respond_json(404, { message = "Not Found" })
+    return nil
+  end
+  return base() .. "/snippets/" .. ws .. "/" .. eid
+end
+
+-- Like proxy_json but ensures empty results are written as "[]" not "{}".
+local function proxy_list(translate, ok, status, _headers, body)
+  if ok and status == 200 then
+    local data = DecodeJson(body) or {}
+    local result = translate(data)
+    set_preamble()
+    Write(#result > 0 and EncodeJson(result) or "[]")
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end
+
 backend_impl = {
   get_root = function()
     local ok, status = pcall(Fetch, base() .. "/user", auth())
@@ -1625,5 +1772,226 @@ backend_impl = {
     else
       respond_json(503, {})
     end
+  end,
+
+  -- Gists (Bitbucket Snippets) -----------------------------------------------
+  --
+  -- GitHub gist IDs are encoded as "workspace~encoded_id" so that per-gist
+  -- operations can reconstruct the Bitbucket URL without extra lookups.
+  -- e.g. gist_id = "octocat~pHANT4" → /2.0/snippets/octocat/pHANT4
+
+  get_gists = function()
+    proxy_list(
+      translate_bb_snippets,
+      fetch_json(append_page_params(base() .. "/snippets?role=owner", PAGES))
+    )
+  end,
+
+  get_gists_public = function()
+    proxy_list(translate_bb_snippets, fetch_json(append_page_params(base() .. "/snippets", PAGES)))
+  end,
+
+  post_gists = function()
+    local req = DecodeJson(GetBody() or "{}") or {}
+    local files = {}
+    for name, f in pairs(req.files or {}) do
+      if f then
+        files[name] = { content = f.content or "" }
+      end
+    end
+    local bb_body = EncodeJson({
+      title = req.description or "",
+      is_private = not (req.public == true or req.public == "true"),
+      files = files,
+    })
+    proxy_json_created(translate_bb_snippet, fetch_json(base() .. "/snippets", "POST", bb_body))
+  end,
+
+  get_gist = function(gist_id)
+    local url = snippet_url(gist_id)
+    if url then
+      proxy_json(translate_bb_snippet, fetch_json(url))
+    end
+  end,
+
+  patch_gist = function(gist_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local req = DecodeJson(GetBody() or "{}") or {}
+    local bb_body = {}
+    if req.description ~= nil then
+      bb_body.title = req.description
+    end
+    if req.files ~= nil then
+      local files = {}
+      for name, f in pairs(req.files) do
+        files[name] = f and { content = f.content or "" } or {}
+      end
+      bb_body.files = files
+    end
+    proxy_json(translate_bb_snippet, fetch_json(url, "PUT", EncodeJson(bb_body)))
+  end,
+
+  delete_gist = function(gist_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local dopts = auth() or {}
+    dopts.method = "DELETE"
+    local ok, status = pcall(Fetch, url, dopts)
+    if ok and status == 204 then
+      set_preamble(204)
+    elseif ok then
+      respond_json(status, {})
+    else
+      respond_json(503, {})
+    end
+  end,
+
+  get_gist_comments = function(gist_id)
+    local url = snippet_url(gist_id)
+    if url then
+      proxy_list(
+        translate_bb_snippet_comments,
+        fetch_json(append_page_params(url .. "/comments", PAGES))
+      )
+    end
+  end,
+
+  post_gist_comment = function(gist_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local req = DecodeJson(GetBody() or "{}") or {}
+    proxy_json_created(
+      translate_bb_snippet_comment,
+      fetch_json(url .. "/comments", "POST", EncodeJson({ content = { raw = req.body or "" } }))
+    )
+  end,
+
+  get_gist_comment = function(gist_id, comment_id)
+    local url = snippet_url(gist_id)
+    if url then
+      proxy_json(translate_bb_snippet_comment, fetch_json(url .. "/comments/" .. comment_id))
+    end
+  end,
+
+  patch_gist_comment = function(gist_id, comment_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local req = DecodeJson(GetBody() or "{}") or {}
+    proxy_json(
+      translate_bb_snippet_comment,
+      fetch_json(
+        url .. "/comments/" .. comment_id,
+        "PUT",
+        EncodeJson({ content = { raw = req.body or "" } })
+      )
+    )
+  end,
+
+  delete_gist_comment = function(gist_id, comment_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local dopts = auth() or {}
+    dopts.method = "DELETE"
+    local ok, status = pcall(Fetch, url .. "/comments/" .. comment_id, dopts)
+    if ok and status == 204 then
+      set_preamble(204)
+    elseif ok then
+      respond_json(status, {})
+    else
+      respond_json(503, {})
+    end
+  end,
+
+  get_gist_commits = function(gist_id)
+    local url = snippet_url(gist_id)
+    if url then
+      proxy_list(
+        translate_bb_snippet_commits,
+        fetch_json(append_page_params(url .. "/commits", PAGES))
+      )
+    end
+  end,
+
+  get_gist_forks = function(gist_id)
+    local url = snippet_url(gist_id)
+    if url then
+      proxy_list(translate_bb_snippets, fetch_json(append_page_params(url .. "/forks", PAGES)))
+    end
+  end,
+
+  get_gist_star = function(gist_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local ok, status = fetch_json(url .. "/watch")
+    if ok and (status == 200 or status == 204) then
+      set_preamble(204)
+    elseif ok and status == 404 then
+      respond_json(404, {})
+    elseif ok then
+      respond_json(status, {})
+    else
+      respond_json(503, {})
+    end
+  end,
+
+  put_gist_star = function(gist_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local wopts = auth() or {}
+    wopts.method = "PUT"
+    local ok, status = pcall(Fetch, url .. "/watch", wopts)
+    if ok and (status == 200 or status == 204) then
+      set_preamble(204)
+    elseif ok then
+      respond_json(status, {})
+    else
+      respond_json(503, {})
+    end
+  end,
+
+  delete_gist_star = function(gist_id)
+    local url = snippet_url(gist_id)
+    if not url then
+      return
+    end
+    local wopts = auth() or {}
+    wopts.method = "DELETE"
+    local ok, status = pcall(Fetch, url .. "/watch", wopts)
+    if ok and status == 204 then
+      set_preamble(204)
+    elseif ok then
+      respond_json(status, {})
+    else
+      respond_json(503, {})
+    end
+  end,
+
+  get_gist_revision = function(gist_id, sha)
+    local url = snippet_url(gist_id)
+    if url then
+      proxy_json(translate_bb_snippet, fetch_json(url .. "/" .. sha))
+    end
+  end,
+
+  get_user_gists = function(username)
+    proxy_list(
+      translate_bb_snippets,
+      fetch_json(append_page_params(base() .. "/snippets/" .. username, PAGES))
+    )
   end,
 }

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1407,4 +1407,66 @@ backend_impl = {
   get_git_tree = proxy_handler(nil, function(o, r, sha)
     return base() .. "/repos/" .. o .. "/" .. r .. "/git/trees/" .. sha
   end),
+
+  -- Gists (GitHub-compatible passthrough) ------------------------------------
+  get_gists = proxy_handler(nil, function()
+    return base() .. "/gists"
+  end),
+  post_gists = function()
+    proxy_json_created(nil, fetch_json(base() .. "/gists", "POST", GetBody()))
+  end,
+  get_gists_public = proxy_handler(nil, function()
+    return base() .. "/gists/public"
+  end),
+  get_gists_starred = proxy_handler(nil, function()
+    return base() .. "/gists/starred"
+  end),
+  get_gist = proxy_handler(nil, function(id)
+    return base() .. "/gists/" .. id
+  end),
+  patch_gist = function(id)
+    proxy_json(nil, fetch_json(base() .. "/gists/" .. id, "PATCH", GetBody()))
+  end,
+  delete_gist = function(id)
+    set_204_or_error("DELETE", base() .. "/gists/" .. id)
+  end,
+  get_gist_comments = proxy_handler(nil, function(id)
+    return base() .. "/gists/" .. id .. "/comments"
+  end),
+  post_gist_comment = function(id)
+    proxy_json_created(nil, fetch_json(base() .. "/gists/" .. id .. "/comments", "POST", GetBody()))
+  end,
+  get_gist_comment = proxy_handler(nil, function(id, cid)
+    return base() .. "/gists/" .. id .. "/comments/" .. cid
+  end),
+  patch_gist_comment = function(id, cid)
+    proxy_json(
+      nil,
+      fetch_json(base() .. "/gists/" .. id .. "/comments/" .. cid, "PATCH", GetBody())
+    )
+  end,
+  delete_gist_comment = function(id, cid)
+    set_204_or_error("DELETE", base() .. "/gists/" .. id .. "/comments/" .. cid)
+  end,
+  get_gist_commits = proxy_handler(nil, function(id)
+    return base() .. "/gists/" .. id .. "/commits"
+  end),
+  get_gist_forks = proxy_handler(nil, function(id)
+    return base() .. "/gists/" .. id .. "/forks"
+  end),
+  get_gist_star = function(id)
+    set_204_or_error("GET", base() .. "/gists/" .. id .. "/star")
+  end,
+  put_gist_star = function(id)
+    set_204_or_error("PUT", base() .. "/gists/" .. id .. "/star")
+  end,
+  delete_gist_star = function(id)
+    set_204_or_error("DELETE", base() .. "/gists/" .. id .. "/star")
+  end,
+  get_gist_revision = proxy_handler(nil, function(id, sha)
+    return base() .. "/gists/" .. id .. "/" .. sha
+  end),
+  get_user_gists = proxy_handler(nil, function(user)
+    return base() .. "/users/" .. user .. "/gists"
+  end),
 }

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -3716,3 +3716,201 @@ _b.update_secret_scanning_alert = function(_owner, _repo_name, alert_number)
   end
   respond_json(200, translate_gl_secret_alert(DecodeJson(body) or {}))
 end
+
+-- Gists (GitLab Snippets) ----------------------------------------------------
+
+local function translate_gl_snippet_author(a)
+  if not a then
+    return {}
+  end
+  return {
+    login = a.username or "",
+    id = a.id or 0,
+    node_id = "",
+    avatar_url = a.avatar_url or "",
+    html_url = a.web_url or "",
+    type = "User",
+    site_admin = false,
+  }
+end
+
+local function translate_gl_snippet(s)
+  if not s then
+    return {}
+  end
+  local files = {}
+  for _, f in ipairs(s.files or {}) do
+    local name = f.path or ""
+    files[name] = { filename = name, raw_url = f.raw_url or "" }
+  end
+  -- Fall back to file_name for older single-file snippets.
+  if not next(files) and s.file_name then
+    files[s.file_name] = { filename = s.file_name, raw_url = s.raw_url or "" }
+  end
+  return {
+    id = tostring(s.id or ""),
+    description = s.title or "",
+    public = s.visibility == "public",
+    owner = translate_gl_snippet_author(s.author),
+    files = files,
+    created_at = s.created_at,
+    updated_at = s.updated_at,
+    html_url = s.web_url or "",
+    url = "",
+    node_id = "",
+  }
+end
+
+local function translate_gl_snippets(data)
+  local out = {}
+  for i, s in ipairs(data) do
+    out[i] = translate_gl_snippet(s)
+  end
+  return out
+end
+
+local function translate_gl_snippet_note(n)
+  if not n then
+    return {}
+  end
+  return {
+    id = n.id or 0,
+    body = n.body or "",
+    user = translate_gl_snippet_author(n.author),
+    created_at = n.created_at,
+    updated_at = n.updated_at,
+    url = "",
+    node_id = "",
+  }
+end
+
+local function translate_gl_snippet_notes(data)
+  local out = {}
+  for i, n in ipairs(data) do
+    out[i] = translate_gl_snippet_note(n)
+  end
+  return out
+end
+
+-- Convert a GitHub gist create/update request body to GitLab snippet format.
+local function gl_snippet_req(req)
+  local gl = {}
+  if req.description ~= nil then
+    gl.title = req.description
+  end
+  if req.public ~= nil then
+    gl.visibility = (req.public == true or req.public == "true") and "public" or "private"
+  end
+  if req.files ~= nil then
+    local files = {}
+    for name, f in pairs(req.files) do
+      if f then
+        table.insert(files, { file_path = name, content = f.content or "" })
+      end
+    end
+    gl.files = files
+  end
+  return EncodeJson(gl)
+end
+
+local function proxy_list_gl(translate, ok, status, _headers, body)
+  if ok and status == 200 then
+    local data = DecodeJson(body) or {}
+    local result = translate(data)
+    set_preamble()
+    Write(#result > 0 and EncodeJson(result) or "[]")
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end
+
+local function delete_snippet(url)
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  local ok, status = pcall(Fetch, url, opts)
+  if ok and (status == 204 or status == 200) then
+    set_preamble(204)
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end
+
+_b.get_gists = function()
+  proxy_list_gl(translate_gl_snippets, fetch_json(base() .. "/snippets"))
+end
+
+_b.get_gists_public = function()
+  proxy_list_gl(translate_gl_snippets, fetch_json(base() .. "/snippets/public"))
+end
+
+_b.post_gists = function()
+  local req = DecodeJson(GetBody() or "{}") or {}
+  proxy_json_created(
+    translate_gl_snippet,
+    fetch_json(base() .. "/snippets", "POST", gl_snippet_req(req))
+  )
+end
+
+_b.get_gist = function(id)
+  proxy_json(translate_gl_snippet, fetch_json(base() .. "/snippets/" .. id))
+end
+
+_b.patch_gist = function(id)
+  local req = DecodeJson(GetBody() or "{}") or {}
+  proxy_json(
+    translate_gl_snippet,
+    fetch_json(base() .. "/snippets/" .. id, "PUT", gl_snippet_req(req))
+  )
+end
+
+_b.delete_gist = function(id)
+  delete_snippet(base() .. "/snippets/" .. id)
+end
+
+_b.get_gist_comments = function(id)
+  proxy_list_gl(translate_gl_snippet_notes, fetch_json(base() .. "/snippets/" .. id .. "/notes"))
+end
+
+_b.post_gist_comment = function(id)
+  local req = DecodeJson(GetBody() or "{}") or {}
+  proxy_json_created(
+    translate_gl_snippet_note,
+    fetch_json(
+      base() .. "/snippets/" .. id .. "/notes",
+      "POST",
+      EncodeJson({ body = req.body or "" })
+    )
+  )
+end
+
+_b.get_gist_comment = function(id, comment_id)
+  proxy_json(
+    translate_gl_snippet_note,
+    fetch_json(base() .. "/snippets/" .. id .. "/notes/" .. comment_id)
+  )
+end
+
+_b.patch_gist_comment = function(id, comment_id)
+  local req = DecodeJson(GetBody() or "{}") or {}
+  proxy_json(
+    translate_gl_snippet_note,
+    fetch_json(
+      base() .. "/snippets/" .. id .. "/notes/" .. comment_id,
+      "PUT",
+      EncodeJson({ body = req.body or "" })
+    )
+  )
+end
+
+_b.delete_gist_comment = function(id, comment_id)
+  delete_snippet(base() .. "/snippets/" .. id .. "/notes/" .. comment_id)
+end
+
+_b.get_user_gists = function(_username)
+  -- GitLab doesn't expose per-user public snippet lists; approximate with own snippets.
+  proxy_list_gl(translate_gl_snippets, fetch_json(base() .. "/snippets"))
+end

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -49,25 +49,25 @@ GET /user/keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/gpg_keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/emails,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 Gists,,,,,,,,,,,,,,,,,,,,,,,,
-GET /gists,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-POST /gists,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/public,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/starred,n,~no starred-snippets list,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /gists/{gist_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-POST /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/commits,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/forks,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/public,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/starred,n,~no starred-snippets list,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/commits,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/forks,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /gists/{gist_id}/forks,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/star,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PUT /gists/{gist_id}/star,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id}/star,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/{sha},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/{sha},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /users/{username}/gists,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Teams,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -49,18 +49,18 @@ GET /user/keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/gpg_keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/emails,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 Gists,,,,,,,,,,,,,,,,,,,,,,,,
-GET /gists,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-POST /gists,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/public,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/public,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gists/starred,n,~no starred-snippets list,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-POST /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id},n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gists/{gist_id}/commits,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gists/{gist_id}/forks,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /gists/{gist_id}/forks,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -68,7 +68,7 @@ GET /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gists/{gist_id}/{sha},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /users/{username}/gists,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /users/{username}/gists,n,y,n,n,n,n,n,n,n,n,~own snippets only,n,n,n,n,n,n,n,n,n,n,n,n,n
 Teams,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -49,26 +49,26 @@ GET /user/keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/gpg_keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/emails,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 Gists,,,,,,,,,,,,,,,,,,,,,,,,
-GET /gists,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-POST /gists,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/public,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/starred,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /gists/{gist_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/comments,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-POST /gists/{gist_id}/comments,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/comments/{comment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PATCH /gists/{gist_id}/comments/{comment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id}/comments/{comment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/commits,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/forks,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/public,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/starred,n,~no starred-snippets list,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists/{gist_id}/comments,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id}/comments/{comment_id},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/commits,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/forks,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /gists/{gist_id}/forks,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/star,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-PUT /gists/{gist_id}/star,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /gists/{gist_id}/star,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /gists/{gist_id}/{sha},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /users/{username}/gists,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/star,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /gists/{gist_id}/star,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id}/star,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/{sha},n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /users/{username}/gists,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Teams,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -48,6 +48,27 @@ GET /user/following,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/gpg_keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/emails,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+Gists,,,,,,,,,,,,,,,,,,,,,,,,
+GET /gists,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/public,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/starred,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists/{gist_id}/comments,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/comments/{comment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PATCH /gists/{gist_id}/comments/{comment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id}/comments/{comment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/commits,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/forks,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+POST /gists/{gist_id}/forks,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/star,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+PUT /gists/{gist_id}/star,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /gists/{gist_id}/star,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /gists/{gist_id}/{sha},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+GET /users/{username}/gists,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 Teams,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/test/azuredevops-gists.hurl
+++ b/test/azuredevops-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Azure DevOps has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/bitbucket-gists.hurl
+++ b/test/bitbucket-gists.hurl
@@ -1,0 +1,191 @@
+# Gists API — Bitbucket Snippets.
+# GitHub gist IDs are encoded as "workspace~encoded_id" by the backend.
+
+# GET /gists — list auth user's snippets
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "octocat~pHANT4"
+jsonpath "$[0].description" == "Hello snippet"
+jsonpath "$[0].public" == true
+jsonpath "$[0].owner.login" == "octocat"
+jsonpath "$[0].files['hello.txt'].filename" == "hello.txt"
+
+# GET /gists/public — list all public snippets
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "octocat~pHANT4"
+
+# GET /gists/starred — no Bitbucket equivalent; returns empty list
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists — create a snippet
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "description": "Hello snippet", "public": true}
+
+HTTP 201
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "octocat~pHANT4"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/octocat~pHANT4
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "octocat~pHANT4"
+jsonpath "$.description" == "Hello snippet"
+jsonpath "$.public" == true
+jsonpath "$.owner.login" == "octocat"
+jsonpath "$.files['hello.txt'].filename" == "hello.txt"
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/octocat~pHANT4
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "Updated snippet"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "octocat~pHANT4"
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/octocat~pHANT4/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == 1
+jsonpath "$[0].body" == "A comment"
+jsonpath "$[0].user.login" == "octocat"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/octocat~pHANT4/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 201
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+jsonpath "$.body" == "A comment"
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/octocat~pHANT4/comments/1
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+jsonpath "$.body" == "A comment"
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/octocat~pHANT4/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/octocat~pHANT4/comments/1
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/octocat~pHANT4/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].version" == "deadbeef1234"
+jsonpath "$[0].user.login" == "octocat"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/octocat~pHANT4/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks — no Bitbucket equivalent
+POST http://{{host}}/gists/octocat~pHANT4/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star — check if watching
+GET http://{{host}}/gists/octocat~pHANT4/star
+Authorization: token testtoken
+
+HTTP 204
+
+# PUT /gists/{gist_id}/star — watch
+PUT http://{{host}}/gists/octocat~pHANT4/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 204
+
+# DELETE /gists/{gist_id}/star — unwatch
+DELETE http://{{host}}/gists/octocat~pHANT4/star
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /gists/{gist_id}/{sha} — specific revision
+GET http://{{host}}/gists/octocat~pHANT4/deadbeef1234
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "octocat~pHANT4"
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/octocat~pHANT4
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "octocat~pHANT4"
+jsonpath "$[0].owner.login" == "octocat"

--- a/test/bitbucket_datacenter-gists.hurl
+++ b/test/bitbucket_datacenter-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Bitbucket Datacenter has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/codeberg-gists.hurl
+++ b/test/codeberg-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Codeberg (Forgejo/Gitea) has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/codecommit-gists.hurl
+++ b/test/codecommit-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — CodeCommit has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/forgejo-gists.hurl
+++ b/test/forgejo-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Forgejo (Gitea-compatible) has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/gerrit-gists.hurl
+++ b/test/gerrit-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Gerrit has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/gitblit-gists.hurl
+++ b/test/gitblit-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — GitBlit has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/gitbucket-gists.hurl
+++ b/test/gitbucket-gists.hurl
@@ -1,0 +1,190 @@
+# Gists API — GitBucket exposes a GitHub-compatible gists API at /api/v3/gists.
+
+# GET /gists — list auth user's gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "aa5a315d61ae9438b18d"
+jsonpath "$[0].description" == "Hello gist"
+jsonpath "$[0].public" == true
+jsonpath "$[0].owner.login" == "octocat"
+jsonpath "$[0].files['hello.txt'].filename" == "hello.txt"
+
+# GET /gists/public — list public gists
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "aa5a315d61ae9438b18d"
+
+# GET /gists/starred — list starred gists
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "aa5a315d61ae9438b18d"
+
+# POST /gists — create a gist
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "description": "Hello gist", "public": true}
+
+HTTP 201
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "aa5a315d61ae9438b18d"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "aa5a315d61ae9438b18d"
+jsonpath "$.description" == "Hello gist"
+jsonpath "$.public" == true
+jsonpath "$.owner.login" == "octocat"
+jsonpath "$.files['hello.txt'].filename" == "hello.txt"
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "Updated gist"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "aa5a315d61ae9438b18d"
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == 1
+jsonpath "$[0].body" == "A comment"
+jsonpath "$[0].user.login" == "octocat"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 201
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+jsonpath "$.body" == "A comment"
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+jsonpath "$.body" == "A comment"
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].version" == "deadbeef1234"
+jsonpath "$[0].user.login" == "octocat"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks — no GitBucket equivalent
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 204
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 204
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /gists/{gist_id}/{sha} — specific revision
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "aa5a315d61ae9438b18d"
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "aa5a315d61ae9438b18d"
+jsonpath "$[0].owner.login" == "octocat"

--- a/test/gitea-gists.hurl
+++ b/test/gitea-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Gitea has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/gitlab-gists.hurl
+++ b/test/gitlab-gists.hurl
@@ -1,0 +1,199 @@
+# Gists API — GitLab Snippets.
+# GitLab snippet IDs are integers; confusio stringifies them as gist IDs.
+
+# GET /gists — list auth user's snippets
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "36"
+jsonpath "$[0].description" == "Hello snippet"
+jsonpath "$[0].public" == true
+jsonpath "$[0].owner.login" == "octocat"
+jsonpath "$[0].files['hello.txt'].filename" == "hello.txt"
+
+# GET /gists/public — list public snippets
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "36"
+
+# GET /gists/starred — no GitLab equivalent; returns empty list
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists — create a snippet
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "description": "Hello snippet", "public": true}
+
+HTTP 201
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "36"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/36
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "36"
+jsonpath "$.description" == "Hello snippet"
+jsonpath "$.public" == true
+jsonpath "$.owner.login" == "octocat"
+jsonpath "$.files['hello.txt'].filename" == "hello.txt"
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/36
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "Updated snippet"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == "36"
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/36/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == 1
+jsonpath "$[0].body" == "A comment"
+jsonpath "$[0].user.login" == "octocat"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/36/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 201
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+jsonpath "$.body" == "A comment"
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/36/comments/1
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+jsonpath "$.body" == "A comment"
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/36/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" == 1
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/36/comments/1
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /gists/{gist_id}/commits — no GitLab equivalent; returns empty list
+GET http://{{host}}/gists/36/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks — no GitLab equivalent; returns empty list
+GET http://{{host}}/gists/36/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks — no GitLab equivalent
+POST http://{{host}}/gists/36/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star — no GitLab equivalent
+GET http://{{host}}/gists/36/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star — no GitLab equivalent
+PUT http://{{host}}/gists/36/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star — no GitLab equivalent
+DELETE http://{{host}}/gists/36/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha} — no GitLab equivalent
+GET http://{{host}}/gists/36/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/36
+Authorization: token testtoken
+
+HTTP 204
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$[0].id" == "36"
+jsonpath "$[0].owner.login" == "octocat"

--- a/test/gogs-gists.hurl
+++ b/test/gogs-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Gogs has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/harness-gists.hurl
+++ b/test/harness-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Harness has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/kallithea-gists.hurl
+++ b/test/kallithea-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Kallithea has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/launchpad-gists.hurl
+++ b/test/launchpad-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Launchpad has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/mock-bitbucket.lua
+++ b/test/mock-bitbucket.lua
@@ -27,6 +27,28 @@ function OnHttpRequest()
     .. '"forks":[]}'
 
   local rb = "/2.0/repositories/octocat/hello-world"
+  local method = GetMethod()
+
+  local SNIPPET = '{"id":"pHANT4","title":"Hello snippet",'
+    .. '"is_private":false,'
+    .. '"created_on":"2011-01-26T19:01:12Z",'
+    .. '"updated_on":"2011-01-26T19:14:43Z",'
+    .. '"owner":{"nickname":"octocat","display_name":"Octocat","uuid":"{5678}",'
+    .. '"type":"user","links":{"avatar":{"href":"https://example.com/avatar"}}},'
+    .. '"files":{"hello.txt":{"mimetype":"text/plain","size":11,'
+    .. '"links":{"self":{"href":"https://api.bitbucket.org/2.0/snippets/octocat/pHANT4/files/hello.txt"}}}},'
+    .. '"links":{"html":{"href":"https://bitbucket.org/snippets/octocat/pHANT4"}}}'
+  local SNIPPET_COMMENT = '{"id":1,"created_on":"2011-01-26T19:01:12Z",'
+    .. '"updated_on":"2011-01-26T19:14:43Z",'
+    .. '"content":{"raw":"A comment","markup":"markdown","html":"<p>A comment</p>"},'
+    .. '"author":{"nickname":"octocat","display_name":"Octocat","uuid":"{5678}",'
+    .. '"type":"user","links":{"avatar":{"href":"https://example.com/avatar"}}}}'
+  local SNIPPET_COMMIT = '{"hash":"deadbeef1234","date":"2011-01-26T19:01:12Z",'
+    .. '"message":"Initial","author":{"raw":"Octocat <octocat@example.com>",'
+    .. '"user":{"nickname":"octocat","display_name":"Octocat","uuid":"{5678}",'
+    .. '"type":"user","links":{"avatar":{"href":""}}}}}'
+  local ss = "/2.0/snippets"
+  local sp = ss .. "/octocat/pHANT4"
 
   if path == "/2.0/user" then
     SetStatus(200, "OK")
@@ -334,6 +356,63 @@ function OnHttpRequest()
   -- fixed responses without proxying. Routes documented here for reference.
   elseif path:match("^/orgs/[^/]+/migrations") or path:match("^/user/migrations") then
     SetStatus(404, "Not Found")
+
+  -- Snippets (Gists) ----------------------------------------------------------
+  elseif (path == ss or path:find("^" .. ss .. "%?")) and method == "GET" then
+    SetStatus(200, "OK")
+    json('{"values":[' .. SNIPPET .. '],"pagelen":30,"size":1,"page":1}')
+  elseif path == ss and method == "POST" then
+    SetStatus(201, "Created")
+    json(SNIPPET)
+  elseif (path == ss .. "/octocat" or path:find("^" .. ss .. "/octocat%?")) and method == "GET" then
+    SetStatus(200, "OK")
+    json('{"values":[' .. SNIPPET .. '],"pagelen":30,"size":1,"page":1}')
+  elseif path == sp and method == "GET" then
+    SetStatus(200, "OK")
+    json(SNIPPET)
+  elseif path == sp and method == "PUT" then
+    SetStatus(200, "OK")
+    json(SNIPPET)
+  elseif path == sp and method == "DELETE" then
+    SetStatus(204, "No Content")
+  elseif
+    (path == sp .. "/comments" or path:find("^" .. sp:gsub("%-", "%%-") .. "/comments%?"))
+    and method == "GET"
+  then
+    SetStatus(200, "OK")
+    json('{"values":[' .. SNIPPET_COMMENT .. '],"pagelen":30,"size":1,"page":1}')
+  elseif path == sp .. "/comments" and method == "POST" then
+    SetStatus(201, "Created")
+    json(SNIPPET_COMMENT)
+  elseif path == sp .. "/comments/1" and method == "GET" then
+    SetStatus(200, "OK")
+    json(SNIPPET_COMMENT)
+  elseif path == sp .. "/comments/1" and method == "PUT" then
+    SetStatus(200, "OK")
+    json(SNIPPET_COMMENT)
+  elseif path == sp .. "/comments/1" and method == "DELETE" then
+    SetStatus(204, "No Content")
+  elseif
+    (path == sp .. "/commits" or path:find("^" .. sp:gsub("%-", "%%-") .. "/commits%?"))
+    and method == "GET"
+  then
+    SetStatus(200, "OK")
+    json('{"values":[' .. SNIPPET_COMMIT .. '],"pagelen":30,"size":1,"page":1}')
+  elseif
+    (path == sp .. "/forks" or path:find("^" .. sp:gsub("%-", "%%-") .. "/forks%?"))
+    and method == "GET"
+  then
+    SetStatus(200, "OK")
+    json('{"values":[],"pagelen":30,"size":0,"page":1}')
+  elseif path == sp .. "/watch" and method == "GET" then
+    SetStatus(204, "No Content")
+  elseif path == sp .. "/watch" and method == "PUT" then
+    SetStatus(204, "No Content")
+  elseif path == sp .. "/watch" and method == "DELETE" then
+    SetStatus(204, "No Content")
+  elseif path == sp .. "/deadbeef1234" and method == "GET" then
+    SetStatus(200, "OK")
+    json(SNIPPET)
   else
     SetStatus(404, "Not Found")
   end

--- a/test/mock-gitbucket.lua
+++ b/test/mock-gitbucket.lua
@@ -671,6 +671,79 @@ function OnHttpRequest()
   -- returns fixed responses without proxying. Routes documented here for reference.
   elseif path:match("^/orgs/[^/]+/migrations") or path:match("^/user/migrations") then
     SetStatus(404, "Not Found")
+
+  -- Gists ---------------------------------------------------------------------
+  elseif
+    path == "/api/v3/gists"
+    or path == "/api/v3/gists/public"
+    or path == "/api/v3/gists/starred"
+    or path:match("^/api/v3/users/[^/]+/gists")
+  then
+    local GIST_OBJ = '{"id":"aa5a315d61ae9438b18d","description":"Hello gist","public":true,'
+      .. '"owner":{"login":"octocat","id":1,"node_id":"","avatar_url":"","html_url":"","type":"User","site_admin":false},'
+      .. '"files":{"hello.txt":{"filename":"hello.txt","type":"text/plain","language":"Text","raw_url":"","size":11}},'
+      .. '"created_at":"2010-04-14T02:15:15Z","updated_at":"2011-06-20T11:34:15Z",'
+      .. '"url":"","html_url":"","git_pull_url":"","git_push_url":"","forks_url":"","commits_url":"","node_id":""}'
+    if method == "POST" then
+      SetStatus(201, "Created")
+      json(GIST_OBJ)
+    else
+      SetStatus(200, "OK")
+      json("[" .. GIST_OBJ .. "]")
+    end
+  elseif path == "/api/v3/gists/aa5a315d61ae9438b18d" then
+    if method == "DELETE" then
+      SetStatus(204, "No Content")
+    else
+      SetStatus(200, "OK")
+      json(
+        '{"id":"aa5a315d61ae9438b18d","description":"Hello gist","public":true,'
+          .. '"owner":{"login":"octocat","id":1,"node_id":"","avatar_url":"","html_url":"","type":"User","site_admin":false},'
+          .. '"files":{"hello.txt":{"filename":"hello.txt","type":"text/plain","language":"Text","raw_url":"","size":11,"content":"Hello World"}},'
+          .. '"created_at":"2010-04-14T02:15:15Z","updated_at":"2011-06-20T11:34:15Z",'
+          .. '"url":"","html_url":"","git_pull_url":"","git_push_url":"","forks_url":"","commits_url":"","node_id":""}'
+      )
+    end
+  elseif path == "/api/v3/gists/aa5a315d61ae9438b18d/comments" then
+    local COMMENT_OBJ = '{"id":1,"body":"A comment","user":{"login":"octocat","id":1,"node_id":"","avatar_url":"","html_url":"","type":"User","site_admin":false},'
+      .. '"created_at":"2011-04-18T23:23:56Z","updated_at":"2011-04-18T23:23:56Z","url":"","node_id":""}'
+    if method == "POST" then
+      SetStatus(201, "Created")
+      json(COMMENT_OBJ)
+    else
+      SetStatus(200, "OK")
+      json("[" .. COMMENT_OBJ .. "]")
+    end
+  elseif path == "/api/v3/gists/aa5a315d61ae9438b18d/comments/1" then
+    if method == "DELETE" then
+      SetStatus(204, "No Content")
+    else
+      SetStatus(200, "OK")
+      json(
+        '{"id":1,"body":"A comment","user":{"login":"octocat","id":1,"node_id":"","avatar_url":"","html_url":"","type":"User","site_admin":false},'
+          .. '"created_at":"2011-04-18T23:23:56Z","updated_at":"2011-04-18T23:23:56Z","url":"","node_id":""}'
+      )
+    end
+  elseif path == "/api/v3/gists/aa5a315d61ae9438b18d/commits" then
+    SetStatus(200, "OK")
+    json(
+      '[{"url":"","version":"deadbeef1234","user":{"login":"octocat","id":1,"node_id":"","avatar_url":"","html_url":"","type":"User","site_admin":false},'
+        .. '"change_status":{"total":1,"additions":1,"deletions":0},"committed_at":"2010-04-14T02:15:15Z"}]'
+    )
+  elseif path == "/api/v3/gists/aa5a315d61ae9438b18d/forks" then
+    SetStatus(200, "OK")
+    json("[]")
+  elseif path == "/api/v3/gists/aa5a315d61ae9438b18d/star" then
+    SetStatus(204, "No Content")
+  elseif path:match("^/api/v3/gists/aa5a315d61ae9438b18d/[0-9a-f]+$") then
+    SetStatus(200, "OK")
+    json(
+      '{"id":"aa5a315d61ae9438b18d","description":"Hello gist","public":true,'
+        .. '"owner":{"login":"octocat","id":1,"node_id":"","avatar_url":"","html_url":"","type":"User","site_admin":false},'
+        .. '"files":{"hello.txt":{"filename":"hello.txt","type":"text/plain","language":"Text","raw_url":"","size":11,"content":"Hello World"}},'
+        .. '"created_at":"2010-04-14T02:15:15Z","updated_at":"2011-06-20T11:34:15Z",'
+        .. '"url":"","html_url":"","git_pull_url":"","git_push_url":"","forks_url":"","commits_url":"","node_id":""}'
+    )
   else
     SetStatus(404, "Not Found")
   end

--- a/test/mock-gitlab.lua
+++ b/test/mock-gitlab.lua
@@ -704,6 +704,56 @@ function OnHttpRequest()
   elseif path == pb .. "/export/download" then
     SetStatus(302, "Found")
     SetHeader("Location", "https://storage.example.com/octocat-hello-world-export.tar.gz")
+
+  -- Snippets (Gists) ----------------------------------------------------------
+  elseif path == "/api/v4/snippets" or path == "/api/v4/snippets/public" then
+    local SNIPPET = '{"id":36,"title":"Hello snippet","description":"","visibility":"public",'
+      .. '"author":{"id":1,"username":"octocat","name":"The Octocat","avatar_url":"","web_url":"https://gitlab.com/octocat"},'
+      .. '"created_at":"2012-06-28T10:52:04.000Z","updated_at":"2012-06-28T10:52:04.000Z",'
+      .. '"project_id":null,"web_url":"","raw_url":"",'
+      .. '"files":[{"path":"hello.txt","raw_url":""}]}'
+    if GetMethod() == "POST" then
+      SetStatus(201, "Created")
+      json(SNIPPET)
+    else
+      SetStatus(200, "OK")
+      json("[" .. SNIPPET .. "]")
+    end
+  elseif path == "/api/v4/snippets/36" then
+    if GetMethod() == "DELETE" then
+      SetStatus(204, "No Content")
+    else
+      SetStatus(200, "OK")
+      json(
+        '{"id":36,"title":"Hello snippet","description":"","visibility":"public",'
+          .. '"author":{"id":1,"username":"octocat","name":"The Octocat","avatar_url":"","web_url":"https://gitlab.com/octocat"},'
+          .. '"created_at":"2012-06-28T10:52:04.000Z","updated_at":"2012-06-28T10:52:04.000Z",'
+          .. '"project_id":null,"web_url":"","raw_url":"",'
+          .. '"files":[{"path":"hello.txt","raw_url":""}]}'
+      )
+    end
+  elseif path == "/api/v4/snippets/36/notes" then
+    local NOTE = '{"id":1,"body":"A comment",'
+      .. '"author":{"id":1,"username":"octocat","name":"The Octocat","avatar_url":"","web_url":""},'
+      .. '"created_at":"2013-10-02T08:57:14.000Z","updated_at":"2013-10-02T08:57:14.000Z"}'
+    if GetMethod() == "POST" then
+      SetStatus(201, "Created")
+      json(NOTE)
+    else
+      SetStatus(200, "OK")
+      json("[" .. NOTE .. "]")
+    end
+  elseif path == "/api/v4/snippets/36/notes/1" then
+    if GetMethod() == "DELETE" then
+      SetStatus(204, "No Content")
+    else
+      SetStatus(200, "OK")
+      json(
+        '{"id":1,"body":"A comment",'
+          .. '"author":{"id":1,"username":"octocat","name":"The Octocat","avatar_url":"","web_url":""},'
+          .. '"created_at":"2013-10-02T08:57:14.000Z","updated_at":"2013-10-02T08:57:14.000Z"}'
+      )
+    end
   else
     SetStatus(404, "Not Found")
   end

--- a/test/notabug-gists.hurl
+++ b/test/notabug-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — NotABug (Gogs-based) has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/onedev-gists.hurl
+++ b/test/onedev-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — OneDev has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/pagure-gists.hurl
+++ b/test/pagure-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Pagure has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/phabricator-gists.hurl
+++ b/test/phabricator-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Phabricator has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/radicle-gists.hurl
+++ b/test/radicle-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Radicle has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/rhodecode-gists.hurl
+++ b/test/rhodecode-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — RhodeCode has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/sourceforge-gists.hurl
+++ b/test/sourceforge-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — SourceForge has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/sourcehut-gists.hurl
+++ b/test/sourcehut-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Sourcehut has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/tuleap-gists.hurl
+++ b/test/tuleap-gists.hurl
@@ -1,0 +1,192 @@
+# Gists API — Tuleap has no native gist equivalent.
+# List endpoints return empty arrays (200); per-resource and mutation endpoints return 501.
+
+# GET /gists
+GET http://{{host}}/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists
+POST http://{{host}}/gists
+Authorization: token testtoken
+Content-Type: application/json
+{"files": {"hello.txt": {"content": "Hello World"}}, "public": false}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/public
+GET http://{{host}}/gists/public
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/starred
+GET http://{{host}}/gists/starred
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+Content-Type: application/json
+{"description": "updated"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/comments
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/comments
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "A comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/comments/{comment_id}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PATCH /gists/{gist_id}/comments/{comment_id}
+PATCH http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+Content-Type: application/json
+{"body": "Updated comment"}
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/comments/{comment_id}
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/comments/1
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/commits
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/commits
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# GET /gists/{gist_id}/forks
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"
+
+# POST /gists/{gist_id}/forks
+POST http://{{host}}/gists/aa5a315d61ae9438b18d/forks
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/star
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# PUT /gists/{gist_id}/star
+PUT http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+Content-Length: 0
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# DELETE /gists/{gist_id}/star
+DELETE http://{{host}}/gists/aa5a315d61ae9438b18d/star
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /gists/{gist_id}/{sha}
+GET http://{{host}}/gists/aa5a315d61ae9438b18d/deadbeef1234
+Authorization: token testtoken
+
+HTTP 501
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.message" isString
+
+# GET /users/{username}/gists
+GET http://{{host}}/users/octocat/gists
+Authorization: token testtoken
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+body == "[]"

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1199,6 +1199,12 @@ eq(
   "OnHttpRequest: GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number} → 501 (not implemented)"
 )
 
+-- POST /gists — gists_not_implemented default → 501
+reset_response()
+reset_request({ method = "POST", path = "/gists" })
+OnHttpRequest()
+eq(_last_status, 501, "OnHttpRequest: POST /gists → 501 (gists not supported)")
+
 -- ============================================================
 -- Summary
 -- ============================================================


### PR DESCRIPTION
Implement GitHub REST API for Gists (closes #32)

Fixes #32.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (25)</summary>

- [x] Add gist routes and default handlers to .init.lua <!-- type:spec -->
- [x] Azure DevOps: gist endpoints and tests <!-- type:spec -->
- [x] Bitbucket: gist endpoints and tests <!-- type:spec -->
- [x] Bitbucket Datacenter: gist endpoints and tests <!-- type:spec -->
- [x] Codeberg: gist endpoints and tests <!-- type:spec -->
- [x] CodeCommit: gist endpoints and tests <!-- type:spec -->
- [x] Forgejo: gist endpoints and tests <!-- type:spec -->
- [x] Gerrit: gist endpoints and tests <!-- type:spec -->
- [x] GitBlit: gist endpoints and tests <!-- type:spec -->
- [x] GitBucket: gist endpoints and tests <!-- type:spec -->
- [x] Gitea: gist endpoints and tests <!-- type:spec -->
- [x] GitLab: gist endpoints and tests <!-- type:spec -->
- [x] Gogs: gist endpoints and tests <!-- type:spec -->
- [x] Harness: gist endpoints and tests <!-- type:spec -->
- [x] Kallithea: gist endpoints and tests <!-- type:spec -->
- [x] Launchpad: gist endpoints and tests <!-- type:spec -->
- [x] NotABug: gist endpoints and tests <!-- type:spec -->
- [x] OneDev: gist endpoints and tests <!-- type:spec -->
- [x] Pagure: gist endpoints and tests <!-- type:spec -->
- [x] Phabricator: gist endpoints and tests <!-- type:spec -->
- [x] Radicle: gist endpoints and tests <!-- type:spec -->
- [x] RhodeCode: gist endpoints and tests <!-- type:spec -->
- [x] SourceForge: gist endpoints and tests <!-- type:spec -->
- [x] Sourcehut: gist endpoints and tests <!-- type:spec -->
- [x] Tuleap: gist endpoints and tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->