### PR TITLE
Make compatibility and test metadata consume authoritative endpoint metadata (closes #112)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -678,2460 +678,2567 @@ local function path_known(path)
   local node = _trie_walk(path_trie, path)
   return node ~= nil and node.handler == true
 end
-
 -- ---------------------------------------------------------------------------
 -- Endpoint catalog
 --
--- Authoritative source for every registered endpoint. Each entry is:
---   { "METHOD /path", handler_name [, default_fn] }
--- where default_fn is the fallback when no backend implements the handler.
--- Entries without a default omit the third element (nil → 404).
+-- Authoritative source for every registered endpoint, organised by API
+-- group. Each section is { group_name, { entries... } } where each entry is
+-- { "METHOD /path", handler_name [, default_fn] }.
 --
--- Entries are organised into named sections. { group = "name" } marker
--- entries separate sections; they carry no route data. The section loop
--- below sets e.group on every real entry and builds the global `endpoints`
--- table, which scripts/dump-endpoints.lua reads to export the catalog.
+-- group_name matches the test file suffix (<backend>-<group>.hurl) and the
+-- compatibility matrix sections in site/compatibility.csv.
 --
 -- Backends override handlers by setting backend_impl.<name>. Parametric
 -- captures from {param} segments are passed positionally to the handler.
 -- ---------------------------------------------------------------------------
 
-local _ep_catalog = {
-
-  { group = "meta" },
-  -- Root
-  {
-    "GET /",
-    "get_root",
-    function()
-      respond_json(200, {})
-    end,
-  },
-
-  -- Meta (https://docs.github.com/en/rest/meta)
-  { "GET /meta", "get_meta", meta_response },
-  { "GET /octocat", "get_octocat", octocat_response },
-  { "GET /teapot", "get_teapot", teapot_response },
-  { "GET /versions", "get_versions", versions_response },
-  { "GET /zen", "get_zen", zen_response },
-
-  -- Emojis
-  { "GET /emojis", "get_emojis" },
-
-  { group = "gitignore" },
-  -- Gitignore templates (https://docs.github.com/en/rest/gitignore)
-  { "GET /gitignore/templates", "get_gitignore_templates" },
-  { "GET /gitignore/templates/{name}", "get_gitignore_template" },
-
-  { group = "licenses" },
-  -- Licenses (https://docs.github.com/en/rest/licenses)
-  { "GET /licenses", "get_licenses", licenses_not_implemented },
-  { "GET /licenses/{license}", "get_license", licenses_not_implemented },
-
-  { group = "rate-limit" },
-  -- Rate Limits (https://docs.github.com/en/rest/rate-limit)
-  { "GET /rate_limit", "get_rate_limit", rate_limit_response },
-
-  { group = "gists" },
-  -- Gists (https://docs.github.com/en/rest/gists)
-  { "GET /gists", "get_gists", empty_list },
-  { "POST /gists", "post_gists", gists_not_implemented },
-  { "GET /gists/public", "get_gists_public", empty_list },
-  { "GET /gists/starred", "get_gists_starred", empty_list },
-  { "GET /gists/{gist_id}", "get_gist", gists_not_implemented },
-  { "PATCH /gists/{gist_id}", "patch_gist", gists_not_implemented },
-  { "DELETE /gists/{gist_id}", "delete_gist", gists_not_implemented },
-  { "GET /gists/{gist_id}/comments", "get_gist_comments", empty_list },
-  { "POST /gists/{gist_id}/comments", "post_gist_comment", gists_not_implemented },
-  { "GET /gists/{gist_id}/comments/{comment_id}", "get_gist_comment", gists_not_implemented },
-  { "PATCH /gists/{gist_id}/comments/{comment_id}", "patch_gist_comment", gists_not_implemented },
-  { "DELETE /gists/{gist_id}/comments/{comment_id}", "delete_gist_comment", gists_not_implemented },
-  { "GET /gists/{gist_id}/commits", "get_gist_commits", empty_list },
-  { "GET /gists/{gist_id}/forks", "get_gist_forks", empty_list },
-  { "POST /gists/{gist_id}/forks", "post_gist_fork", gists_not_implemented },
-  { "GET /gists/{gist_id}/star", "get_gist_star", gists_not_implemented },
-  { "PUT /gists/{gist_id}/star", "put_gist_star", gists_not_implemented },
-  { "DELETE /gists/{gist_id}/star", "delete_gist_star", gists_not_implemented },
-  { "GET /gists/{gist_id}/{sha}", "get_gist_revision", gists_not_implemented },
-  { "GET /users/{username}/gists", "get_user_gists", empty_list },
-
-  { group = "activity" },
-  -- Activity (https://docs.github.com/en/rest/activity)
-  { "GET /events", "get_events", activity_list_empty },
-  { "GET /feeds", "get_feeds", activity_not_implemented },
-  { "GET /networks/{owner}/{repo}/events", "get_network_events", activity_list_empty },
-  { "GET /notifications", "get_notifications", activity_list_empty },
-  { "PUT /notifications", "put_notifications", activity_not_implemented },
-  { "GET /notifications/threads/{thread_id}", "get_notification_thread", activity_not_implemented },
-  {
-    "PATCH /notifications/threads/{thread_id}",
-    "patch_notification_thread",
-    activity_not_implemented,
-  },
-  {
-    "DELETE /notifications/threads/{thread_id}",
-    "delete_notification_thread",
-    activity_not_implemented,
-  },
-  {
-    "GET /notifications/threads/{thread_id}/subscription",
-    "get_notification_thread_subscription",
-    activity_not_implemented,
-  },
-  {
-    "PUT /notifications/threads/{thread_id}/subscription",
-    "put_notification_thread_subscription",
-    activity_not_implemented,
-  },
-  {
-    "DELETE /notifications/threads/{thread_id}/subscription",
-    "delete_notification_thread_subscription",
-    activity_not_implemented,
-  },
-  { "GET /orgs/{org}/events", "get_org_events", activity_list_empty },
-  { "GET /repos/{owner}/{repo}/events", "get_repo_events", activity_list_empty },
-  { "GET /repos/{owner}/{repo}/notifications", "get_repo_notifications", activity_list_empty },
-  { "PUT /repos/{owner}/{repo}/notifications", "put_repo_notifications", activity_not_implemented },
-  { "GET /repos/{owner}/{repo}/stargazers", "get_repo_stargazers", activity_list_empty },
-  { "GET /repos/{owner}/{repo}/subscribers", "get_repo_subscribers", activity_list_empty },
-  { "GET /repos/{owner}/{repo}/subscription", "get_repo_subscription", activity_not_implemented },
-  { "PUT /repos/{owner}/{repo}/subscription", "put_repo_subscription", activity_not_implemented },
-  {
-    "DELETE /repos/{owner}/{repo}/subscription",
-    "delete_repo_subscription",
-    activity_not_implemented,
-  },
-  { "GET /user/starred", "get_user_starred", activity_list_empty },
-  { "GET /user/starred/{owner}/{repo}", "get_user_starred_repo", activity_not_implemented },
-  { "PUT /user/starred/{owner}/{repo}", "put_user_starred_repo", activity_not_implemented },
-  { "DELETE /user/starred/{owner}/{repo}", "delete_user_starred_repo", activity_not_implemented },
-  { "GET /user/subscriptions", "get_user_subscriptions", activity_list_empty },
-  { "GET /users/{username}/events", "get_users_events", activity_list_empty },
-  { "GET /users/{username}/events/orgs/{org}", "get_users_org_events", activity_list_empty },
-  { "GET /users/{username}/events/public", "get_users_public_events", activity_list_empty },
-  { "GET /users/{username}/received_events", "get_users_received_events", activity_list_empty },
-  {
-    "GET /users/{username}/received_events/public",
-    "get_users_received_public_events",
-    activity_list_empty,
-  },
-  { "GET /users/{username}/starred", "get_users_starred", activity_list_empty },
-  { "GET /users/{username}/subscriptions", "get_users_subscriptions", activity_list_empty },
-
-  { group = "repos" },
-  -- Repos core (https://docs.github.com/en/rest/repos/repos)
-  { "GET /repos/{owner}/{repo}", "get_repo" },
-  { "PATCH /repos/{owner}/{repo}", "patch_repo" },
-  { "DELETE /repos/{owner}/{repo}", "delete_repo" },
-  { "GET /user/repos", "get_user_repos" },
-  { "POST /user/repos", "post_user_repos" },
-  { "GET /orgs/{org}/repos", "get_org_repos" },
-  { "POST /orgs/{org}/repos", "post_org_repos" },
-  { "GET /users/{username}/repos", "get_users_repos" },
-  { "GET /repositories", "get_repositories" },
-
-  -- Topics / languages / contributors / tags / teams
-  { "GET /repos/{owner}/{repo}/topics", "get_repo_topics" },
-  { "PUT /repos/{owner}/{repo}/topics", "put_repo_topics" },
-  { "GET /repos/{owner}/{repo}/languages", "get_repo_languages" },
-  { "GET /repos/{owner}/{repo}/contributors", "get_repo_contributors" },
-  { "GET /repos/{owner}/{repo}/tags", "get_repo_tags" },
-  { "GET /repos/{owner}/{repo}/teams", "get_repo_teams" },
-
-  { group = "repos-ext" },
-  -- Branches (https://docs.github.com/en/rest/branches)
-  { "GET /repos/{owner}/{repo}/branches", "get_repo_branches" },
-  { "GET /repos/{owner}/{repo}/branches/{branch}", "get_repo_branch" },
-
-  -- Commits (https://docs.github.com/en/rest/commits)
-  { "GET /repos/{owner}/{repo}/commits", "get_repo_commits" },
-  { "GET /repos/{owner}/{repo}/commits/{ref}", "get_repo_commit" },
-
-  -- Commit comments
-  { "GET /repos/{owner}/{repo}/comments", "get_repo_comments" },
-  { "GET /repos/{owner}/{repo}/comments/{comment_id}", "get_repo_comment" },
-  { "PATCH /repos/{owner}/{repo}/comments/{comment_id}", "patch_repo_comment" },
-  { "DELETE /repos/{owner}/{repo}/comments/{comment_id}", "delete_repo_comment" },
-  { "GET /repos/{owner}/{repo}/commits/{commit_sha}/comments", "get_commit_comments" },
-  { "POST /repos/{owner}/{repo}/commits/{commit_sha}/comments", "post_commit_comment" },
-
-  -- Statuses
-  { "GET /repos/{owner}/{repo}/commits/{ref}/statuses", "get_commit_statuses" },
-  { "GET /repos/{owner}/{repo}/commits/{ref}/status", "get_commit_combined_status" },
-  { "POST /repos/{owner}/{repo}/statuses/{sha}", "post_commit_status" },
-
-  -- Contents (https://docs.github.com/en/rest/repos/contents)
-  { "GET /repos/{owner}/{repo}/readme", "get_repo_readme" },
-  { "GET /repos/{owner}/{repo}/readme/{dir}", "get_repo_readme_dir" },
-  { "GET /repos/{owner}/{repo}/contents/{path}", "get_repo_content" },
-  { "PUT /repos/{owner}/{repo}/contents/{path}", "put_repo_content" },
-  { "DELETE /repos/{owner}/{repo}/contents/{path}", "delete_repo_content" },
-  { "GET /repos/{owner}/{repo}/tarball/{ref}", "get_repo_tarball" },
-  { "GET /repos/{owner}/{repo}/zipball/{ref}", "get_repo_zipball" },
-
-  { group = "licenses" },
-  -- Repo license (https://docs.github.com/en/rest/licenses)
-  { "GET /repos/{owner}/{repo}/license", "get_repo_license", licenses_not_implemented },
-
-  { group = "repos-ext" },
-  -- Compare
-  { "GET /repos/{owner}/{repo}/compare/{basehead}", "get_repo_compare" },
-
-  -- Collaborators (https://docs.github.com/en/rest/collaborators)
-  { "GET /repos/{owner}/{repo}/collaborators", "get_repo_collaborators" },
-  { "GET /repos/{owner}/{repo}/collaborators/{username}", "get_repo_collaborator" },
-  { "PUT /repos/{owner}/{repo}/collaborators/{username}", "put_repo_collaborator" },
-  { "DELETE /repos/{owner}/{repo}/collaborators/{username}", "delete_repo_collaborator" },
-  {
-    "GET /repos/{owner}/{repo}/collaborators/{username}/permission",
-    "get_repo_collaborator_permission",
-  },
-
-  -- Forks (https://docs.github.com/en/rest/repos/forks)
-  { "GET /repos/{owner}/{repo}/forks", "get_repo_forks" },
-  { "POST /repos/{owner}/{repo}/forks", "post_repo_forks" },
-
-  -- Merges (https://docs.github.com/en/rest/branches/merging)
-  { "POST /repos/{owner}/{repo}/merges", "post_repo_merges" },
-  { "POST /repos/{owner}/{repo}/merge-upstream", "post_repo_merge_upstream" },
-
-  { group = "releases" },
-  -- Releases (https://docs.github.com/en/rest/releases)
-  { "GET /repos/{owner}/{repo}/releases", "get_repo_releases" },
-  { "POST /repos/{owner}/{repo}/releases", "post_repo_releases" },
-  { "GET /repos/{owner}/{repo}/releases/latest", "get_repo_release_latest" },
-  { "GET /repos/{owner}/{repo}/releases/tags/{tag}", "get_repo_release_by_tag" },
-  { "GET /repos/{owner}/{repo}/releases/{release_id}", "get_repo_release" },
-  { "PATCH /repos/{owner}/{repo}/releases/{release_id}", "patch_repo_release" },
-  { "DELETE /repos/{owner}/{repo}/releases/{release_id}", "delete_repo_release" },
-  { "GET /repos/{owner}/{repo}/releases/{release_id}/assets", "get_repo_release_assets" },
-  { "POST /repos/{owner}/{repo}/releases/{release_id}/assets", "post_repo_release_assets" },
-  { "GET /repos/{owner}/{repo}/releases/assets/{asset_id}", "get_repo_release_asset" },
-  { "PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}", "patch_repo_release_asset" },
-  { "DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}", "delete_repo_release_asset" },
-
-  { group = "repos-ext" },
-  -- Deploy keys (https://docs.github.com/en/rest/deploy-keys)
-  { "GET /repos/{owner}/{repo}/keys", "get_repo_keys" },
-  { "POST /repos/{owner}/{repo}/keys", "post_repo_keys" },
-  { "GET /repos/{owner}/{repo}/keys/{key_id}", "get_repo_key" },
-  { "DELETE /repos/{owner}/{repo}/keys/{key_id}", "delete_repo_key" },
-
-  -- Webhooks (https://docs.github.com/en/rest/repos/webhooks)
-  { "GET /repos/{owner}/{repo}/hooks", "get_repo_hooks" },
-  { "POST /repos/{owner}/{repo}/hooks", "post_repo_hooks" },
-  { "GET /repos/{owner}/{repo}/hooks/{hook_id}", "get_repo_hook" },
-  { "PATCH /repos/{owner}/{repo}/hooks/{hook_id}", "patch_repo_hook" },
-  { "DELETE /repos/{owner}/{repo}/hooks/{hook_id}", "delete_repo_hook" },
-  { "GET /repos/{owner}/{repo}/hooks/{hook_id}/config", "get_repo_hook_config" },
-  { "PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config", "patch_repo_hook_config" },
-  { "POST /repos/{owner}/{repo}/hooks/{hook_id}/pings", "post_repo_hook_ping" },
-  { "POST /repos/{owner}/{repo}/hooks/{hook_id}/tests", "post_repo_hook_test" },
-
-  -- Statistics (https://docs.github.com/en/rest/metrics/statistics)
-  { "GET /repos/{owner}/{repo}/stats/code_frequency", "get_repo_stats_code_frequency" },
-  { "GET /repos/{owner}/{repo}/stats/commit_activity", "get_repo_stats_commit_activity" },
-  { "GET /repos/{owner}/{repo}/stats/contributors", "get_repo_stats_contributors" },
-  { "GET /repos/{owner}/{repo}/stats/participation", "get_repo_stats_participation" },
-  { "GET /repos/{owner}/{repo}/stats/punch_card", "get_repo_stats_punch_card" },
-
-  -- Traffic (https://docs.github.com/en/rest/metrics/traffic)
-  { "GET /repos/{owner}/{repo}/traffic/clones", "get_repo_traffic_clones" },
-  { "GET /repos/{owner}/{repo}/traffic/popular/paths", "get_repo_traffic_paths" },
-  { "GET /repos/{owner}/{repo}/traffic/popular/referrers", "get_repo_traffic_referrers" },
-  { "GET /repos/{owner}/{repo}/traffic/views", "get_repo_traffic_views" },
-
-  -- Invitations (https://docs.github.com/en/rest/collaborators/invitations)
-  { "GET /repos/{owner}/{repo}/invitations", "get_repo_invitations" },
-  { "PATCH /repos/{owner}/{repo}/invitations/{invitation_id}", "patch_repo_invitation" },
-  { "DELETE /repos/{owner}/{repo}/invitations/{invitation_id}", "delete_repo_invitation" },
-  { "GET /user/repository_invitations", "get_user_repo_invitations" },
-  { "PATCH /user/repository_invitations/{invitation_id}", "patch_user_repo_invitation" },
-  { "DELETE /user/repository_invitations/{invitation_id}", "delete_user_repo_invitation" },
-
-  -- Deployments (https://docs.github.com/en/rest/deployments)
-  { "GET /repos/{owner}/{repo}/deployments", "get_repo_deployments" },
-  { "POST /repos/{owner}/{repo}/deployments", "post_repo_deployments" },
-  { "GET /repos/{owner}/{repo}/deployments/{deployment_id}", "get_repo_deployment" },
-  { "DELETE /repos/{owner}/{repo}/deployments/{deployment_id}", "delete_repo_deployment" },
-  {
-    "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
-    "get_repo_deployment_statuses",
-  },
-  {
-    "POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
-    "post_repo_deployment_status",
-  },
-  {
-    "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}",
-    "get_repo_deployment_status",
-  },
-
-  { group = "teams" },
-  -- Teams (https://docs.github.com/en/rest/teams)
-  { "GET /orgs/{org}/teams", "get_org_teams", empty_list },
-  { "POST /orgs/{org}/teams", "post_org_teams" },
-  { "GET /orgs/{org}/teams/{team_slug}", "get_org_team" },
-  { "PATCH /orgs/{org}/teams/{team_slug}", "patch_org_team" },
-  { "DELETE /orgs/{org}/teams/{team_slug}", "delete_org_team" },
-  { "GET /orgs/{org}/teams/{team_slug}/invitations", "get_org_team_invitations", empty_list },
-  { "GET /orgs/{org}/teams/{team_slug}/members", "get_org_team_members", empty_list },
-  { "GET /orgs/{org}/teams/{team_slug}/memberships/{username}", "get_org_team_membership" },
-  { "PUT /orgs/{org}/teams/{team_slug}/memberships/{username}", "put_org_team_membership" },
-  { "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}", "delete_org_team_membership" },
-  { "GET /orgs/{org}/teams/{team_slug}/repos", "get_org_team_repos", empty_list },
-  { "GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "get_org_team_repo" },
-  { "PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "put_org_team_repo" },
-  { "DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "delete_org_team_repo" },
-  { "GET /orgs/{org}/teams/{team_slug}/teams", "get_org_team_children", empty_list },
-
-  -- Legacy team endpoints (team_id-based) — deprecated in favour of slug-based above
-  { "GET /user/teams", "get_user_teams", empty_list },
-  { "GET /teams/{team_id}", "get_team" },
-  { "PATCH /teams/{team_id}", "patch_team" },
-  { "DELETE /teams/{team_id}", "delete_team" },
-  { "GET /teams/{team_id}/invitations", "get_team_invitations", empty_list },
-  { "GET /teams/{team_id}/members", "get_team_members", empty_list },
-  { "GET /teams/{team_id}/members/{username}", "get_team_member" },
-  { "PUT /teams/{team_id}/members/{username}", "put_team_member" },
-  { "DELETE /teams/{team_id}/members/{username}", "delete_team_member" },
-  { "GET /teams/{team_id}/memberships/{username}", "get_team_membership" },
-  { "PUT /teams/{team_id}/memberships/{username}", "put_team_membership" },
-  { "DELETE /teams/{team_id}/memberships/{username}", "delete_team_membership" },
-  { "GET /teams/{team_id}/repos", "get_team_repos", empty_list },
-  { "GET /teams/{team_id}/repos/{owner}/{repo}", "get_team_repo" },
-  { "PUT /teams/{team_id}/repos/{owner}/{repo}", "put_team_repo" },
-  { "DELETE /teams/{team_id}/repos/{owner}/{repo}", "delete_team_repo" },
-  { "GET /teams/{team_id}/teams", "get_team_children", empty_list },
-
-  { group = "security-advisories" },
-  -- Security advisories (https://docs.github.com/en/rest/security-advisories)
-  { "GET /advisories", "get_global_advisories", empty_list },
-  { "GET /advisories/{ghsa_id}", "get_global_advisory" },
-  { "GET /orgs/{org}/security-advisories", "get_org_security_advisories", empty_list },
-  { "GET /repos/{owner}/{repo}/security-advisories", "get_repo_security_advisories", empty_list },
-  { "POST /repos/{owner}/{repo}/security-advisories", "post_repo_security_advisory" },
-  {
-    "POST /repos/{owner}/{repo}/security-advisories/reports",
-    "post_repo_security_advisory_report",
-  },
-  { "GET /repos/{owner}/{repo}/security-advisories/{ghsa_id}", "get_repo_security_advisory" },
-  { "PATCH /repos/{owner}/{repo}/security-advisories/{ghsa_id}", "patch_repo_security_advisory" },
-  {
-    "POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/cve",
-    "post_repo_security_advisory_cve",
-  },
-  {
-    "POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/forks",
-    "post_repo_security_advisory_fork",
-  },
-
-  { group = "issues" },
-  -- Issues (https://docs.github.com/en/rest/issues)
-  { "GET /issues", "get_issues", empty_list },
-  { "GET /orgs/{org}/issues", "get_org_issues", empty_list },
-  { "GET /user/issues", "get_user_issues", empty_list },
-  { "GET /repos/{owner}/{repo}/issues", "get_repo_issues", empty_list },
-  { "POST /repos/{owner}/{repo}/issues", "post_repo_issues" },
-  { "GET /repos/{owner}/{repo}/issues/comments", "get_repo_issue_comments", empty_list },
-  { "GET /repos/{owner}/{repo}/issues/comments/{comment_id}", "get_repo_issue_comment" },
-  { "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", "patch_repo_issue_comment" },
-  { "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}", "delete_repo_issue_comment" },
-  { "PUT /repos/{owner}/{repo}/issues/comments/{comment_id}/pin", "put_repo_issue_comment_pin" },
-  {
-    "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/pin",
-    "delete_repo_issue_comment_pin",
-  },
-  { "GET /repos/{owner}/{repo}/issues/events", "get_repo_issue_events", empty_list },
-  { "GET /repos/{owner}/{repo}/issues/events/{event_id}", "get_repo_issue_event" },
-  { "GET /repos/{owner}/{repo}/issues/{issue_number}", "get_repo_issue" },
-  { "PATCH /repos/{owner}/{repo}/issues/{issue_number}", "patch_repo_issue" },
-  { "POST /repos/{owner}/{repo}/issues/{issue_number}/assignees", "post_issue_assignees" },
-  { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees", "delete_issue_assignees" },
-  { "GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}", "get_issue_assignee" },
-  { "GET /repos/{owner}/{repo}/issues/{issue_number}/comments", "get_issue_comments", empty_list },
-  { "POST /repos/{owner}/{repo}/issues/{issue_number}/comments", "post_issue_comment" },
-  {
-    "GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by",
-    "get_issue_deps_blocked_by",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by",
-    "post_issue_deps_blocked_by",
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by/{issue_id}",
-    "delete_issue_dep_blocked_by",
-  },
-  {
-    "GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocking",
-    "get_issue_deps_blocking",
-    empty_list,
-  },
-  { "GET /repos/{owner}/{repo}/issues/{issue_number}/events", "get_issue_events", empty_list },
-  {
-    "GET /repos/{owner}/{repo}/issues/{issue_number}/issue-field-values",
-    "get_issue_field_values",
-    empty_list,
-  },
-  { "GET /repos/{owner}/{repo}/issues/{issue_number}/labels", "get_issue_labels", empty_list },
-  { "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", "post_issue_labels" },
-  { "PUT /repos/{owner}/{repo}/issues/{issue_number}/labels", "put_issue_labels" },
-  { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels", "delete_issue_labels" },
-  { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}", "delete_issue_label" },
-  { "PUT /repos/{owner}/{repo}/issues/{issue_number}/lock", "put_issue_lock" },
-  { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock", "delete_issue_lock" },
-  { "GET /repos/{owner}/{repo}/issues/{issue_number}/parent", "get_issue_parent" },
-  {
-    "GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues",
-    "get_issue_sub_issues",
-    empty_list,
-  },
-  { "POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues", "post_issue_sub_issues" },
-  { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/sub_issue", "delete_issue_sub_issue" },
-  {
-    "PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority",
-    "patch_issue_sub_issues_priority",
-  },
-  { "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline", "get_issue_timeline", empty_list },
-
-  -- Assignees (https://docs.github.com/en/rest/issues/assignees)
-  { "GET /repos/{owner}/{repo}/assignees", "get_repo_assignees", empty_list },
-  { "GET /repos/{owner}/{repo}/assignees/{assignee}", "get_repo_assignee" },
-
-  -- Labels (https://docs.github.com/en/rest/issues/labels)
-  { "GET /repos/{owner}/{repo}/labels", "get_repo_labels", empty_list },
-  { "POST /repos/{owner}/{repo}/labels", "post_repo_labels" },
-  { "GET /repos/{owner}/{repo}/labels/{name}", "get_repo_label" },
-  { "PATCH /repos/{owner}/{repo}/labels/{name}", "patch_repo_label" },
-  { "DELETE /repos/{owner}/{repo}/labels/{name}", "delete_repo_label" },
-
-  -- Milestones (https://docs.github.com/en/rest/issues/milestones)
-  { "GET /repos/{owner}/{repo}/milestones", "get_repo_milestones", empty_list },
-  { "POST /repos/{owner}/{repo}/milestones", "post_repo_milestones" },
-  { "GET /repos/{owner}/{repo}/milestones/{milestone_number}", "get_repo_milestone" },
-  { "PATCH /repos/{owner}/{repo}/milestones/{milestone_number}", "patch_repo_milestone" },
-  { "DELETE /repos/{owner}/{repo}/milestones/{milestone_number}", "delete_repo_milestone" },
-  {
-    "GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels",
-    "get_repo_milestone_labels",
-    empty_list,
-  },
-
-  -- Issue field values via repository_id (GitHub-specific)
-  {
-    "POST /repositories/{repository_id}/issues/{issue_number}/issue-field-values",
-    "post_repository_issue_field_values",
-  },
-  {
-    "PUT /repositories/{repository_id}/issues/{issue_number}/issue-field-values",
-    "put_repository_issue_field_values",
-  },
-  {
-    "DELETE /repositories/{repository_id}/issues/{issue_number}/issue-field-values/{issue_field_id}",
-    "delete_repository_issue_field_value",
-  },
-
-  { group = "pulls" },
-  -- Pull Requests (https://docs.github.com/en/rest/pulls)
-  { "GET /repos/{owner}/{repo}/pulls", "get_repo_pulls", empty_list },
-  { "POST /repos/{owner}/{repo}/pulls", "post_repo_pulls" },
-  { "GET /repos/{owner}/{repo}/pulls/comments", "get_repo_pull_comments", empty_list },
-  { "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}", "get_repo_pull_comment" },
-  { "PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}", "patch_repo_pull_comment" },
-  { "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}", "delete_repo_pull_comment" },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}", "get_repo_pull" },
-  { "PATCH /repos/{owner}/{repo}/pulls/{pull_number}", "patch_repo_pull" },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}/codespaces", "get_pull_codespaces", empty_list },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments", "get_pull_comments", empty_list },
-  { "POST /repos/{owner}/{repo}/pulls/{pull_number}/comments", "post_pull_comment" },
-  {
-    "POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies",
-    "post_pull_comment_reply",
-  },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits", "get_pull_commits", empty_list },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}/files", "get_pull_files", empty_list },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}/merge", "get_pull_merge" },
-  { "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge", "put_pull_merge" },
-  {
-    "GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
-    "get_pull_requested_reviewers",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
-    "post_pull_requested_reviewers",
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
-    "delete_pull_requested_reviewers",
-  },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews", "get_pull_reviews", empty_list },
-  { "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews", "post_pull_review" },
-  { "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "get_pull_review" },
-  { "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "put_pull_review" },
-  { "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "delete_pull_review" },
-  {
-    "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
-    "get_pull_review_comments",
-    empty_list,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals",
-    "put_pull_review_dismissal",
-  },
-  {
-    "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events",
-    "post_pull_review_event",
-  },
-  { "POST /repos/{owner}/{repo}/pulls/{pull_number}/update-branch", "post_pull_update_branch" },
-  { "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls", "get_commit_pulls", empty_list },
-
-
-  -- Reactions (https://docs.github.com/en/rest/reactions)
-  { group = "reactions" },
-  {
-    "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
-    "get_repo_pull_comment_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
-    "post_repo_pull_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
-    "delete_repo_pull_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/issues/{issue_number}/reactions",
-    "get_issue_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/issues/{issue_number}/reactions",
-    "post_issue_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",
-    "delete_issue_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
-    "get_repo_issue_comment_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
-    "post_repo_issue_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",
-    "delete_repo_issue_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/releases/{release_id}/reactions",
-    "get_repo_release_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/releases/{release_id}/reactions",
-    "post_repo_release_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}",
-    "delete_repo_release_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/comments/{comment_id}/reactions",
-    "get_repo_comment_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/comments/{comment_id}/reactions",
-    "post_repo_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}",
-    "delete_repo_comment_reaction",
-    reactions_not_implemented,
-  },
-  { group = "users" },
-  -- Users (https://docs.github.com/en/rest/users)
-  { "GET /user", "get_user" },
-  { "PATCH /user", "patch_user" },
-  { "GET /user/{account_id}", "get_user_by_id" },
-  { "GET /users", "get_users" },
-  { "GET /users/{username}", "get_users_username" },
-  { "GET /users/{username}/hovercard", "get_users_hovercard" },
-
-  -- Blocking
-  { "GET /user/blocks", "get_user_blocks" },
-  { "GET /user/blocks/{username}", "get_user_block" },
-  { "PUT /user/blocks/{username}", "put_user_block" },
-  { "DELETE /user/blocks/{username}", "delete_user_block" },
-
-  -- Emails
-  { "GET /user/emails", "get_user_emails" },
-  { "POST /user/emails", "post_user_emails" },
-  { "DELETE /user/emails", "delete_user_emails" },
-  { "PATCH /user/email/visibility", "patch_user_email_visibility" },
-  { "GET /user/public_emails", "get_user_public_emails" },
-
-  -- Followers
-  { "GET /user/followers", "get_user_followers" },
-  { "GET /user/following", "get_user_following" },
-  { "GET /user/following/{username}", "get_user_is_following" },
-  { "PUT /user/following/{username}", "put_user_following" },
-  { "DELETE /user/following/{username}", "delete_user_following" },
-  { "GET /users/{username}/followers", "get_users_followers" },
-  { "GET /users/{username}/following", "get_users_following" },
-  { "GET /users/{username}/following/{target_user}", "get_users_is_following" },
-
-  -- GPG Keys
-  { "GET /user/gpg_keys", "get_user_gpg_keys" },
-  { "POST /user/gpg_keys", "post_user_gpg_keys" },
-  { "GET /user/gpg_keys/{gpg_key_id}", "get_user_gpg_key" },
-  { "DELETE /user/gpg_keys/{gpg_key_id}", "delete_user_gpg_key" },
-  { "GET /users/{username}/gpg_keys", "get_users_gpg_keys" },
-
-  -- SSH Keys
-  { "GET /user/keys", "get_user_keys" },
-  { "POST /user/keys", "post_user_keys" },
-  { "GET /user/keys/{key_id}", "get_user_key" },
-  { "DELETE /user/keys/{key_id}", "delete_user_key" },
-  { "GET /users/{username}/keys", "get_users_keys" },
-
-  -- Social Accounts
-  { "GET /user/social_accounts", "get_user_social_accounts" },
-  { "POST /user/social_accounts", "post_user_social_accounts" },
-  { "DELETE /user/social_accounts", "delete_user_social_accounts" },
-  { "GET /users/{username}/social_accounts", "get_users_social_accounts" },
-
-  -- SSH Signing Keys
-  { "GET /user/ssh_signing_keys", "get_user_ssh_signing_keys" },
-  { "POST /user/ssh_signing_keys", "post_user_ssh_signing_keys" },
-  { "GET /user/ssh_signing_keys/{ssh_signing_key_id}", "get_user_ssh_signing_key" },
-  { "DELETE /user/ssh_signing_keys/{ssh_signing_key_id}", "delete_user_ssh_signing_key" },
-  { "GET /users/{username}/ssh_signing_keys", "get_users_ssh_signing_keys" },
-
-  { group = "search" },
-  -- Search (https://docs.github.com/en/rest/search)
-  { "GET /search/code", "search_code", search_empty },
-  { "GET /search/commits", "search_commits", search_empty },
-  { "GET /search/issues", "search_issues", search_empty },
-  { "GET /search/labels", "search_labels", search_empty },
-  { "GET /search/repositories", "search_repositories", search_empty },
-  { "GET /search/topics", "search_topics", search_empty },
-  { "GET /search/users", "search_users", search_empty },
-
-  { group = "apps" },
-  -- Apps (https://docs.github.com/en/rest/apps)
-  { "GET /app", "get_app" },
-  { "GET /app/hook/config", "get_app_hook_config" },
-  { "PATCH /app/hook/config", "patch_app_hook_config" },
-  { "GET /app/hook/deliveries", "get_app_hook_deliveries" },
-  { "GET /app/hook/deliveries/{delivery_id}", "get_app_hook_delivery" },
-  { "POST /app/hook/deliveries/{delivery_id}/attempts", "post_app_hook_delivery_attempt" },
-  { "GET /app/installation-requests", "get_app_installation_requests" },
-  { "GET /app/installations", "get_app_installations" },
-  { "GET /app/installations/{installation_id}", "get_app_installation" },
-  { "DELETE /app/installations/{installation_id}", "delete_app_installation" },
-  {
-    "POST /app/installations/{installation_id}/access_tokens",
-    "post_app_installation_access_tokens",
-  },
-  { "PUT /app/installations/{installation_id}/suspended", "put_app_installation_suspended" },
-  { "DELETE /app/installations/{installation_id}/suspended", "delete_app_installation_suspended" },
-  { "GET /apps/{app_slug}", "get_apps_app_slug" },
-  { "POST /app-manifests/{code}/conversions", "post_app_manifest_conversions" },
-  { "GET /installation/repositories", "get_installation_repositories" },
-  { "DELETE /installation/token", "delete_installation_token" },
-  { "POST /applications/{client_id}/token", "post_applications_token" },
-  { "PATCH /applications/{client_id}/token", "patch_applications_token" },
-  { "DELETE /applications/{client_id}/token", "delete_applications_token" },
-  { "POST /applications/{client_id}/token/scoped", "post_applications_token_scoped" },
-  { "DELETE /applications/{client_id}/grant", "delete_applications_grant" },
-  { "GET /orgs/{org}/installation", "get_org_installation" },
-  { "GET /orgs/{org}/installations", "get_org_installations" },
-  { "GET /repos/{owner}/{repo}/installation", "get_repo_installation" },
-  { "GET /user/installations", "get_user_installations" },
-  {
-    "GET /user/installations/{installation_id}/repositories",
-    "get_user_installation_repositories",
-  },
-  {
-    "PUT /user/installations/{installation_id}/repositories/{repository_id}",
-    "put_user_installation_repository",
-  },
-  {
-    "DELETE /user/installations/{installation_id}/repositories/{repository_id}",
-    "delete_user_installation_repository",
-  },
-  { "GET /users/{username}/installation", "get_users_installation" },
-
-  { group = "checks" },
-  -- Checks (https://docs.github.com/en/rest/checks)
-  {
-    "POST /repos/{owner}/{repo}/check-runs",
-    "post_check_runs",
-    function(_owner, _repo_name)
-      local req = DecodeJson(GetBody() or "{}")
-      respond_json(201, {
-        id = 0,
-        node_id = "",
-        head_sha = req.head_sha or "",
-        name = req.name or "",
-        status = req.status or "queued",
-        conclusion = req.conclusion,
-        started_at = nil,
-        completed_at = nil,
-        output = {
-          title = (req.output and req.output.title) or "",
-          summary = (req.output and req.output.summary) or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = "",
-        details_url = req.details_url or "",
-      })
-    end,
-  },
-  {
-    "GET /repos/{owner}/{repo}/check-runs/{check_run_id}",
-    "get_check_run",
-    function(_owner, _repo_name, check_run_id)
-      respond_json(200, {
-        id = tonumber(check_run_id) or 0,
-        node_id = "",
-        head_sha = "",
-        name = "",
-        status = "completed",
-        conclusion = "success",
-        started_at = nil,
-        completed_at = nil,
-        output = {
-          title = "",
-          summary = "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = "",
-        details_url = "",
-      })
-    end,
-  },
-  {
-    "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
-    "patch_check_run",
-    function(_owner, _repo_name, check_run_id)
-      respond_json(200, {
-        id = tonumber(check_run_id) or 0,
-        node_id = "",
-        head_sha = "",
-        name = "",
-        status = "completed",
-        conclusion = "success",
-        started_at = nil,
-        completed_at = nil,
-        output = {
-          title = "",
-          summary = "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = "",
-        details_url = "",
-      })
-    end,
-  },
-  {
-    "GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
-    "get_check_run_annotations",
-    function(_owner, _repo_name, _check_run_id)
-      set_preamble()
-      Write("[]")
-    end,
-  },
-  {
-    "POST /repos/{owner}/{repo}/check-runs/{check_run_id}/rerequest",
-    "post_check_run_rerequest",
-    function(_owner, _repo_name, _check_run_id)
-      respond_json(201, {})
-    end,
-  },
-  {
-    "POST /repos/{owner}/{repo}/check-suites",
-    "post_check_suites",
-    function(owner, repo_name)
-      local req = DecodeJson(GetBody() or "{}")
-      respond_json(201, {
-        id = 0,
-        node_id = "",
-        head_sha = req.head_sha or "",
-        status = "completed",
-        conclusion = "success",
-        app = { id = 0, slug = "", name = "" },
-        repository = { full_name = owner .. "/" .. repo_name },
-      })
-    end,
-  },
-  {
-    "PATCH /repos/{owner}/{repo}/check-suites/preferences",
-    "patch_check_suites_preferences",
-    function(_owner, _repo_name) -- luacheck: ignore 212
-      local req = DecodeJson(GetBody() or "{}") or {}
-      respond_json(200, {
-        preferences = req.auto_trigger_checks or {},
-      })
-    end,
-  },
-  {
-    "GET /repos/{owner}/{repo}/check-suites/{check_suite_id}",
-    "get_check_suite",
-    function(owner, repo_name, check_suite_id)
-      respond_json(200, {
-        id = tonumber(check_suite_id) or 0,
-        node_id = "",
-        head_sha = "",
-        status = "completed",
-        conclusion = "success",
-        app = { id = 0, slug = "", name = "" },
-        repository = { full_name = owner .. "/" .. repo_name },
-      })
-    end,
-  },
-  {
-    "GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",
-    "get_check_suite_check_runs",
-    function(_owner, _repo_name, _check_suite_id)
-      respond_json(200, { total_count = 0, check_runs = {} })
-    end,
-  },
-  {
-    "POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest",
-    "post_check_suite_rerequest",
-    function(_owner, _repo_name, _check_suite_id)
-      respond_json(201, {})
-    end,
-  },
-  {
-    "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
-    "get_commit_check_runs",
-    function(_owner, _repo_name, _ref)
-      respond_json(200, { total_count = 0, check_runs = {} })
-    end,
-  },
-  {
-    "GET /repos/{owner}/{repo}/commits/{ref}/check-suites",
-    "get_commit_check_suites",
-    function(_owner, _repo_name, _ref)
-      respond_json(200, { total_count = 0, check_suites = {} })
-    end,
-  },
-
-  { group = "code-scanning" },
-  -- Code Scanning (https://docs.github.com/en/rest/code-scanning)
-  {
-    "GET /orgs/{org}/code-scanning/alerts",
-    "list_org_code_scanning_alerts",
-    code_scanning_list_empty,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/alerts",
-    "list_repo_code_scanning_alerts",
-    code_scanning_list_empty,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
-    "get_code_scanning_alert",
-    code_scanning_not_implemented,
-  },
-  {
-    "PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
-    "update_code_scanning_alert",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix",
-    "get_code_scanning_autofix",
-    code_scanning_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix",
-    "create_code_scanning_autofix",
-    code_scanning_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix/commits",
-    "commit_code_scanning_autofix",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances",
-    "list_code_scanning_alert_instances",
-    code_scanning_list_empty,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/analyses",
-    "list_code_scanning_analyses",
-    code_scanning_list_empty,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",
-    "get_code_scanning_analysis",
-    code_scanning_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",
-    "delete_code_scanning_analysis",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/codeql/databases",
-    "list_codeql_databases",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/codeql/databases/{language}",
-    "get_codeql_database",
-    code_scanning_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/code-scanning/codeql/databases/{language}",
-    "delete_codeql_database",
-    code_scanning_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/code-scanning/codeql/variant-analyses",
-    "create_codeql_variant_analysis",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/codeql/variant-analyses/{codeql_variant_analysis_id}",
-    "get_codeql_variant_analysis",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/codeql/variant-analyses/{codeql_variant_analysis_id}/repos/{repo_owner}/{repo_name}",
-    "get_codeql_variant_analysis_repo_task",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/default-setup",
-    "get_code_scanning_default_setup",
-    code_scanning_not_implemented,
-  },
-  {
-    "PATCH /repos/{owner}/{repo}/code-scanning/default-setup",
-    "update_code_scanning_default_setup",
-    code_scanning_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/code-scanning/sarifs",
-    "upload_code_scanning_sarif",
-    code_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}",
-    "get_code_scanning_sarif",
-    code_scanning_not_implemented,
-  },
-
-  { group = "secret-scanning" },
-  -- Secret Scanning (https://docs.github.com/en/rest/secret-scanning)
-  {
-    "GET /orgs/{org}/secret-scanning/alerts",
-    "list_org_secret_scanning_alerts",
-    secret_scanning_list_empty,
-  },
-  {
-    "GET /orgs/{org}/secret-scanning/pattern-configurations",
-    "get_org_secret_scanning_pattern_configs",
-    secret_scanning_not_implemented,
-  },
-  {
-    "PATCH /orgs/{org}/secret-scanning/pattern-configurations",
-    "update_org_secret_scanning_pattern_configs",
-    secret_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/secret-scanning/alerts",
-    "list_repo_secret_scanning_alerts",
-    secret_scanning_list_empty,
-  },
-  {
-    "GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
-    "get_secret_scanning_alert",
-    secret_scanning_not_implemented,
-  },
-  {
-    "PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
-    "update_secret_scanning_alert",
-    secret_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations",
-    "list_secret_scanning_alert_locations",
-    secret_scanning_list_empty,
-  },
-  {
-    "POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses",
-    "create_secret_scanning_push_protection_bypass",
-    secret_scanning_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/secret-scanning/scan-history",
-    "get_secret_scanning_scan_history",
-    secret_scanning_not_implemented,
-  },
-
-  { group = "dependabot" },
-  -- Dependabot (https://docs.github.com/en/rest/dependabot)
-  {
-    "GET /enterprises/{enterprise}/dependabot/alerts",
-    "list_enterprise_dependabot_alerts",
-    dependabot_list_empty,
-  },
-  { "GET /orgs/{org}/dependabot/alerts", "list_org_dependabot_alerts", dependabot_list_empty },
-  {
-    "GET /orgs/{org}/dependabot/secrets",
-    "list_org_dependabot_secrets",
-    make_empty_collection("secrets"),
-  },
-  {
-    "GET /orgs/{org}/dependabot/secrets/public-key",
-    "get_org_dependabot_public_key",
-    dependabot_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/dependabot/secrets/{secret_name}",
-    "get_org_dependabot_secret",
-    dependabot_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/dependabot/secrets/{secret_name}",
-    "put_org_dependabot_secret",
-    dependabot_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/dependabot/secrets/{secret_name}",
-    "delete_org_dependabot_secret",
-    dependabot_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories",
-    "list_org_dependabot_secret_repos",
-    make_empty_collection("repositories"),
-  },
-  {
-    "PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories",
-    "put_org_dependabot_secret_repos",
-    dependabot_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",
-    "add_org_dependabot_secret_repo",
-    dependabot_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",
-    "remove_org_dependabot_secret_repo",
-    dependabot_not_implemented,
-  },
-  {
-    "GET /organizations/{org}/dependabot/repository-access",
-    "get_org_dependabot_repo_access",
-    dependabot_not_implemented,
-  },
-  {
-    "PATCH /organizations/{org}/dependabot/repository-access",
-    "update_org_dependabot_repo_access",
-    dependabot_not_implemented,
-  },
-  {
-    "PUT /organizations/{org}/dependabot/repository-access/default-level",
-    "set_org_dependabot_repo_access_default_level",
-    dependabot_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/dependabot/alerts",
-    "list_repo_dependabot_alerts",
-    dependabot_list_empty,
-  },
-  {
-    "GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
-    "get_repo_dependabot_alert",
-    dependabot_not_implemented,
-  },
-  {
-    "PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
-    "update_repo_dependabot_alert",
-    dependabot_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/dependabot/secrets",
-    "list_repo_dependabot_secrets",
-    make_empty_collection("secrets"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/dependabot/secrets/public-key",
-    "get_repo_dependabot_public_key",
-    dependabot_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
-    "get_repo_dependabot_secret",
-    dependabot_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
-    "put_repo_dependabot_secret",
-    dependabot_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
-    "delete_repo_dependabot_secret",
-    dependabot_not_implemented,
-  },
-
-  { group = "dependency-graph" },
-  -- Dependency Graph (https://docs.github.com/en/rest/dependency-graph)
-  {
-    "GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}",
-    "get_repo_dependency_graph_compare",
-    dependency_graph_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/dependency-graph/sbom",
-    "get_repo_dependency_graph_sbom",
-    dependency_graph_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/dependency-graph/snapshots",
-    "post_repo_dependency_graph_snapshots",
-    dependency_graph_not_implemented,
-  },
-
-  { group = "projects" },
-  -- Projects (https://docs.github.com/en/rest/projects)
-  { "GET /orgs/{org}/projectsV2", "projects_list_for_org", projects_list_empty },
-  {
-    "GET /orgs/{org}/projectsV2/{project_number}",
-    "projects_get_for_org",
-    projects_not_implemented,
-  },
-  {
-    "POST /orgs/{org}/projectsV2/{project_number}/drafts",
-    "projects_create_draft_item_for_org",
-    projects_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/projectsV2/{project_number}/fields",
-    "projects_list_fields_for_org",
-    projects_list_empty,
-  },
-  {
-    "POST /orgs/{org}/projectsV2/{project_number}/fields",
-    "projects_add_field_for_org",
-    projects_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/projectsV2/{project_number}/fields/{field_id}",
-    "projects_get_field_for_org",
-    projects_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/projectsV2/{project_number}/items",
-    "projects_list_items_for_org",
-    projects_list_empty,
-  },
-  {
-    "POST /orgs/{org}/projectsV2/{project_number}/items",
-    "projects_add_item_for_org",
-    projects_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/projectsV2/{project_number}/items/{item_id}",
-    "projects_get_item_for_org",
-    projects_not_implemented,
-  },
-  {
-    "PATCH /orgs/{org}/projectsV2/{project_number}/items/{item_id}",
-    "projects_update_item_for_org",
-    projects_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/projectsV2/{project_number}/items/{item_id}",
-    "projects_delete_item_for_org",
-    projects_not_implemented,
-  },
-  {
-    "POST /orgs/{org}/projectsV2/{project_number}/views",
-    "projects_create_view_for_org",
-    projects_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/projectsV2/{project_number}/views/{view_number}/items",
-    "projects_list_view_items_for_org",
-    projects_list_empty,
-  },
-  {
-    "POST /user/{user_id}/projectsV2/{project_number}/drafts",
-    "projects_create_draft_item_for_user",
-    projects_not_implemented,
-  },
-  {
-    "POST /users/{user_id}/projectsV2/{project_number}/views",
-    "projects_create_view_for_user",
-    projects_not_implemented,
-  },
-  { "GET /users/{username}/projectsV2", "projects_list_for_user", projects_list_empty },
-  {
-    "GET /users/{username}/projectsV2/{project_number}",
-    "projects_get_for_user",
-    projects_not_implemented,
-  },
-  {
-    "GET /users/{username}/projectsV2/{project_number}/fields",
-    "projects_list_fields_for_user",
-    projects_list_empty,
-  },
-  {
-    "POST /users/{username}/projectsV2/{project_number}/fields",
-    "projects_add_field_for_user",
-    projects_not_implemented,
-  },
-  {
-    "GET /users/{username}/projectsV2/{project_number}/fields/{field_id}",
-    "projects_get_field_for_user",
-    projects_not_implemented,
-  },
-  {
-    "GET /users/{username}/projectsV2/{project_number}/items",
-    "projects_list_items_for_user",
-    projects_list_empty,
-  },
-  {
-    "POST /users/{username}/projectsV2/{project_number}/items",
-    "projects_add_item_for_user",
-    projects_not_implemented,
-  },
-  {
-    "GET /users/{username}/projectsV2/{project_number}/items/{item_id}",
-    "projects_get_item_for_user",
-    projects_not_implemented,
-  },
-  {
-    "PATCH /users/{username}/projectsV2/{project_number}/items/{item_id}",
-    "projects_update_item_for_user",
-    projects_not_implemented,
-  },
-  {
-    "DELETE /users/{username}/projectsV2/{project_number}/items/{item_id}",
-    "projects_delete_item_for_user",
-    projects_not_implemented,
-  },
-  {
-    "GET /users/{username}/projectsV2/{project_number}/views/{view_number}/items",
-    "projects_list_view_items_for_user",
-    projects_list_empty,
-  },
-
-  { group = "packages" },
-  -- Packages (https://docs.github.com/en/rest/packages)
-  { "GET /orgs/{org}/packages", "get_org_packages", empty_list },
-  { "GET /orgs/{org}/packages/{package_type}/{package_name}", "get_org_package" },
-  { "DELETE /orgs/{org}/packages/{package_type}/{package_name}", "delete_org_package" },
-  { "POST /orgs/{org}/packages/{package_type}/{package_name}/restore", "restore_org_package" },
-  {
-    "GET /orgs/{org}/packages/{package_type}/{package_name}/versions",
-    "get_org_package_versions",
-    empty_list,
-  },
-  {
-    "GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
-    "get_org_package_version",
-  },
-  {
-    "DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
-    "delete_org_package_version",
-  },
-  {
-    "POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
-    "restore_org_package_version",
-  },
-  { "GET /user/packages", "get_user_packages", empty_list },
-  { "GET /user/packages/{package_type}/{package_name}", "get_user_package" },
-  { "DELETE /user/packages/{package_type}/{package_name}", "delete_user_package" },
-  { "POST /user/packages/{package_type}/{package_name}/restore", "restore_user_package" },
-  {
-    "GET /user/packages/{package_type}/{package_name}/versions",
-    "get_user_package_versions",
-    empty_list,
-  },
-  {
-    "GET /user/packages/{package_type}/{package_name}/versions/{package_version_id}",
-    "get_user_package_version",
-  },
-  {
-    "DELETE /user/packages/{package_type}/{package_name}/versions/{package_version_id}",
-    "delete_user_package_version",
-  },
-  {
-    "POST /user/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
-    "restore_user_package_version",
-  },
-  { "GET /users/{username}/packages", "get_users_packages", empty_list },
-  { "GET /users/{username}/packages/{package_type}/{package_name}", "get_users_package" },
-  { "DELETE /users/{username}/packages/{package_type}/{package_name}", "delete_users_package" },
-  {
-    "POST /users/{username}/packages/{package_type}/{package_name}/restore",
-    "restore_users_package",
-  },
-  {
-    "GET /users/{username}/packages/{package_type}/{package_name}/versions",
-    "get_users_package_versions",
-    empty_list,
-  },
-  {
-    "GET /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",
-    "get_users_package_version",
-  },
-  {
-    "DELETE /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",
-    "delete_users_package_version",
-  },
-  {
-    "POST /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
-    "restore_users_package_version",
-  },
-
-  { group = "interactions" },
-  -- Interactions (https://docs.github.com/en/rest/interactions)
-  { "GET /orgs/{org}/interaction-limits", "get_org_interaction_limits", interaction_limits_empty },
-  { "PUT /orgs/{org}/interaction-limits", "put_org_interaction_limits", interaction_limits_put },
-  {
-    "DELETE /orgs/{org}/interaction-limits",
-    "delete_org_interaction_limits",
-    interaction_limits_delete,
-  },
-  {
-    "GET /repos/{owner}/{repo}/interaction-limits",
-    "get_repo_interaction_limits",
-    interaction_limits_empty,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/interaction-limits",
-    "put_repo_interaction_limits",
-    interaction_limits_put,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/interaction-limits",
-    "delete_repo_interaction_limits",
-    interaction_limits_delete,
-  },
-  { "GET /user/interaction-limits", "get_user_interaction_limits", interaction_limits_empty },
-  { "PUT /user/interaction-limits", "put_user_interaction_limits", interaction_limits_put },
-  {
-    "DELETE /user/interaction-limits",
-    "delete_user_interaction_limits",
-    interaction_limits_delete,
-  },
-
-  { group = "migrations" },
-  -- Migrations (https://docs.github.com/en/rest/migrations)
-  -- Organization migrations
-  { "GET /orgs/{org}/migrations", "get_org_migrations", empty_list },
-  { "POST /orgs/{org}/migrations", "post_org_migrations", migrations_not_supported },
-  { "GET /orgs/{org}/migrations/{migration_id}", "get_org_migration", migration_not_found },
-  {
-    "GET /orgs/{org}/migrations/{migration_id}/archive",
-    "get_org_migration_archive",
-    migration_not_found,
-  },
-  {
-    "DELETE /orgs/{org}/migrations/{migration_id}/archive",
-    "delete_org_migration_archive",
-    migration_not_found,
-  },
-  {
-    "DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock",
-    "delete_org_migration_repo_lock",
-    migration_not_found,
-  },
-  {
-    "GET /orgs/{org}/migrations/{migration_id}/repositories",
-    "get_org_migration_repos",
-    empty_list,
-  },
-
-  -- User migrations
-  { "GET /user/migrations", "get_user_migrations", empty_list },
-  { "POST /user/migrations", "post_user_migrations", migrations_not_supported },
-  { "GET /user/migrations/{migration_id}", "get_user_migration", migration_not_found },
-  {
-    "GET /user/migrations/{migration_id}/archive",
-    "get_user_migration_archive",
-    migration_not_found,
-  },
-  {
-    "DELETE /user/migrations/{migration_id}/archive",
-    "delete_user_migration_archive",
-    migration_not_found,
-  },
-  {
-    "DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock",
-    "delete_user_migration_repo_lock",
-    migration_not_found,
-  },
-  { "GET /user/migrations/{migration_id}/repositories", "get_user_migration_repos", empty_list },
-
-  { group = "pages" },
-  -- Pages (https://docs.github.com/en/rest/pages)
-  { "GET /repos/{owner}/{repo}/pages", "get_repo_pages", pages_not_implemented },
-  { "POST /repos/{owner}/{repo}/pages", "post_repo_pages", pages_not_implemented },
-  { "PUT /repos/{owner}/{repo}/pages", "put_repo_pages", pages_not_implemented },
-  { "DELETE /repos/{owner}/{repo}/pages", "delete_repo_pages", pages_not_implemented },
-  { "GET /repos/{owner}/{repo}/pages/builds", "get_repo_pages_builds", empty_list },
-  { "POST /repos/{owner}/{repo}/pages/builds", "post_repo_pages_builds", pages_not_implemented },
-  {
-    "GET /repos/{owner}/{repo}/pages/builds/latest",
-    "get_repo_pages_build_latest",
-    pages_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/pages/builds/{build_id}",
-    "get_repo_pages_build",
-    pages_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/pages/deployments",
-    "post_repo_pages_deployments",
-    pages_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}",
-    "get_repo_pages_deployment",
-    pages_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}/cancel",
-    "post_repo_pages_deployment_cancel",
-    pages_not_implemented,
-  },
-  { "GET /repos/{owner}/{repo}/pages/health", "get_repo_pages_health", pages_not_implemented },
-
-  -- Source imports (deprecated May 2023 — returns 410 Gone)
-  { "GET /repos/{owner}/{repo}/import", "get_repo_import", source_import_gone },
-  { "PUT /repos/{owner}/{repo}/import", "put_repo_import", source_import_gone },
-  { "PATCH /repos/{owner}/{repo}/import", "patch_repo_import", source_import_gone },
-  { "DELETE /repos/{owner}/{repo}/import", "delete_repo_import", source_import_gone },
-  { "GET /repos/{owner}/{repo}/import/authors", "get_repo_import_authors", source_import_gone },
-  {
-    "PATCH /repos/{owner}/{repo}/import/authors/{author_id}",
-    "patch_repo_import_author",
-    source_import_gone,
-  },
-  {
-    "GET /repos/{owner}/{repo}/import/large_files",
-    "get_repo_import_large_files",
-    source_import_gone,
-  },
-  { "PATCH /repos/{owner}/{repo}/import/lfs", "patch_repo_import_lfs", source_import_gone },
-
-  { group = "markdown" },
-  -- Markdown (https://docs.github.com/en/rest/markdown)
-  { "POST /markdown", "render_markdown", markdown_not_implemented },
-  { "POST /markdown/raw", "render_markdown_raw", markdown_not_implemented },
-
-  { group = "actions" },
-  -- Actions (https://docs.github.com/en/rest/actions)
-  -- Enterprise-level cache limits
-  {
-    "GET /enterprises/{enterprise}/actions/cache/retention-limit",
-    "get_enterprise_actions_cache_retention_limit",
-    actions_not_implemented,
-  },
-  {
-    "PUT /enterprises/{enterprise}/actions/cache/retention-limit",
-    "put_enterprise_actions_cache_retention_limit",
-    actions_not_implemented,
-  },
-  {
-    "GET /enterprises/{enterprise}/actions/cache/storage-limit",
-    "get_enterprise_actions_cache_storage_limit",
-    actions_not_implemented,
-  },
-  {
-    "PUT /enterprises/{enterprise}/actions/cache/storage-limit",
-    "put_enterprise_actions_cache_storage_limit",
-    actions_not_implemented,
-  },
-
-  -- Enterprise-level OIDC
-  {
-    "GET /enterprises/{enterprise}/actions/oidc/customization/properties/repo",
-    "get_enterprise_actions_oidc_custom_props",
-    empty_list,
-  },
-  {
-    "POST /enterprises/{enterprise}/actions/oidc/customization/properties/repo",
-    "post_enterprise_actions_oidc_custom_prop",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /enterprises/{enterprise}/actions/oidc/customization/properties/repo/{custom_property_name}",
-    "delete_enterprise_actions_oidc_custom_prop",
-    actions_not_implemented,
-  },
-
-  -- Organization-level cache limits (via /organizations/ alias path)
-  {
-    "GET /organizations/{org}/actions/cache/retention-limit",
-    "get_org_actions_cache_retention_limit_v2",
-    actions_not_implemented,
-  },
-  {
-    "PUT /organizations/{org}/actions/cache/retention-limit",
-    "put_org_actions_cache_retention_limit_v2",
-    actions_not_implemented,
-  },
-  {
-    "GET /organizations/{org}/actions/cache/storage-limit",
-    "get_org_actions_cache_storage_limit_v2",
-    actions_not_implemented,
-  },
-  {
-    "PUT /organizations/{org}/actions/cache/storage-limit",
-    "put_org_actions_cache_storage_limit_v2",
-    actions_not_implemented,
-  },
-
-  -- Organization cache
-  { "GET /orgs/{org}/actions/cache/usage", "get_org_actions_cache_usage", actions_not_implemented },
-  {
-    "GET /orgs/{org}/actions/cache/usage-by-repository",
-    "get_org_actions_cache_usage_by_repo",
-    actions_not_implemented,
-  },
-
-  -- Organization hosted runners
-  {
-    "GET /orgs/{org}/actions/hosted-runners",
-    "get_org_actions_hosted_runners",
-    make_empty_collection("runners"),
-  },
-  {
-    "POST /orgs/{org}/actions/hosted-runners",
-    "post_org_actions_hosted_runner",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/images/custom",
-    "get_org_actions_hosted_runner_custom_images",
-    empty_list,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}",
-    "get_org_actions_hosted_runner_custom_image",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}",
-    "delete_org_actions_hosted_runner_custom_image",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions",
-    "get_org_actions_hosted_runner_custom_image_versions",
-    empty_list,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}",
-    "get_org_actions_hosted_runner_custom_image_version",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}",
-    "delete_org_actions_hosted_runner_custom_image_version",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/images/github-owned",
-    "get_org_actions_hosted_runner_github_images",
-    empty_list,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/images/partner",
-    "get_org_actions_hosted_runner_partner_images",
-    empty_list,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/limits",
-    "get_org_actions_hosted_runner_limits",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/machine-sizes",
-    "get_org_actions_hosted_runner_machine_sizes",
-    empty_list,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/platforms",
-    "get_org_actions_hosted_runner_platforms",
-    empty_list,
-  },
-  {
-    "GET /orgs/{org}/actions/hosted-runners/{hosted_runner_id}",
-    "get_org_actions_hosted_runner",
-    actions_not_implemented,
-  },
-  {
-    "PATCH /orgs/{org}/actions/hosted-runners/{hosted_runner_id}",
-    "patch_org_actions_hosted_runner",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/hosted-runners/{hosted_runner_id}",
-    "delete_org_actions_hosted_runner",
-    actions_not_implemented,
-  },
-
-  -- Organization OIDC
-  {
-    "GET /orgs/{org}/actions/oidc/customization/properties/repo",
-    "get_org_actions_oidc_custom_props",
-    empty_list,
-  },
-  {
-    "POST /orgs/{org}/actions/oidc/customization/properties/repo",
-    "post_org_actions_oidc_custom_prop",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/oidc/customization/properties/repo/{custom_property_name}",
-    "delete_org_actions_oidc_custom_prop",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/oidc/customization/sub",
-    "get_org_actions_oidc_sub",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/oidc/customization/sub",
-    "put_org_actions_oidc_sub",
-    actions_not_implemented,
-  },
-
-  -- Organization permissions
-  { "GET /orgs/{org}/actions/permissions", "get_org_actions_permissions", actions_not_implemented },
-  { "PUT /orgs/{org}/actions/permissions", "put_org_actions_permissions", actions_not_implemented },
-  {
-    "GET /orgs/{org}/actions/permissions/artifact-and-log-retention",
-    "get_org_actions_artifact_log_retention",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/artifact-and-log-retention",
-    "put_org_actions_artifact_log_retention",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/permissions/fork-pr-contributor-approval",
-    "get_org_actions_fork_pr_approval",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/fork-pr-contributor-approval",
-    "put_org_actions_fork_pr_approval",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/permissions/fork-pr-workflows-private-repos",
-    "get_org_actions_fork_pr_private_repos",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/fork-pr-workflows-private-repos",
-    "put_org_actions_fork_pr_private_repos",
-    actions_not_implemented,
-  },
-  { "GET /orgs/{org}/actions/permissions/repositories", "get_org_actions_perm_repos", empty_list },
-  {
-    "PUT /orgs/{org}/actions/permissions/repositories",
-    "put_org_actions_perm_repos",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/repositories/{repository_id}",
-    "put_org_actions_perm_repo",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}",
-    "delete_org_actions_perm_repo",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/permissions/selected-actions",
-    "get_org_actions_selected_actions",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/selected-actions",
-    "put_org_actions_selected_actions",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/permissions/self-hosted-runners",
-    "get_org_actions_self_hosted_runners_perm",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/self-hosted-runners",
-    "put_org_actions_self_hosted_runners_perm",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/permissions/self-hosted-runners/repositories",
-    "get_org_actions_self_hosted_runner_repos",
-    empty_list,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/self-hosted-runners/repositories",
-    "put_org_actions_self_hosted_runner_repos",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/self-hosted-runners/repositories/{repository_id}",
-    "put_org_actions_self_hosted_runner_repo",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/permissions/self-hosted-runners/repositories/{repository_id}",
-    "delete_org_actions_self_hosted_runner_repo",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/permissions/workflow",
-    "get_org_actions_default_workflow_perms",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/permissions/workflow",
-    "put_org_actions_default_workflow_perms",
-    actions_not_implemented,
-  },
-
-  -- Organization runner groups
-  {
-    "GET /orgs/{org}/actions/runner-groups",
-    "get_org_actions_runner_groups",
-    make_empty_collection("runner_groups"),
-  },
-  {
-    "POST /orgs/{org}/actions/runner-groups",
-    "post_org_actions_runner_group",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "get_org_actions_runner_group",
-    actions_not_implemented,
-  },
-  {
-    "PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "patch_org_actions_runner_group",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "delete_org_actions_runner_group",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/hosted-runners",
-    "get_org_actions_runner_group_hosted_runners",
-    make_empty_collection("runners"),
-  },
-  {
-    "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
-    "get_org_actions_runner_group_repos",
-    empty_list,
-  },
-  {
-    "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
-    "put_org_actions_runner_group_repos",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
-    "put_org_actions_runner_group_repo",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
-    "delete_org_actions_runner_group_repo",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
-    "get_org_actions_runner_group_runners",
-    make_empty_collection("runners"),
-  },
-  {
-    "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
-    "put_org_actions_runner_group_runners",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "put_org_actions_runner_group_runner",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "delete_org_actions_runner_group_runner",
-    actions_not_implemented,
-  },
-
-  -- Organization runners
-  {
-    "GET /orgs/{org}/actions/runners",
-    "get_org_actions_runners",
-    make_empty_collection("runners"),
-  },
-  { "GET /orgs/{org}/actions/runners/downloads", "get_org_actions_runner_downloads", empty_list },
-  {
-    "POST /orgs/{org}/actions/runners/generate-jitconfig",
-    "post_org_actions_runner_jitconfig",
-    actions_not_implemented,
-  },
-  {
-    "POST /orgs/{org}/actions/runners/registration-token",
-    "post_org_actions_runner_registration_token",
-    actions_not_implemented,
-  },
-  {
-    "POST /orgs/{org}/actions/runners/remove-token",
-    "post_org_actions_runner_remove_token",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/runners/{runner_id}",
-    "get_org_actions_runner",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/runners/{runner_id}",
-    "delete_org_actions_runner",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/runners/{runner_id}/labels",
-    "get_org_actions_runner_labels",
-    empty_list,
-  },
-  {
-    "POST /orgs/{org}/actions/runners/{runner_id}/labels",
-    "post_org_actions_runner_labels",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/runners/{runner_id}/labels",
-    "put_org_actions_runner_labels",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/runners/{runner_id}/labels",
-    "delete_org_actions_runner_labels",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/runners/{runner_id}/labels/{name}",
-    "delete_org_actions_runner_label",
-    actions_not_implemented,
-  },
-
-  -- Organization secrets
-  {
-    "GET /orgs/{org}/actions/secrets",
-    "get_org_actions_secrets",
-    make_empty_collection("secrets"),
-  },
-  {
-    "GET /orgs/{org}/actions/secrets/public-key",
-    "get_org_actions_secrets_public_key",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/secrets/{secret_name}",
-    "get_org_actions_secret",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/secrets/{secret_name}",
-    "put_org_actions_secret",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/secrets/{secret_name}",
-    "delete_org_actions_secret",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/secrets/{secret_name}/repositories",
-    "get_org_actions_secret_repos",
-    empty_list,
-  },
-  {
-    "PUT /orgs/{org}/actions/secrets/{secret_name}/repositories",
-    "put_org_actions_secret_repos",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
-    "put_org_actions_secret_repo",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
-    "delete_org_actions_secret_repo",
-    actions_not_implemented,
-  },
-
-  -- Organization variables
-  {
-    "GET /orgs/{org}/actions/variables",
-    "get_org_actions_variables",
-    make_empty_collection("variables"),
-  },
-  { "POST /orgs/{org}/actions/variables", "post_org_actions_variable", actions_not_implemented },
-  {
-    "GET /orgs/{org}/actions/variables/{name}",
-    "get_org_actions_variable",
-    actions_not_implemented,
-  },
-  {
-    "PATCH /orgs/{org}/actions/variables/{name}",
-    "patch_org_actions_variable",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/variables/{name}",
-    "delete_org_actions_variable",
-    actions_not_implemented,
-  },
-  {
-    "GET /orgs/{org}/actions/variables/{name}/repositories",
-    "get_org_actions_variable_repos",
-    empty_list,
-  },
-  {
-    "PUT /orgs/{org}/actions/variables/{name}/repositories",
-    "put_org_actions_variable_repos",
-    actions_not_implemented,
-  },
-  {
-    "PUT /orgs/{org}/actions/variables/{name}/repositories/{repository_id}",
-    "put_org_actions_variable_repo",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /orgs/{org}/actions/variables/{name}/repositories/{repository_id}",
-    "delete_org_actions_variable_repo",
-    actions_not_implemented,
-  },
-
-  -- Repository artifacts
-  {
-    "GET /repos/{owner}/{repo}/actions/artifacts",
-    "get_repo_actions_artifacts",
-    make_empty_collection("artifacts"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
-    "get_repo_actions_artifact",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
-    "delete_repo_actions_artifact",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
-    "get_repo_actions_artifact_archive",
-    actions_not_implemented,
-  },
-
-  -- Repository cache
-  {
-    "GET /repos/{owner}/{repo}/actions/cache/retention-limit",
-    "get_repo_actions_cache_retention_limit",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/cache/retention-limit",
-    "put_repo_actions_cache_retention_limit",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/cache/storage-limit",
-    "get_repo_actions_cache_storage_limit",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/cache/storage-limit",
-    "put_repo_actions_cache_storage_limit",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/cache/usage",
-    "get_repo_actions_cache_usage",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/caches",
-    "get_repo_actions_caches",
-    make_empty_collection("actions_caches"),
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/caches",
-    "delete_repo_actions_caches",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}",
-    "delete_repo_actions_cache",
-    actions_not_implemented,
-  },
-
-  -- Repository jobs
-  {
-    "GET /repos/{owner}/{repo}/actions/jobs/{job_id}",
-    "get_repo_actions_job",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
-    "get_repo_actions_job_logs",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun",
-    "post_repo_actions_job_rerun",
-    actions_not_implemented,
-  },
-
-  -- Repository OIDC
-  {
-    "GET /repos/{owner}/{repo}/actions/oidc/customization/sub",
-    "get_repo_actions_oidc_sub",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/oidc/customization/sub",
-    "put_repo_actions_oidc_sub",
-    actions_not_implemented,
-  },
-
-  -- Repository org secrets/variables (read-only inherited view)
-  {
-    "GET /repos/{owner}/{repo}/actions/organization-secrets",
-    "get_repo_actions_org_secrets",
-    make_empty_collection("secrets"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/organization-variables",
-    "get_repo_actions_org_variables",
-    make_empty_collection("variables"),
-  },
-
-  -- Repository permissions
-  {
-    "GET /repos/{owner}/{repo}/actions/permissions",
-    "get_repo_actions_permissions",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/permissions",
-    "put_repo_actions_permissions",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/permissions/access",
-    "get_repo_actions_access_level",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/permissions/access",
-    "put_repo_actions_access_level",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention",
-    "get_repo_actions_artifact_log_retention",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention",
-    "put_repo_actions_artifact_log_retention",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval",
-    "get_repo_actions_fork_pr_approval",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval",
-    "put_repo_actions_fork_pr_approval",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos",
-    "get_repo_actions_fork_pr_private_repos",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos",
-    "put_repo_actions_fork_pr_private_repos",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/permissions/selected-actions",
-    "get_repo_actions_selected_actions",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/permissions/selected-actions",
-    "put_repo_actions_selected_actions",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/permissions/workflow",
-    "get_repo_actions_default_workflow_perms",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/permissions/workflow",
-    "put_repo_actions_default_workflow_perms",
-    actions_not_implemented,
-  },
-
-  -- Repository runners
-  {
-    "GET /repos/{owner}/{repo}/actions/runners",
-    "get_repo_actions_runners",
-    make_empty_collection("runners"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runners/downloads",
-    "get_repo_actions_runner_downloads",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig",
-    "post_repo_actions_runner_jitconfig",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runners/registration-token",
-    "post_repo_actions_runner_registration_token",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runners/remove-token",
-    "post_repo_actions_runner_remove_token",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runners/{runner_id}",
-    "get_repo_actions_runner",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}",
-    "delete_repo_actions_runner",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
-    "get_repo_actions_runner_labels",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
-    "post_repo_actions_runner_labels",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
-    "put_repo_actions_runner_labels",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
-    "delete_repo_actions_runner_labels",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels/{name}",
-    "delete_repo_actions_runner_label",
-    actions_not_implemented,
-  },
-
-  -- Repository workflow runs
-  {
-    "GET /repos/{owner}/{repo}/actions/runs",
-    "get_repo_actions_runs",
-    make_empty_collection("workflow_runs"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}",
-    "get_repo_actions_run",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/runs/{run_id}",
-    "delete_repo_actions_run",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/approvals",
-    "get_repo_actions_run_approvals",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve",
-    "post_repo_actions_run_approve",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
-    "get_repo_actions_run_artifacts",
-    make_empty_collection("artifacts"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}",
-    "get_repo_actions_run_attempt",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",
-    "get_repo_actions_run_attempt_jobs",
-    make_empty_collection("jobs"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs",
-    "get_repo_actions_run_attempt_logs",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
-    "post_repo_actions_run_cancel",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/deployment_protection_rule",
-    "post_repo_actions_run_deployment_prot",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel",
-    "post_repo_actions_run_force_cancel",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-    "get_repo_actions_run_jobs",
-    make_empty_collection("jobs"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
-    "get_repo_actions_run_logs",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
-    "delete_repo_actions_run_logs",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
-    "get_repo_actions_run_pending_deployments",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
-    "post_repo_actions_run_pending_deployments",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun",
-    "post_repo_actions_run_rerun",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs",
-    "post_repo_actions_run_rerun_failed",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing",
-    "get_repo_actions_run_timing",
-    actions_not_implemented,
-  },
-
-  -- Repository secrets
-  {
-    "GET /repos/{owner}/{repo}/actions/secrets",
-    "get_repo_actions_secrets",
-    make_empty_collection("secrets"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/secrets/public-key",
-    "get_repo_actions_secrets_public_key",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/secrets/{secret_name}",
-    "get_repo_actions_secret",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}",
-    "put_repo_actions_secret",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}",
-    "delete_repo_actions_secret",
-    actions_not_implemented,
-  },
-
-  -- Repository variables
-  {
-    "GET /repos/{owner}/{repo}/actions/variables",
-    "get_repo_actions_variables",
-    make_empty_collection("variables"),
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/variables",
-    "post_repo_actions_variable",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/variables/{name}",
-    "get_repo_actions_variable",
-    actions_not_implemented,
-  },
-  {
-    "PATCH /repos/{owner}/{repo}/actions/variables/{name}",
-    "patch_repo_actions_variable",
-    actions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/actions/variables/{name}",
-    "delete_repo_actions_variable",
-    actions_not_implemented,
-  },
-
-  -- Repository workflows
-  {
-    "GET /repos/{owner}/{repo}/actions/workflows",
-    "get_repo_actions_workflows",
-    make_empty_collection("workflows"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}",
-    "get_repo_actions_workflow",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable",
-    "put_repo_actions_workflow_disable",
-    actions_not_implemented,
-  },
-  {
-    "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
-    "post_repo_actions_workflow_dispatch",
-    actions_not_implemented,
-  },
-  {
-    "PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable",
-    "put_repo_actions_workflow_enable",
-    actions_not_implemented,
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
-    "get_repo_actions_workflow_runs",
-    make_empty_collection("workflow_runs"),
-  },
-  {
-    "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing",
-    "get_repo_actions_workflow_timing",
-    actions_not_implemented,
-  },
-
-  { group = "git" },
-  -- Git database (https://docs.github.com/en/rest/git)
-  -- Blobs
-  { "POST /repos/{owner}/{repo}/git/blobs", "create_git_blob", git_not_implemented },
-  { "GET /repos/{owner}/{repo}/git/blobs/{file_sha}", "get_git_blob", git_not_implemented },
-
-  -- Commits
-  { "POST /repos/{owner}/{repo}/git/commits", "create_git_commit", git_not_implemented },
-  { "GET /repos/{owner}/{repo}/git/commits/{commit_sha}", "get_git_commit", git_not_implemented },
-
-  -- Refs
-  {
-    "GET /repos/{owner}/{repo}/git/matching-refs/{ref+}",
-    "list_git_matching_refs",
-    git_not_implemented,
+local endpoint_sections = {
+  {
+    "meta",
+    {
+      -- Root
+      {
+        "GET /",
+        "get_root",
+        function()
+          respond_json(200, {})
+        end,
+      },
+
+      -- Meta (https://docs.github.com/en/rest/meta)
+      { "GET /meta", "get_meta", meta_response },
+      { "GET /octocat", "get_octocat", octocat_response },
+      { "GET /teapot", "get_teapot", teapot_response },
+      { "GET /versions", "get_versions", versions_response },
+      { "GET /zen", "get_zen", zen_response },
+
+      -- Emojis
+      { "GET /emojis", "get_emojis" },
+
+    },
+  },
+  {
+    "gitignore",
+    {
+      -- Gitignore templates (https://docs.github.com/en/rest/gitignore)
+      { "GET /gitignore/templates", "get_gitignore_templates" },
+      { "GET /gitignore/templates/{name}", "get_gitignore_template" },
+
+    },
+  },
+  {
+    "licenses",
+    {
+      -- Licenses (https://docs.github.com/en/rest/licenses)
+      { "GET /licenses", "get_licenses", licenses_not_implemented },
+      { "GET /licenses/{license}", "get_license", licenses_not_implemented },
+
+      -- Repo license (https://docs.github.com/en/rest/licenses)
+      { "GET /repos/{owner}/{repo}/license", "get_repo_license", licenses_not_implemented },
+
+    },
+  },
+  {
+    "rate-limit",
+    {
+      -- Rate Limits (https://docs.github.com/en/rest/rate-limit)
+      { "GET /rate_limit", "get_rate_limit", rate_limit_response },
+
+    },
+  },
+  {
+    "gists",
+    {
+      -- Gists (https://docs.github.com/en/rest/gists)
+      { "GET /gists", "get_gists", empty_list },
+      { "POST /gists", "post_gists", gists_not_implemented },
+      { "GET /gists/public", "get_gists_public", empty_list },
+      { "GET /gists/starred", "get_gists_starred", empty_list },
+      { "GET /gists/{gist_id}", "get_gist", gists_not_implemented },
+      { "PATCH /gists/{gist_id}", "patch_gist", gists_not_implemented },
+      { "DELETE /gists/{gist_id}", "delete_gist", gists_not_implemented },
+      { "GET /gists/{gist_id}/comments", "get_gist_comments", empty_list },
+      { "POST /gists/{gist_id}/comments", "post_gist_comment", gists_not_implemented },
+      { "GET /gists/{gist_id}/comments/{comment_id}", "get_gist_comment", gists_not_implemented },
+      { "PATCH /gists/{gist_id}/comments/{comment_id}", "patch_gist_comment", gists_not_implemented },
+      { "DELETE /gists/{gist_id}/comments/{comment_id}", "delete_gist_comment", gists_not_implemented },
+      { "GET /gists/{gist_id}/commits", "get_gist_commits", empty_list },
+      { "GET /gists/{gist_id}/forks", "get_gist_forks", empty_list },
+      { "POST /gists/{gist_id}/forks", "post_gist_fork", gists_not_implemented },
+      { "GET /gists/{gist_id}/star", "get_gist_star", gists_not_implemented },
+      { "PUT /gists/{gist_id}/star", "put_gist_star", gists_not_implemented },
+      { "DELETE /gists/{gist_id}/star", "delete_gist_star", gists_not_implemented },
+      { "GET /gists/{gist_id}/{sha}", "get_gist_revision", gists_not_implemented },
+      { "GET /users/{username}/gists", "get_user_gists", empty_list },
+
+    },
+  },
+  {
+    "activity",
+    {
+      -- Activity (https://docs.github.com/en/rest/activity)
+      { "GET /events", "get_events", activity_list_empty },
+      { "GET /feeds", "get_feeds", activity_not_implemented },
+      { "GET /networks/{owner}/{repo}/events", "get_network_events", activity_list_empty },
+      { "GET /notifications", "get_notifications", activity_list_empty },
+      { "PUT /notifications", "put_notifications", activity_not_implemented },
+      { "GET /notifications/threads/{thread_id}", "get_notification_thread", activity_not_implemented },
+      {
+        "PATCH /notifications/threads/{thread_id}",
+        "patch_notification_thread",
+        activity_not_implemented,
+      },
+      {
+        "DELETE /notifications/threads/{thread_id}",
+        "delete_notification_thread",
+        activity_not_implemented,
+      },
+      {
+        "GET /notifications/threads/{thread_id}/subscription",
+        "get_notification_thread_subscription",
+        activity_not_implemented,
+      },
+      {
+        "PUT /notifications/threads/{thread_id}/subscription",
+        "put_notification_thread_subscription",
+        activity_not_implemented,
+      },
+      {
+        "DELETE /notifications/threads/{thread_id}/subscription",
+        "delete_notification_thread_subscription",
+        activity_not_implemented,
+      },
+      { "GET /orgs/{org}/events", "get_org_events", activity_list_empty },
+      { "GET /repos/{owner}/{repo}/events", "get_repo_events", activity_list_empty },
+      { "GET /repos/{owner}/{repo}/notifications", "get_repo_notifications", activity_list_empty },
+      { "PUT /repos/{owner}/{repo}/notifications", "put_repo_notifications", activity_not_implemented },
+      { "GET /repos/{owner}/{repo}/stargazers", "get_repo_stargazers", activity_list_empty },
+      { "GET /repos/{owner}/{repo}/subscribers", "get_repo_subscribers", activity_list_empty },
+      { "GET /repos/{owner}/{repo}/subscription", "get_repo_subscription", activity_not_implemented },
+      { "PUT /repos/{owner}/{repo}/subscription", "put_repo_subscription", activity_not_implemented },
+      {
+        "DELETE /repos/{owner}/{repo}/subscription",
+        "delete_repo_subscription",
+        activity_not_implemented,
+      },
+      { "GET /user/starred", "get_user_starred", activity_list_empty },
+      { "GET /user/starred/{owner}/{repo}", "get_user_starred_repo", activity_not_implemented },
+      { "PUT /user/starred/{owner}/{repo}", "put_user_starred_repo", activity_not_implemented },
+      { "DELETE /user/starred/{owner}/{repo}", "delete_user_starred_repo", activity_not_implemented },
+      { "GET /user/subscriptions", "get_user_subscriptions", activity_list_empty },
+      { "GET /users/{username}/events", "get_users_events", activity_list_empty },
+      { "GET /users/{username}/events/orgs/{org}", "get_users_org_events", activity_list_empty },
+      { "GET /users/{username}/events/public", "get_users_public_events", activity_list_empty },
+      { "GET /users/{username}/received_events", "get_users_received_events", activity_list_empty },
+      {
+        "GET /users/{username}/received_events/public",
+        "get_users_received_public_events",
+        activity_list_empty,
+      },
+      { "GET /users/{username}/starred", "get_users_starred", activity_list_empty },
+      { "GET /users/{username}/subscriptions", "get_users_subscriptions", activity_list_empty },
+
+    },
+  },
+  {
+    "repos",
+    {
+      -- Repos core (https://docs.github.com/en/rest/repos/repos)
+      { "GET /repos/{owner}/{repo}", "get_repo" },
+      { "PATCH /repos/{owner}/{repo}", "patch_repo" },
+      { "DELETE /repos/{owner}/{repo}", "delete_repo" },
+      { "GET /user/repos", "get_user_repos" },
+      { "POST /user/repos", "post_user_repos" },
+      { "GET /orgs/{org}/repos", "get_org_repos" },
+      { "POST /orgs/{org}/repos", "post_org_repos" },
+      { "GET /users/{username}/repos", "get_users_repos" },
+      { "GET /repositories", "get_repositories" },
+
+      -- Topics / languages / contributors / tags / teams
+      { "GET /repos/{owner}/{repo}/topics", "get_repo_topics" },
+      { "PUT /repos/{owner}/{repo}/topics", "put_repo_topics" },
+      { "GET /repos/{owner}/{repo}/languages", "get_repo_languages" },
+      { "GET /repos/{owner}/{repo}/contributors", "get_repo_contributors" },
+      { "GET /repos/{owner}/{repo}/tags", "get_repo_tags" },
+      { "GET /repos/{owner}/{repo}/teams", "get_repo_teams" },
+
+    },
+  },
+  {
+    "repos-ext",
+    {
+      -- Branches (https://docs.github.com/en/rest/branches)
+      { "GET /repos/{owner}/{repo}/branches", "get_repo_branches" },
+      { "GET /repos/{owner}/{repo}/branches/{branch}", "get_repo_branch" },
+
+      -- Commits (https://docs.github.com/en/rest/commits)
+      { "GET /repos/{owner}/{repo}/commits", "get_repo_commits" },
+      { "GET /repos/{owner}/{repo}/commits/{ref}", "get_repo_commit" },
+
+      -- Commit comments
+      { "GET /repos/{owner}/{repo}/comments", "get_repo_comments" },
+      { "GET /repos/{owner}/{repo}/comments/{comment_id}", "get_repo_comment" },
+      { "PATCH /repos/{owner}/{repo}/comments/{comment_id}", "patch_repo_comment" },
+      { "DELETE /repos/{owner}/{repo}/comments/{comment_id}", "delete_repo_comment" },
+      { "GET /repos/{owner}/{repo}/commits/{commit_sha}/comments", "get_commit_comments" },
+      { "POST /repos/{owner}/{repo}/commits/{commit_sha}/comments", "post_commit_comment" },
+
+      -- Statuses
+      { "GET /repos/{owner}/{repo}/commits/{ref}/statuses", "get_commit_statuses" },
+      { "GET /repos/{owner}/{repo}/commits/{ref}/status", "get_commit_combined_status" },
+      { "POST /repos/{owner}/{repo}/statuses/{sha}", "post_commit_status" },
+
+      -- Contents (https://docs.github.com/en/rest/repos/contents)
+      { "GET /repos/{owner}/{repo}/readme", "get_repo_readme" },
+      { "GET /repos/{owner}/{repo}/readme/{dir}", "get_repo_readme_dir" },
+      { "GET /repos/{owner}/{repo}/contents/{path}", "get_repo_content" },
+      { "PUT /repos/{owner}/{repo}/contents/{path}", "put_repo_content" },
+      { "DELETE /repos/{owner}/{repo}/contents/{path}", "delete_repo_content" },
+      { "GET /repos/{owner}/{repo}/tarball/{ref}", "get_repo_tarball" },
+      { "GET /repos/{owner}/{repo}/zipball/{ref}", "get_repo_zipball" },
+
+      -- Compare
+      { "GET /repos/{owner}/{repo}/compare/{basehead}", "get_repo_compare" },
+
+      -- Collaborators (https://docs.github.com/en/rest/collaborators)
+      { "GET /repos/{owner}/{repo}/collaborators", "get_repo_collaborators" },
+      { "GET /repos/{owner}/{repo}/collaborators/{username}", "get_repo_collaborator" },
+      { "PUT /repos/{owner}/{repo}/collaborators/{username}", "put_repo_collaborator" },
+      { "DELETE /repos/{owner}/{repo}/collaborators/{username}", "delete_repo_collaborator" },
+      {
+        "GET /repos/{owner}/{repo}/collaborators/{username}/permission",
+        "get_repo_collaborator_permission",
+      },
+
+      -- Forks (https://docs.github.com/en/rest/repos/forks)
+      { "GET /repos/{owner}/{repo}/forks", "get_repo_forks" },
+      { "POST /repos/{owner}/{repo}/forks", "post_repo_forks" },
+
+      -- Merges (https://docs.github.com/en/rest/branches/merging)
+      { "POST /repos/{owner}/{repo}/merges", "post_repo_merges" },
+      { "POST /repos/{owner}/{repo}/merge-upstream", "post_repo_merge_upstream" },
+
+      -- Deploy keys (https://docs.github.com/en/rest/deploy-keys)
+      { "GET /repos/{owner}/{repo}/keys", "get_repo_keys" },
+      { "POST /repos/{owner}/{repo}/keys", "post_repo_keys" },
+      { "GET /repos/{owner}/{repo}/keys/{key_id}", "get_repo_key" },
+      { "DELETE /repos/{owner}/{repo}/keys/{key_id}", "delete_repo_key" },
+
+      -- Webhooks (https://docs.github.com/en/rest/repos/webhooks)
+      { "GET /repos/{owner}/{repo}/hooks", "get_repo_hooks" },
+      { "POST /repos/{owner}/{repo}/hooks", "post_repo_hooks" },
+      { "GET /repos/{owner}/{repo}/hooks/{hook_id}", "get_repo_hook" },
+      { "PATCH /repos/{owner}/{repo}/hooks/{hook_id}", "patch_repo_hook" },
+      { "DELETE /repos/{owner}/{repo}/hooks/{hook_id}", "delete_repo_hook" },
+      { "GET /repos/{owner}/{repo}/hooks/{hook_id}/config", "get_repo_hook_config" },
+      { "PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config", "patch_repo_hook_config" },
+      { "POST /repos/{owner}/{repo}/hooks/{hook_id}/pings", "post_repo_hook_ping" },
+      { "POST /repos/{owner}/{repo}/hooks/{hook_id}/tests", "post_repo_hook_test" },
+
+      -- Statistics (https://docs.github.com/en/rest/metrics/statistics)
+      { "GET /repos/{owner}/{repo}/stats/code_frequency", "get_repo_stats_code_frequency" },
+      { "GET /repos/{owner}/{repo}/stats/commit_activity", "get_repo_stats_commit_activity" },
+      { "GET /repos/{owner}/{repo}/stats/contributors", "get_repo_stats_contributors" },
+      { "GET /repos/{owner}/{repo}/stats/participation", "get_repo_stats_participation" },
+      { "GET /repos/{owner}/{repo}/stats/punch_card", "get_repo_stats_punch_card" },
+
+      -- Traffic (https://docs.github.com/en/rest/metrics/traffic)
+      { "GET /repos/{owner}/{repo}/traffic/clones", "get_repo_traffic_clones" },
+      { "GET /repos/{owner}/{repo}/traffic/popular/paths", "get_repo_traffic_paths" },
+      { "GET /repos/{owner}/{repo}/traffic/popular/referrers", "get_repo_traffic_referrers" },
+      { "GET /repos/{owner}/{repo}/traffic/views", "get_repo_traffic_views" },
+
+      -- Invitations (https://docs.github.com/en/rest/collaborators/invitations)
+      { "GET /repos/{owner}/{repo}/invitations", "get_repo_invitations" },
+      { "PATCH /repos/{owner}/{repo}/invitations/{invitation_id}", "patch_repo_invitation" },
+      { "DELETE /repos/{owner}/{repo}/invitations/{invitation_id}", "delete_repo_invitation" },
+      { "GET /user/repository_invitations", "get_user_repo_invitations" },
+      { "PATCH /user/repository_invitations/{invitation_id}", "patch_user_repo_invitation" },
+      { "DELETE /user/repository_invitations/{invitation_id}", "delete_user_repo_invitation" },
+
+      -- Deployments (https://docs.github.com/en/rest/deployments)
+      { "GET /repos/{owner}/{repo}/deployments", "get_repo_deployments" },
+      { "POST /repos/{owner}/{repo}/deployments", "post_repo_deployments" },
+      { "GET /repos/{owner}/{repo}/deployments/{deployment_id}", "get_repo_deployment" },
+      { "DELETE /repos/{owner}/{repo}/deployments/{deployment_id}", "delete_repo_deployment" },
+      {
+        "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+        "get_repo_deployment_statuses",
+      },
+      {
+        "POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+        "post_repo_deployment_status",
+      },
+      {
+        "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}",
+        "get_repo_deployment_status",
+      },
+    },
+  },
+  {
+    "releases",
+    {
+      -- Releases (https://docs.github.com/en/rest/releases)
+      { "GET /repos/{owner}/{repo}/releases", "get_repo_releases" },
+      { "POST /repos/{owner}/{repo}/releases", "post_repo_releases" },
+      { "GET /repos/{owner}/{repo}/releases/latest", "get_repo_release_latest" },
+      { "GET /repos/{owner}/{repo}/releases/tags/{tag}", "get_repo_release_by_tag" },
+      { "GET /repos/{owner}/{repo}/releases/{release_id}", "get_repo_release" },
+      { "PATCH /repos/{owner}/{repo}/releases/{release_id}", "patch_repo_release" },
+      { "DELETE /repos/{owner}/{repo}/releases/{release_id}", "delete_repo_release" },
+      { "GET /repos/{owner}/{repo}/releases/{release_id}/assets", "get_repo_release_assets" },
+      { "POST /repos/{owner}/{repo}/releases/{release_id}/assets", "post_repo_release_assets" },
+      { "GET /repos/{owner}/{repo}/releases/assets/{asset_id}", "get_repo_release_asset" },
+      { "PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}", "patch_repo_release_asset" },
+      { "DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}", "delete_repo_release_asset" },
+    },
+  },
+  {
+    "teams",
+    {
+      -- Teams (https://docs.github.com/en/rest/teams)
+      { "GET /orgs/{org}/teams", "get_org_teams", empty_list },
+      { "POST /orgs/{org}/teams", "post_org_teams" },
+      { "GET /orgs/{org}/teams/{team_slug}", "get_org_team" },
+      { "PATCH /orgs/{org}/teams/{team_slug}", "patch_org_team" },
+      { "DELETE /orgs/{org}/teams/{team_slug}", "delete_org_team" },
+      { "GET /orgs/{org}/teams/{team_slug}/invitations", "get_org_team_invitations", empty_list },
+      { "GET /orgs/{org}/teams/{team_slug}/members", "get_org_team_members", empty_list },
+      { "GET /orgs/{org}/teams/{team_slug}/memberships/{username}", "get_org_team_membership" },
+      { "PUT /orgs/{org}/teams/{team_slug}/memberships/{username}", "put_org_team_membership" },
+      { "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}", "delete_org_team_membership" },
+      { "GET /orgs/{org}/teams/{team_slug}/repos", "get_org_team_repos", empty_list },
+      { "GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "get_org_team_repo" },
+      { "PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "put_org_team_repo" },
+      { "DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "delete_org_team_repo" },
+      { "GET /orgs/{org}/teams/{team_slug}/teams", "get_org_team_children", empty_list },
+
+      -- Legacy team endpoints (team_id-based) — deprecated in favour of slug-based above
+      { "GET /user/teams", "get_user_teams", empty_list },
+      { "GET /teams/{team_id}", "get_team" },
+      { "PATCH /teams/{team_id}", "patch_team" },
+      { "DELETE /teams/{team_id}", "delete_team" },
+      { "GET /teams/{team_id}/invitations", "get_team_invitations", empty_list },
+      { "GET /teams/{team_id}/members", "get_team_members", empty_list },
+      { "GET /teams/{team_id}/members/{username}", "get_team_member" },
+      { "PUT /teams/{team_id}/members/{username}", "put_team_member" },
+      { "DELETE /teams/{team_id}/members/{username}", "delete_team_member" },
+      { "GET /teams/{team_id}/memberships/{username}", "get_team_membership" },
+      { "PUT /teams/{team_id}/memberships/{username}", "put_team_membership" },
+      { "DELETE /teams/{team_id}/memberships/{username}", "delete_team_membership" },
+      { "GET /teams/{team_id}/repos", "get_team_repos", empty_list },
+      { "GET /teams/{team_id}/repos/{owner}/{repo}", "get_team_repo" },
+      { "PUT /teams/{team_id}/repos/{owner}/{repo}", "put_team_repo" },
+      { "DELETE /teams/{team_id}/repos/{owner}/{repo}", "delete_team_repo" },
+      { "GET /teams/{team_id}/teams", "get_team_children", empty_list },
+
+    },
+  },
+  {
+    "security-advisories",
+    {
+      -- Security advisories (https://docs.github.com/en/rest/security-advisories)
+      { "GET /advisories", "get_global_advisories", empty_list },
+      { "GET /advisories/{ghsa_id}", "get_global_advisory" },
+      { "GET /orgs/{org}/security-advisories", "get_org_security_advisories", empty_list },
+      { "GET /repos/{owner}/{repo}/security-advisories", "get_repo_security_advisories", empty_list },
+      { "POST /repos/{owner}/{repo}/security-advisories", "post_repo_security_advisory" },
+      {
+        "POST /repos/{owner}/{repo}/security-advisories/reports",
+        "post_repo_security_advisory_report",
+      },
+      { "GET /repos/{owner}/{repo}/security-advisories/{ghsa_id}", "get_repo_security_advisory" },
+      { "PATCH /repos/{owner}/{repo}/security-advisories/{ghsa_id}", "patch_repo_security_advisory" },
+      {
+        "POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/cve",
+        "post_repo_security_advisory_cve",
+      },
+      {
+        "POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/forks",
+        "post_repo_security_advisory_fork",
+      },
+
+    },
+  },
+  {
+    "issues",
+    {
+      -- Issues (https://docs.github.com/en/rest/issues)
+      { "GET /issues", "get_issues", empty_list },
+      { "GET /orgs/{org}/issues", "get_org_issues", empty_list },
+      { "GET /user/issues", "get_user_issues", empty_list },
+      { "GET /repos/{owner}/{repo}/issues", "get_repo_issues", empty_list },
+      { "POST /repos/{owner}/{repo}/issues", "post_repo_issues" },
+      { "GET /repos/{owner}/{repo}/issues/comments", "get_repo_issue_comments", empty_list },
+      { "GET /repos/{owner}/{repo}/issues/comments/{comment_id}", "get_repo_issue_comment" },
+      { "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", "patch_repo_issue_comment" },
+      { "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}", "delete_repo_issue_comment" },
+      { "PUT /repos/{owner}/{repo}/issues/comments/{comment_id}/pin", "put_repo_issue_comment_pin" },
+      {
+        "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/pin",
+        "delete_repo_issue_comment_pin",
+      },
+      { "GET /repos/{owner}/{repo}/issues/events", "get_repo_issue_events", empty_list },
+      { "GET /repos/{owner}/{repo}/issues/events/{event_id}", "get_repo_issue_event" },
+      { "GET /repos/{owner}/{repo}/issues/{issue_number}", "get_repo_issue" },
+      { "PATCH /repos/{owner}/{repo}/issues/{issue_number}", "patch_repo_issue" },
+      { "POST /repos/{owner}/{repo}/issues/{issue_number}/assignees", "post_issue_assignees" },
+      { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees", "delete_issue_assignees" },
+      { "GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}", "get_issue_assignee" },
+      { "GET /repos/{owner}/{repo}/issues/{issue_number}/comments", "get_issue_comments", empty_list },
+      { "POST /repos/{owner}/{repo}/issues/{issue_number}/comments", "post_issue_comment" },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by",
+        "get_issue_deps_blocked_by",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by",
+        "post_issue_deps_blocked_by",
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by/{issue_id}",
+        "delete_issue_dep_blocked_by",
+      },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocking",
+        "get_issue_deps_blocking",
+        empty_list,
+      },
+      { "GET /repos/{owner}/{repo}/issues/{issue_number}/events", "get_issue_events", empty_list },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/issue-field-values",
+        "get_issue_field_values",
+        empty_list,
+      },
+      { "GET /repos/{owner}/{repo}/issues/{issue_number}/labels", "get_issue_labels", empty_list },
+      { "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", "post_issue_labels" },
+      { "PUT /repos/{owner}/{repo}/issues/{issue_number}/labels", "put_issue_labels" },
+      { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels", "delete_issue_labels" },
+      { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}", "delete_issue_label" },
+      { "PUT /repos/{owner}/{repo}/issues/{issue_number}/lock", "put_issue_lock" },
+      { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock", "delete_issue_lock" },
+      { "GET /repos/{owner}/{repo}/issues/{issue_number}/parent", "get_issue_parent" },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues",
+        "get_issue_sub_issues",
+        empty_list,
+      },
+      { "POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues", "post_issue_sub_issues" },
+      { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/sub_issue", "delete_issue_sub_issue" },
+      {
+        "PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority",
+        "patch_issue_sub_issues_priority",
+      },
+      { "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline", "get_issue_timeline", empty_list },
+
+      -- Assignees (https://docs.github.com/en/rest/issues/assignees)
+      { "GET /repos/{owner}/{repo}/assignees", "get_repo_assignees", empty_list },
+      { "GET /repos/{owner}/{repo}/assignees/{assignee}", "get_repo_assignee" },
+
+      -- Labels (https://docs.github.com/en/rest/issues/labels)
+      { "GET /repos/{owner}/{repo}/labels", "get_repo_labels", empty_list },
+      { "POST /repos/{owner}/{repo}/labels", "post_repo_labels" },
+      { "GET /repos/{owner}/{repo}/labels/{name}", "get_repo_label" },
+      { "PATCH /repos/{owner}/{repo}/labels/{name}", "patch_repo_label" },
+      { "DELETE /repos/{owner}/{repo}/labels/{name}", "delete_repo_label" },
+
+      -- Milestones (https://docs.github.com/en/rest/issues/milestones)
+      { "GET /repos/{owner}/{repo}/milestones", "get_repo_milestones", empty_list },
+      { "POST /repos/{owner}/{repo}/milestones", "post_repo_milestones" },
+      { "GET /repos/{owner}/{repo}/milestones/{milestone_number}", "get_repo_milestone" },
+      { "PATCH /repos/{owner}/{repo}/milestones/{milestone_number}", "patch_repo_milestone" },
+      { "DELETE /repos/{owner}/{repo}/milestones/{milestone_number}", "delete_repo_milestone" },
+      {
+        "GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels",
+        "get_repo_milestone_labels",
+        empty_list,
+      },
+
+      -- Issue field values via repository_id (GitHub-specific)
+      {
+        "POST /repositories/{repository_id}/issues/{issue_number}/issue-field-values",
+        "post_repository_issue_field_values",
+      },
+      {
+        "PUT /repositories/{repository_id}/issues/{issue_number}/issue-field-values",
+        "put_repository_issue_field_values",
+      },
+      {
+        "DELETE /repositories/{repository_id}/issues/{issue_number}/issue-field-values/{issue_field_id}",
+        "delete_repository_issue_field_value",
+      },
+
+    },
+  },
+  {
+    "pulls",
+    {
+      -- Pull Requests (https://docs.github.com/en/rest/pulls)
+      { "GET /repos/{owner}/{repo}/pulls", "get_repo_pulls", empty_list },
+      { "POST /repos/{owner}/{repo}/pulls", "post_repo_pulls" },
+      { "GET /repos/{owner}/{repo}/pulls/comments", "get_repo_pull_comments", empty_list },
+      { "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}", "get_repo_pull_comment" },
+      { "PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}", "patch_repo_pull_comment" },
+      { "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}", "delete_repo_pull_comment" },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}", "get_repo_pull" },
+      { "PATCH /repos/{owner}/{repo}/pulls/{pull_number}", "patch_repo_pull" },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/codespaces", "get_pull_codespaces", empty_list },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments", "get_pull_comments", empty_list },
+      { "POST /repos/{owner}/{repo}/pulls/{pull_number}/comments", "post_pull_comment" },
+      {
+        "POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies",
+        "post_pull_comment_reply",
+      },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits", "get_pull_commits", empty_list },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/files", "get_pull_files", empty_list },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/merge", "get_pull_merge" },
+      { "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge", "put_pull_merge" },
+      {
+        "GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+        "get_pull_requested_reviewers",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+        "post_pull_requested_reviewers",
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+        "delete_pull_requested_reviewers",
+      },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews", "get_pull_reviews", empty_list },
+      { "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews", "post_pull_review" },
+      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "get_pull_review" },
+      { "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "put_pull_review" },
+      { "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "delete_pull_review" },
+      {
+        "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
+        "get_pull_review_comments",
+        empty_list,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals",
+        "put_pull_review_dismissal",
+      },
+      {
+        "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events",
+        "post_pull_review_event",
+      },
+      { "POST /repos/{owner}/{repo}/pulls/{pull_number}/update-branch", "post_pull_update_branch" },
+      { "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls", "get_commit_pulls", empty_list },
+    },
+  },
+  {
+    "reactions",
+    {
+      -- Reactions (https://docs.github.com/en/rest/reactions)
+      {
+        "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+        "get_repo_pull_comment_reactions",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+        "post_repo_pull_comment_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
+        "delete_repo_pull_comment_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+        "get_issue_reactions",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+        "post_issue_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",
+        "delete_issue_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+        "get_repo_issue_comment_reactions",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+        "post_repo_issue_comment_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",
+        "delete_repo_issue_comment_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/releases/{release_id}/reactions",
+        "get_repo_release_reactions",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/releases/{release_id}/reactions",
+        "post_repo_release_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}",
+        "delete_repo_release_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/comments/{comment_id}/reactions",
+        "get_repo_comment_reactions",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/comments/{comment_id}/reactions",
+        "post_repo_comment_reaction",
+        reactions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}",
+        "delete_repo_comment_reaction",
+        reactions_not_implemented,
+      },
+    },
+  },
+  {
+    "users",
+    {
+      -- Users (https://docs.github.com/en/rest/users)
+      { "GET /user", "get_user" },
+      { "PATCH /user", "patch_user" },
+      { "GET /user/{account_id}", "get_user_by_id" },
+      { "GET /users", "get_users" },
+      { "GET /users/{username}", "get_users_username" },
+      { "GET /users/{username}/hovercard", "get_users_hovercard" },
+
+      -- Blocking
+      { "GET /user/blocks", "get_user_blocks" },
+      { "GET /user/blocks/{username}", "get_user_block" },
+      { "PUT /user/blocks/{username}", "put_user_block" },
+      { "DELETE /user/blocks/{username}", "delete_user_block" },
+
+      -- Emails
+      { "GET /user/emails", "get_user_emails" },
+      { "POST /user/emails", "post_user_emails" },
+      { "DELETE /user/emails", "delete_user_emails" },
+      { "PATCH /user/email/visibility", "patch_user_email_visibility" },
+      { "GET /user/public_emails", "get_user_public_emails" },
+
+      -- Followers
+      { "GET /user/followers", "get_user_followers" },
+      { "GET /user/following", "get_user_following" },
+      { "GET /user/following/{username}", "get_user_is_following" },
+      { "PUT /user/following/{username}", "put_user_following" },
+      { "DELETE /user/following/{username}", "delete_user_following" },
+      { "GET /users/{username}/followers", "get_users_followers" },
+      { "GET /users/{username}/following", "get_users_following" },
+      { "GET /users/{username}/following/{target_user}", "get_users_is_following" },
+
+      -- GPG Keys
+      { "GET /user/gpg_keys", "get_user_gpg_keys" },
+      { "POST /user/gpg_keys", "post_user_gpg_keys" },
+      { "GET /user/gpg_keys/{gpg_key_id}", "get_user_gpg_key" },
+      { "DELETE /user/gpg_keys/{gpg_key_id}", "delete_user_gpg_key" },
+      { "GET /users/{username}/gpg_keys", "get_users_gpg_keys" },
+
+      -- SSH Keys
+      { "GET /user/keys", "get_user_keys" },
+      { "POST /user/keys", "post_user_keys" },
+      { "GET /user/keys/{key_id}", "get_user_key" },
+      { "DELETE /user/keys/{key_id}", "delete_user_key" },
+      { "GET /users/{username}/keys", "get_users_keys" },
+
+      -- Social Accounts
+      { "GET /user/social_accounts", "get_user_social_accounts" },
+      { "POST /user/social_accounts", "post_user_social_accounts" },
+      { "DELETE /user/social_accounts", "delete_user_social_accounts" },
+      { "GET /users/{username}/social_accounts", "get_users_social_accounts" },
+
+      -- SSH Signing Keys
+      { "GET /user/ssh_signing_keys", "get_user_ssh_signing_keys" },
+      { "POST /user/ssh_signing_keys", "post_user_ssh_signing_keys" },
+      { "GET /user/ssh_signing_keys/{ssh_signing_key_id}", "get_user_ssh_signing_key" },
+      { "DELETE /user/ssh_signing_keys/{ssh_signing_key_id}", "delete_user_ssh_signing_key" },
+      { "GET /users/{username}/ssh_signing_keys", "get_users_ssh_signing_keys" },
+
+    },
+  },
+  {
+    "search",
+    {
+      -- Search (https://docs.github.com/en/rest/search)
+      { "GET /search/code", "search_code", search_empty },
+      { "GET /search/commits", "search_commits", search_empty },
+      { "GET /search/issues", "search_issues", search_empty },
+      { "GET /search/labels", "search_labels", search_empty },
+      { "GET /search/repositories", "search_repositories", search_empty },
+      { "GET /search/topics", "search_topics", search_empty },
+      { "GET /search/users", "search_users", search_empty },
+
+    },
+  },
+  {
+    "apps",
+    {
+      -- Apps (https://docs.github.com/en/rest/apps)
+      { "GET /app", "get_app" },
+      { "GET /app/hook/config", "get_app_hook_config" },
+      { "PATCH /app/hook/config", "patch_app_hook_config" },
+      { "GET /app/hook/deliveries", "get_app_hook_deliveries" },
+      { "GET /app/hook/deliveries/{delivery_id}", "get_app_hook_delivery" },
+      { "POST /app/hook/deliveries/{delivery_id}/attempts", "post_app_hook_delivery_attempt" },
+      { "GET /app/installation-requests", "get_app_installation_requests" },
+      { "GET /app/installations", "get_app_installations" },
+      { "GET /app/installations/{installation_id}", "get_app_installation" },
+      { "DELETE /app/installations/{installation_id}", "delete_app_installation" },
+      {
+        "POST /app/installations/{installation_id}/access_tokens",
+        "post_app_installation_access_tokens",
+      },
+      { "PUT /app/installations/{installation_id}/suspended", "put_app_installation_suspended" },
+      { "DELETE /app/installations/{installation_id}/suspended", "delete_app_installation_suspended" },
+      { "GET /apps/{app_slug}", "get_apps_app_slug" },
+      { "POST /app-manifests/{code}/conversions", "post_app_manifest_conversions" },
+      { "GET /installation/repositories", "get_installation_repositories" },
+      { "DELETE /installation/token", "delete_installation_token" },
+      { "POST /applications/{client_id}/token", "post_applications_token" },
+      { "PATCH /applications/{client_id}/token", "patch_applications_token" },
+      { "DELETE /applications/{client_id}/token", "delete_applications_token" },
+      { "POST /applications/{client_id}/token/scoped", "post_applications_token_scoped" },
+      { "DELETE /applications/{client_id}/grant", "delete_applications_grant" },
+      { "GET /orgs/{org}/installation", "get_org_installation" },
+      { "GET /orgs/{org}/installations", "get_org_installations" },
+      { "GET /repos/{owner}/{repo}/installation", "get_repo_installation" },
+      { "GET /user/installations", "get_user_installations" },
+      {
+        "GET /user/installations/{installation_id}/repositories",
+        "get_user_installation_repositories",
+      },
+      {
+        "PUT /user/installations/{installation_id}/repositories/{repository_id}",
+        "put_user_installation_repository",
+      },
+      {
+        "DELETE /user/installations/{installation_id}/repositories/{repository_id}",
+        "delete_user_installation_repository",
+      },
+      { "GET /users/{username}/installation", "get_users_installation" },
+
+    },
+  },
+  {
+    "checks",
+    {
+      -- Checks (https://docs.github.com/en/rest/checks)
+      {
+        "POST /repos/{owner}/{repo}/check-runs",
+        "post_check_runs",
+        function(_owner, _repo_name)
+          local req = DecodeJson(GetBody() or "{}")
+          respond_json(201, {
+            id = 0,
+            node_id = "",
+            head_sha = req.head_sha or "",
+            name = req.name or "",
+            status = req.status or "queued",
+            conclusion = req.conclusion,
+            started_at = nil,
+            completed_at = nil,
+            output = {
+              title = (req.output and req.output.title) or "",
+              summary = (req.output and req.output.summary) or "",
+              text = "",
+              annotations_count = 0,
+              annotations_url = "",
+            },
+            url = "",
+            html_url = "",
+            details_url = req.details_url or "",
+          })
+        end,
+      },
+      {
+        "GET /repos/{owner}/{repo}/check-runs/{check_run_id}",
+        "get_check_run",
+        function(_owner, _repo_name, check_run_id)
+          respond_json(200, {
+            id = tonumber(check_run_id) or 0,
+            node_id = "",
+            head_sha = "",
+            name = "",
+            status = "completed",
+            conclusion = "success",
+            started_at = nil,
+            completed_at = nil,
+            output = {
+              title = "",
+              summary = "",
+              text = "",
+              annotations_count = 0,
+              annotations_url = "",
+            },
+            url = "",
+            html_url = "",
+            details_url = "",
+          })
+        end,
+      },
+      {
+        "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
+        "patch_check_run",
+        function(_owner, _repo_name, check_run_id)
+          respond_json(200, {
+            id = tonumber(check_run_id) or 0,
+            node_id = "",
+            head_sha = "",
+            name = "",
+            status = "completed",
+            conclusion = "success",
+            started_at = nil,
+            completed_at = nil,
+            output = {
+              title = "",
+              summary = "",
+              text = "",
+              annotations_count = 0,
+              annotations_url = "",
+            },
+            url = "",
+            html_url = "",
+            details_url = "",
+          })
+        end,
+      },
+      {
+        "GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
+        "get_check_run_annotations",
+        function(_owner, _repo_name, _check_run_id)
+          set_preamble()
+          Write("[]")
+        end,
+      },
+      {
+        "POST /repos/{owner}/{repo}/check-runs/{check_run_id}/rerequest",
+        "post_check_run_rerequest",
+        function(_owner, _repo_name, _check_run_id)
+          respond_json(201, {})
+        end,
+      },
+      {
+        "POST /repos/{owner}/{repo}/check-suites",
+        "post_check_suites",
+        function(owner, repo_name)
+          local req = DecodeJson(GetBody() or "{}")
+          respond_json(201, {
+            id = 0,
+            node_id = "",
+            head_sha = req.head_sha or "",
+            status = "completed",
+            conclusion = "success",
+            app = { id = 0, slug = "", name = "" },
+            repository = { full_name = owner .. "/" .. repo_name },
+          })
+        end,
+      },
+      {
+        "PATCH /repos/{owner}/{repo}/check-suites/preferences",
+        "patch_check_suites_preferences",
+        function(_owner, _repo_name) -- luacheck: ignore 212
+          local req = DecodeJson(GetBody() or "{}") or {}
+          respond_json(200, {
+            preferences = req.auto_trigger_checks or {},
+          })
+        end,
+      },
+      {
+        "GET /repos/{owner}/{repo}/check-suites/{check_suite_id}",
+        "get_check_suite",
+        function(owner, repo_name, check_suite_id)
+          respond_json(200, {
+            id = tonumber(check_suite_id) or 0,
+            node_id = "",
+            head_sha = "",
+            status = "completed",
+            conclusion = "success",
+            app = { id = 0, slug = "", name = "" },
+            repository = { full_name = owner .. "/" .. repo_name },
+          })
+        end,
+      },
+      {
+        "GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",
+        "get_check_suite_check_runs",
+        function(_owner, _repo_name, _check_suite_id)
+          respond_json(200, { total_count = 0, check_runs = {} })
+        end,
+      },
+      {
+        "POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest",
+        "post_check_suite_rerequest",
+        function(_owner, _repo_name, _check_suite_id)
+          respond_json(201, {})
+        end,
+      },
+      {
+        "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+        "get_commit_check_runs",
+        function(_owner, _repo_name, _ref)
+          respond_json(200, { total_count = 0, check_runs = {} })
+        end,
+      },
+      {
+        "GET /repos/{owner}/{repo}/commits/{ref}/check-suites",
+        "get_commit_check_suites",
+        function(_owner, _repo_name, _ref)
+          respond_json(200, { total_count = 0, check_suites = {} })
+        end,
+      },
+
+    },
+  },
+  {
+    "code-scanning",
+    {
+      -- Code Scanning (https://docs.github.com/en/rest/code-scanning)
+      {
+        "GET /orgs/{org}/code-scanning/alerts",
+        "list_org_code_scanning_alerts",
+        code_scanning_list_empty,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/alerts",
+        "list_repo_code_scanning_alerts",
+        code_scanning_list_empty,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
+        "get_code_scanning_alert",
+        code_scanning_not_implemented,
+      },
+      {
+        "PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
+        "update_code_scanning_alert",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix",
+        "get_code_scanning_autofix",
+        code_scanning_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix",
+        "create_code_scanning_autofix",
+        code_scanning_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix/commits",
+        "commit_code_scanning_autofix",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances",
+        "list_code_scanning_alert_instances",
+        code_scanning_list_empty,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/analyses",
+        "list_code_scanning_analyses",
+        code_scanning_list_empty,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",
+        "get_code_scanning_analysis",
+        code_scanning_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",
+        "delete_code_scanning_analysis",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/codeql/databases",
+        "list_codeql_databases",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/codeql/databases/{language}",
+        "get_codeql_database",
+        code_scanning_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/code-scanning/codeql/databases/{language}",
+        "delete_codeql_database",
+        code_scanning_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/code-scanning/codeql/variant-analyses",
+        "create_codeql_variant_analysis",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/codeql/variant-analyses/{codeql_variant_analysis_id}",
+        "get_codeql_variant_analysis",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/codeql/variant-analyses/{codeql_variant_analysis_id}/repos/{repo_owner}/{repo_name}",
+        "get_codeql_variant_analysis_repo_task",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/default-setup",
+        "get_code_scanning_default_setup",
+        code_scanning_not_implemented,
+      },
+      {
+        "PATCH /repos/{owner}/{repo}/code-scanning/default-setup",
+        "update_code_scanning_default_setup",
+        code_scanning_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/code-scanning/sarifs",
+        "upload_code_scanning_sarif",
+        code_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}",
+        "get_code_scanning_sarif",
+        code_scanning_not_implemented,
+      },
+
+    },
+  },
+  {
+    "secret-scanning",
+    {
+      -- Secret Scanning (https://docs.github.com/en/rest/secret-scanning)
+      {
+        "GET /orgs/{org}/secret-scanning/alerts",
+        "list_org_secret_scanning_alerts",
+        secret_scanning_list_empty,
+      },
+      {
+        "GET /orgs/{org}/secret-scanning/pattern-configurations",
+        "get_org_secret_scanning_pattern_configs",
+        secret_scanning_not_implemented,
+      },
+      {
+        "PATCH /orgs/{org}/secret-scanning/pattern-configurations",
+        "update_org_secret_scanning_pattern_configs",
+        secret_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/secret-scanning/alerts",
+        "list_repo_secret_scanning_alerts",
+        secret_scanning_list_empty,
+      },
+      {
+        "GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
+        "get_secret_scanning_alert",
+        secret_scanning_not_implemented,
+      },
+      {
+        "PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
+        "update_secret_scanning_alert",
+        secret_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations",
+        "list_secret_scanning_alert_locations",
+        secret_scanning_list_empty,
+      },
+      {
+        "POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses",
+        "create_secret_scanning_push_protection_bypass",
+        secret_scanning_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/secret-scanning/scan-history",
+        "get_secret_scanning_scan_history",
+        secret_scanning_not_implemented,
+      },
+
+    },
+  },
+  {
+    "dependabot",
+    {
+      -- Dependabot (https://docs.github.com/en/rest/dependabot)
+      {
+        "GET /enterprises/{enterprise}/dependabot/alerts",
+        "list_enterprise_dependabot_alerts",
+        dependabot_list_empty,
+      },
+      { "GET /orgs/{org}/dependabot/alerts", "list_org_dependabot_alerts", dependabot_list_empty },
+      {
+        "GET /orgs/{org}/dependabot/secrets",
+        "list_org_dependabot_secrets",
+        make_empty_collection("secrets"),
+      },
+      {
+        "GET /orgs/{org}/dependabot/secrets/public-key",
+        "get_org_dependabot_public_key",
+        dependabot_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/dependabot/secrets/{secret_name}",
+        "get_org_dependabot_secret",
+        dependabot_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/dependabot/secrets/{secret_name}",
+        "put_org_dependabot_secret",
+        dependabot_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/dependabot/secrets/{secret_name}",
+        "delete_org_dependabot_secret",
+        dependabot_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories",
+        "list_org_dependabot_secret_repos",
+        make_empty_collection("repositories"),
+      },
+      {
+        "PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories",
+        "put_org_dependabot_secret_repos",
+        dependabot_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",
+        "add_org_dependabot_secret_repo",
+        dependabot_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",
+        "remove_org_dependabot_secret_repo",
+        dependabot_not_implemented,
+      },
+      {
+        "GET /organizations/{org}/dependabot/repository-access",
+        "get_org_dependabot_repo_access",
+        dependabot_not_implemented,
+      },
+      {
+        "PATCH /organizations/{org}/dependabot/repository-access",
+        "update_org_dependabot_repo_access",
+        dependabot_not_implemented,
+      },
+      {
+        "PUT /organizations/{org}/dependabot/repository-access/default-level",
+        "set_org_dependabot_repo_access_default_level",
+        dependabot_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/dependabot/alerts",
+        "list_repo_dependabot_alerts",
+        dependabot_list_empty,
+      },
+      {
+        "GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
+        "get_repo_dependabot_alert",
+        dependabot_not_implemented,
+      },
+      {
+        "PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
+        "update_repo_dependabot_alert",
+        dependabot_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/dependabot/secrets",
+        "list_repo_dependabot_secrets",
+        make_empty_collection("secrets"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/dependabot/secrets/public-key",
+        "get_repo_dependabot_public_key",
+        dependabot_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
+        "get_repo_dependabot_secret",
+        dependabot_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
+        "put_repo_dependabot_secret",
+        dependabot_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
+        "delete_repo_dependabot_secret",
+        dependabot_not_implemented,
+      },
+
+    },
+  },
+  {
+    "dependency-graph",
+    {
+      -- Dependency Graph (https://docs.github.com/en/rest/dependency-graph)
+      {
+        "GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}",
+        "get_repo_dependency_graph_compare",
+        dependency_graph_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/dependency-graph/sbom",
+        "get_repo_dependency_graph_sbom",
+        dependency_graph_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/dependency-graph/snapshots",
+        "post_repo_dependency_graph_snapshots",
+        dependency_graph_not_implemented,
+      },
+
+    },
+  },
+  {
+    "projects",
+    {
+      -- Projects (https://docs.github.com/en/rest/projects)
+      { "GET /orgs/{org}/projectsV2", "projects_list_for_org", projects_list_empty },
+      {
+        "GET /orgs/{org}/projectsV2/{project_number}",
+        "projects_get_for_org",
+        projects_not_implemented,
+      },
+      {
+        "POST /orgs/{org}/projectsV2/{project_number}/drafts",
+        "projects_create_draft_item_for_org",
+        projects_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/projectsV2/{project_number}/fields",
+        "projects_list_fields_for_org",
+        projects_list_empty,
+      },
+      {
+        "POST /orgs/{org}/projectsV2/{project_number}/fields",
+        "projects_add_field_for_org",
+        projects_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/projectsV2/{project_number}/fields/{field_id}",
+        "projects_get_field_for_org",
+        projects_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/projectsV2/{project_number}/items",
+        "projects_list_items_for_org",
+        projects_list_empty,
+      },
+      {
+        "POST /orgs/{org}/projectsV2/{project_number}/items",
+        "projects_add_item_for_org",
+        projects_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/projectsV2/{project_number}/items/{item_id}",
+        "projects_get_item_for_org",
+        projects_not_implemented,
+      },
+      {
+        "PATCH /orgs/{org}/projectsV2/{project_number}/items/{item_id}",
+        "projects_update_item_for_org",
+        projects_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/projectsV2/{project_number}/items/{item_id}",
+        "projects_delete_item_for_org",
+        projects_not_implemented,
+      },
+      {
+        "POST /orgs/{org}/projectsV2/{project_number}/views",
+        "projects_create_view_for_org",
+        projects_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/projectsV2/{project_number}/views/{view_number}/items",
+        "projects_list_view_items_for_org",
+        projects_list_empty,
+      },
+      {
+        "POST /user/{user_id}/projectsV2/{project_number}/drafts",
+        "projects_create_draft_item_for_user",
+        projects_not_implemented,
+      },
+      {
+        "POST /users/{user_id}/projectsV2/{project_number}/views",
+        "projects_create_view_for_user",
+        projects_not_implemented,
+      },
+      { "GET /users/{username}/projectsV2", "projects_list_for_user", projects_list_empty },
+      {
+        "GET /users/{username}/projectsV2/{project_number}",
+        "projects_get_for_user",
+        projects_not_implemented,
+      },
+      {
+        "GET /users/{username}/projectsV2/{project_number}/fields",
+        "projects_list_fields_for_user",
+        projects_list_empty,
+      },
+      {
+        "POST /users/{username}/projectsV2/{project_number}/fields",
+        "projects_add_field_for_user",
+        projects_not_implemented,
+      },
+      {
+        "GET /users/{username}/projectsV2/{project_number}/fields/{field_id}",
+        "projects_get_field_for_user",
+        projects_not_implemented,
+      },
+      {
+        "GET /users/{username}/projectsV2/{project_number}/items",
+        "projects_list_items_for_user",
+        projects_list_empty,
+      },
+      {
+        "POST /users/{username}/projectsV2/{project_number}/items",
+        "projects_add_item_for_user",
+        projects_not_implemented,
+      },
+      {
+        "GET /users/{username}/projectsV2/{project_number}/items/{item_id}",
+        "projects_get_item_for_user",
+        projects_not_implemented,
+      },
+      {
+        "PATCH /users/{username}/projectsV2/{project_number}/items/{item_id}",
+        "projects_update_item_for_user",
+        projects_not_implemented,
+      },
+      {
+        "DELETE /users/{username}/projectsV2/{project_number}/items/{item_id}",
+        "projects_delete_item_for_user",
+        projects_not_implemented,
+      },
+      {
+        "GET /users/{username}/projectsV2/{project_number}/views/{view_number}/items",
+        "projects_list_view_items_for_user",
+        projects_list_empty,
+      },
+
+    },
+  },
+  {
+    "packages",
+    {
+      -- Packages (https://docs.github.com/en/rest/packages)
+      { "GET /orgs/{org}/packages", "get_org_packages", empty_list },
+      { "GET /orgs/{org}/packages/{package_type}/{package_name}", "get_org_package" },
+      { "DELETE /orgs/{org}/packages/{package_type}/{package_name}", "delete_org_package" },
+      { "POST /orgs/{org}/packages/{package_type}/{package_name}/restore", "restore_org_package" },
+      {
+        "GET /orgs/{org}/packages/{package_type}/{package_name}/versions",
+        "get_org_package_versions",
+        empty_list,
+      },
+      {
+        "GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        "get_org_package_version",
+      },
+      {
+        "DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        "delete_org_package_version",
+      },
+      {
+        "POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+        "restore_org_package_version",
+      },
+      { "GET /user/packages", "get_user_packages", empty_list },
+      { "GET /user/packages/{package_type}/{package_name}", "get_user_package" },
+      { "DELETE /user/packages/{package_type}/{package_name}", "delete_user_package" },
+      { "POST /user/packages/{package_type}/{package_name}/restore", "restore_user_package" },
+      {
+        "GET /user/packages/{package_type}/{package_name}/versions",
+        "get_user_package_versions",
+        empty_list,
+      },
+      {
+        "GET /user/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        "get_user_package_version",
+      },
+      {
+        "DELETE /user/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        "delete_user_package_version",
+      },
+      {
+        "POST /user/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+        "restore_user_package_version",
+      },
+      { "GET /users/{username}/packages", "get_users_packages", empty_list },
+      { "GET /users/{username}/packages/{package_type}/{package_name}", "get_users_package" },
+      { "DELETE /users/{username}/packages/{package_type}/{package_name}", "delete_users_package" },
+      {
+        "POST /users/{username}/packages/{package_type}/{package_name}/restore",
+        "restore_users_package",
+      },
+      {
+        "GET /users/{username}/packages/{package_type}/{package_name}/versions",
+        "get_users_package_versions",
+        empty_list,
+      },
+      {
+        "GET /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        "get_users_package_version",
+      },
+      {
+        "DELETE /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        "delete_users_package_version",
+      },
+      {
+        "POST /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+        "restore_users_package_version",
+      },
+
+    },
+  },
+  {
+    "interactions",
+    {
+      -- Interactions (https://docs.github.com/en/rest/interactions)
+      { "GET /orgs/{org}/interaction-limits", "get_org_interaction_limits", interaction_limits_empty },
+      { "PUT /orgs/{org}/interaction-limits", "put_org_interaction_limits", interaction_limits_put },
+      {
+        "DELETE /orgs/{org}/interaction-limits",
+        "delete_org_interaction_limits",
+        interaction_limits_delete,
+      },
+      {
+        "GET /repos/{owner}/{repo}/interaction-limits",
+        "get_repo_interaction_limits",
+        interaction_limits_empty,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/interaction-limits",
+        "put_repo_interaction_limits",
+        interaction_limits_put,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/interaction-limits",
+        "delete_repo_interaction_limits",
+        interaction_limits_delete,
+      },
+      { "GET /user/interaction-limits", "get_user_interaction_limits", interaction_limits_empty },
+      { "PUT /user/interaction-limits", "put_user_interaction_limits", interaction_limits_put },
+      {
+        "DELETE /user/interaction-limits",
+        "delete_user_interaction_limits",
+        interaction_limits_delete,
+      },
+
+    },
+  },
+  {
+    "migrations",
+    {
+      -- Migrations (https://docs.github.com/en/rest/migrations)
+      -- Organization migrations
+      { "GET /orgs/{org}/migrations", "get_org_migrations", empty_list },
+      { "POST /orgs/{org}/migrations", "post_org_migrations", migrations_not_supported },
+      { "GET /orgs/{org}/migrations/{migration_id}", "get_org_migration", migration_not_found },
+      {
+        "GET /orgs/{org}/migrations/{migration_id}/archive",
+        "get_org_migration_archive",
+        migration_not_found,
+      },
+      {
+        "DELETE /orgs/{org}/migrations/{migration_id}/archive",
+        "delete_org_migration_archive",
+        migration_not_found,
+      },
+      {
+        "DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock",
+        "delete_org_migration_repo_lock",
+        migration_not_found,
+      },
+      {
+        "GET /orgs/{org}/migrations/{migration_id}/repositories",
+        "get_org_migration_repos",
+        empty_list,
+      },
+
+      -- User migrations
+      { "GET /user/migrations", "get_user_migrations", empty_list },
+      { "POST /user/migrations", "post_user_migrations", migrations_not_supported },
+      { "GET /user/migrations/{migration_id}", "get_user_migration", migration_not_found },
+      {
+        "GET /user/migrations/{migration_id}/archive",
+        "get_user_migration_archive",
+        migration_not_found,
+      },
+      {
+        "DELETE /user/migrations/{migration_id}/archive",
+        "delete_user_migration_archive",
+        migration_not_found,
+      },
+      {
+        "DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock",
+        "delete_user_migration_repo_lock",
+        migration_not_found,
+      },
+      { "GET /user/migrations/{migration_id}/repositories", "get_user_migration_repos", empty_list },
+
+    },
+  },
+  {
+    "pages",
+    {
+      -- Pages (https://docs.github.com/en/rest/pages)
+      { "GET /repos/{owner}/{repo}/pages", "get_repo_pages", pages_not_implemented },
+      { "POST /repos/{owner}/{repo}/pages", "post_repo_pages", pages_not_implemented },
+      { "PUT /repos/{owner}/{repo}/pages", "put_repo_pages", pages_not_implemented },
+      { "DELETE /repos/{owner}/{repo}/pages", "delete_repo_pages", pages_not_implemented },
+      { "GET /repos/{owner}/{repo}/pages/builds", "get_repo_pages_builds", empty_list },
+      { "POST /repos/{owner}/{repo}/pages/builds", "post_repo_pages_builds", pages_not_implemented },
+      {
+        "GET /repos/{owner}/{repo}/pages/builds/latest",
+        "get_repo_pages_build_latest",
+        pages_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/pages/builds/{build_id}",
+        "get_repo_pages_build",
+        pages_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/pages/deployments",
+        "post_repo_pages_deployments",
+        pages_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}",
+        "get_repo_pages_deployment",
+        pages_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}/cancel",
+        "post_repo_pages_deployment_cancel",
+        pages_not_implemented,
+      },
+      { "GET /repos/{owner}/{repo}/pages/health", "get_repo_pages_health", pages_not_implemented },
+
+      -- Source imports (deprecated May 2023 — returns 410 Gone)
+      { "GET /repos/{owner}/{repo}/import", "get_repo_import", source_import_gone },
+      { "PUT /repos/{owner}/{repo}/import", "put_repo_import", source_import_gone },
+      { "PATCH /repos/{owner}/{repo}/import", "patch_repo_import", source_import_gone },
+      { "DELETE /repos/{owner}/{repo}/import", "delete_repo_import", source_import_gone },
+      { "GET /repos/{owner}/{repo}/import/authors", "get_repo_import_authors", source_import_gone },
+      {
+        "PATCH /repos/{owner}/{repo}/import/authors/{author_id}",
+        "patch_repo_import_author",
+        source_import_gone,
+      },
+      {
+        "GET /repos/{owner}/{repo}/import/large_files",
+        "get_repo_import_large_files",
+        source_import_gone,
+      },
+      { "PATCH /repos/{owner}/{repo}/import/lfs", "patch_repo_import_lfs", source_import_gone },
+
+    },
+  },
+  {
+    "markdown",
+    {
+      -- Markdown (https://docs.github.com/en/rest/markdown)
+      { "POST /markdown", "render_markdown", markdown_not_implemented },
+      { "POST /markdown/raw", "render_markdown_raw", markdown_not_implemented },
+
+    },
+  },
+  {
+    "actions",
+    {
+      -- Actions (https://docs.github.com/en/rest/actions)
+      -- Enterprise-level cache limits
+      {
+        "GET /enterprises/{enterprise}/actions/cache/retention-limit",
+        "get_enterprise_actions_cache_retention_limit",
+        actions_not_implemented,
+      },
+      {
+        "PUT /enterprises/{enterprise}/actions/cache/retention-limit",
+        "put_enterprise_actions_cache_retention_limit",
+        actions_not_implemented,
+      },
+      {
+        "GET /enterprises/{enterprise}/actions/cache/storage-limit",
+        "get_enterprise_actions_cache_storage_limit",
+        actions_not_implemented,
+      },
+      {
+        "PUT /enterprises/{enterprise}/actions/cache/storage-limit",
+        "put_enterprise_actions_cache_storage_limit",
+        actions_not_implemented,
+      },
+
+      -- Enterprise-level OIDC
+      {
+        "GET /enterprises/{enterprise}/actions/oidc/customization/properties/repo",
+        "get_enterprise_actions_oidc_custom_props",
+        empty_list,
+      },
+      {
+        "POST /enterprises/{enterprise}/actions/oidc/customization/properties/repo",
+        "post_enterprise_actions_oidc_custom_prop",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /enterprises/{enterprise}/actions/oidc/customization/properties/repo/{custom_property_name}",
+        "delete_enterprise_actions_oidc_custom_prop",
+        actions_not_implemented,
+      },
+
+      -- Organization-level cache limits (via /organizations/ alias path)
+      {
+        "GET /organizations/{org}/actions/cache/retention-limit",
+        "get_org_actions_cache_retention_limit_v2",
+        actions_not_implemented,
+      },
+      {
+        "PUT /organizations/{org}/actions/cache/retention-limit",
+        "put_org_actions_cache_retention_limit_v2",
+        actions_not_implemented,
+      },
+      {
+        "GET /organizations/{org}/actions/cache/storage-limit",
+        "get_org_actions_cache_storage_limit_v2",
+        actions_not_implemented,
+      },
+      {
+        "PUT /organizations/{org}/actions/cache/storage-limit",
+        "put_org_actions_cache_storage_limit_v2",
+        actions_not_implemented,
+      },
+
+      -- Organization cache
+      { "GET /orgs/{org}/actions/cache/usage", "get_org_actions_cache_usage", actions_not_implemented },
+      {
+        "GET /orgs/{org}/actions/cache/usage-by-repository",
+        "get_org_actions_cache_usage_by_repo",
+        actions_not_implemented,
+      },
+
+      -- Organization hosted runners
+      {
+        "GET /orgs/{org}/actions/hosted-runners",
+        "get_org_actions_hosted_runners",
+        make_empty_collection("runners"),
+      },
+      {
+        "POST /orgs/{org}/actions/hosted-runners",
+        "post_org_actions_hosted_runner",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/images/custom",
+        "get_org_actions_hosted_runner_custom_images",
+        empty_list,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}",
+        "get_org_actions_hosted_runner_custom_image",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}",
+        "delete_org_actions_hosted_runner_custom_image",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions",
+        "get_org_actions_hosted_runner_custom_image_versions",
+        empty_list,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}",
+        "get_org_actions_hosted_runner_custom_image_version",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}",
+        "delete_org_actions_hosted_runner_custom_image_version",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/images/github-owned",
+        "get_org_actions_hosted_runner_github_images",
+        empty_list,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/images/partner",
+        "get_org_actions_hosted_runner_partner_images",
+        empty_list,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/limits",
+        "get_org_actions_hosted_runner_limits",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/machine-sizes",
+        "get_org_actions_hosted_runner_machine_sizes",
+        empty_list,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/platforms",
+        "get_org_actions_hosted_runner_platforms",
+        empty_list,
+      },
+      {
+        "GET /orgs/{org}/actions/hosted-runners/{hosted_runner_id}",
+        "get_org_actions_hosted_runner",
+        actions_not_implemented,
+      },
+      {
+        "PATCH /orgs/{org}/actions/hosted-runners/{hosted_runner_id}",
+        "patch_org_actions_hosted_runner",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/hosted-runners/{hosted_runner_id}",
+        "delete_org_actions_hosted_runner",
+        actions_not_implemented,
+      },
+
+      -- Organization OIDC
+      {
+        "GET /orgs/{org}/actions/oidc/customization/properties/repo",
+        "get_org_actions_oidc_custom_props",
+        empty_list,
+      },
+      {
+        "POST /orgs/{org}/actions/oidc/customization/properties/repo",
+        "post_org_actions_oidc_custom_prop",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/oidc/customization/properties/repo/{custom_property_name}",
+        "delete_org_actions_oidc_custom_prop",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/oidc/customization/sub",
+        "get_org_actions_oidc_sub",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/oidc/customization/sub",
+        "put_org_actions_oidc_sub",
+        actions_not_implemented,
+      },
+
+      -- Organization permissions
+      { "GET /orgs/{org}/actions/permissions", "get_org_actions_permissions", actions_not_implemented },
+      { "PUT /orgs/{org}/actions/permissions", "put_org_actions_permissions", actions_not_implemented },
+      {
+        "GET /orgs/{org}/actions/permissions/artifact-and-log-retention",
+        "get_org_actions_artifact_log_retention",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/artifact-and-log-retention",
+        "put_org_actions_artifact_log_retention",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/permissions/fork-pr-contributor-approval",
+        "get_org_actions_fork_pr_approval",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/fork-pr-contributor-approval",
+        "put_org_actions_fork_pr_approval",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/permissions/fork-pr-workflows-private-repos",
+        "get_org_actions_fork_pr_private_repos",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/fork-pr-workflows-private-repos",
+        "put_org_actions_fork_pr_private_repos",
+        actions_not_implemented,
+      },
+      { "GET /orgs/{org}/actions/permissions/repositories", "get_org_actions_perm_repos", empty_list },
+      {
+        "PUT /orgs/{org}/actions/permissions/repositories",
+        "put_org_actions_perm_repos",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/repositories/{repository_id}",
+        "put_org_actions_perm_repo",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}",
+        "delete_org_actions_perm_repo",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/permissions/selected-actions",
+        "get_org_actions_selected_actions",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/selected-actions",
+        "put_org_actions_selected_actions",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/permissions/self-hosted-runners",
+        "get_org_actions_self_hosted_runners_perm",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/self-hosted-runners",
+        "put_org_actions_self_hosted_runners_perm",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/permissions/self-hosted-runners/repositories",
+        "get_org_actions_self_hosted_runner_repos",
+        empty_list,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/self-hosted-runners/repositories",
+        "put_org_actions_self_hosted_runner_repos",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/self-hosted-runners/repositories/{repository_id}",
+        "put_org_actions_self_hosted_runner_repo",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/permissions/self-hosted-runners/repositories/{repository_id}",
+        "delete_org_actions_self_hosted_runner_repo",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/permissions/workflow",
+        "get_org_actions_default_workflow_perms",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions/workflow",
+        "put_org_actions_default_workflow_perms",
+        actions_not_implemented,
+      },
+
+      -- Organization runner groups
+      {
+        "GET /orgs/{org}/actions/runner-groups",
+        "get_org_actions_runner_groups",
+        make_empty_collection("runner_groups"),
+      },
+      {
+        "POST /orgs/{org}/actions/runner-groups",
+        "post_org_actions_runner_group",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/runner-groups/{runner_group_id}",
+        "get_org_actions_runner_group",
+        actions_not_implemented,
+      },
+      {
+        "PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}",
+        "patch_org_actions_runner_group",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}",
+        "delete_org_actions_runner_group",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/hosted-runners",
+        "get_org_actions_runner_group_hosted_runners",
+        make_empty_collection("runners"),
+      },
+      {
+        "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
+        "get_org_actions_runner_group_repos",
+        empty_list,
+      },
+      {
+        "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
+        "put_org_actions_runner_group_repos",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
+        "put_org_actions_runner_group_repo",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
+        "delete_org_actions_runner_group_repo",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
+        "get_org_actions_runner_group_runners",
+        make_empty_collection("runners"),
+      },
+      {
+        "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
+        "put_org_actions_runner_group_runners",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+        "put_org_actions_runner_group_runner",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+        "delete_org_actions_runner_group_runner",
+        actions_not_implemented,
+      },
+
+      -- Organization runners
+      {
+        "GET /orgs/{org}/actions/runners",
+        "get_org_actions_runners",
+        make_empty_collection("runners"),
+      },
+      { "GET /orgs/{org}/actions/runners/downloads", "get_org_actions_runner_downloads", empty_list },
+      {
+        "POST /orgs/{org}/actions/runners/generate-jitconfig",
+        "post_org_actions_runner_jitconfig",
+        actions_not_implemented,
+      },
+      {
+        "POST /orgs/{org}/actions/runners/registration-token",
+        "post_org_actions_runner_registration_token",
+        actions_not_implemented,
+      },
+      {
+        "POST /orgs/{org}/actions/runners/remove-token",
+        "post_org_actions_runner_remove_token",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/runners/{runner_id}",
+        "get_org_actions_runner",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/runners/{runner_id}",
+        "delete_org_actions_runner",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/runners/{runner_id}/labels",
+        "get_org_actions_runner_labels",
+        empty_list,
+      },
+      {
+        "POST /orgs/{org}/actions/runners/{runner_id}/labels",
+        "post_org_actions_runner_labels",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/runners/{runner_id}/labels",
+        "put_org_actions_runner_labels",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/runners/{runner_id}/labels",
+        "delete_org_actions_runner_labels",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/runners/{runner_id}/labels/{name}",
+        "delete_org_actions_runner_label",
+        actions_not_implemented,
+      },
+
+      -- Organization secrets
+      {
+        "GET /orgs/{org}/actions/secrets",
+        "get_org_actions_secrets",
+        make_empty_collection("secrets"),
+      },
+      {
+        "GET /orgs/{org}/actions/secrets/public-key",
+        "get_org_actions_secrets_public_key",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/secrets/{secret_name}",
+        "get_org_actions_secret",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/secrets/{secret_name}",
+        "put_org_actions_secret",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/secrets/{secret_name}",
+        "delete_org_actions_secret",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/secrets/{secret_name}/repositories",
+        "get_org_actions_secret_repos",
+        empty_list,
+      },
+      {
+        "PUT /orgs/{org}/actions/secrets/{secret_name}/repositories",
+        "put_org_actions_secret_repos",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+        "put_org_actions_secret_repo",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+        "delete_org_actions_secret_repo",
+        actions_not_implemented,
+      },
+
+      -- Organization variables
+      {
+        "GET /orgs/{org}/actions/variables",
+        "get_org_actions_variables",
+        make_empty_collection("variables"),
+      },
+      { "POST /orgs/{org}/actions/variables", "post_org_actions_variable", actions_not_implemented },
+      {
+        "GET /orgs/{org}/actions/variables/{name}",
+        "get_org_actions_variable",
+        actions_not_implemented,
+      },
+      {
+        "PATCH /orgs/{org}/actions/variables/{name}",
+        "patch_org_actions_variable",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/variables/{name}",
+        "delete_org_actions_variable",
+        actions_not_implemented,
+      },
+      {
+        "GET /orgs/{org}/actions/variables/{name}/repositories",
+        "get_org_actions_variable_repos",
+        empty_list,
+      },
+      {
+        "PUT /orgs/{org}/actions/variables/{name}/repositories",
+        "put_org_actions_variable_repos",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/variables/{name}/repositories/{repository_id}",
+        "put_org_actions_variable_repo",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /orgs/{org}/actions/variables/{name}/repositories/{repository_id}",
+        "delete_org_actions_variable_repo",
+        actions_not_implemented,
+      },
+
+      -- Repository artifacts
+      {
+        "GET /repos/{owner}/{repo}/actions/artifacts",
+        "get_repo_actions_artifacts",
+        make_empty_collection("artifacts"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
+        "get_repo_actions_artifact",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
+        "delete_repo_actions_artifact",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
+        "get_repo_actions_artifact_archive",
+        actions_not_implemented,
+      },
+
+      -- Repository cache
+      {
+        "GET /repos/{owner}/{repo}/actions/cache/retention-limit",
+        "get_repo_actions_cache_retention_limit",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/cache/retention-limit",
+        "put_repo_actions_cache_retention_limit",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/cache/storage-limit",
+        "get_repo_actions_cache_storage_limit",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/cache/storage-limit",
+        "put_repo_actions_cache_storage_limit",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/cache/usage",
+        "get_repo_actions_cache_usage",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/caches",
+        "get_repo_actions_caches",
+        make_empty_collection("actions_caches"),
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/caches",
+        "delete_repo_actions_caches",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}",
+        "delete_repo_actions_cache",
+        actions_not_implemented,
+      },
+
+      -- Repository jobs
+      {
+        "GET /repos/{owner}/{repo}/actions/jobs/{job_id}",
+        "get_repo_actions_job",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
+        "get_repo_actions_job_logs",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun",
+        "post_repo_actions_job_rerun",
+        actions_not_implemented,
+      },
+
+      -- Repository OIDC
+      {
+        "GET /repos/{owner}/{repo}/actions/oidc/customization/sub",
+        "get_repo_actions_oidc_sub",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/oidc/customization/sub",
+        "put_repo_actions_oidc_sub",
+        actions_not_implemented,
+      },
+
+      -- Repository org secrets/variables (read-only inherited view)
+      {
+        "GET /repos/{owner}/{repo}/actions/organization-secrets",
+        "get_repo_actions_org_secrets",
+        make_empty_collection("secrets"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/organization-variables",
+        "get_repo_actions_org_variables",
+        make_empty_collection("variables"),
+      },
+
+      -- Repository permissions
+      {
+        "GET /repos/{owner}/{repo}/actions/permissions",
+        "get_repo_actions_permissions",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/permissions",
+        "put_repo_actions_permissions",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/permissions/access",
+        "get_repo_actions_access_level",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/permissions/access",
+        "put_repo_actions_access_level",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention",
+        "get_repo_actions_artifact_log_retention",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention",
+        "put_repo_actions_artifact_log_retention",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval",
+        "get_repo_actions_fork_pr_approval",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval",
+        "put_repo_actions_fork_pr_approval",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos",
+        "get_repo_actions_fork_pr_private_repos",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos",
+        "put_repo_actions_fork_pr_private_repos",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/permissions/selected-actions",
+        "get_repo_actions_selected_actions",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/permissions/selected-actions",
+        "put_repo_actions_selected_actions",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/permissions/workflow",
+        "get_repo_actions_default_workflow_perms",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/permissions/workflow",
+        "put_repo_actions_default_workflow_perms",
+        actions_not_implemented,
+      },
+
+      -- Repository runners
+      {
+        "GET /repos/{owner}/{repo}/actions/runners",
+        "get_repo_actions_runners",
+        make_empty_collection("runners"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runners/downloads",
+        "get_repo_actions_runner_downloads",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig",
+        "post_repo_actions_runner_jitconfig",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runners/registration-token",
+        "post_repo_actions_runner_registration_token",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runners/remove-token",
+        "post_repo_actions_runner_remove_token",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runners/{runner_id}",
+        "get_repo_actions_runner",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}",
+        "delete_repo_actions_runner",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+        "get_repo_actions_runner_labels",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+        "post_repo_actions_runner_labels",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+        "put_repo_actions_runner_labels",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+        "delete_repo_actions_runner_labels",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels/{name}",
+        "delete_repo_actions_runner_label",
+        actions_not_implemented,
+      },
+
+      -- Repository workflow runs
+      {
+        "GET /repos/{owner}/{repo}/actions/runs",
+        "get_repo_actions_runs",
+        make_empty_collection("workflow_runs"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}",
+        "get_repo_actions_run",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/runs/{run_id}",
+        "delete_repo_actions_run",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/approvals",
+        "get_repo_actions_run_approvals",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve",
+        "post_repo_actions_run_approve",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+        "get_repo_actions_run_artifacts",
+        make_empty_collection("artifacts"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}",
+        "get_repo_actions_run_attempt",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",
+        "get_repo_actions_run_attempt_jobs",
+        make_empty_collection("jobs"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs",
+        "get_repo_actions_run_attempt_logs",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
+        "post_repo_actions_run_cancel",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runs/{run_id}/deployment_protection_rule",
+        "post_repo_actions_run_deployment_prot",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel",
+        "post_repo_actions_run_force_cancel",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+        "get_repo_actions_run_jobs",
+        make_empty_collection("jobs"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+        "get_repo_actions_run_logs",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+        "delete_repo_actions_run_logs",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
+        "get_repo_actions_run_pending_deployments",
+        empty_list,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
+        "post_repo_actions_run_pending_deployments",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun",
+        "post_repo_actions_run_rerun",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs",
+        "post_repo_actions_run_rerun_failed",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing",
+        "get_repo_actions_run_timing",
+        actions_not_implemented,
+      },
+
+      -- Repository secrets
+      {
+        "GET /repos/{owner}/{repo}/actions/secrets",
+        "get_repo_actions_secrets",
+        make_empty_collection("secrets"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/secrets/public-key",
+        "get_repo_actions_secrets_public_key",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/secrets/{secret_name}",
+        "get_repo_actions_secret",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}",
+        "put_repo_actions_secret",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}",
+        "delete_repo_actions_secret",
+        actions_not_implemented,
+      },
+
+      -- Repository variables
+      {
+        "GET /repos/{owner}/{repo}/actions/variables",
+        "get_repo_actions_variables",
+        make_empty_collection("variables"),
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/variables",
+        "post_repo_actions_variable",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/variables/{name}",
+        "get_repo_actions_variable",
+        actions_not_implemented,
+      },
+      {
+        "PATCH /repos/{owner}/{repo}/actions/variables/{name}",
+        "patch_repo_actions_variable",
+        actions_not_implemented,
+      },
+      {
+        "DELETE /repos/{owner}/{repo}/actions/variables/{name}",
+        "delete_repo_actions_variable",
+        actions_not_implemented,
+      },
+
+      -- Repository workflows
+      {
+        "GET /repos/{owner}/{repo}/actions/workflows",
+        "get_repo_actions_workflows",
+        make_empty_collection("workflows"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}",
+        "get_repo_actions_workflow",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable",
+        "put_repo_actions_workflow_disable",
+        actions_not_implemented,
+      },
+      {
+        "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+        "post_repo_actions_workflow_dispatch",
+        actions_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable",
+        "put_repo_actions_workflow_enable",
+        actions_not_implemented,
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+        "get_repo_actions_workflow_runs",
+        make_empty_collection("workflow_runs"),
+      },
+      {
+        "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing",
+        "get_repo_actions_workflow_timing",
+        actions_not_implemented,
+      },
+
+    },
+  },
+  {
+    "git",
+    {
+      -- Git database (https://docs.github.com/en/rest/git)
+      -- Blobs
+      { "POST /repos/{owner}/{repo}/git/blobs", "create_git_blob", git_not_implemented },
+      { "GET /repos/{owner}/{repo}/git/blobs/{file_sha}", "get_git_blob", git_not_implemented },
+
+      -- Commits
+      { "POST /repos/{owner}/{repo}/git/commits", "create_git_commit", git_not_implemented },
+      { "GET /repos/{owner}/{repo}/git/commits/{commit_sha}", "get_git_commit", git_not_implemented },
+
+      -- Refs
+      {
+        "GET /repos/{owner}/{repo}/git/matching-refs/{ref+}",
+        "list_git_matching_refs",
+        git_not_implemented,
+      },
+      { "GET /repos/{owner}/{repo}/git/ref/{ref+}", "get_git_ref", git_not_implemented },
+      { "POST /repos/{owner}/{repo}/git/refs", "create_git_ref", git_not_implemented },
+      { "PATCH /repos/{owner}/{repo}/git/refs/{ref+}", "update_git_ref", git_not_implemented },
+      { "DELETE /repos/{owner}/{repo}/git/refs/{ref+}", "delete_git_ref", git_not_implemented },
+
+      -- Tags
+      { "POST /repos/{owner}/{repo}/git/tags", "create_git_tag", git_not_implemented },
+      { "GET /repos/{owner}/{repo}/git/tags/{tag_sha}", "get_git_tag", git_not_implemented },
+
+      -- Trees
+      { "POST /repos/{owner}/{repo}/git/trees", "create_git_tree", git_not_implemented },
+      { "GET /repos/{owner}/{repo}/git/trees/{tree_sha}", "get_git_tree", git_not_implemented },
+    },
   },
-  { "GET /repos/{owner}/{repo}/git/ref/{ref+}", "get_git_ref", git_not_implemented },
-  { "POST /repos/{owner}/{repo}/git/refs", "create_git_ref", git_not_implemented },
-  { "PATCH /repos/{owner}/{repo}/git/refs/{ref+}", "update_git_ref", git_not_implemented },
-  { "DELETE /repos/{owner}/{repo}/git/refs/{ref+}", "delete_git_ref", git_not_implemented },
-
-  -- Tags
-  { "POST /repos/{owner}/{repo}/git/tags", "create_git_tag", git_not_implemented },
-  { "GET /repos/{owner}/{repo}/git/tags/{tag_sha}", "get_git_tag", git_not_implemented },
-
-  -- Trees
-  { "POST /repos/{owner}/{repo}/git/trees", "create_git_tree", git_not_implemented },
-  { "GET /repos/{owner}/{repo}/git/trees/{tree_sha}", "get_git_tree", git_not_implemented },
 }
--- Build the global `endpoints` table (consumed by scripts/dump-endpoints.lua)
--- and register routes. Marker entries { group = "name" } set the current
--- group; real entries get e.group set and are added to `endpoints`.
+
+-- Flatten sections into the global endpoints table and register routes.
+-- endpoints[i].group is the authoritative group name for each endpoint;
+-- downstream tools (scripts/dump-endpoints.lua) consume it.
 endpoints = {}
-local _group = ""
-for _, e in ipairs(_ep_catalog) do
-  if not e[1] then
-    _group = e.group
-  else
-    e.group = _group
+for _, section in ipairs(endpoint_sections) do
+  local g = section[1]
+  for _, e in ipairs(section[2]) do
+    e.group = g
     endpoints[#endpoints + 1] = e
     route_add(e[1], e[2], e[3])
   end

--- a/.init.lua
+++ b/.init.lua
@@ -682,17 +682,23 @@ end
 -- ---------------------------------------------------------------------------
 -- Endpoint catalog
 --
--- Authoritative source for every registered endpoint. Each entry is
--- { "METHOD /path", handler_name, default_fn } where default_fn is the
--- fallback when no backend implements the handler. Entries without a
--- default omit the third element (nil → 404 when unimplemented).
+-- Authoritative source for every registered endpoint. Each entry is:
+--   { "METHOD /path", handler_name [, default_fn] }
+-- where default_fn is the fallback when no backend implements the handler.
+-- Entries without a default omit the third element (nil → 404).
+--
+-- Entries are organised into named sections. { group = "name" } marker
+-- entries separate sections; they carry no route data. The section loop
+-- below sets e.group on every real entry and builds the global `endpoints`
+-- table, which scripts/dump-endpoints.lua reads to export the catalog.
 --
 -- Backends override handlers by setting backend_impl.<name>. Parametric
 -- captures from {param} segments are passed positionally to the handler.
 -- ---------------------------------------------------------------------------
 
-local endpoints = {
+local _ep_catalog = {
 
+  { group = "meta" },
   -- Root
   {
     "GET /",
@@ -712,17 +718,21 @@ local endpoints = {
   -- Emojis
   { "GET /emojis", "get_emojis" },
 
+  { group = "gitignore" },
   -- Gitignore templates (https://docs.github.com/en/rest/gitignore)
   { "GET /gitignore/templates", "get_gitignore_templates" },
   { "GET /gitignore/templates/{name}", "get_gitignore_template" },
 
+  { group = "licenses" },
   -- Licenses (https://docs.github.com/en/rest/licenses)
   { "GET /licenses", "get_licenses", licenses_not_implemented },
   { "GET /licenses/{license}", "get_license", licenses_not_implemented },
 
+  { group = "rate-limit" },
   -- Rate Limits (https://docs.github.com/en/rest/rate-limit)
   { "GET /rate_limit", "get_rate_limit", rate_limit_response },
 
+  { group = "gists" },
   -- Gists (https://docs.github.com/en/rest/gists)
   { "GET /gists", "get_gists", empty_list },
   { "POST /gists", "post_gists", gists_not_implemented },
@@ -745,6 +755,7 @@ local endpoints = {
   { "GET /gists/{gist_id}/{sha}", "get_gist_revision", gists_not_implemented },
   { "GET /users/{username}/gists", "get_user_gists", empty_list },
 
+  { group = "activity" },
   -- Activity (https://docs.github.com/en/rest/activity)
   { "GET /events", "get_events", activity_list_empty },
   { "GET /feeds", "get_feeds", activity_not_implemented },
@@ -807,6 +818,7 @@ local endpoints = {
   { "GET /users/{username}/starred", "get_users_starred", activity_list_empty },
   { "GET /users/{username}/subscriptions", "get_users_subscriptions", activity_list_empty },
 
+  { group = "repos" },
   -- Repos core (https://docs.github.com/en/rest/repos/repos)
   { "GET /repos/{owner}/{repo}", "get_repo" },
   { "PATCH /repos/{owner}/{repo}", "patch_repo" },
@@ -826,6 +838,7 @@ local endpoints = {
   { "GET /repos/{owner}/{repo}/tags", "get_repo_tags" },
   { "GET /repos/{owner}/{repo}/teams", "get_repo_teams" },
 
+  { group = "repos-ext" },
   -- Branches (https://docs.github.com/en/rest/branches)
   { "GET /repos/{owner}/{repo}/branches", "get_repo_branches" },
   { "GET /repos/{owner}/{repo}/branches/{branch}", "get_repo_branch" },
@@ -839,21 +852,6 @@ local endpoints = {
   { "GET /repos/{owner}/{repo}/comments/{comment_id}", "get_repo_comment" },
   { "PATCH /repos/{owner}/{repo}/comments/{comment_id}", "patch_repo_comment" },
   { "DELETE /repos/{owner}/{repo}/comments/{comment_id}", "delete_repo_comment" },
-  {
-    "GET /repos/{owner}/{repo}/comments/{comment_id}/reactions",
-    "get_repo_comment_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/comments/{comment_id}/reactions",
-    "post_repo_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}",
-    "delete_repo_comment_reaction",
-    reactions_not_implemented,
-  },
   { "GET /repos/{owner}/{repo}/commits/{commit_sha}/comments", "get_commit_comments" },
   { "POST /repos/{owner}/{repo}/commits/{commit_sha}/comments", "post_commit_comment" },
 
@@ -871,9 +869,11 @@ local endpoints = {
   { "GET /repos/{owner}/{repo}/tarball/{ref}", "get_repo_tarball" },
   { "GET /repos/{owner}/{repo}/zipball/{ref}", "get_repo_zipball" },
 
+  { group = "licenses" },
   -- Repo license (https://docs.github.com/en/rest/licenses)
   { "GET /repos/{owner}/{repo}/license", "get_repo_license", licenses_not_implemented },
 
+  { group = "repos-ext" },
   -- Compare
   { "GET /repos/{owner}/{repo}/compare/{basehead}", "get_repo_compare" },
 
@@ -895,6 +895,7 @@ local endpoints = {
   { "POST /repos/{owner}/{repo}/merges", "post_repo_merges" },
   { "POST /repos/{owner}/{repo}/merge-upstream", "post_repo_merge_upstream" },
 
+  { group = "releases" },
   -- Releases (https://docs.github.com/en/rest/releases)
   { "GET /repos/{owner}/{repo}/releases", "get_repo_releases" },
   { "POST /repos/{owner}/{repo}/releases", "post_repo_releases" },
@@ -908,22 +909,8 @@ local endpoints = {
   { "GET /repos/{owner}/{repo}/releases/assets/{asset_id}", "get_repo_release_asset" },
   { "PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}", "patch_repo_release_asset" },
   { "DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}", "delete_repo_release_asset" },
-  {
-    "GET /repos/{owner}/{repo}/releases/{release_id}/reactions",
-    "get_repo_release_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/releases/{release_id}/reactions",
-    "post_repo_release_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}",
-    "delete_repo_release_reaction",
-    reactions_not_implemented,
-  },
 
+  { group = "repos-ext" },
   -- Deploy keys (https://docs.github.com/en/rest/deploy-keys)
   { "GET /repos/{owner}/{repo}/keys", "get_repo_keys" },
   { "POST /repos/{owner}/{repo}/keys", "post_repo_keys" },
@@ -980,6 +967,7 @@ local endpoints = {
     "get_repo_deployment_status",
   },
 
+  { group = "teams" },
   -- Teams (https://docs.github.com/en/rest/teams)
   { "GET /orgs/{org}/teams", "get_org_teams", empty_list },
   { "POST /orgs/{org}/teams", "post_org_teams" },
@@ -1016,6 +1004,7 @@ local endpoints = {
   { "DELETE /teams/{team_id}/repos/{owner}/{repo}", "delete_team_repo" },
   { "GET /teams/{team_id}/teams", "get_team_children", empty_list },
 
+  { group = "security-advisories" },
   -- Security advisories (https://docs.github.com/en/rest/security-advisories)
   { "GET /advisories", "get_global_advisories", empty_list },
   { "GET /advisories/{ghsa_id}", "get_global_advisory" },
@@ -1037,6 +1026,7 @@ local endpoints = {
     "post_repo_security_advisory_fork",
   },
 
+  { group = "issues" },
   -- Issues (https://docs.github.com/en/rest/issues)
   { "GET /issues", "get_issues", empty_list },
   { "GET /orgs/{org}/issues", "get_org_issues", empty_list },
@@ -1051,21 +1041,6 @@ local endpoints = {
   {
     "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/pin",
     "delete_repo_issue_comment_pin",
-  },
-  {
-    "GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
-    "get_repo_issue_comment_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
-    "post_repo_issue_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",
-    "delete_repo_issue_comment_reaction",
-    reactions_not_implemented,
   },
   { "GET /repos/{owner}/{repo}/issues/events", "get_repo_issue_events", empty_list },
   { "GET /repos/{owner}/{repo}/issues/events/{event_id}", "get_repo_issue_event" },
@@ -1120,21 +1095,6 @@ local endpoints = {
     "patch_issue_sub_issues_priority",
   },
   { "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline", "get_issue_timeline", empty_list },
-  {
-    "GET /repos/{owner}/{repo}/issues/{issue_number}/reactions",
-    "get_issue_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/issues/{issue_number}/reactions",
-    "post_issue_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",
-    "delete_issue_reaction",
-    reactions_not_implemented,
-  },
 
   -- Assignees (https://docs.github.com/en/rest/issues/assignees)
   { "GET /repos/{owner}/{repo}/assignees", "get_repo_assignees", empty_list },
@@ -1173,6 +1133,7 @@ local endpoints = {
     "delete_repository_issue_field_value",
   },
 
+  { group = "pulls" },
   -- Pull Requests (https://docs.github.com/en/rest/pulls)
   { "GET /repos/{owner}/{repo}/pulls", "get_repo_pulls", empty_list },
   { "POST /repos/{owner}/{repo}/pulls", "post_repo_pulls" },
@@ -1180,21 +1141,6 @@ local endpoints = {
   { "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}", "get_repo_pull_comment" },
   { "PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}", "patch_repo_pull_comment" },
   { "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}", "delete_repo_pull_comment" },
-  {
-    "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
-    "get_repo_pull_comment_reactions",
-    empty_list,
-  },
-  {
-    "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
-    "post_repo_pull_comment_reaction",
-    reactions_not_implemented,
-  },
-  {
-    "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
-    "delete_repo_pull_comment_reaction",
-    reactions_not_implemented,
-  },
   { "GET /repos/{owner}/{repo}/pulls/{pull_number}", "get_repo_pull" },
   { "PATCH /repos/{owner}/{repo}/pulls/{pull_number}", "patch_repo_pull" },
   { "GET /repos/{owner}/{repo}/pulls/{pull_number}/codespaces", "get_pull_codespaces", empty_list },
@@ -1242,6 +1188,85 @@ local endpoints = {
   { "POST /repos/{owner}/{repo}/pulls/{pull_number}/update-branch", "post_pull_update_branch" },
   { "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls", "get_commit_pulls", empty_list },
 
+
+  -- Reactions (https://docs.github.com/en/rest/reactions)
+  { group = "reactions" },
+  {
+    "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+    "get_repo_pull_comment_reactions",
+    empty_list,
+  },
+  {
+    "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+    "post_repo_pull_comment_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
+    "delete_repo_pull_comment_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "GET /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+    "get_issue_reactions",
+    empty_list,
+  },
+  {
+    "POST /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+    "post_issue_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",
+    "delete_issue_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+    "get_repo_issue_comment_reactions",
+    empty_list,
+  },
+  {
+    "POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+    "post_repo_issue_comment_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",
+    "delete_repo_issue_comment_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "GET /repos/{owner}/{repo}/releases/{release_id}/reactions",
+    "get_repo_release_reactions",
+    empty_list,
+  },
+  {
+    "POST /repos/{owner}/{repo}/releases/{release_id}/reactions",
+    "post_repo_release_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}",
+    "delete_repo_release_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "GET /repos/{owner}/{repo}/comments/{comment_id}/reactions",
+    "get_repo_comment_reactions",
+    empty_list,
+  },
+  {
+    "POST /repos/{owner}/{repo}/comments/{comment_id}/reactions",
+    "post_repo_comment_reaction",
+    reactions_not_implemented,
+  },
+  {
+    "DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}",
+    "delete_repo_comment_reaction",
+    reactions_not_implemented,
+  },
+  { group = "users" },
   -- Users (https://docs.github.com/en/rest/users)
   { "GET /user", "get_user" },
   { "PATCH /user", "patch_user" },
@@ -1300,6 +1325,7 @@ local endpoints = {
   { "DELETE /user/ssh_signing_keys/{ssh_signing_key_id}", "delete_user_ssh_signing_key" },
   { "GET /users/{username}/ssh_signing_keys", "get_users_ssh_signing_keys" },
 
+  { group = "search" },
   -- Search (https://docs.github.com/en/rest/search)
   { "GET /search/code", "search_code", search_empty },
   { "GET /search/commits", "search_commits", search_empty },
@@ -1309,6 +1335,7 @@ local endpoints = {
   { "GET /search/topics", "search_topics", search_empty },
   { "GET /search/users", "search_users", search_empty },
 
+  { group = "apps" },
   -- Apps (https://docs.github.com/en/rest/apps)
   { "GET /app", "get_app" },
   { "GET /app/hook/config", "get_app_hook_config" },
@@ -1353,6 +1380,7 @@ local endpoints = {
   },
   { "GET /users/{username}/installation", "get_users_installation" },
 
+  { group = "checks" },
   -- Checks (https://docs.github.com/en/rest/checks)
   {
     "POST /repos/{owner}/{repo}/check-runs",
@@ -1518,6 +1546,7 @@ local endpoints = {
     end,
   },
 
+  { group = "code-scanning" },
   -- Code Scanning (https://docs.github.com/en/rest/code-scanning)
   {
     "GET /orgs/{org}/code-scanning/alerts",
@@ -1625,6 +1654,7 @@ local endpoints = {
     code_scanning_not_implemented,
   },
 
+  { group = "secret-scanning" },
   -- Secret Scanning (https://docs.github.com/en/rest/secret-scanning)
   {
     "GET /orgs/{org}/secret-scanning/alerts",
@@ -1672,6 +1702,7 @@ local endpoints = {
     secret_scanning_not_implemented,
   },
 
+  { group = "dependabot" },
   -- Dependabot (https://docs.github.com/en/rest/dependabot)
   {
     "GET /enterprises/{enterprise}/dependabot/alerts",
@@ -1780,6 +1811,7 @@ local endpoints = {
     dependabot_not_implemented,
   },
 
+  { group = "dependency-graph" },
   -- Dependency Graph (https://docs.github.com/en/rest/dependency-graph)
   {
     "GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}",
@@ -1797,6 +1829,7 @@ local endpoints = {
     dependency_graph_not_implemented,
   },
 
+  { group = "projects" },
   -- Projects (https://docs.github.com/en/rest/projects)
   { "GET /orgs/{org}/projectsV2", "projects_list_for_org", projects_list_empty },
   {
@@ -1921,6 +1954,7 @@ local endpoints = {
     projects_list_empty,
   },
 
+  { group = "packages" },
   -- Packages (https://docs.github.com/en/rest/packages)
   { "GET /orgs/{org}/packages", "get_org_packages", empty_list },
   { "GET /orgs/{org}/packages/{package_type}/{package_name}", "get_org_package" },
@@ -1989,6 +2023,7 @@ local endpoints = {
     "restore_users_package_version",
   },
 
+  { group = "interactions" },
   -- Interactions (https://docs.github.com/en/rest/interactions)
   { "GET /orgs/{org}/interaction-limits", "get_org_interaction_limits", interaction_limits_empty },
   { "PUT /orgs/{org}/interaction-limits", "put_org_interaction_limits", interaction_limits_put },
@@ -2020,6 +2055,7 @@ local endpoints = {
     interaction_limits_delete,
   },
 
+  { group = "migrations" },
   -- Migrations (https://docs.github.com/en/rest/migrations)
   -- Organization migrations
   { "GET /orgs/{org}/migrations", "get_org_migrations", empty_list },
@@ -2067,6 +2103,7 @@ local endpoints = {
   },
   { "GET /user/migrations/{migration_id}/repositories", "get_user_migration_repos", empty_list },
 
+  { group = "pages" },
   -- Pages (https://docs.github.com/en/rest/pages)
   { "GET /repos/{owner}/{repo}/pages", "get_repo_pages", pages_not_implemented },
   { "POST /repos/{owner}/{repo}/pages", "post_repo_pages", pages_not_implemented },
@@ -2119,10 +2156,12 @@ local endpoints = {
   },
   { "PATCH /repos/{owner}/{repo}/import/lfs", "patch_repo_import_lfs", source_import_gone },
 
+  { group = "markdown" },
   -- Markdown (https://docs.github.com/en/rest/markdown)
   { "POST /markdown", "render_markdown", markdown_not_implemented },
   { "POST /markdown/raw", "render_markdown_raw", markdown_not_implemented },
 
+  { group = "actions" },
   -- Actions (https://docs.github.com/en/rest/actions)
   -- Enterprise-level cache limits
   {
@@ -3054,6 +3093,7 @@ local endpoints = {
     actions_not_implemented,
   },
 
+  { group = "git" },
   -- Git database (https://docs.github.com/en/rest/git)
   -- Blobs
   { "POST /repos/{owner}/{repo}/git/blobs", "create_git_blob", git_not_implemented },
@@ -3082,8 +3122,19 @@ local endpoints = {
   { "POST /repos/{owner}/{repo}/git/trees", "create_git_tree", git_not_implemented },
   { "GET /repos/{owner}/{repo}/git/trees/{tree_sha}", "get_git_tree", git_not_implemented },
 }
-for _, e in ipairs(endpoints) do
-  route_add(e[1], e[2], e[3])
+-- Build the global `endpoints` table (consumed by scripts/dump-endpoints.lua)
+-- and register routes. Marker entries { group = "name" } set the current
+-- group; real entries get e.group set and are added to `endpoints`.
+endpoints = {}
+local _group = ""
+for _, e in ipairs(_ep_catalog) do
+  if not e[1] then
+    _group = e.group
+  else
+    e.group = _group
+    endpoints[#endpoints + 1] = e
+    route_add(e[1], e[2], e[3])
+  end
 end
 function OnHttpRequest()
   if not backend_allow_anonymous and not GetHeader("Authorization") then

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -39,4 +39,6 @@ globals = {
   -- Set by backends/*.lua, read by .init.lua
   "backend_impl",
   "backend_allow_anonymous",
+  -- Endpoint catalog: populated by .init.lua, read by scripts/dump-endpoints.lua
+  "endpoints",
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,12 @@ Makefile                     — build, test, and download targets
 .hurl-version                — pinned Hurl version (curl'd by make)
 site/
   index.html                 — GitHub Pages template (contains <!-- COMPAT_MATRIX --> placeholder)
-  compatibility.csv          — compatibility matrix source data (one row per route group, one column per provider)
+  compatibility.csv          — support values only: one row per endpoint (keyed by "METHOD /path"), one column per provider; section structure comes from the catalog
 scripts/
-  gen-matrix.py              — generates the HTML table from compatibility.csv into the template
+  dump-endpoints.lua         — exports endpoint catalog as JSON (run via redbean.com -i)
+  gen-matrix.py              — generates HTML table from catalog JSON + compatibility.csv
+  validate-csv.py            — checks every CSV row exists in the catalog
+  validate-tests.py          — checks every catalog group has test coverage per backend
 _site/                       — generated output (gitignored; produced by `make site` or the Pages workflow)
 test/
   test-unit.sh               — unit test harness (starts confusio + mock, runs hurl)
@@ -92,14 +95,22 @@ When implementing a new endpoint, check the spec for:
 ## Adding a new endpoint
 
 1. Check `vendor/github-rest-api-description/api.github.com.yaml` for the endpoint's contract.
-2. Add a `route_add(...)` call in `.init.lua`:
-   - Exact path: `route_add("/emojis", "emojis")`
-   - Parametric path: `route_add("/repos/{owner}/{repo}", "repo")`
+2. Add the endpoint to the appropriate `endpoint_sections` entry in `.init.lua`. Each entry is
+   `{ "VERB /path", "handler_name" }` or `{ "VERB /path", "handler_name", default_fn }`.
+   Endpoints are grouped into named sections (e.g. `"repos"`, `"issues"`) that drive the
+   compatibility matrix sections and test file naming.
 3. Add a default handler to the `defaults` table in `.init.lua`.
 4. If any backend behaves differently, add an override in `backends/<name>.lua`.
    Parametric captures are passed positionally: `repo = function(owner, repo) ... end`
-5. Add a hurl assertion file in `test/` and wire it into `test/test-unit.sh` (mock) and `test/test-integration.sh` (live).
-6. Update `site/compatibility.csv`: add a row (or update an existing row) for the new endpoint. Values: `y` = native support, `~` = partial/stub, `~explanation` = partial with tooltip explanation, `n` = returns 404/501. The GitHub Pages site is regenerated automatically from this CSV in CI — never edit the generated HTML.
+5. Add a hurl assertion file in `test/` named `test/stub-<group>.hurl` (if the default behavior
+   is the same for all backends) or `test/<backend>-<group>.hurl` (for backend-specific
+   behavior). The `BACKEND_RULE` in the Makefile automatically includes stub files as fallback
+   for any backend without its own group file.
+6. Update `site/compatibility.csv`: add a row for the new endpoint. Values: `y` = native
+   support, `~` = partial/stub, `~explanation` = partial with tooltip explanation,
+   `n` = returns 404/501. The endpoint column must match exactly what the catalog emits
+   (`make dump-endpoints`). Run `make validate-csv` to check. The GitHub Pages site is
+   regenerated automatically from the catalog + CSV in CI — never edit the generated HTML.
 
 ## Adding a new backend
 
@@ -108,7 +119,12 @@ When implementing a new endpoint, check the spec for:
    `config.backend == "<name>"` — no changes to `.init.lua` needed.
 2. Add mock server as `test/mock-<newbackend>.lua` and build it in the `Makefile` (copy pattern from `mock-gitea.com`).
 3. Add a `test/test-mock-validate.sh`-equivalent for the new backend if its spec differs meaningfully.
-4. Add a column for the new backend in `site/compatibility.csv` and fill in support values for every row.
+4. Add `<name>` to the `BACKENDS` list in the Makefile. Port numbers are assigned automatically.
+5. For each catalog group where this backend has native support, create `test/<name>-<group>.hurl`.
+   Groups with no custom file fall back to `test/stub-<group>.hurl` automatically. Run
+   `make validate-tests` to see which groups lack coverage.
+6. Add a column for the new backend in `site/compatibility.csv` and fill in support values
+   for every endpoint row. Run `make validate-csv` to check consistency.
 
 ## Redbean API notes
 
@@ -165,6 +181,23 @@ Hard-won insights from building this project. **Keep this section current**: whe
 ### GitHub Actions composite actions
 
 - **A local composite action (`uses: ./.github/actions/setup`) cannot contain `actions/checkout`.** The workflow runner needs to find the action file before checkout has run — chicken-and-egg. Always put `actions/checkout@v4` as an explicit first step in each job; the composite action handles everything after.
+
+### Endpoint catalog
+
+- **`endpoint_sections` is the single source of truth** for all routes. It drives route
+  registration, the compatibility matrix, and test file discovery. When adding endpoints,
+  only touch `endpoint_sections` in `.init.lua` — never manually update the matrix HTML or
+  add hardcoded group lists elsewhere.
+- **Group names** (the first element of each `endpoint_sections` entry) match test file
+  suffixes (`test/<backend>-<group>.hurl`) and CSV section keys. They are stable identifiers;
+  changing a group name requires updating test files and CSV rows.
+- **Stub files as universal fallback**: `test/stub-<group>.hurl` is automatically run for
+  any backend that lacks a `test/<backend>-<group>.hurl`. Write stubs to test the **default**
+  confusio behavior (empty arrays, 404s). If a backend has native support for a group, create
+  `test/<backend>-<group>.hurl` instead — never rely on the stub for a backend that returns
+  real data, or the stub's 404 assertions will fail.
+- **`make dump-endpoints`** exports the catalog as JSON. Used internally by `make site`,
+  `make validate-csv`, and `make validate-tests`.
 
 ### Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,10 @@ Built with [Redbean](https://redbean.dev): a self-contained web server + Lua int
 | `make -j test-format` | Check StyLua formatting only (no changes — fails if any file needs reformatting) |
 | `make -j test-lint` | Run luacheck linting only |
 | `make -j validate-mock` | Run `test/validate/gitea-api-version.hurl` against both the mock and a real Gitea instance to check they agree |
-| `make -j site` | Build GitHub Pages site into `_site/` (generates matrix from CSV) |
+| `make -j validate-csv` | Check every `site/compatibility.csv` row exists in the catalog |
+| `make -j validate-tests` | Check every catalog group has test coverage per backend |
+| `make -j dump-endpoints` | Print catalog as JSON to stdout |
+| `make -j site` | Build GitHub Pages site into `_site/` (catalog + CSV → matrix HTML) |
 
 **Before any commit and before any push: run `make -j test`.** This runs unit tests, integration tests, format check, and lint in one shot. CI enforces all of these — fix any failures before pushing.
 

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,12 @@ endef
 
 $(foreach b,$(BACKENDS),$(eval $(call BACKEND_RULE,$(b))))
 
-.PHONY: build site test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
+.PHONY: build site dump-endpoints test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
 
 build: confusio.com
+
+dump-endpoints: redbean.com
+	./redbean.com -i scripts/dump-endpoints.lua
 
 site:
 	mkdir -p _site

--- a/Makefile
+++ b/Makefile
@@ -99,19 +99,23 @@ endef
 
 $(foreach b,$(BACKENDS),$(eval $(call BACKEND_RULE,$(b))))
 
-.PHONY: build site dump-endpoints test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
+.PHONY: build site dump-endpoints validate-csv test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
 
 build: confusio.com
 
 dump-endpoints: redbean.com
 	./redbean.com -i scripts/dump-endpoints.lua
 
-site:
+validate-csv: redbean.com
+	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | python3 scripts/validate-csv.py site/compatibility.csv
+
+site: redbean.com
 	mkdir -p _site
 	cp -r site/. _site/
-	python3 scripts/gen-matrix.py site/compatibility.csv site/index.html _site/index.html
+	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | \
+	  python3 scripts/gen-matrix.py - site/compatibility.csv site/index.html _site/index.html
 
-test: test-unit test-integration test-format test-lint
+test: test-unit test-integration test-format test-lint validate-csv
 
 # Unit tests for .init.lua global functions (pure Lua, no HTTP server needed)
 test-unit-functions: redbean.com

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,15 @@ test-unit-$(1): confusio.com mock-$(1).com hurl
 	bash test/run-backend.sh mock-$(1).com \
 	  $($(1)_CPORT) $($(1)_MPORT) \
 	  "-- $(1) http://127.0.0.1:$($(1)_MPORT)" \
-	  $(wildcard test/$(1)-*.hurl)
+	  $(wildcard test/$(1)-*.hurl) \
+	  $(filter-out \
+	    $(patsubst test/$(1)-%.hurl,test/stub-%.hurl,$(wildcard test/$(1)-*.hurl)), \
+	    $(wildcard test/stub-*.hurl))
 endef
 
 $(foreach b,$(BACKENDS),$(eval $(call BACKEND_RULE,$(b))))
 
-.PHONY: build site dump-endpoints validate-csv test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
+.PHONY: build site dump-endpoints validate-csv validate-tests test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
 
 build: confusio.com
 
@@ -109,13 +112,16 @@ dump-endpoints: redbean.com
 validate-csv: redbean.com
 	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | python3 scripts/validate-csv.py site/compatibility.csv
 
+validate-tests: redbean.com
+	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | python3 scripts/validate-tests.py $(BACKENDS)
+
 site: redbean.com
 	mkdir -p _site
 	cp -r site/. _site/
 	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | \
 	  python3 scripts/gen-matrix.py - site/compatibility.csv site/index.html _site/index.html
 
-test: test-unit test-integration test-format test-lint validate-csv
+test: test-unit test-integration test-format test-lint validate-csv validate-tests
 
 # Unit tests for .init.lua global functions (pure Lua, no HTTP server needed)
 test-unit-functions: redbean.com

--- a/scripts/dump-endpoints.lua
+++ b/scripts/dump-endpoints.lua
@@ -1,0 +1,34 @@
+-- Export the endpoint catalog as a JSON array to stdout.
+-- Run from the project root: ./redbean.com -i scripts/dump-endpoints.lua
+
+-- Block backend files so only the core catalog is loaded.
+local _real_dofile = dofile
+function dofile(path) -- luacheck: globals dofile
+  if path and path:match("^/zip/backends/") then
+    return
+  end
+  return _real_dofile(path)
+end
+
+-- Load .init.lua, which populates the global `endpoints` table.
+_real_dofile(".init.lua")
+dofile = _real_dofile -- luacheck: globals dofile
+
+-- Serialize the catalog.
+local parts = {}
+for i, e in ipairs(endpoints) do -- luacheck: globals endpoints
+  local verb, path = e[1]:match("^(%S+)%s+(.+)$")
+  parts[i] = "  {"
+    .. '"method":'
+    .. EncodeJson(verb)
+    .. ',"path":'
+    .. EncodeJson(path)
+    .. ',"handler":'
+    .. EncodeJson(e[2])
+    .. ',"group":'
+    .. EncodeJson(e.group)
+    .. ',"has_default":'
+    .. (e[3] ~= nil and "true" or "false")
+    .. "}"
+end
+io.write("[\n" .. table.concat(parts, ",\n") .. "\n]\n")

--- a/scripts/gen-matrix.py
+++ b/scripts/gen-matrix.py
@@ -1,17 +1,25 @@
 #!/usr/bin/env python3
-"""Generate the compatibility matrix HTML from site/compatibility.csv.
+"""Generate the compatibility matrix HTML from the endpoint catalog and site/compatibility.csv.
 
 Usage:
-  python3 scripts/gen-matrix.py [csv] [template] [output]
+  python3 scripts/gen-matrix.py [catalog] [csv] [template] [output]
 
+  catalog  path to catalog JSON, or '-' for stdin (default: '-')
   csv      path to compatibility CSV  (default: site/compatibility.csv)
   template path to index.html template (default: site/index.html)
   output   path to write result        (default: stdout)
 
 The template must contain the marker <!-- COMPAT_MATRIX --> where the
 generated <table> element will be inserted.
+
+The catalog JSON is produced by: ./redbean.com -i scripts/dump-endpoints.lua
+Each entry has: method, path, handler, group, has_default.
+
+The CSV contains support values (y/n/~) keyed by "METHOD /path". Section
+headers are derived from the catalog group names; the CSV has no section rows.
 """
 import csv
+import json
 import sys
 from pathlib import Path
 
@@ -22,7 +30,8 @@ PROVIDER_NAMES = {
     "codeberg":            "Codeberg",
     "forgejo":             "Forgejo",
     "gerrit":              "Gerrit",
-    "gitbucket":           "Gitbucket",
+    "gitblit":             "GitBlit",
+    "gitbucket":           "GitBucket",
     "gitea":               "Gitea",
     "gitlab":              "GitLab",
     "gogs":                "Gogs",
@@ -37,7 +46,43 @@ PROVIDER_NAMES = {
     "rhodecode":           "RhodeCode",
     "sourceforge":         "SourceForge",
     "sourcehut":           "Sourcehut",
+    "codecommit":          "CodeCommit",
+    "tuleap":              "Tuleap",
 }
+
+GROUP_NAMES = {
+    "meta":                 "Meta",
+    "gitignore":            "Gitignore",
+    "licenses":             "Licenses",
+    "rate-limit":           "Rate Limits",
+    "gists":                "Gists",
+    "activity":             "Activity",
+    "repos":                "Repositories",
+    "repos-ext":            "Repo Content & Metadata",
+    "releases":             "Releases",
+    "reactions":            "Reactions",
+    "teams":                "Teams",
+    "security-advisories":  "Security Advisories",
+    "issues":               "Issues",
+    "pulls":                "Pull Requests",
+    "users":                "Users",
+    "search":               "Search",
+    "apps":                 "GitHub Apps",
+    "checks":               "Checks",
+    "code-scanning":        "Code Scanning",
+    "secret-scanning":      "Secret Scanning",
+    "dependabot":           "Dependabot",
+    "dependency-graph":     "Dependency Graph",
+    "projects":             "Projects",
+    "packages":             "Packages",
+    "interactions":         "Interaction Limits",
+    "migrations":           "Migrations",
+    "pages":                "Pages",
+    "markdown":             "Markdown",
+    "actions":              "Actions",
+    "git":                  "Git Database",
+}
+
 
 def make_cell(val):
     val = val.strip()
@@ -52,7 +97,7 @@ def make_cell(val):
     return '<td class="partial">&#x26A0;&#xFE0F;</td>'
 
 
-def generate_table(rows, providers):
+def generate_table(catalog, support, providers):
     num_cols = len(providers) + 1  # +1 for the endpoint column
 
     # thead
@@ -61,37 +106,50 @@ def generate_table(rows, providers):
         header_cells.append(f"<th>{PROVIDER_NAMES.get(p, p)}</th>")
     thead = "      <thead>\n        <tr>" + "".join(header_cells) + "</tr>\n      </thead>"
 
-    # tbody
+    # tbody — iterate catalog in group order, injecting section headers on group change
     tbody_rows = []
-    for row in rows:
-        endpoint = row["endpoint"]
-        if all(row.get(p, "") == "" for p in providers):
-            section = endpoint
+    current_group = None
+    for entry in catalog:
+        group = entry["group"]
+        if group != current_group:
+            section = GROUP_NAMES.get(group, group)
             tbody_rows.append(
                 f'        <tr><td colspan="{num_cols}" class="section-hdr">{section}</td></tr>'
             )
-        else:
-            cells = [f'<td class="ep">{endpoint}</td>']
-            for p in providers:
-                val = row.get(p, "n")
-                cells.append(make_cell(val))
-            tbody_rows.append("        <tr>" + "".join(cells) + "</tr>")
+            current_group = group
+        endpoint = entry["method"] + " " + entry["path"]
+        row = support.get(endpoint, {})
+        cells = [f'<td class="ep">{endpoint}</td>']
+        for p in providers:
+            val = row.get(p, "n")
+            cells.append(make_cell(val))
+        tbody_rows.append("        <tr>" + "".join(cells) + "</tr>")
 
     tbody = "      <tbody>\n" + "\n".join(tbody_rows) + "\n      </tbody>"
     return f"    <table>\n{thead}\n{tbody}\n    </table>"
 
 
 def main():
-    csv_path      = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("site/compatibility.csv")
-    template_path = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("site/index.html")
-    output_path   = Path(sys.argv[3]) if len(sys.argv) > 3 else None
+    catalog_arg  = sys.argv[1] if len(sys.argv) > 1 else "-"
+    csv_path     = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("site/compatibility.csv")
+    template_path = Path(sys.argv[3]) if len(sys.argv) > 3 else Path("site/index.html")
+    output_path  = Path(sys.argv[4]) if len(sys.argv) > 4 else None
 
+    if catalog_arg == "-":
+        catalog = json.load(sys.stdin)
+    else:
+        with open(catalog_arg) as f:
+            catalog = json.load(f)
+
+    # Load support values: keyed by "METHOD /path" → {provider: value}
+    support = {}
     with open(csv_path, newline="") as f:
         reader = csv.DictReader(f)
         providers = [h for h in reader.fieldnames if h != "endpoint"]
-        rows = [r for r in reader]
+        for row in reader:
+            support[row["endpoint"]] = {p: row.get(p, "n") for p in providers}
 
-    table_html = generate_table(rows, providers)
+    table_html = generate_table(catalog, support, providers)
     template = template_path.read_text()
     output = template.replace("<!-- COMPAT_MATRIX -->", table_html, 1)
 

--- a/scripts/validate-csv.py
+++ b/scripts/validate-csv.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Validate that every row in compatibility.csv corresponds to a catalog endpoint.
+
+Usage:
+  ./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | python3 scripts/validate-csv.py [csv]
+
+  csv  path to compatibility CSV (default: site/compatibility.csv)
+
+Exits non-zero if any CSV endpoint is not found in the catalog.
+"""
+import csv
+import json
+import sys
+from pathlib import Path
+
+csv_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("site/compatibility.csv")
+
+catalog = json.load(sys.stdin)
+catalog_eps = {e["method"] + " " + e["path"] for e in catalog}
+
+with open(csv_path, newline="") as f:
+    reader = csv.DictReader(f)
+    providers = [h for h in reader.fieldnames if h != "endpoint"]
+    csv_eps = [row["endpoint"] for row in reader]
+
+orphans = [ep for ep in csv_eps if ep not in catalog_eps]
+if orphans:
+    for ep in orphans:
+        print(f"ERROR: CSV row not in catalog: {ep}", file=sys.stderr)
+    sys.exit(1)

--- a/scripts/validate-tests.py
+++ b/scripts/validate-tests.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Report catalog groups with no test coverage for any backend.
+
+Usage:
+  ./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | python3 scripts/validate-tests.py <backend>...
+
+A group has coverage for a backend if either:
+  test/<backend>-<group>.hurl  exists (backend-specific), or
+  test/stub-<group>.hurl       exists (shared stub fallback).
+
+Groups with neither file are reported to stderr. Exits non-zero if any
+gap is found.
+"""
+import json
+import os
+import sys
+
+catalog = json.load(sys.stdin)
+groups = list(dict.fromkeys(e["group"] for e in catalog))
+backends = sys.argv[1:]
+
+gaps = []
+for b in backends:
+    for g in groups:
+        if not os.path.exists(f"test/{b}-{g}.hurl") and not os.path.exists(
+            f"test/stub-{g}.hurl"
+        ):
+            gaps.append(f"{b}/{g}")
+
+if gaps:
+    for gap in gaps:
+        print(f"ERROR: no test coverage for {gap}", file=sys.stderr)
+    sys.exit(1)

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,5 +1,4 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
-Repositories,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo},n,y,y,y,y,y,n,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},n,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},n,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,n,n,n,y,n
@@ -9,7 +8,6 @@ GET /orgs/{org}/repos,n,y,y,y,n,y,n,y,y,y,y,y,y,n,n,y,y,y,n,n,n,n,n,~
 POST /orgs/{org}/repos,n,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,n,n,n,n,n
 GET /users/{username}/repos,n,n,y,y,n,y,n,y,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repositories,n,y,y,n,y,n,y,y,y,y,y,n,n,n,n,n,n,y,n,y,n,n,n,n
-Repo Content & Metadata,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/tags,n,n,y,y,n,y,n,n,n,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 GET /repos/{owner}/{repo}/topics,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/topics,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
@@ -23,7 +21,6 @@ GET /repos/{owner}/{repo}/license,y,y,y,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/collaborators,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/forks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-Releases,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/releases,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/releases,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/releases/latest,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -38,7 +35,6 @@ PATCH /repos/{owner}/{repo}/releases/assets/{asset_id},n,n,n,y,n,y,n,n,y,y,y,y,n
 DELETE /repos/{owner}/{repo}/releases/assets/{asset_id},n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/keys,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/hooks,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-Users,,,,,,,,,,,,,,,,,,,,,,,,
 GET /user,n,y,n,y,n,y,y,n,y,y,y,y,y,n,n,y,n,y,n,n,n,n,y,n
 PATCH /user,n,y,n,y,n,y,y,n,y,y,y,y,y,n,n,y,n,y,n,n,n,n,y,n
 GET /users,n,n,y,y,n,y,y,y,y,y,y,y,n,n,n,y,y,y,n,n,n,n,n,~
@@ -48,7 +44,6 @@ GET /user/following,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/gpg_keys,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/emails,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-Gists,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gists,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /gists,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gists/public,n,y,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -69,13 +64,10 @@ PUT /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /gists/{gist_id}/star,n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gists/{gist_id}/{sha},n,y,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /users/{username}/gists,n,y,n,n,n,n,n,n,n,n,~own snippets only,n,n,n,n,n,n,n,n,n,n,n,n,n
-Teams,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /user/teams,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-Security Advisories,,,,,,,,,,,,,,,,,,,,,,,,
 GET /advisories,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/security-advisories,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Issues,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/issues,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,n
 POST /repos/{owner}/{repo}/issues,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,n,n,n,n,n,y,n
 GET /repos/{owner}/{repo}/issues/{issue_number},y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,n
@@ -87,7 +79,6 @@ POST /repos/{owner}/{repo}/issues/{issue_number}/labels,n,n,n,y,n,y,n,n,y,y,y,y,
 GET /repos/{owner}/{repo}/labels,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,~stub only,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/milestones,n,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/assignees,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-Pull Requests,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/pulls,n,y,y,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/pulls,n,y,y,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/pulls/{pull_number},n,y,y,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
@@ -101,7 +92,6 @@ GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id},n,~via partici
 GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments,n,~inline PR comments,~inline PR comments,y,n,y,n,n,y,y,~via MR notes,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/pulls/comments,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/pulls/comments/{comment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Reactions,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/comments/{comment_id}/reactions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/comments/{comment_id}/reactions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -117,7 +107,6 @@ DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}
 GET /repos/{owner}/{repo}/releases/{release_id}/reactions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/releases/{release_id}/reactions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Packages,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/packages,n,n,n,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/packages/{package_type}/{package_name},n,n,n,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /orgs/{org}/packages/{package_type}/{package_name},n,n,n,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -142,7 +131,6 @@ GET /users/{username}/packages/{package_type}/{package_name}/versions,n,n,n,y,n,
 GET /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Migrations,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/migrations,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 POST /orgs/{org}/migrations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/migrations/{migration_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -165,7 +153,6 @@ GET /repos/{owner}/{repo}/import/authors,~stub; returns 410 Gone,~stub; returns 
 PATCH /repos/{owner}/{repo}/import/authors/{author_id},~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone
 GET /repos/{owner}/{repo}/import/large_files,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone
 PATCH /repos/{owner}/{repo}/import/lfs,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone,~stub; returns 410 Gone
-Pages,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/pages,n,n,n,~inferred from gh-pages branch,n,~inferred from gh-pages branch,n,n,n,~inferred from gh-pages branch,n,~inferred from gh-pages branch,n,n,n,~inferred from gh-pages branch,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/pages,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/pages,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -178,7 +165,6 @@ POST /repos/{owner}/{repo}/pages/deployments,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}/cancel,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/pages/health,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Search,,,,,,,,,,,,,,,,,,,,,,,,
 GET /search/repositories,n,y,y,y,~via list filtering,y,n,y,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,~via projects API
 GET /search/users,n,y,y,y,n,y,n,y,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,~
 GET /search/issues,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -186,21 +172,16 @@ GET /search/commits,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /search/code,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /search/labels,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /search/topics,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Gitignore,,,,,,,,,,,,,,,,,,,,,,,,
 GET /gitignore/templates,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 GET /gitignore/templates/{name},n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-Licenses,,,,,,,,,,,,,,,,,,,,,,,,
 GET /licenses,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /licenses/{license},n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-Meta,,,,,,,,,,,,,,,,,,,,,,,,
 GET /meta,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /octocat,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /versions,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /teapot,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
 GET /zen,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
-Rate Limits,,,,,,,,,,,,,,,,,,,,,,,,
 GET /rate_limit,~unlimited stub,~unlimited stub,~unlimited stub,y,~unlimited stub,y,~unlimited stub,~unlimited stub,y,y,~unlimited stub,y,~unlimited stub,~unlimited stub,~unlimited stub,y,~unlimited stub,~unlimited stub,~unlimited stub,~unlimited stub,~unlimited stub,~unlimited stub,~unlimited stub,~unlimited stub
-Interaction Limits,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/interaction-limits,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions
 PUT /orgs/{org}/interaction-limits,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced
 DELETE /orgs/{org}/interaction-limits,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204
@@ -210,7 +191,6 @@ DELETE /repos/{owner}/{repo}/interaction-limits,~stub; always returns 204,~stub;
 GET /user/interaction-limits,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions,~stub; always returns no restrictions
 PUT /user/interaction-limits,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced,~stub; echoes input but not enforced
 DELETE /user/interaction-limits,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204,~stub; always returns 204
-Checks,,,,,,,,,,,,,,,,,,,,,,,,
 POST /repos/{owner}/{repo}/check-runs,y,y,y,y,~stub only,y,~stub only,~stub only,y,y,y,y,~stub only,~stub only,~stub only,y,~stub only,~via flags,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only
 GET /repos/{owner}/{repo}/check-runs/{check_run_id},~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only
 PATCH /repos/{owner}/{repo}/check-runs/{check_run_id},~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only
@@ -223,7 +203,6 @@ GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs,~stub only,~s
 POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only
 GET /repos/{owner}/{repo}/commits/{ref}/check-runs,y,y,y,y,~stub only,y,~stub only,~stub only,y,y,y,y,y,~stub only,~stub only,y,y,y,y,~stub only,~stub only,~stub only,y,~stub only
 GET /repos/{owner}/{repo}/commits/{ref}/check-suites,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only,~stub only
-Code Scanning,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/code-scanning/alerts,~empty list,n,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,n,~empty list,n,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,n,n,~empty list
 GET /repos/{owner}/{repo}/code-scanning/alerts,y,n,~via Code Insights annotations,~empty list,~empty list,~empty list,~empty list,~empty list,n,~empty list,n,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,n,n,~empty list
 GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number},y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -245,7 +224,6 @@ GET /repos/{owner}/{repo}/code-scanning/default-setup,n,n,n,n,n,n,n,n,n,n,n,n,n,
 PATCH /repos/{owner}/{repo}/code-scanning/default-setup,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/code-scanning/sarifs,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Secret Scanning,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/secret-scanning/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PATCH /orgs/{org}/secret-scanning/pattern-configurations,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -255,7 +233,6 @@ PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number},y,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 POST /repos/{owner}/{repo}/secret-scanning/push-protection-bypasses,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/secret-scanning/scan-history,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GitHub Apps,,,,,,,,,,,,,,,,,,,,,,,,
 GET /app,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /app/hook/config,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PATCH /app/hook/config,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -286,29 +263,21 @@ GET /user/installations/{installation_id}/repositories,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /user/installations/{installation_id}/repositories/{repository_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /user/installations/{installation_id}/repositories/{repository_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /users/{username}/installation,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Markdown,,,,,,,,,,,,,,,,,,,,,,,,
 POST /markdown,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /markdown/raw,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-Actions,,,,,,,,,,,,,,,,,,,,,,,,
-Actions — Enterprise cache,,,,,,,,,,,,,,,,,,,,,,,,
 GET /enterprises/{enterprise}/actions/cache/retention-limit,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /enterprises/{enterprise}/actions/cache/retention-limit,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /enterprises/{enterprise}/actions/cache/storage-limit,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /enterprises/{enterprise}/actions/cache/storage-limit,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Enterprise OIDC,,,,,,,,,,,,,,,,,,,,,,,,
 GET /enterprises/{enterprise}/actions/oidc/customization/properties/repo,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /enterprises/{enterprise}/actions/oidc/customization/properties/repo,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /enterprises/{enterprise}/actions/oidc/customization/properties/repo/{custom_property_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org cache,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/cache/usage,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/cache/usage-by-repository,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org hosted runners,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/hosted-runners,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /orgs/{org}/actions/hosted-runners,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org OIDC,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/oidc/customization/sub,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /orgs/{org}/actions/oidc/customization/sub,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org permissions,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/permissions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /orgs/{org}/actions/permissions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/permissions/repositories,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -317,13 +286,11 @@ GET /orgs/{org}/actions/permissions/selected-actions,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /orgs/{org}/actions/permissions/selected-actions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/permissions/workflow,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /orgs/{org}/actions/permissions/workflow,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org runner groups,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/runner-groups,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /orgs/{org}/actions/runner-groups,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/runner-groups/{runner_group_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PATCH /orgs/{org}/actions/runner-groups/{runner_group_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /orgs/{org}/actions/runner-groups/{runner_group_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org runners,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/runners,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/runners/downloads,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /orgs/{org}/actions/runners/registration-token,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -331,48 +298,39 @@ POST /orgs/{org}/actions/runners/remove-token,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,
 GET /orgs/{org}/actions/runners/{runner_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /orgs/{org}/actions/runners/{runner_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/runners/{runner_id}/labels,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org secrets,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/secrets,n,n,n,~list and delete only,n,~list and delete only,n,n,n,~list and delete only,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/secrets/{secret_name},n,n,n,~list and delete only,n,~list and delete only,n,n,n,~list and delete only,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /orgs/{org}/actions/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /orgs/{org}/actions/secrets/{secret_name},n,n,n,~list and delete only,n,~list and delete only,n,n,n,~list and delete only,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/secrets/{secret_name}/repositories,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Org variables,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/actions/variables,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /orgs/{org}/actions/variables,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/variables/{name},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PATCH /orgs/{org}/actions/variables/{name},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /orgs/{org}/actions/variables/{name},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /orgs/{org}/actions/variables/{name}/repositories,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo artifacts,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/artifacts,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo cache,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/cache/usage,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/caches,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/actions/caches,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo jobs,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/jobs/{job_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo OIDC,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/oidc/customization/sub,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/actions/oidc/customization/sub,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo permissions,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/permissions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/actions/permissions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/permissions/selected-actions,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/permissions/workflow,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo runners,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/runners,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/runners/downloads,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/actions/runners/registration-token,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/actions/runners/remove-token,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/runners/{runner_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/actions/runners/{runner_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo runs,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/runs,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/runs/{run_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/actions/runs/{run_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -380,44 +338,38 @@ GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts,n,n,n,n,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo secrets,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/secrets,n,n,n,~list and delete only,n,~list and delete only,n,n,n,~list and delete only,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/secrets/{secret_name},n,n,n,~list and delete only,n,~list and delete only,n,n,n,~list and delete only,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/actions/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name},n,n,n,~list and delete only,n,~list and delete only,n,n,n,~list and delete only,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Actions — Repo variables,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/variables,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/actions/variables,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/variables/{name},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 PATCH /repos/{owner}/{repo}/actions/variables/{name},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/actions/variables/{name},n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-Actions — Repo workflows,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/actions/workflows,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/workflows/{workflow_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Git Database,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/git/blobs/{file_sha},n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/git/blobs,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/git/commits/{commit_sha},n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/git/commits,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/git/matching-refs/{ref},y,y,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-GET /repos/{owner}/{repo}/git/ref/{ref},y,y,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/git/matching-refs/{ref+},y,y,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+GET /repos/{owner}/{repo}/git/ref/{ref+},y,y,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/git/refs,y,y,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-PATCH /repos/{owner}/{repo}/git/refs/{ref},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-DELETE /repos/{owner}/{repo}/git/refs/{ref},y,y,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+PATCH /repos/{owner}/{repo}/git/refs/{ref+},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+DELETE /repos/{owner}/{repo}/git/refs/{ref+},y,y,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/git/tags/{tag_sha},n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/git/tags,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/git/trees/{tree_sha},n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/git/trees,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Dependency Graph,,,,,,,,,,,,,,,,,,,,,,,,
 GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /repos/{owner}/{repo}/dependency-graph/sbom,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /repos/{owner}/{repo}/dependency-graph/snapshots,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Dependabot,,,,,,,,,,,,,,,,,,,,,,,,
 GET /enterprises/{enterprise}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/dependabot/alerts,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/dependabot/secrets,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
@@ -440,7 +392,6 @@ GET /repos/{owner}/{repo}/dependabot/secrets/public-key,n,n,n,n,n,n,n,n,n,n,n,n,
 GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-Projects,,,,,,,,,,,,,,,,,,,,,,,,
 GET /orgs/{org}/projectsV2,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /orgs/{org}/projectsV2/{project_number},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 POST /orgs/{org}/projectsV2/{project_number}/drafts,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -467,7 +418,6 @@ GET /users/{username}/projectsV2/{project_number}/items/{item_id},n,n,n,n,n,n,n,
 PATCH /users/{username}/projectsV2/{project_number}/items/{item_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 DELETE /users/{username}/projectsV2/{project_number}/items/{item_id},n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /users/{username}/projectsV2/{project_number}/views/{view_number}/items,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-Activity,,,,,,,,,,,,,,,,,,,,,,,,
 GET /events,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /feeds,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 GET /networks/{owner}/{repo}/events,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list

--- a/test/azuredevops-apps.hurl
+++ b/test/azuredevops-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/azuredevops-markdown.hurl
+++ b/test/azuredevops-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/azuredevops-packages.hurl
+++ b/test/azuredevops-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/azuredevops-pages.hurl
+++ b/test/azuredevops-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/azuredevops-projects.hurl
+++ b/test/azuredevops-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/azuredevops-releases.hurl
+++ b/test/azuredevops-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/azuredevops-search.hurl
+++ b/test/azuredevops-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/azuredevops-teams.hurl
+++ b/test/azuredevops-teams.hurl
@@ -1,0 +1,11 @@
+# Teams API — Azure DevOps projects map to GitHub orgs; ADO teams map to GitHub teams.
+
+# GET /orgs/{org}/teams
+GET http://{{host}}/orgs/testorg/teams
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].slug" == "core"
+jsonpath "$[0].name" isString

--- a/test/bitbucket-apps.hurl
+++ b/test/bitbucket-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/bitbucket-code-scanning.hurl
+++ b/test/bitbucket-code-scanning.hurl
@@ -1,1 +1,0 @@
-stub-code-scanning.hurl

--- a/test/bitbucket-dependabot.hurl
+++ b/test/bitbucket-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/bitbucket-markdown.hurl
+++ b/test/bitbucket-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/bitbucket-packages.hurl
+++ b/test/bitbucket-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/bitbucket-pages.hurl
+++ b/test/bitbucket-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/bitbucket-projects.hurl
+++ b/test/bitbucket-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/bitbucket_datacenter-apps.hurl
+++ b/test/bitbucket_datacenter-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/bitbucket_datacenter-dependabot.hurl
+++ b/test/bitbucket_datacenter-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/bitbucket_datacenter-markdown.hurl
+++ b/test/bitbucket_datacenter-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/bitbucket_datacenter-packages.hurl
+++ b/test/bitbucket_datacenter-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/bitbucket_datacenter-pages.hurl
+++ b/test/bitbucket_datacenter-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/bitbucket_datacenter-projects.hurl
+++ b/test/bitbucket_datacenter-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/codeberg-apps.hurl
+++ b/test/codeberg-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/codeberg-interactions.hurl
+++ b/test/codeberg-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/codeberg-projects.hurl
+++ b/test/codeberg-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/codeberg-releases.hurl
+++ b/test/codeberg-releases.hurl
@@ -1,0 +1,1 @@
+gitea-releases.hurl

--- a/test/codeberg-teams.hurl
+++ b/test/codeberg-teams.hurl
@@ -1,0 +1,1 @@
+gitea-teams.hurl

--- a/test/codecommit-apps.hurl
+++ b/test/codecommit-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/codecommit-dependabot.hurl
+++ b/test/codecommit-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/codecommit-interactions.hurl
+++ b/test/codecommit-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/codecommit-markdown.hurl
+++ b/test/codecommit-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/codecommit-packages.hurl
+++ b/test/codecommit-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/codecommit-pages.hurl
+++ b/test/codecommit-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/codecommit-projects.hurl
+++ b/test/codecommit-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/codecommit-releases.hurl
+++ b/test/codecommit-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/forgejo-apps.hurl
+++ b/test/forgejo-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/forgejo-projects.hurl
+++ b/test/forgejo-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/forgejo-releases.hurl
+++ b/test/forgejo-releases.hurl
@@ -1,0 +1,1 @@
+gitea-releases.hurl

--- a/test/forgejo-teams.hurl
+++ b/test/forgejo-teams.hurl
@@ -1,0 +1,1 @@
+gitea-teams.hurl

--- a/test/gerrit-apps.hurl
+++ b/test/gerrit-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/gerrit-dependabot.hurl
+++ b/test/gerrit-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/gerrit-interactions.hurl
+++ b/test/gerrit-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/gerrit-markdown.hurl
+++ b/test/gerrit-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/gerrit-packages.hurl
+++ b/test/gerrit-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/gerrit-pages.hurl
+++ b/test/gerrit-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/gerrit-projects.hurl
+++ b/test/gerrit-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/gerrit-releases.hurl
+++ b/test/gerrit-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/gerrit-search.hurl
+++ b/test/gerrit-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/gitblit-apps.hurl
+++ b/test/gitblit-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/gitblit-dependabot.hurl
+++ b/test/gitblit-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/gitblit-markdown.hurl
+++ b/test/gitblit-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/gitblit-packages.hurl
+++ b/test/gitblit-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/gitblit-pages.hurl
+++ b/test/gitblit-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/gitblit-projects.hurl
+++ b/test/gitblit-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/gitblit-releases.hurl
+++ b/test/gitblit-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/gitbucket-apps.hurl
+++ b/test/gitbucket-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/gitbucket-dependabot.hurl
+++ b/test/gitbucket-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/gitbucket-markdown.hurl
+++ b/test/gitbucket-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/gitbucket-packages.hurl
+++ b/test/gitbucket-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/gitbucket-pages.hurl
+++ b/test/gitbucket-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/gitbucket-projects.hurl
+++ b/test/gitbucket-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/gitbucket-releases.hurl
+++ b/test/gitbucket-releases.hurl
@@ -1,0 +1,48 @@
+# Releases API — GitBucket has a native releases API.
+
+# GET /repos/{owner}/{repo}/releases
+GET http://{{host}}/repos/octocat/hello-world/releases
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].id" == 1
+jsonpath "$[0].tag_name" == "v1.0"
+jsonpath "$[0].name" isString
+
+# GET /repos/{owner}/{repo}/releases/latest
+GET http://{{host}}/repos/octocat/hello-world/releases/latest
+
+HTTP 200
+[Asserts]
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/tags/{tag}
+GET http://{{host}}/repos/octocat/hello-world/releases/tags/v1.0
+
+HTTP 200
+[Asserts]
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/{release_id}
+GET http://{{host}}/repos/octocat/hello-world/releases/1
+
+HTTP 200
+[Asserts]
+jsonpath "$.id" == 1
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/{release_id}/assets
+GET http://{{host}}/repos/octocat/hello-world/releases/1/assets
+
+HTTP 200
+[Asserts]
+jsonpath "$" isCollection
+
+# GET /repos/{owner}/{repo}/releases/assets/{asset_id}
+GET http://{{host}}/repos/octocat/hello-world/releases/assets/1
+
+HTTP 200
+[Asserts]
+jsonpath "$.id" == 1

--- a/test/gitbucket-teams.hurl
+++ b/test/gitbucket-teams.hurl
@@ -1,0 +1,12 @@
+# Teams API — GitBucket supports org teams.
+
+# GET /orgs/{org}/teams
+GET http://{{host}}/orgs/testorg/teams
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].id" == 1
+jsonpath "$[0].slug" == "core"
+jsonpath "$[0].name" isString

--- a/test/gitea-apps.hurl
+++ b/test/gitea-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/gitea-projects.hurl
+++ b/test/gitea-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/gitea-releases.hurl
+++ b/test/gitea-releases.hurl
@@ -1,0 +1,48 @@
+# Releases API — Gitea has a native releases API.
+
+# GET /repos/{owner}/{repo}/releases
+GET http://{{host}}/repos/octocat/hello-world/releases
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].id" == 1
+jsonpath "$[0].tag_name" == "v1.0"
+jsonpath "$[0].name" isString
+
+# GET /repos/{owner}/{repo}/releases/latest
+GET http://{{host}}/repos/octocat/hello-world/releases/latest
+
+HTTP 200
+[Asserts]
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/tags/{tag}
+GET http://{{host}}/repos/octocat/hello-world/releases/tags/v1.0
+
+HTTP 200
+[Asserts]
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/{release_id}
+GET http://{{host}}/repos/octocat/hello-world/releases/1
+
+HTTP 200
+[Asserts]
+jsonpath "$.id" == 1
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/{release_id}/assets
+GET http://{{host}}/repos/octocat/hello-world/releases/1/assets
+
+HTTP 200
+[Asserts]
+jsonpath "$" isCollection
+
+# GET /repos/{owner}/{repo}/releases/assets/{asset_id}
+GET http://{{host}}/repos/octocat/hello-world/releases/assets/1
+
+HTTP 200
+[Asserts]
+jsonpath "$.id" == 1

--- a/test/gitea-teams.hurl
+++ b/test/gitea-teams.hurl
@@ -1,0 +1,12 @@
+# Teams API — Gitea supports org teams.
+
+# GET /orgs/{org}/teams
+GET http://{{host}}/orgs/testorg/teams
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].id" == 1
+jsonpath "$[0].slug" == "core"
+jsonpath "$[0].name" isString

--- a/test/gitlab-apps.hurl
+++ b/test/gitlab-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/gitlab-code-scanning.hurl
+++ b/test/gitlab-code-scanning.hurl
@@ -1,1 +1,0 @@
-stub-code-scanning.hurl

--- a/test/gitlab-pages.hurl
+++ b/test/gitlab-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/gitlab-projects.hurl
+++ b/test/gitlab-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/gitlab-releases.hurl
+++ b/test/gitlab-releases.hurl
@@ -1,0 +1,34 @@
+# Releases API — GitLab has a native releases API.
+# GitLab releases use tag_name as identifier; confusio maps integer release_id to tag_name.
+
+# GET /repos/{owner}/{repo}/releases
+GET http://{{host}}/repos/octocat/hello-world/releases
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].id" == 1
+jsonpath "$[0].tag_name" == "v1.0"
+jsonpath "$[0].name" isString
+
+# GET /repos/{owner}/{repo}/releases/latest
+GET http://{{host}}/repos/octocat/hello-world/releases/latest
+
+HTTP 200
+[Asserts]
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/tags/{tag}
+GET http://{{host}}/repos/octocat/hello-world/releases/tags/v1.0
+
+HTTP 200
+[Asserts]
+jsonpath "$.tag_name" == "v1.0"
+
+# GET /repos/{owner}/{repo}/releases/{release_id}
+GET http://{{host}}/repos/octocat/hello-world/releases/1
+
+HTTP 200
+[Asserts]
+jsonpath "$.tag_name" == "v1.0"

--- a/test/gitlab-teams.hurl
+++ b/test/gitlab-teams.hurl
@@ -1,0 +1,12 @@
+# Teams API — GitLab maps subgroups to GitHub teams.
+
+# GET /orgs/{org}/teams
+GET http://{{host}}/orgs/testorg/teams
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$" isCollection
+jsonpath "$[0].id" == 10
+jsonpath "$[0].slug" == "core"
+jsonpath "$[0].name" isString

--- a/test/gogs-apps.hurl
+++ b/test/gogs-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/gogs-packages.hurl
+++ b/test/gogs-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/gogs-projects.hurl
+++ b/test/gogs-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/gogs-releases.hurl
+++ b/test/gogs-releases.hurl
@@ -1,0 +1,1 @@
+gitea-releases.hurl

--- a/test/gogs-teams.hurl
+++ b/test/gogs-teams.hurl
@@ -1,0 +1,1 @@
+gitea-teams.hurl

--- a/test/harness-apps.hurl
+++ b/test/harness-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/harness-dependabot.hurl
+++ b/test/harness-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/harness-markdown.hurl
+++ b/test/harness-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/harness-packages.hurl
+++ b/test/harness-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/harness-pages.hurl
+++ b/test/harness-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/harness-projects.hurl
+++ b/test/harness-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/harness-search.hurl
+++ b/test/harness-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/kallithea-apps.hurl
+++ b/test/kallithea-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/kallithea-dependabot.hurl
+++ b/test/kallithea-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/kallithea-markdown.hurl
+++ b/test/kallithea-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/kallithea-packages.hurl
+++ b/test/kallithea-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/kallithea-pages.hurl
+++ b/test/kallithea-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/kallithea-projects.hurl
+++ b/test/kallithea-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/kallithea-releases.hurl
+++ b/test/kallithea-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/kallithea-repos.hurl
+++ b/test/kallithea-repos.hurl
@@ -1,1 +1,0 @@
-stub-repos.hurl

--- a/test/kallithea-search.hurl
+++ b/test/kallithea-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/kallithea-security-advisories.hurl
+++ b/test/kallithea-security-advisories.hurl
@@ -1,1 +1,0 @@
-stub-security-advisories.hurl

--- a/test/kallithea-teams.hurl
+++ b/test/kallithea-teams.hurl
@@ -1,1 +1,0 @@
-stub-teams.hurl

--- a/test/kallithea-users.hurl
+++ b/test/kallithea-users.hurl
@@ -1,1 +1,0 @@
-stub-users.hurl

--- a/test/launchpad-apps.hurl
+++ b/test/launchpad-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/launchpad-dependabot.hurl
+++ b/test/launchpad-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/launchpad-interactions.hurl
+++ b/test/launchpad-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/launchpad-markdown.hurl
+++ b/test/launchpad-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/launchpad-packages.hurl
+++ b/test/launchpad-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/launchpad-pages.hurl
+++ b/test/launchpad-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/launchpad-projects.hurl
+++ b/test/launchpad-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/launchpad-releases.hurl
+++ b/test/launchpad-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/launchpad-repos.hurl
+++ b/test/launchpad-repos.hurl
@@ -1,1 +1,0 @@
-stub-repos.hurl

--- a/test/launchpad-search.hurl
+++ b/test/launchpad-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/launchpad-security-advisories.hurl
+++ b/test/launchpad-security-advisories.hurl
@@ -1,1 +1,0 @@
-stub-security-advisories.hurl

--- a/test/launchpad-teams.hurl
+++ b/test/launchpad-teams.hurl
@@ -1,1 +1,0 @@
-stub-teams.hurl

--- a/test/launchpad-users.hurl
+++ b/test/launchpad-users.hurl
@@ -1,1 +1,0 @@
-stub-users.hurl

--- a/test/notabug-apps.hurl
+++ b/test/notabug-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/notabug-packages.hurl
+++ b/test/notabug-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/notabug-projects.hurl
+++ b/test/notabug-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/notabug-releases.hurl
+++ b/test/notabug-releases.hurl
@@ -1,0 +1,1 @@
+gitea-releases.hurl

--- a/test/notabug-teams.hurl
+++ b/test/notabug-teams.hurl
@@ -1,0 +1,1 @@
+gitea-teams.hurl

--- a/test/onedev-apps.hurl
+++ b/test/onedev-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/onedev-dependabot.hurl
+++ b/test/onedev-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/onedev-markdown.hurl
+++ b/test/onedev-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/onedev-packages.hurl
+++ b/test/onedev-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/onedev-pages.hurl
+++ b/test/onedev-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/onedev-projects.hurl
+++ b/test/onedev-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/onedev-search.hurl
+++ b/test/onedev-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/pagure-apps.hurl
+++ b/test/pagure-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/pagure-dependabot.hurl
+++ b/test/pagure-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/pagure-interactions.hurl
+++ b/test/pagure-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/pagure-markdown.hurl
+++ b/test/pagure-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/pagure-packages.hurl
+++ b/test/pagure-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/pagure-pages.hurl
+++ b/test/pagure-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/pagure-projects.hurl
+++ b/test/pagure-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/pagure-search.hurl
+++ b/test/pagure-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/phabricator-apps.hurl
+++ b/test/phabricator-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/phabricator-dependabot.hurl
+++ b/test/phabricator-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/phabricator-interactions.hurl
+++ b/test/phabricator-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/phabricator-markdown.hurl
+++ b/test/phabricator-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/phabricator-packages.hurl
+++ b/test/phabricator-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/phabricator-pages.hurl
+++ b/test/phabricator-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/phabricator-projects.hurl
+++ b/test/phabricator-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/phabricator-releases.hurl
+++ b/test/phabricator-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/phabricator-repos.hurl
+++ b/test/phabricator-repos.hurl
@@ -1,1 +1,0 @@
-stub-repos.hurl

--- a/test/phabricator-search.hurl
+++ b/test/phabricator-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/phabricator-security-advisories.hurl
+++ b/test/phabricator-security-advisories.hurl
@@ -1,1 +1,0 @@
-stub-security-advisories.hurl

--- a/test/phabricator-teams.hurl
+++ b/test/phabricator-teams.hurl
@@ -1,1 +1,0 @@
-stub-teams.hurl

--- a/test/phabricator-users.hurl
+++ b/test/phabricator-users.hurl
@@ -1,1 +1,0 @@
-stub-users.hurl

--- a/test/radicle-apps.hurl
+++ b/test/radicle-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/radicle-dependabot.hurl
+++ b/test/radicle-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/radicle-interactions.hurl
+++ b/test/radicle-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/radicle-markdown.hurl
+++ b/test/radicle-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/radicle-packages.hurl
+++ b/test/radicle-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/radicle-pages.hurl
+++ b/test/radicle-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/radicle-projects.hurl
+++ b/test/radicle-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/radicle-search.hurl
+++ b/test/radicle-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/radicle-users.hurl
+++ b/test/radicle-users.hurl
@@ -1,1 +1,0 @@
-stub-users.hurl

--- a/test/rhodecode-apps.hurl
+++ b/test/rhodecode-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/rhodecode-dependabot.hurl
+++ b/test/rhodecode-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/rhodecode-interactions.hurl
+++ b/test/rhodecode-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/rhodecode-markdown.hurl
+++ b/test/rhodecode-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/rhodecode-packages.hurl
+++ b/test/rhodecode-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/rhodecode-pages.hurl
+++ b/test/rhodecode-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/rhodecode-projects.hurl
+++ b/test/rhodecode-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/rhodecode-releases.hurl
+++ b/test/rhodecode-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/rhodecode-repos.hurl
+++ b/test/rhodecode-repos.hurl
@@ -1,1 +1,0 @@
-stub-repos.hurl

--- a/test/rhodecode-search.hurl
+++ b/test/rhodecode-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/rhodecode-security-advisories.hurl
+++ b/test/rhodecode-security-advisories.hurl
@@ -1,1 +1,0 @@
-stub-security-advisories.hurl

--- a/test/rhodecode-teams.hurl
+++ b/test/rhodecode-teams.hurl
@@ -1,1 +1,0 @@
-stub-teams.hurl

--- a/test/rhodecode-users.hurl
+++ b/test/rhodecode-users.hurl
@@ -1,1 +1,0 @@
-stub-users.hurl

--- a/test/sourceforge-apps.hurl
+++ b/test/sourceforge-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/sourceforge-code-scanning.hurl
+++ b/test/sourceforge-code-scanning.hurl
@@ -1,1 +1,0 @@
-stub-code-scanning.hurl

--- a/test/sourceforge-dependabot.hurl
+++ b/test/sourceforge-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/sourceforge-interactions.hurl
+++ b/test/sourceforge-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/sourceforge-markdown.hurl
+++ b/test/sourceforge-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/sourceforge-packages.hurl
+++ b/test/sourceforge-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/sourceforge-pages.hurl
+++ b/test/sourceforge-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/sourceforge-projects.hurl
+++ b/test/sourceforge-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/sourceforge-releases.hurl
+++ b/test/sourceforge-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl

--- a/test/sourceforge-repos.hurl
+++ b/test/sourceforge-repos.hurl
@@ -1,1 +1,0 @@
-stub-repos.hurl

--- a/test/sourceforge-search.hurl
+++ b/test/sourceforge-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/sourceforge-security-advisories.hurl
+++ b/test/sourceforge-security-advisories.hurl
@@ -1,1 +1,0 @@
-stub-security-advisories.hurl

--- a/test/sourceforge-teams.hurl
+++ b/test/sourceforge-teams.hurl
@@ -1,1 +1,0 @@
-stub-teams.hurl

--- a/test/sourceforge-users.hurl
+++ b/test/sourceforge-users.hurl
@@ -1,1 +1,0 @@
-stub-users.hurl

--- a/test/sourcehut-apps.hurl
+++ b/test/sourcehut-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/sourcehut-code-scanning.hurl
+++ b/test/sourcehut-code-scanning.hurl
@@ -1,1 +1,0 @@
-stub-code-scanning.hurl

--- a/test/sourcehut-dependabot.hurl
+++ b/test/sourcehut-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/sourcehut-interactions.hurl
+++ b/test/sourcehut-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/sourcehut-markdown.hurl
+++ b/test/sourcehut-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/sourcehut-packages.hurl
+++ b/test/sourcehut-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/sourcehut-pages.hurl
+++ b/test/sourcehut-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/sourcehut-projects.hurl
+++ b/test/sourcehut-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/sourcehut-search.hurl
+++ b/test/sourcehut-search.hurl
@@ -1,1 +1,0 @@
-stub-search.hurl

--- a/test/stub-issues.hurl
+++ b/test/stub-issues.hurl
@@ -1,0 +1,20 @@
+# Issues API — no native support; list endpoints return [], individual → 404.
+
+# GET /repos/{owner}/{repo}/issues → []
+GET http://{{host}}/repos/octocat/hello-world/issues
+
+HTTP 200
+[Asserts]
+body == "[]"
+
+# GET /repos/{owner}/{repo}/issues/{issue_number} → 404
+GET http://{{host}}/repos/octocat/hello-world/issues/1
+
+HTTP 404
+
+# POST /repos/{owner}/{repo}/issues → 404
+POST http://{{host}}/repos/octocat/hello-world/issues
+Content-Type: application/json
+{"title": "Bug"}
+
+HTTP 404

--- a/test/stub-pulls.hurl
+++ b/test/stub-pulls.hurl
@@ -1,0 +1,20 @@
+# Pull requests API — no native support; list endpoints return [], individual → 404.
+
+# GET /repos/{owner}/{repo}/pulls → []
+GET http://{{host}}/repos/octocat/hello-world/pulls
+
+HTTP 200
+[Asserts]
+body == "[]"
+
+# GET /repos/{owner}/{repo}/pulls/{pull_number} → 404
+GET http://{{host}}/repos/octocat/hello-world/pulls/1
+
+HTTP 404
+
+# POST /repos/{owner}/{repo}/pulls → 404
+POST http://{{host}}/repos/octocat/hello-world/pulls
+Content-Type: application/json
+{"title": "Fix", "head": "feature", "base": "main"}
+
+HTTP 404

--- a/test/stub-repos-ext.hurl
+++ b/test/stub-repos-ext.hurl
@@ -1,0 +1,10 @@
+# Repo content & metadata — minimum coverage stub.
+# Uses only endpoints that return 404 across all backends (no backend implements them).
+# Backends with partial repos-ext support should override this with a backend-specific file.
+
+# POST /repos/{owner}/{repo}/merge-upstream → 404 (no backend implements this)
+POST http://{{host}}/repos/octocat/hello-world/merge-upstream
+Content-Type: application/json
+{"branch": "main"}
+
+HTTP 404

--- a/test/tuleap-apps.hurl
+++ b/test/tuleap-apps.hurl
@@ -1,1 +1,0 @@
-stub-apps.hurl

--- a/test/tuleap-dependabot.hurl
+++ b/test/tuleap-dependabot.hurl
@@ -1,1 +1,0 @@
-stub-dependabot.hurl

--- a/test/tuleap-interactions.hurl
+++ b/test/tuleap-interactions.hurl
@@ -1,1 +1,0 @@
-stub-interactions.hurl

--- a/test/tuleap-markdown.hurl
+++ b/test/tuleap-markdown.hurl
@@ -1,1 +1,0 @@
-stub-markdown.hurl

--- a/test/tuleap-packages.hurl
+++ b/test/tuleap-packages.hurl
@@ -1,1 +1,0 @@
-stub-packages.hurl

--- a/test/tuleap-pages.hurl
+++ b/test/tuleap-pages.hurl
@@ -1,1 +1,0 @@
-stub-pages.hurl

--- a/test/tuleap-projects.hurl
+++ b/test/tuleap-projects.hurl
@@ -1,1 +1,0 @@
-stub-projects.hurl

--- a/test/tuleap-releases.hurl
+++ b/test/tuleap-releases.hurl
@@ -1,1 +1,0 @@
-stub-releases.hurl


### PR DESCRIPTION
Makes the endpoint catalog the single source of truth by adding an explicit group field, exporting it as JSON, and sourcing the compatibility matrix and backend test discovery from it. Also updates the contributor workflow in CLAUDE.md to reflect the authoritative catalog.

Fixes #112.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Add explicit group field to endpoint catalog entries <!-- type:spec -->
- [x] Add scripts/dump-endpoints.lua to export catalog as JSON <!-- type:spec -->
- [x] Source compatibility matrix endpoints and sections from catalog <!-- type:spec -->
- [x] Drive backend test file discovery from catalog groups <!-- type:spec -->
- [x] Update CLAUDE.md contributor workflow for authoritative catalog <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->