### PR TITLE
Make provider-family metadata explicit for backend, mock, and test reuse (closes #113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 luacov.stats.out
 luacov.report.out
+.make-families.mk

--- a/.init.lua
+++ b/.init.lua
@@ -356,6 +356,30 @@ provider_families = {
   },
 }
 
+-- load_family_backend is global: alias backends call it to inherit a family
+-- implementation.  Looks up config.backend in provider_families[root].aliases,
+-- sets config.base_url from the alias's default_url when the user hasn't
+-- supplied one, loads the root backend via dofile, then clears any backend_impl
+-- keys whose names match the alias's strip patterns (features absent from this
+-- variant).
+function load_family_backend(root)
+  local family = provider_families[root]
+  assert(family, "unknown provider family: " .. root)
+  local alias = family.aliases[config.backend]
+  assert(alias, config.backend .. " is not an alias in the " .. root .. " family")
+  if config.base_url == "" then
+    config.base_url = alias.default_url
+  end
+  dofile("/zip/backends/" .. root .. ".lua")
+  for _, pattern in ipairs(alias.strip or {}) do
+    for k in pairs(backend_impl) do
+      if k:find(pattern) then
+        backend_impl[k] = nil
+      end
+    end
+  end
+end
+
 -- backend_impl is global: set by backends/<name>.lua at startup.
 backend_impl = {}
 -- backend_allow_anonymous is global: backends that require sign-in set this to false

--- a/.init.lua
+++ b/.init.lua
@@ -337,6 +337,25 @@ function translate_migration(m)
   }
 end
 
+-- Provider-family metadata (global: backends/<name>.lua can read at startup).
+-- Authoritative source for backend, mock, and test reuse relationships.
+-- The table key is the root backend name (the canonical family implementation).
+-- Each alias entry declares:
+--   default_url  string — backend default when no base_url is given
+--   strip        table  — Lua patterns; backend_impl keys matching any are
+--                         cleared after inheriting from the root implementation,
+--                         because those features are absent from this variant
+provider_families = {
+  gitea = {
+    aliases = {
+      forgejo  = { default_url = "https://codeberg.org" },
+      codeberg = { default_url = "https://codeberg.org" },
+      gogs     = { default_url = "https://try.gogs.io", strip = { "_package", "_actions_" } },
+      notabug  = { default_url = "https://notabug.org", strip = { "gitignore", "_package", "_actions_" } },
+    },
+  },
+}
+
 -- backend_impl is global: set by backends/<name>.lua at startup.
 backend_impl = {}
 -- backend_allow_anonymous is global: backends that require sign-in set this to false

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -24,6 +24,7 @@ globals = {
   "OnHttpRequest",
   -- App globals defined in .init.lua, read by backends/*.lua
   "provider_families",
+  "load_family_backend",
   "config",
   "set_preamble",
   "respond_json",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,6 +23,7 @@ globals = {
   "Route",
   "OnHttpRequest",
   -- App globals defined in .init.lua, read by backends/*.lua
+  "provider_families",
   "config",
   "set_preamble",
   "respond_json",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,12 +151,11 @@ will catch any mismatch.
    -- MyAlias is API-compatible with Gitea v1.  Family metadata in provider_families.
    load_family_backend("gitea")
    ```
-3. Add the alias to `<ROOT_UPPER>_FAMILY_ALIASES` in the Makefile (e.g. `GITEA_FAMILY_ALIASES`).
-   No `test/mock-<alias>.lua` file is needed — the Makefile `ALIAS_MOCK_RULE` builds
-   `mock-<alias>.com` from `test/mock-gitea.lua` automatically.
-4. Add `<alias>` to the `BACKENDS` list in the Makefile.
-5. Add hurl test files and a `site/compatibility.csv` column as for a standalone backend (steps 5–6 above).
-6. Run `make validate-providers` to confirm all four locations agree.
+3. Add `<alias>` to the `BACKENDS` list in the Makefile.
+   No `test/mock-<alias>.lua` file is needed — `.make-families.mk` is auto-generated
+   from `provider_families` and builds `mock-<alias>.com` from the root family's mock.
+4. Add hurl test files and a `site/compatibility.csv` column as for a standalone backend (steps 5–6 above).
+5. Run `make validate-providers` to confirm all three locations agree.
 
 ## Redbean API notes
 
@@ -246,13 +245,15 @@ Hard-won insights from building this project. **Keep this section current**: whe
   containing `_package` (e.g. `list_packages`, `get_package`). Keep patterns tight enough
   not to accidentally strip unrelated keys.
 - **Mock reuse is driven by `ALIAS_MOCK_RULE` in the Makefile**, not by `test/mock-<alias>.lua`
-  symlinks. The Makefile variable `GITEA_FAMILY_ALIASES` must match `provider_families["gitea"].aliases`.
-  `make validate-providers` catches any mismatch between these two locations.
+  symlinks. The `mock-<alias>.com` rule is generated automatically into `.make-families.mk`
+  (gitignored) by `scripts/gen-family-mk.py` reading `dump-families.lua` output.  The
+  Makefile `-include`s this file; if it doesn't exist Make rebuilds it before re-reading.
+  No family-specific variable (e.g. `GITEA_FAMILY_ALIASES`) is needed in the Makefile.
 - **`make dump-families`** exports `provider_families` as JSON. Useful for debugging and
   piped into `make validate-providers`.
 - **`make validate-providers`** is wired into `make test`. It checks: root backend and mock
   exist; each alias backend calls `load_family_backend`; no stale `test/mock-<alias>.lua`
-  files; Makefile `FAMILY_ALIASES` matches `provider_families`; every alias is in `BACKENDS`.
+  files; every alias is in `BACKENDS`.
 
 ### Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ When implementing a new endpoint, check the spec for:
 
 ## Adding a new backend
 
+### Standalone backend (new API family)
+
 1. Create `backends/<name>.lua`. Set `backend_impl = { endpoint = function, ... }` with only
    the endpoints that differ from the defaults. The file is loaded automatically when
    `config.backend == "<name>"` — no changes to `.init.lua` needed.
@@ -128,6 +130,33 @@ When implementing a new endpoint, check the spec for:
    `make validate-tests` to see which groups lack coverage.
 6. Add a column for the new backend in `site/compatibility.csv` and fill in support values
    for every endpoint row. Run `make validate-csv` to check consistency.
+
+### Family-alias backend (API-compatible with an existing family)
+
+A family alias shares one backend implementation, mock, and most tests with an existing root
+backend. All four authoritative locations must be updated consistently — `make validate-providers`
+will catch any mismatch.
+
+1. Add the alias to `provider_families` in `.init.lua` (the single authoritative declaration):
+   ```lua
+   gitea = {
+     aliases = {
+       myalias = { default_url = "https://myalias.example.com",
+                   strip = { "_package" } },  -- omit strip if no feature gaps
+     },
+   },
+   ```
+2. Create `backends/<alias>.lua` — one line plus a comment:
+   ```lua
+   -- MyAlias is API-compatible with Gitea v1.  Family metadata in provider_families.
+   load_family_backend("gitea")
+   ```
+3. Add the alias to `<ROOT_UPPER>_FAMILY_ALIASES` in the Makefile (e.g. `GITEA_FAMILY_ALIASES`).
+   No `test/mock-<alias>.lua` file is needed — the Makefile `ALIAS_MOCK_RULE` builds
+   `mock-<alias>.com` from `test/mock-gitea.lua` automatically.
+4. Add `<alias>` to the `BACKENDS` list in the Makefile.
+5. Add hurl test files and a `site/compatibility.csv` column as for a standalone backend (steps 5–6 above).
+6. Run `make validate-providers` to confirm all four locations agree.
 
 ## Redbean API notes
 
@@ -202,6 +231,29 @@ Hard-won insights from building this project. **Keep this section current**: whe
 - **`make dump-endpoints`** exports the catalog as JSON. Used internally by `make site`,
   `make validate-csv`, and `make validate-tests`.
 
+### Provider families
+
+- **`provider_families` in `.init.lua` is the single authoritative source** for which
+  backends belong to the same API family. It drives backend loading, mock building, and
+  the `validate-providers` check. Never encode family membership only in filesystem layout
+  or Makefile variables — both are derived from this table.
+- **`load_family_backend(root)`** is the helper alias backends call instead of raw `dofile`.
+  It reads the alias's entry from `provider_families[root].aliases[config.backend]`, sets
+  `config.base_url` from `default_url` when none was supplied, dofiles the root backend,
+  then clears any `backend_impl` keys matching the alias's `strip` patterns. All of this
+  replaces the old per-file `dofile` + manual `for k in pairs(backend_impl)` strip loops.
+- **`strip` patterns are Lua patterns, not exact names.** `"_package"` matches any key
+  containing `_package` (e.g. `list_packages`, `get_package`). Keep patterns tight enough
+  not to accidentally strip unrelated keys.
+- **Mock reuse is driven by `ALIAS_MOCK_RULE` in the Makefile**, not by `test/mock-<alias>.lua`
+  symlinks. The Makefile variable `GITEA_FAMILY_ALIASES` must match `provider_families["gitea"].aliases`.
+  `make validate-providers` catches any mismatch between these two locations.
+- **`make dump-families`** exports `provider_families` as JSON. Useful for debugging and
+  piped into `make validate-providers`.
+- **`make validate-providers`** is wired into `make test`. It checks: root backend and mock
+  exist; each alias backend calls `load_family_backend`; no stale `test/mock-<alias>.lua`
+  files; Makefile `FAMILY_ALIASES` matches `provider_families`; every alias is in `BACKENDS`.
+
 ### Routing
 
 - **Segment-based radix trie** (`route_add` / `route_match` in `.init.lua`): O(k) lookup where
@@ -228,7 +280,7 @@ Hard-won insights from building this project. **Keep this section current**: whe
 - **`backend_allow_anonymous` is a global boolean** defaulting to `true`. `OnHttpRequest()` checks it on every request: if `false` and no `Authorization` header is present, confusio returns `401 { message = "This instance requires authentication." }` immediately, before routing.
 - **Only Gitea probes its backend at startup.** The Gitea backend calls `GET /api/v1/settings/api` and sets `backend_allow_anonymous = (settings.require_signin_view ~= true)`. If the probe fails (network error or non-200), the default `true` is preserved and anonymous requests are allowed.
 - **All other backends leave the default `true`.** They neither probe nor set `backend_allow_anonymous`, so anonymous access is always permitted regardless of the upstream's actual configuration.
-- **`dofile`'d backends (forgejo, gogs, codeberg, notabug) inherit Gitea's probe** because they `dofile` `backends/gitea.lua`, which includes the probe block.
+- **Gitea-family backends (forgejo, gogs, codeberg, notabug) inherit Gitea's probe** because `load_family_backend("gitea")` dofiles `backends/gitea.lua`, which includes the probe block.
 - **Test pattern**: `*-anon.hurl` files verify that unauthenticated requests succeed when the mock advertises anonymous access. The mock's `/api/v1/settings/api` route returns `{"require_signin_view": false}` to simulate an open instance. Closed-instance (401) behavior is covered by unit tests that set `backend_allow_anonymous = false` directly.
 
 ### Mock server design

--- a/Makefile
+++ b/Makefile
@@ -89,17 +89,21 @@ mock-$(1).com: redbean.com test/mock-$(2).lua
 	rm -rf .tmp-mock-$(1)
 endef
 
-# Gitea-family aliases — must match provider_families["gitea"].aliases in .init.lua.
-# validate-providers will catch any mismatch.
-GITEA_FAMILY_ALIASES := codeberg forgejo gogs notabug
-$(foreach a,$(GITEA_FAMILY_ALIASES),$(eval $(call ALIAS_MOCK_RULE,$(a),gitea)))
+# .make-families.mk is auto-generated from provider_families in .init.lua.
+# It contains $(eval $(call ALIAS_MOCK_RULE,...)) lines for every family alias
+# so that mock-<alias>.com is built from the root family's mock lua.
+# If the file does not exist, Make rebuilds it before re-reading the Makefile.
+-include .make-families.mk
+
+.make-families.mk: redbean.com scripts/dump-families.lua .init.lua
+	sh redbean.com -i scripts/dump-families.lua 2>/dev/null | python3 scripts/gen-family-mk.py > $@
 
 # Backend test configuration.
 # To add a standalone backend: append to BACKENDS (ports auto-assigned from 18080).
 # Each backend needs test/mock-<name>.lua and at least one test/<name>-*.hurl file
 # (symlinks ok — used by wildcard discovery).
-# To add a family-alias backend: add to BACKENDS and to the appropriate FAMILY_ALIASES
-# list above; no test/mock-<name>.lua needed.
+# To add a family-alias backend: add to BACKENDS; no test/mock-<name>.lua needed —
+# .make-families.mk auto-generates mock-<alias>.com from the root family's mock.
 BACKENDS = azuredevops bitbucket bitbucket_datacenter codeberg codecommit forgejo gerrit gitblit gitbucket gitea gitlab gogs \
            harness kallithea launchpad notabug onedev pagure phabricator radicle \
            rhodecode sourceforge sourcehut tuleap
@@ -180,5 +184,5 @@ test-coverage: redbean.com luacov
 	./redbean.com -i scripts/luacov-report.lua
 
 clean:
-	rm -f redbean.com confusio.com $(MOCKS) hurl stylua luacheck
+	rm -f redbean.com confusio.com $(MOCKS) hurl stylua luacheck .make-families.mk
 	rm -rf _site luacov

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ endef
 
 $(foreach b,$(BACKENDS),$(eval $(call BACKEND_RULE,$(b))))
 
-.PHONY: build site dump-endpoints validate-csv validate-tests test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
+.PHONY: build site dump-endpoints dump-families validate-csv validate-tests validate-providers test test-unit test-unit-functions test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
 
 build: confusio.com
 
@@ -135,13 +135,19 @@ validate-csv: redbean.com
 validate-tests: redbean.com
 	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | python3 scripts/validate-tests.py $(BACKENDS)
 
+dump-families: redbean.com
+	./redbean.com -i scripts/dump-families.lua
+
+validate-providers: redbean.com
+	./redbean.com -i scripts/dump-families.lua 2>/dev/null | python3 scripts/validate-providers.py
+
 site: redbean.com
 	mkdir -p _site
 	cp -r site/. _site/
 	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | \
 	  python3 scripts/gen-matrix.py - site/compatibility.csv site/index.html _site/index.html
 
-test: test-unit test-integration test-format test-lint validate-csv validate-tests
+test: test-unit test-integration test-format test-lint validate-csv validate-tests validate-providers
 
 # Unit tests for .init.lua global functions (pure Lua, no HTTP server needed)
 test-unit-functions: redbean.com

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,30 @@ mock-%.com: redbean.com test/mock-%.lua
 	(cd .tmp-mock-$* && zip -u ../$@ .init.lua)
 	rm -rf .tmp-mock-$*
 
+# Family-alias mock rules: build mock-<alias>.com from the root family's mock lua
+# instead of a per-alias test/mock-<alias>.lua.  Explicit rules take precedence over
+# the mock-%.com pattern rule above.
+# ALIAS_MOCK_RULE(alias, root): builds mock-<alias>.com from test/mock-<root>.lua
+define ALIAS_MOCK_RULE
+mock-$(1).com: redbean.com test/mock-$(2).lua
+	cp redbean.com $$@
+	@mkdir -p .tmp-mock-$(1)
+	cp test/mock-$(2).lua .tmp-mock-$(1)/.init.lua
+	(cd .tmp-mock-$(1) && zip -u ../$$@ .init.lua)
+	rm -rf .tmp-mock-$(1)
+endef
+
+# Gitea-family aliases — must match provider_families["gitea"].aliases in .init.lua.
+# validate-providers will catch any mismatch.
+GITEA_FAMILY_ALIASES := codeberg forgejo gogs notabug
+$(foreach a,$(GITEA_FAMILY_ALIASES),$(eval $(call ALIAS_MOCK_RULE,$(a),gitea)))
+
 # Backend test configuration.
-# To add a backend: append to BACKENDS (ports auto-assigned from 18080).
-# Each backend needs test/mock-<name>.lua (symlink ok) and
-# at least one test/<name>-*.hurl file (symlinks ok — used by wildcard discovery).
+# To add a standalone backend: append to BACKENDS (ports auto-assigned from 18080).
+# Each backend needs test/mock-<name>.lua and at least one test/<name>-*.hurl file
+# (symlinks ok — used by wildcard discovery).
+# To add a family-alias backend: add to BACKENDS and to the appropriate FAMILY_ALIASES
+# list above; no test/mock-<name>.lua needed.
 BACKENDS = azuredevops bitbucket bitbucket_datacenter codeberg codecommit forgejo gerrit gitblit gitbucket gitea gitlab gogs \
            harness kallithea launchpad notabug onedev pagure phabricator radicle \
            rhodecode sourceforge sourcehut tuleap

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ endef
 -include .make-families.mk
 
 .make-families.mk: redbean.com scripts/dump-families.lua .init.lua
-	sh redbean.com -i scripts/dump-families.lua 2>/dev/null | python3 scripts/gen-family-mk.py > $@
+	./redbean.com -i scripts/dump-families.lua 2>/dev/null | python3 scripts/gen-family-mk.py > $@
 
 # Backend test configuration.
 # To add a standalone backend: append to BACKENDS (ports auto-assigned from 18080).

--- a/backends/codeberg.lua
+++ b/backends/codeberg.lua
@@ -1,5 +1,3 @@
--- Codeberg runs Forgejo, which is API-compatible with Gitea v1 — delegate.
-if config.base_url == "" then
-  config.base_url = "https://codeberg.org"
-end
-dofile("/zip/backends/gitea.lua")
+-- Codeberg runs Forgejo, which is API-compatible with Gitea v1.  Family metadata
+-- in provider_families.
+load_family_backend("gitea")

--- a/backends/forgejo.lua
+++ b/backends/forgejo.lua
@@ -1,5 +1,2 @@
--- Forgejo is API-compatible with Gitea v1 — delegate to the Gitea backend.
-if config.base_url == "" then
-  config.base_url = "https://codeberg.org"
-end
-dofile("/zip/backends/gitea.lua")
+-- Forgejo is API-compatible with Gitea v1.  Family metadata in provider_families.
+load_family_backend("gitea")

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -1,7 +1,7 @@
 -- Gitea backend handler overrides.
--- Loaded by .init.lua when config.backend == "gitea".
+-- Loaded by .init.lua when config.backend == "gitea", and by load_family_backend
+-- for API-compatible family members (forgejo, codeberg, gogs, notabug).
 -- Only endpoints that behave differently from the default need to be listed here.
--- Also dofile'd by API-compatible backends: forgejo, gogs, codeberg, notabug.
 if config.base_url == "" then
   config.base_url = "https://gitea.com"
 end

--- a/backends/gogs.lua
+++ b/backends/gogs.lua
@@ -1,13 +1,3 @@
--- Gogs is API-compatible with Gitea v1 — delegate to the Gitea backend.
-if config.base_url == "" then
-  config.base_url = "https://try.gogs.io"
-end
-dofile("/zip/backends/gitea.lua")
-
--- Gogs does not have a packages or Actions API; clear inherited Gitea handlers
--- so the routes fall back to their .init.lua defaults (empty list or 501).
-for k in pairs(backend_impl) do
-  if k:find("_package") or k:find("_actions_") then
-    backend_impl[k] = nil
-  end
-end
+-- Gogs is API-compatible with Gitea v1.  Family metadata (including which
+-- features Gogs lacks) is declared in provider_families.
+load_family_backend("gitea")

--- a/backends/notabug.lua
+++ b/backends/notabug.lua
@@ -1,14 +1,3 @@
--- NotABug runs Gogs, which is API-compatible with Gitea v1 — delegate.
-if config.base_url == "" then
-  config.base_url = "https://notabug.org"
-end
-dofile("/zip/backends/gitea.lua")
-
--- Gogs does not have a gitignores, packages, or Actions API; clear inherited
--- Gitea handlers so the routes fall back to their .init.lua defaults (404,
--- empty list, or 501).
-for k in pairs(backend_impl) do
-  if k:find("gitignore") or k:find("_package") or k:find("_actions_") then
-    backend_impl[k] = nil
-  end
-end
+-- NotABug runs Gogs, which is API-compatible with Gitea v1.  Family metadata
+-- (including which features Gogs lacks) is declared in provider_families.
+load_family_backend("gitea")

--- a/scripts/dump-families.lua
+++ b/scripts/dump-families.lua
@@ -1,0 +1,43 @@
+-- Export provider-family metadata as a JSON array to stdout.
+-- Run from the project root: ./redbean.com -i scripts/dump-families.lua
+
+-- Block backend files so only the core metadata is loaded.
+local _real_dofile = dofile
+function dofile(path) -- luacheck: globals dofile
+  if path and path:match("^/zip/backends/") then
+    return
+  end
+  return _real_dofile(path)
+end
+
+-- Load .init.lua, which populates the global `provider_families` table.
+_real_dofile(".init.lua")
+dofile = _real_dofile -- luacheck: globals dofile
+
+-- Collect and sort families for stable output.
+local families = {}
+for root, family in pairs(provider_families) do -- luacheck: globals provider_families
+  local aliases = {}
+  for alias in pairs(family.aliases) do
+    aliases[#aliases + 1] = alias
+  end
+  table.sort(aliases)
+  families[#families + 1] = { root = root, aliases = aliases }
+end
+table.sort(families, function(a, b)
+  return a.root < b.root
+end)
+
+local parts = {}
+for i, f in ipairs(families) do
+  local alias_parts = {}
+  for j, a in ipairs(f.aliases) do
+    alias_parts[j] = EncodeJson(a)
+  end
+  parts[i] = '  {"root":'
+    .. EncodeJson(f.root)
+    .. ',"aliases":['
+    .. table.concat(alias_parts, ",")
+    .. "]}"
+end
+io.write("[\n" .. table.concat(parts, ",\n") .. "\n]\n")

--- a/scripts/gen-family-mk.py
+++ b/scripts/gen-family-mk.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Generate Makefile alias-mock rules from dump-families JSON.
+
+Each family alias becomes one $(eval $(call ALIAS_MOCK_RULE,...)) line
+in .make-families.mk, which the Makefile -includes so that mock-<alias>.com
+is built from the root family's mock lua rather than a per-alias file.
+
+Usage:
+  ./redbean.com -i scripts/dump-families.lua 2>/dev/null | python3 scripts/gen-family-mk.py > .make-families.mk
+"""
+import json
+import sys
+
+families = json.load(sys.stdin)
+for family in sorted(families, key=lambda f: f["root"]):
+    root = family["root"]
+    for alias in sorted(family["aliases"]):
+        print(f"$(eval $(call ALIAS_MOCK_RULE,{alias},{root}))")

--- a/scripts/validate-providers.py
+++ b/scripts/validate-providers.py
@@ -4,7 +4,6 @@
 Checks that provider_families in .init.lua agrees with:
   - backend files (each alias calls load_family_backend)
   - mock files (no stale test/mock-<alias>.lua for aliases)
-  - Makefile <ROOT_UPPER>_FAMILY_ALIASES variable
   - Makefile BACKENDS list (every alias must be present)
 
 Usage:
@@ -37,7 +36,6 @@ else:
 for family in families:
     root = family["root"]
     aliases = family["aliases"]
-    root_upper = root.upper()
 
     # Root backend and mock must exist.
     if not os.path.exists(f"backends/{root}.lua"):
@@ -68,25 +66,6 @@ for family in families:
         # Every alias must appear in BACKENDS.
         if backends and alias not in backends:
             errors.append(f"ERROR: alias {alias} missing from Makefile BACKENDS")
-
-    # Makefile <ROOT_UPPER>_FAMILY_ALIASES must match provider_families aliases.
-    makefile_var = f"{root_upper}_FAMILY_ALIASES"
-    var_match = re.search(
-        rf"^{makefile_var}\s*:?=\s*(.+)$", makefile, re.MULTILINE
-    )
-    if not var_match:
-        errors.append(f"ERROR: {makefile_var} not found in Makefile")
-    else:
-        makefile_aliases = set(var_match.group(1).split())
-        metadata_aliases = set(aliases)
-        for a in metadata_aliases - makefile_aliases:
-            errors.append(
-                f"ERROR: alias {a} in provider_families but missing from {makefile_var}"
-            )
-        for a in makefile_aliases - metadata_aliases:
-            errors.append(
-                f"ERROR: alias {a} in {makefile_var} but missing from provider_families"
-            )
 
 if errors:
     for e in errors:

--- a/scripts/validate-providers.py
+++ b/scripts/validate-providers.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Validate provider-family metadata consistency.
+
+Checks that provider_families in .init.lua agrees with:
+  - backend files (each alias calls load_family_backend)
+  - mock files (no stale test/mock-<alias>.lua for aliases)
+  - Makefile <ROOT_UPPER>_FAMILY_ALIASES variable
+  - Makefile BACKENDS list (every alias must be present)
+
+Usage:
+  ./redbean.com -i scripts/dump-families.lua 2>/dev/null | python3 scripts/validate-providers.py
+
+Exits non-zero if any inconsistency is found.
+"""
+import json
+import os
+import re
+import sys
+
+families = json.load(sys.stdin)
+errors = []
+
+with open("Makefile") as f:
+    makefile = f.read()
+
+# Parse BACKENDS (may span continuation lines).
+backends_match = re.search(
+    r"^BACKENDS\s*=\s*((?:[^\n]*\\\n\s*)*[^\n]+)", makefile, re.MULTILINE
+)
+backends = set()
+if backends_match:
+    raw = backends_match.group(1).replace("\\\n", " ")
+    backends = set(raw.split())
+else:
+    errors.append("ERROR: BACKENDS variable not found in Makefile")
+
+for family in families:
+    root = family["root"]
+    aliases = family["aliases"]
+    root_upper = root.upper()
+
+    # Root backend and mock must exist.
+    if not os.path.exists(f"backends/{root}.lua"):
+        errors.append(f"ERROR: missing backend for family root: backends/{root}.lua")
+    if not os.path.exists(f"test/mock-{root}.lua"):
+        errors.append(f"ERROR: missing mock for family root: test/mock-{root}.lua")
+
+    for alias in aliases:
+        # Alias backend must exist and call load_family_backend.
+        backend_path = f"backends/{alias}.lua"
+        if not os.path.exists(backend_path):
+            errors.append(f"ERROR: missing backend for alias {alias}: {backend_path}")
+        else:
+            with open(backend_path) as f:
+                content = f.read()
+            if "load_family_backend" not in content:
+                errors.append(
+                    f"ERROR: {backend_path} does not call load_family_backend"
+                )
+
+        # No stale per-alias mock lua (aliases share the root mock via the Makefile rule).
+        if os.path.exists(f"test/mock-{alias}.lua"):
+            errors.append(
+                f"ERROR: stale mock file test/mock-{alias}.lua"
+                f" (aliases use test/mock-{root}.lua via ALIAS_MOCK_RULE)"
+            )
+
+        # Every alias must appear in BACKENDS.
+        if backends and alias not in backends:
+            errors.append(f"ERROR: alias {alias} missing from Makefile BACKENDS")
+
+    # Makefile <ROOT_UPPER>_FAMILY_ALIASES must match provider_families aliases.
+    makefile_var = f"{root_upper}_FAMILY_ALIASES"
+    var_match = re.search(
+        rf"^{makefile_var}\s*:?=\s*(.+)$", makefile, re.MULTILINE
+    )
+    if not var_match:
+        errors.append(f"ERROR: {makefile_var} not found in Makefile")
+    else:
+        makefile_aliases = set(var_match.group(1).split())
+        metadata_aliases = set(aliases)
+        for a in metadata_aliases - makefile_aliases:
+            errors.append(
+                f"ERROR: alias {a} in provider_families but missing from {makefile_var}"
+            )
+        for a in makefile_aliases - metadata_aliases:
+            errors.append(
+                f"ERROR: alias {a} in {makefile_var} but missing from provider_families"
+            )
+
+if errors:
+    for e in errors:
+        print(e, file=sys.stderr)
+    sys.exit(1)

--- a/test/mock-codeberg.lua
+++ b/test/mock-codeberg.lua
@@ -1,1 +1,0 @@
-mock-gitea.lua

--- a/test/mock-forgejo.lua
+++ b/test/mock-forgejo.lua
@@ -1,1 +1,0 @@
-mock-gitea.lua

--- a/test/mock-gogs.lua
+++ b/test/mock-gogs.lua
@@ -1,1 +1,0 @@
-mock-gitea.lua

--- a/test/mock-notabug.lua
+++ b/test/mock-notabug.lua
@@ -1,1 +1,0 @@
-mock-gitea.lua

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1229,6 +1229,71 @@ OnHttpRequest()
 eq(_last_status, 501, "OnHttpRequest: GET /feeds → 501 (activity not implemented)")
 
 -- ============================================================
+-- load_family_backend
+-- ============================================================
+
+do
+  local _saved_backend = config.backend
+  local _saved_base_url = config.base_url
+  local _saved_impl = backend_impl
+
+  -- Stub dofile so load_family_backend's dofile("/zip/backends/gitea.lua") is a no-op.
+  -- luacheck: push
+  -- luacheck: globals dofile
+  local _real_dofile2 = dofile
+  dofile = function(path)
+    if path and path:match("^/zip/backends/") then
+      return
+    end
+    return _real_dofile2(path)
+  end
+  -- luacheck: pop
+
+  -- Happy path: sets base_url from alias default when config.base_url is empty.
+  config.backend = "forgejo"
+  config.base_url = ""
+  backend_impl = {}
+  load_family_backend("gitea")
+  eq(
+    config.base_url,
+    "https://codeberg.org",
+    "load_family_backend: sets base_url from alias default"
+  )
+
+  -- Explicit base_url is preserved (not overwritten by alias default).
+  config.backend = "forgejo"
+  config.base_url = "https://custom.example.com"
+  backend_impl = {}
+  load_family_backend("gitea")
+  eq(
+    config.base_url,
+    "https://custom.example.com",
+    "load_family_backend: preserves explicit base_url"
+  )
+
+  -- Strip patterns remove matching backend_impl keys (gogs strips _package and _actions_).
+  config.backend = "gogs"
+  config.base_url = "https://try.gogs.io"
+  backend_impl = {
+    get_package_info = function() end,
+    list_actions_runs = function() end,
+    get_repo = function() end,
+  }
+  load_family_backend("gitea")
+  ok(backend_impl["get_package_info"] == nil, "load_family_backend: strips _package keys for gogs")
+  ok(
+    backend_impl["list_actions_runs"] == nil,
+    "load_family_backend: strips _actions_ keys for gogs"
+  )
+  ok(backend_impl["get_repo"] ~= nil, "load_family_backend: preserves non-stripped keys for gogs")
+
+  dofile = _real_dofile2 -- luacheck: globals dofile
+  config.backend = _saved_backend
+  config.base_url = _saved_base_url
+  backend_impl = _saved_impl
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 


### PR DESCRIPTION
Introduces an authoritative provider-family metadata table and refactors the Gitea-family backends and mock-server reuse to consume it. Generalizes the Makefile mock rules to drive off that metadata instead of hardcoding Gitea, and adds a validate-providers consistency check documented in CLAUDE.md.

Fixes #113.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [Generalize Makefile mock rules to consume provider-family metadata without hardcoding Gitea](https://github.com/rhencke/confusio/pull/120#discussion_r3076706469) <!-- type:thread -->
- [x] Add authoritative provider-family metadata table <!-- type:spec -->
- [x] Refactor Gitea-family backends to consume provider-family metadata <!-- type:spec -->
- [x] Drive mock-server reuse from provider-family metadata <!-- type:spec -->
- [x] Add validate-providers check for family metadata consistency <!-- type:spec -->
- [x] Document provider-family metadata in CLAUDE.md <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->