### PR TITLE
Extract shared backend transport context and tiny repeated backend utilities (closes #114)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -229,6 +229,47 @@ function make_proxy_handler(fetch_fn, proxy_fn)
   end
 end
 
+-- make_backend_transport is global: builds the standard transport scaffolding for a backend.
+--
+-- Returns a table with:
+--   fetch_json(url[, method[, body]])  — authorized fetch; adds method + Content-Type for
+--                                        non-GET calls with a body
+--   proxy_handler                       — make_proxy_handler(fetch_json) using proxy_json
+--   proxy_handler_created               — make_proxy_handler(fetch_json, proxy_json_created)
+--   proxy_handler_paged                 — make_proxy_handler bound to proxy_json_paged with
+--                                         the given pages mapping; nil when pages is omitted
+--
+-- scheme: "token" | "bearer" | "basic" | "basic-colon"  (forwarded to make_fetch_opts)
+-- pages:  { per_page = "upstream_name" [, page = "upstream_name"] } for paged endpoints;
+--         omit (or pass nil) when the backend has no paged handler.
+function make_backend_transport(scheme, pages)
+  local function fetch_json(url, method, body)
+    local opts = make_fetch_opts(scheme)
+    if method ~= nil and method ~= "GET" then
+      opts = opts or {}
+      opts.method = method
+      if body then
+        opts.body = body
+        opts.headers = opts.headers or {}
+        opts.headers["Content-Type"] = "application/json"
+      end
+    end
+    return pcall(Fetch, url, opts)
+  end
+  local proxy_handler_paged = pages and make_proxy_handler(
+    fetch_json,
+    function(translate, ok, status, headers, body)
+      proxy_json_paged(translate, pages, ok, status, headers, body)
+    end
+  ) or nil
+  return {
+    fetch_json = fetch_json,
+    proxy_handler = make_proxy_handler(fetch_json),
+    proxy_handler_created = make_proxy_handler(fetch_json, proxy_json_created),
+    proxy_handler_paged = proxy_handler_paged,
+  }
+end
+
 -- translate_repo is global: maps a Gitea-style repo object to GitHub field names.
 -- Called by any Gitea-API-compatible backend (gitea, forgejo, gogs, codeberg, notabug).
 function translate_repo(r)

--- a/.init.lua
+++ b/.init.lua
@@ -270,6 +270,13 @@ function make_backend_transport(scheme, pages)
   }
 end
 
+-- owner_repo_id is global: URL-encodes owner/repo as "owner%2Frepo".
+-- Used by backends (GitLab, Gerrit, Harness) whose APIs address repositories
+-- by a URL-encoded "owner/repo" composite identifier rather than separate segments.
+function owner_repo_id(owner, repo_name)
+  return owner .. "%2F" .. repo_name
+end
+
 -- translate_repo is global: maps a Gitea-style repo object to GitHub field names.
 -- Called by any Gitea-API-compatible backend (gitea, forgejo, gogs, codeberg, notabug).
 function translate_repo(r)

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -36,6 +36,7 @@ globals = {
   "make_fetch_opts",
   "make_proxy_handler",
   "make_backend_transport",
+  "owner_repo_id",
   "translate_repo",
   "translate_user",
   "translate_migration",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -35,6 +35,7 @@ globals = {
   "append_page_params",
   "make_fetch_opts",
   "make_proxy_handler",
+  "make_backend_transport",
   "translate_repo",
   "translate_user",
   "translate_migration",

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -8,23 +8,10 @@ local auth = function()
   return make_fetch_opts("basic-colon")
 end
 local API_VER = "api-version=7.0"
+local fetch_json = make_backend_transport("basic-colon").fetch_json
 
 local function repos_base(owner)
   return config.base_url .. "/" .. owner .. "/_apis/git/repositories"
-end
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
 end
 
 local function ado_url(path)

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -11,20 +11,9 @@ local auth = function()
   return make_fetch_opts("basic")
 end
 local PAGES = { per_page = "pagelen", page = "page" }
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("basic", PAGES)
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
 
 -- Map a Bitbucket repository object to GitHub format.
 local function translate_bb_repo(r)
@@ -239,8 +228,6 @@ local function translate_bb_hook(h)
     active = h.active ~= false,
   }
 end
-
-local proxy_handler = make_proxy_handler(fetch_json)
 
 -- Map a Bitbucket pull request branch ref to GitHub format.
 local function translate_bb_pr_branch(ref)

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -9,20 +9,9 @@ end
 local auth = function()
   return make_fetch_opts("basic")
 end
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("basic")
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
 
 -- Bitbucket DC pagination: { values, isLastPage, start, limit }
 -- Upstream query params: start (offset) and limit (page size).
@@ -238,8 +227,6 @@ local function proxy_search_bbs(translate_item, url)
       .. "}"
   )
 end
-
-local proxy_handler = make_proxy_handler(fetch_json)
 
 -- Repo path helper: /projects/{owner}/repos/{repo}
 local function repo_path(owner, repo_name)

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -13,20 +13,7 @@ end
 local auth = function()
   return make_fetch_opts("basic")
 end
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local fetch_json = make_backend_transport("basic").fetch_json
 
 -- Translate a CodeCommit repositoryMetadata (or summary) object to GitHub format.
 local function translate_repo(r)

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -12,10 +12,7 @@ local _t = make_backend_transport("basic")
 local fetch_json = _t.fetch_json
 local proxy_handler = _t.proxy_handler
 
--- Gerrit project names use "/" as path separator; URL-encode it.
-local function project_id(owner, repo_name)
-  return owner .. "%2F" .. repo_name
-end
+local project_id = owner_repo_id
 
 -- Map a Gerrit project object to GitHub format.
 local function translate_gerrit_repo(r, owner, repo_name)

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -8,20 +8,9 @@ end
 local auth = function()
   return make_fetch_opts("basic")
 end
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("basic")
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
 
 -- Gerrit project names use "/" as path separator; URL-encode it.
 local function project_id(owner, repo_name)
@@ -115,8 +104,6 @@ local function translate_gerrit_branch(b)
   local name = b.ref and b.ref:match("^refs/heads/(.+)") or (b.ref or "")
   return { name = name, commit = { sha = b.revision or "", url = "" }, protected = false }
 end
-
-local proxy_handler = make_proxy_handler(fetch_json)
 
 -- Gerrit tag: { ref, revision, object }
 local function translate_gerrit_tag(t)

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -9,20 +9,10 @@ local auth = function()
   return make_fetch_opts("bearer")
 end
 local PAGES = { per_page = "per_page", page = "page" }
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("bearer", PAGES)
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
+local proxy_handler_created = _t.proxy_handler_created
 
 local function set_204_or_error(method, url)
   local opts = auth() or {}
@@ -36,9 +26,6 @@ local function set_204_or_error(method, url)
     respond_json(503, {})
   end
 end
-
-local proxy_handler = make_proxy_handler(fetch_json)
-local proxy_handler_created = make_proxy_handler(fetch_json, proxy_json_created)
 
 backend_impl = {
   get_root = function()

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -13,6 +13,11 @@ local auth = function()
   return make_fetch_opts("token")
 end
 local PAGES = { per_page = "limit", page = "page" }
+local _t = make_backend_transport("token", PAGES)
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
+local proxy_handler_created = _t.proxy_handler_created
+local proxy_handler_paged = _t.proxy_handler_paged
 
 -- Check if this Gitea instance allows anonymous access.
 -- Sets the global backend_allow_anonymous so OnHttpRequest can gate unauthenticated requests.
@@ -22,21 +27,6 @@ do
     local settings = DecodeJson(body) or {}
     backend_allow_anonymous = settings.require_signin_view ~= true
   end
-end
-
--- Thin wrappers that forward request body and headers for mutating calls.
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
 end
 
 local function translate_repos(repos)
@@ -73,20 +63,6 @@ local function proxy_users_follow_list(username, rel)
     fetch_json(append_page_params(base() .. "/users/" .. username .. "/" .. rel, PAGES))
   )
 end
-
--- Returns a handler function: defers fetch_json(url_fn(...)) to request time.
--- xform receives (response_body, ...handler_args) so closures over handler args are not needed.
--- Named translate functions that only take the response body work as-is (extra args ignored).
-local proxy_handler = make_proxy_handler(fetch_json)
-local proxy_handler_created = make_proxy_handler(fetch_json, proxy_json_created)
--- proxy_handler_paged: like proxy_handler but rewrites the upstream Link header.
--- Use for endpoints whose url_fn calls append_page_params.
-local proxy_handler_paged = make_proxy_handler(
-  fetch_json,
-  function(translate, ok, status, headers, body)
-    proxy_json_paged(translate, PAGES, ok, status, headers, body)
-  end
-)
 
 -- Proxy a Gitea search response {"data":[...],"ok":true} to the GitHub search
 -- envelope {"total_count":N,"incomplete_results":false,"items":[...]}.

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -17,12 +17,7 @@ local proxy_handler = _t.proxy_handler
 local proxy_handler_created = _t.proxy_handler_created
 local proxy_handler_paged = _t.proxy_handler_paged
 
--- Encode owner/repo as GitLab project ID (URL-encoded "owner/repo").
-local function project_id(owner, repo_name)
-  -- Replace / with %2F and percent-encode other special chars.
-  -- owner and repo_name come from the URL path so they contain no slashes.
-  return owner .. "%2F" .. repo_name
-end
+local project_id = owner_repo_id
 
 -- Map a GitLab project object to GitHub repo format.
 local function translate_gl_repo(p)

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -11,26 +11,17 @@ local auth = function()
   return make_fetch_opts("bearer")
 end
 local PAGES = { per_page = "per_page", page = "page" }
+local _t = make_backend_transport("bearer", PAGES)
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
+local proxy_handler_created = _t.proxy_handler_created
+local proxy_handler_paged = _t.proxy_handler_paged
 
 -- Encode owner/repo as GitLab project ID (URL-encoded "owner/repo").
 local function project_id(owner, repo_name)
   -- Replace / with %2F and percent-encode other special chars.
   -- owner and repo_name come from the URL path so they contain no slashes.
   return owner .. "%2F" .. repo_name
-end
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
 end
 
 -- Map a GitLab project object to GitHub repo format.
@@ -142,15 +133,6 @@ local function translate_gl_users(users)
   end
   return users
 end
-
-local proxy_handler = make_proxy_handler(fetch_json)
-local proxy_handler_created = make_proxy_handler(fetch_json, proxy_json_created)
-local proxy_handler_paged = make_proxy_handler(
-  fetch_json,
-  function(translate, ok, status, headers, body)
-    return proxy_json_paged(translate, PAGES, ok, status, headers, body)
-  end
-)
 
 -- Proxy a GitLab search response (plain JSON array) to the GitHub search
 -- envelope {"total_count":N,"incomplete_results":false,"items":[...]}.

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -16,9 +16,7 @@ local _t = make_backend_transport("bearer", PAGES)
 local fetch_json = _t.fetch_json
 local proxy_handler = _t.proxy_handler
 
-local function repo_ref(owner, repo_name)
-  return owner .. "%2F" .. repo_name
-end
+local repo_ref = owner_repo_id
 
 -- Map a Harness Code repository object to GitHub format.
 local function translate_harness_repo(r)

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -12,20 +12,9 @@ local auth = function()
   return make_fetch_opts("bearer")
 end
 local PAGES = { per_page = "limit", page = "page" }
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("bearer", PAGES)
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
 
 local function repo_ref(owner, repo_name)
   return owner .. "%2F" .. repo_name
@@ -186,8 +175,6 @@ local function translate_harness_hook(h)
 end
 
 -- Translate GitHub webhook request to Harness format.
-local proxy_handler = make_proxy_handler(fetch_json)
-
 local function translate_harness_hook_req(body_str)
   local req = DecodeJson(body_str or "{}")
   local cfg = req.config or {}

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -11,20 +11,9 @@ end
 local auth = function()
   return make_fetch_opts("bearer")
 end
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("bearer")
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
 
 -- Resolve owner/repo to a OneDev project ID by querying by path.
 local function resolve_project_id(owner, repo_name)
@@ -115,8 +104,6 @@ local function translate_onedev_repos(repos)
   end
   return repos
 end
-
-local proxy_handler = make_proxy_handler(fetch_json)
 
 local function translate_onedev_user(u)
   if not u then

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -12,20 +12,9 @@ local auth = function()
   return make_fetch_opts("token")
 end
 local PAGES = { per_page = "per_page", page = "page" }
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("token", PAGES)
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
 
 -- Map a Pagure project object to GitHub repo format.
 local function translate_pagure_repo(r)
@@ -85,7 +74,6 @@ end
 
 -- Translate a Pagure commit object to GitHub format.
 -- Pagure: { id, message, date, date_utc, author: { name, email } }
-local proxy_handler = make_proxy_handler(fetch_json)
 
 -- Translate a Pagure user to GitHub format.
 local function translate_pagure_user(u)

--- a/backends/radicle.lua
+++ b/backends/radicle.lua
@@ -13,20 +13,7 @@ local auth = function()
   return make_fetch_opts("bearer")
 end
 local PAGES = { per_page = "perPage", page = "page" }
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local fetch_json = make_backend_transport("bearer", PAGES).fetch_json
 
 -- Map a Radicle repository object to GitHub format.
 local function translate_radicle_repo(r)

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -27,20 +27,9 @@ local auth = function()
   return make_fetch_opts("token")
 end
 local PAGES = { per_page = "limit" }
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local _t = make_backend_transport("token", PAGES)
+local fetch_json = _t.fetch_json
+local proxy_handler = _t.proxy_handler
 
 -- Map a Sourcehut repository object to GitHub format.
 local function translate_srht_repo(r)
@@ -178,7 +167,6 @@ end
 
 -- Translate a Sourcehut log entry to GitHub commit format.
 -- Sourcehut: { id, message, timestamp, author: { name, email } }
-local proxy_handler = make_proxy_handler(fetch_json)
 
 -- Checks (via builds.sr.ht jobs) -----------------------------------------------
 --

--- a/backends/tuleap.lua
+++ b/backends/tuleap.lua
@@ -12,20 +12,7 @@ end
 local auth = function()
   return make_fetch_opts("bearer")
 end
-
-local function fetch_json(url, method, body)
-  local opts = auth()
-  if method ~= nil and method ~= "GET" then
-    opts = opts or {}
-    opts.method = method
-    if body then
-      opts.body = body
-      opts.headers = opts.headers or {}
-      opts.headers["Content-Type"] = "application/json"
-    end
-  end
-  return pcall(Fetch, url, opts)
-end
+local fetch_json = make_backend_transport("bearer").fetch_json
 
 -- Translate a Tuleap git repository object to GitHub format.
 local function translate_tuleap_repo(r)

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -613,6 +613,169 @@ handler3()
 eq(_last_status, 201, "make_proxy_handler: custom proxy_fn (proxy_json_created) used")
 
 -- ============================================================
+-- make_backend_transport
+-- ============================================================
+
+do
+  -- Stub Fetch for this section so fetch_json doesn't hit the network.
+  -- luacheck: push
+  -- luacheck: globals Fetch
+  local captured_url, captured_opts, stub_ok, stub_status, stub_headers, stub_body
+
+  local function set_fetch_stub(stub_ok_arg, status, headers, body)
+    stub_ok = stub_ok_arg
+    stub_status = status
+    stub_headers = headers
+    stub_body = body
+    Fetch = function(url, opts)
+      captured_url = url
+      captured_opts = opts
+      if stub_ok then
+        return stub_status, stub_headers, stub_body
+      else
+        error("network error")
+      end
+    end
+  end
+  -- luacheck: pop
+
+  -- Returns the four sub-fields.
+  local t_tok = make_backend_transport("token", { per_page = "limit", page = "page" })
+  ok(type(t_tok.fetch_json) == "function", "make_backend_transport: fetch_json is a function")
+  ok(type(t_tok.proxy_handler) == "function", "make_backend_transport: proxy_handler is a function")
+  ok(
+    type(t_tok.proxy_handler_created) == "function",
+    "make_backend_transport: proxy_handler_created is a function"
+  )
+  ok(
+    type(t_tok.proxy_handler_paged) == "function",
+    "make_backend_transport: proxy_handler_paged is a function when pages supplied"
+  )
+
+  -- Without pages, proxy_handler_paged is nil.
+  local t_nopages = make_backend_transport("bearer")
+  ok(
+    t_nopages.proxy_handler_paged == nil,
+    "make_backend_transport: proxy_handler_paged is nil when pages omitted"
+  )
+
+  -- fetch_json GET: no method or body modifications.
+  reset_request({ headers = { Authorization = "token mytoken" } })
+  set_fetch_stub(true, 200, {}, '{"ok":true}')
+  captured_url, captured_opts = nil, nil
+  local ok2, status2 = t_tok.fetch_json("https://example.com/api/repos")
+  ok(ok2, "make_backend_transport fetch_json GET: pcall ok")
+  eq(status2, 200, "make_backend_transport fetch_json GET: status 200")
+  eq(
+    captured_url,
+    "https://example.com/api/repos",
+    "make_backend_transport fetch_json GET: url forwarded"
+  )
+  ok(
+    captured_opts == nil or captured_opts.method == nil,
+    "make_backend_transport fetch_json GET: no method override"
+  )
+  ok(
+    captured_opts == nil
+      or captured_opts.headers == nil
+      or captured_opts.headers["Content-Type"] == nil,
+    "make_backend_transport fetch_json GET: no Content-Type"
+  )
+
+  -- fetch_json POST with body: sets method and Content-Type.
+  reset_request({ headers = { Authorization = "token mytoken" } })
+  set_fetch_stub(true, 201, {}, '{"id":1}')
+  captured_opts = nil
+  t_tok.fetch_json("https://example.com/api/repos", "POST", '{"name":"foo"}')
+  eq(
+    captured_opts and captured_opts.method,
+    "POST",
+    "make_backend_transport fetch_json POST: method set"
+  )
+  eq(
+    captured_opts and captured_opts.body,
+    '{"name":"foo"}',
+    "make_backend_transport fetch_json POST: body set"
+  )
+  eq(
+    captured_opts and captured_opts.headers and captured_opts.headers["Content-Type"],
+    "application/json",
+    "make_backend_transport fetch_json POST: Content-Type set"
+  )
+
+  -- fetch_json POST without body: method set, no Content-Type.
+  reset_request({ headers = { Authorization = "token mytoken" } })
+  set_fetch_stub(true, 204, {}, "")
+  captured_opts = nil
+  t_tok.fetch_json("https://example.com/api/repos", "DELETE")
+  eq(
+    captured_opts and captured_opts.method,
+    "DELETE",
+    "make_backend_transport fetch_json DELETE: method set"
+  )
+  ok(
+    captured_opts == nil
+      or captured_opts.headers == nil
+      or captured_opts.headers["Content-Type"] == nil,
+    "make_backend_transport fetch_json DELETE: no Content-Type without body"
+  )
+
+  -- fetch_json: auth header forwarded under the requested scheme.
+  reset_request({ headers = { Authorization = "token mytoken" } })
+  set_fetch_stub(true, 200, {}, "{}")
+  captured_opts = nil
+  t_tok.fetch_json("https://example.com/api")
+  ok(
+    captured_opts ~= nil and captured_opts.headers["Authorization"] == "token mytoken",
+    "make_backend_transport fetch_json: token auth scheme forwarded"
+  )
+
+  reset_request({ headers = { Authorization = "token mybearer" } })
+  local t_bearer = make_backend_transport("bearer")
+  set_fetch_stub(true, 200, {}, "{}")
+  captured_opts = nil
+  t_bearer.fetch_json("https://example.com/api")
+  ok(
+    captured_opts ~= nil and captured_opts.headers["Authorization"] == "Bearer mybearer",
+    "make_backend_transport fetch_json: bearer auth scheme forwarded"
+  )
+
+  -- fetch_json with no Authorization: opts nil, no header sent.
+  reset_request({ headers = {} })
+  set_fetch_stub(true, 200, {}, "{}")
+  captured_opts = "sentinel"
+  t_tok.fetch_json("https://example.com/api")
+  ok(captured_opts == nil, "make_backend_transport fetch_json: nil opts when no Authorization")
+
+  -- proxy_handler_paged uses the correct pages mapping.
+  reset_request({
+    headers = { Host = "proxy.example.com", ["X-Forwarded-Proto"] = "http" },
+    path = "/user/repos",
+    params = {},
+  })
+  set_fetch_stub(
+    true,
+    200,
+    { Link = '<https://upstream.example.com/api/repos?limit=10&page=2>; rel="next"' },
+    '[{"id":1}]'
+  )
+  reset_response()
+  local paged_h = t_tok.proxy_handler_paged(nil, function()
+    return "https://upstream.example.com/api/repos?limit=10"
+  end)
+  paged_h()
+  eq(_last_status, 200, "make_backend_transport proxy_handler_paged: 200 on success")
+  ok(
+    _last_headers["Link"] ~= nil,
+    "make_backend_transport proxy_handler_paged: Link header rewritten"
+  )
+  ok(
+    _last_headers["Link"]:find("per_page=10") ~= nil,
+    "make_backend_transport proxy_handler_paged: limit translated to per_page"
+  )
+end
+
+-- ============================================================
 -- OnHttpRequest
 -- ============================================================
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -276,6 +276,14 @@ ok(
 )
 
 -- ============================================================
+-- owner_repo_id
+-- ============================================================
+
+eq(owner_repo_id("alice", "myrepo"), "alice%2Fmyrepo", "owner_repo_id: basic case")
+eq(owner_repo_id("org", "my-repo"), "org%2Fmy-repo", "owner_repo_id: hyphen in repo name")
+eq(owner_repo_id("a", "b"), "a%2Fb", "owner_repo_id: single-char segments")
+
+-- ============================================================
 -- translate_repo
 -- ============================================================
 


### PR DESCRIPTION
Introduces a shared backend transport factory in `.init.lua` that consolidates `fetch_json` and proxy handler logic, then migrates every backend (gitea, gitlab, bitbucket, sourcehut, and the rest) onto it. Also extracts the `owner%2Frepo` project_id helper so gitlab, harness, and gerrit can share it.

Fixes #114.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] Add shared backend transport factory (fetch_json + proxy_handlers) in .init.lua <!-- type:spec -->
- [x] Migrate gitea backend to shared transport factory <!-- type:spec -->
- [x] Migrate gitlab backend to shared transport factory <!-- type:spec -->
- [x] Migrate bitbucket and bitbucket_datacenter backends to shared transport <!-- type:spec -->
- [x] Migrate sourcehut backend to shared transport (preserving multi-subdomain bases) <!-- type:spec -->
- [x] Migrate remaining backends (azuredevops, codecommit, gerrit, gitbucket, harness, onedev, pagure, radicle, tuleap) to shared transport <!-- type:spec -->
- [x] Share owner%2Frepo project_id helper across gitlab, harness, gerrit <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->