### PR TITLE
Standardize shared proxy and error-handling usage across backends (closes #115)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -167,6 +167,35 @@ function proxy_health_check(ok, status)
   end
 end
 
+-- proxy_204 is global: standard mutation/DELETE response helper.
+-- Responds 204 No Content if the upstream status is 204 or any status in also_ok.
+-- Forwards any other upstream status as-is; responds 503 on connection failure.
+--
+-- also_ok: nil for 204-only, or a list of additional accepted success statuses.
+-- Designed to receive the return values of pcall(Fetch,...) or fetch_json(...):
+--   proxy_204(nil, pcall(Fetch, url, opts))          -- 204-only
+--   proxy_204({200}, fetch_json(url, "DELETE"))      -- also accept 200
+--   proxy_204({202}, pcall(Fetch, url, opts))        -- also accept 202
+--   proxy_204({200, 201}, pcall(Fetch, url, opts))   -- also accept 200 or 201
+function proxy_204(also_ok, ok, status)
+  local success = status == 204
+  if not success and also_ok then
+    for _, s in ipairs(also_ok) do
+      if s == status then
+        success = true
+        break
+      end
+    end
+  end
+  if ok and success then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end
+
 -- append_page_params appends translated pagination params to url.
 -- mapping: { per_page = "upstream_name", page = "upstream_name" }
 --   Omit the page key for providers that only support limit (e.g. Sourcehut).

--- a/.init.lua
+++ b/.init.lua
@@ -316,11 +316,12 @@ function make_backend_transport(scheme, pages)
     end
     return pcall(Fetch, url, opts)
   end
-  local proxy_handler_paged = pages
-      and make_proxy_handler(fetch_json, function(translate, ok, status, headers, body)
-        proxy_json_paged(translate, pages, ok, status, headers, body)
-      end)
-    or nil
+  local proxy_handler_paged
+  if pages then
+    proxy_handler_paged = make_proxy_handler(fetch_json, function(translate, ok, status, headers, body)
+      proxy_json_paged(translate, pages, ok, status, headers, body)
+    end)
+  end
   return {
     fetch_json = fetch_json,
     proxy_handler = make_proxy_handler(fetch_json),

--- a/.init.lua
+++ b/.init.lua
@@ -155,6 +155,18 @@ function proxy_json_created(translate, ok, status, _headers, body)
   end
 end
 
+-- proxy_health_check is global: backends use it to implement get_root.
+-- Probes an upstream endpoint; responds 200 {} on success, 503 {} otherwise.
+-- Accepts the first two return values of pcall(Fetch, url, opts):
+--   proxy_health_check(pcall(Fetch, url, opts))
+function proxy_health_check(ok, status)
+  if ok and status == 200 then
+    respond_json(200, {})
+  else
+    respond_json(503, {})
+  end
+end
+
 -- append_page_params appends translated pagination params to url.
 -- mapping: { per_page = "upstream_name", page = "upstream_name" }
 --   Omit the page key for providers that only support limit (e.g. Sourcehut).

--- a/.init.lua
+++ b/.init.lua
@@ -196,6 +196,25 @@ function proxy_204(also_ok, ok, status)
   end
 end
 
+-- proxy_json_list is global: standard list-endpoint response helper.
+-- Translates a successful 200 upstream array response to a JSON array,
+-- writing "[]" rather than "{}" when the result is empty.
+-- translate receives the decoded array and returns the translated array.
+-- Designed to receive the return values of fetch_json(...):
+--   proxy_json_list(translate, fetch_json(url))
+function proxy_json_list(translate, ok, status, _headers, body)
+  if ok and status == 200 then
+    local data = DecodeJson(body) or {}
+    local result = translate(data)
+    set_preamble()
+    Write(#result > 0 and EncodeJson(result) or "[]")
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end
+
 -- append_page_params appends translated pagination params to url.
 -- mapping: { per_page = "upstream_name", page = "upstream_name" }
 --   Omit the page key for providers that only support limit (e.g. Sourcehut).
@@ -297,12 +316,11 @@ function make_backend_transport(scheme, pages)
     end
     return pcall(Fetch, url, opts)
   end
-  local proxy_handler_paged = pages and make_proxy_handler(
-    fetch_json,
-    function(translate, ok, status, headers, body)
-      proxy_json_paged(translate, pages, ok, status, headers, body)
-    end
-  ) or nil
+  local proxy_handler_paged = pages
+      and make_proxy_handler(fetch_json, function(translate, ok, status, headers, body)
+        proxy_json_paged(translate, pages, ok, status, headers, body)
+      end)
+    or nil
   return {
     fetch_json = fetch_json,
     proxy_handler = make_proxy_handler(fetch_json),
@@ -437,10 +455,13 @@ end
 provider_families = {
   gitea = {
     aliases = {
-      forgejo  = { default_url = "https://codeberg.org" },
+      forgejo = { default_url = "https://codeberg.org" },
       codeberg = { default_url = "https://codeberg.org" },
-      gogs     = { default_url = "https://try.gogs.io", strip = { "_package", "_actions_" } },
-      notabug  = { default_url = "https://notabug.org", strip = { "gitignore", "_package", "_actions_" } },
+      gogs = { default_url = "https://try.gogs.io", strip = { "_package", "_actions_" } },
+      notabug = {
+        default_url = "https://notabug.org",
+        strip = { "gitignore", "_package", "_actions_" },
+      },
     },
   },
 }
@@ -846,7 +867,6 @@ local endpoint_sections = {
 
       -- Emojis
       { "GET /emojis", "get_emojis" },
-
     },
   },
   {
@@ -855,7 +875,6 @@ local endpoint_sections = {
       -- Gitignore templates (https://docs.github.com/en/rest/gitignore)
       { "GET /gitignore/templates", "get_gitignore_templates" },
       { "GET /gitignore/templates/{name}", "get_gitignore_template" },
-
     },
   },
   {
@@ -867,7 +886,6 @@ local endpoint_sections = {
 
       -- Repo license (https://docs.github.com/en/rest/licenses)
       { "GET /repos/{owner}/{repo}/license", "get_repo_license", licenses_not_implemented },
-
     },
   },
   {
@@ -875,7 +893,6 @@ local endpoint_sections = {
     {
       -- Rate Limits (https://docs.github.com/en/rest/rate-limit)
       { "GET /rate_limit", "get_rate_limit", rate_limit_response },
-
     },
   },
   {
@@ -892,8 +909,16 @@ local endpoint_sections = {
       { "GET /gists/{gist_id}/comments", "get_gist_comments", empty_list },
       { "POST /gists/{gist_id}/comments", "post_gist_comment", gists_not_implemented },
       { "GET /gists/{gist_id}/comments/{comment_id}", "get_gist_comment", gists_not_implemented },
-      { "PATCH /gists/{gist_id}/comments/{comment_id}", "patch_gist_comment", gists_not_implemented },
-      { "DELETE /gists/{gist_id}/comments/{comment_id}", "delete_gist_comment", gists_not_implemented },
+      {
+        "PATCH /gists/{gist_id}/comments/{comment_id}",
+        "patch_gist_comment",
+        gists_not_implemented,
+      },
+      {
+        "DELETE /gists/{gist_id}/comments/{comment_id}",
+        "delete_gist_comment",
+        gists_not_implemented,
+      },
       { "GET /gists/{gist_id}/commits", "get_gist_commits", empty_list },
       { "GET /gists/{gist_id}/forks", "get_gist_forks", empty_list },
       { "POST /gists/{gist_id}/forks", "post_gist_fork", gists_not_implemented },
@@ -902,7 +927,6 @@ local endpoint_sections = {
       { "DELETE /gists/{gist_id}/star", "delete_gist_star", gists_not_implemented },
       { "GET /gists/{gist_id}/{sha}", "get_gist_revision", gists_not_implemented },
       { "GET /users/{username}/gists", "get_user_gists", empty_list },
-
     },
   },
   {
@@ -914,7 +938,11 @@ local endpoint_sections = {
       { "GET /networks/{owner}/{repo}/events", "get_network_events", activity_list_empty },
       { "GET /notifications", "get_notifications", activity_list_empty },
       { "PUT /notifications", "put_notifications", activity_not_implemented },
-      { "GET /notifications/threads/{thread_id}", "get_notification_thread", activity_not_implemented },
+      {
+        "GET /notifications/threads/{thread_id}",
+        "get_notification_thread",
+        activity_not_implemented,
+      },
       {
         "PATCH /notifications/threads/{thread_id}",
         "patch_notification_thread",
@@ -943,11 +971,23 @@ local endpoint_sections = {
       { "GET /orgs/{org}/events", "get_org_events", activity_list_empty },
       { "GET /repos/{owner}/{repo}/events", "get_repo_events", activity_list_empty },
       { "GET /repos/{owner}/{repo}/notifications", "get_repo_notifications", activity_list_empty },
-      { "PUT /repos/{owner}/{repo}/notifications", "put_repo_notifications", activity_not_implemented },
+      {
+        "PUT /repos/{owner}/{repo}/notifications",
+        "put_repo_notifications",
+        activity_not_implemented,
+      },
       { "GET /repos/{owner}/{repo}/stargazers", "get_repo_stargazers", activity_list_empty },
       { "GET /repos/{owner}/{repo}/subscribers", "get_repo_subscribers", activity_list_empty },
-      { "GET /repos/{owner}/{repo}/subscription", "get_repo_subscription", activity_not_implemented },
-      { "PUT /repos/{owner}/{repo}/subscription", "put_repo_subscription", activity_not_implemented },
+      {
+        "GET /repos/{owner}/{repo}/subscription",
+        "get_repo_subscription",
+        activity_not_implemented,
+      },
+      {
+        "PUT /repos/{owner}/{repo}/subscription",
+        "put_repo_subscription",
+        activity_not_implemented,
+      },
       {
         "DELETE /repos/{owner}/{repo}/subscription",
         "delete_repo_subscription",
@@ -956,7 +996,11 @@ local endpoint_sections = {
       { "GET /user/starred", "get_user_starred", activity_list_empty },
       { "GET /user/starred/{owner}/{repo}", "get_user_starred_repo", activity_not_implemented },
       { "PUT /user/starred/{owner}/{repo}", "put_user_starred_repo", activity_not_implemented },
-      { "DELETE /user/starred/{owner}/{repo}", "delete_user_starred_repo", activity_not_implemented },
+      {
+        "DELETE /user/starred/{owner}/{repo}",
+        "delete_user_starred_repo",
+        activity_not_implemented,
+      },
       { "GET /user/subscriptions", "get_user_subscriptions", activity_list_empty },
       { "GET /users/{username}/events", "get_users_events", activity_list_empty },
       { "GET /users/{username}/events/orgs/{org}", "get_users_org_events", activity_list_empty },
@@ -969,7 +1013,6 @@ local endpoint_sections = {
       },
       { "GET /users/{username}/starred", "get_users_starred", activity_list_empty },
       { "GET /users/{username}/subscriptions", "get_users_subscriptions", activity_list_empty },
-
     },
   },
   {
@@ -993,7 +1036,6 @@ local endpoint_sections = {
       { "GET /repos/{owner}/{repo}/contributors", "get_repo_contributors" },
       { "GET /repos/{owner}/{repo}/tags", "get_repo_tags" },
       { "GET /repos/{owner}/{repo}/teams", "get_repo_teams" },
-
     },
   },
   {
@@ -1138,7 +1180,10 @@ local endpoint_sections = {
       { "GET /orgs/{org}/teams/{team_slug}/members", "get_org_team_members", empty_list },
       { "GET /orgs/{org}/teams/{team_slug}/memberships/{username}", "get_org_team_membership" },
       { "PUT /orgs/{org}/teams/{team_slug}/memberships/{username}", "put_org_team_membership" },
-      { "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}", "delete_org_team_membership" },
+      {
+        "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}",
+        "delete_org_team_membership",
+      },
       { "GET /orgs/{org}/teams/{team_slug}/repos", "get_org_team_repos", empty_list },
       { "GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "get_org_team_repo" },
       { "PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", "put_org_team_repo" },
@@ -1163,7 +1208,6 @@ local endpoint_sections = {
       { "PUT /teams/{team_id}/repos/{owner}/{repo}", "put_team_repo" },
       { "DELETE /teams/{team_id}/repos/{owner}/{repo}", "delete_team_repo" },
       { "GET /teams/{team_id}/teams", "get_team_children", empty_list },
-
     },
   },
   {
@@ -1173,14 +1217,21 @@ local endpoint_sections = {
       { "GET /advisories", "get_global_advisories", empty_list },
       { "GET /advisories/{ghsa_id}", "get_global_advisory" },
       { "GET /orgs/{org}/security-advisories", "get_org_security_advisories", empty_list },
-      { "GET /repos/{owner}/{repo}/security-advisories", "get_repo_security_advisories", empty_list },
+      {
+        "GET /repos/{owner}/{repo}/security-advisories",
+        "get_repo_security_advisories",
+        empty_list,
+      },
       { "POST /repos/{owner}/{repo}/security-advisories", "post_repo_security_advisory" },
       {
         "POST /repos/{owner}/{repo}/security-advisories/reports",
         "post_repo_security_advisory_report",
       },
       { "GET /repos/{owner}/{repo}/security-advisories/{ghsa_id}", "get_repo_security_advisory" },
-      { "PATCH /repos/{owner}/{repo}/security-advisories/{ghsa_id}", "patch_repo_security_advisory" },
+      {
+        "PATCH /repos/{owner}/{repo}/security-advisories/{ghsa_id}",
+        "patch_repo_security_advisory",
+      },
       {
         "POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/cve",
         "post_repo_security_advisory_cve",
@@ -1189,7 +1240,6 @@ local endpoint_sections = {
         "POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/forks",
         "post_repo_security_advisory_fork",
       },
-
     },
   },
   {
@@ -1205,7 +1255,10 @@ local endpoint_sections = {
       { "GET /repos/{owner}/{repo}/issues/comments/{comment_id}", "get_repo_issue_comment" },
       { "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", "patch_repo_issue_comment" },
       { "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}", "delete_repo_issue_comment" },
-      { "PUT /repos/{owner}/{repo}/issues/comments/{comment_id}/pin", "put_repo_issue_comment_pin" },
+      {
+        "PUT /repos/{owner}/{repo}/issues/comments/{comment_id}/pin",
+        "put_repo_issue_comment_pin",
+      },
       {
         "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/pin",
         "delete_repo_issue_comment_pin",
@@ -1216,8 +1269,15 @@ local endpoint_sections = {
       { "PATCH /repos/{owner}/{repo}/issues/{issue_number}", "patch_repo_issue" },
       { "POST /repos/{owner}/{repo}/issues/{issue_number}/assignees", "post_issue_assignees" },
       { "DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees", "delete_issue_assignees" },
-      { "GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}", "get_issue_assignee" },
-      { "GET /repos/{owner}/{repo}/issues/{issue_number}/comments", "get_issue_comments", empty_list },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}",
+        "get_issue_assignee",
+      },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+        "get_issue_comments",
+        empty_list,
+      },
       { "POST /repos/{owner}/{repo}/issues/{issue_number}/comments", "post_issue_comment" },
       {
         "GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by",
@@ -1262,7 +1322,11 @@ local endpoint_sections = {
         "PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority",
         "patch_issue_sub_issues_priority",
       },
-      { "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline", "get_issue_timeline", empty_list },
+      {
+        "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline",
+        "get_issue_timeline",
+        empty_list,
+      },
 
       -- Assignees (https://docs.github.com/en/rest/issues/assignees)
       { "GET /repos/{owner}/{repo}/assignees", "get_repo_assignees", empty_list },
@@ -1300,7 +1364,6 @@ local endpoint_sections = {
         "DELETE /repositories/{repository_id}/issues/{issue_number}/issue-field-values/{issue_field_id}",
         "delete_repository_issue_field_value",
       },
-
     },
   },
   {
@@ -1315,7 +1378,11 @@ local endpoint_sections = {
       { "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}", "delete_repo_pull_comment" },
       { "GET /repos/{owner}/{repo}/pulls/{pull_number}", "get_repo_pull" },
       { "PATCH /repos/{owner}/{repo}/pulls/{pull_number}", "patch_repo_pull" },
-      { "GET /repos/{owner}/{repo}/pulls/{pull_number}/codespaces", "get_pull_codespaces", empty_list },
+      {
+        "GET /repos/{owner}/{repo}/pulls/{pull_number}/codespaces",
+        "get_pull_codespaces",
+        empty_list,
+      },
       { "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments", "get_pull_comments", empty_list },
       { "POST /repos/{owner}/{repo}/pulls/{pull_number}/comments", "post_pull_comment" },
       {
@@ -1343,7 +1410,10 @@ local endpoint_sections = {
       { "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews", "post_pull_review" },
       { "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "get_pull_review" },
       { "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "put_pull_review" },
-      { "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}", "delete_pull_review" },
+      {
+        "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+        "delete_pull_review",
+      },
       {
         "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
         "get_pull_review_comments",
@@ -1502,7 +1572,6 @@ local endpoint_sections = {
       { "GET /user/ssh_signing_keys/{ssh_signing_key_id}", "get_user_ssh_signing_key" },
       { "DELETE /user/ssh_signing_keys/{ssh_signing_key_id}", "delete_user_ssh_signing_key" },
       { "GET /users/{username}/ssh_signing_keys", "get_users_ssh_signing_keys" },
-
     },
   },
   {
@@ -1516,7 +1585,6 @@ local endpoint_sections = {
       { "GET /search/repositories", "search_repositories", search_empty },
       { "GET /search/topics", "search_topics", search_empty },
       { "GET /search/users", "search_users", search_empty },
-
     },
   },
   {
@@ -1538,7 +1606,10 @@ local endpoint_sections = {
         "post_app_installation_access_tokens",
       },
       { "PUT /app/installations/{installation_id}/suspended", "put_app_installation_suspended" },
-      { "DELETE /app/installations/{installation_id}/suspended", "delete_app_installation_suspended" },
+      {
+        "DELETE /app/installations/{installation_id}/suspended",
+        "delete_app_installation_suspended",
+      },
       { "GET /apps/{app_slug}", "get_apps_app_slug" },
       { "POST /app-manifests/{code}/conversions", "post_app_manifest_conversions" },
       { "GET /installation/repositories", "get_installation_repositories" },
@@ -1565,7 +1636,6 @@ local endpoint_sections = {
         "delete_user_installation_repository",
       },
       { "GET /users/{username}/installation", "get_users_installation" },
-
     },
   },
   {
@@ -1735,7 +1805,6 @@ local endpoint_sections = {
           respond_json(200, { total_count = 0, check_suites = {} })
         end,
       },
-
     },
   },
   {
@@ -1847,7 +1916,6 @@ local endpoint_sections = {
         "get_code_scanning_sarif",
         code_scanning_not_implemented,
       },
-
     },
   },
   {
@@ -1899,7 +1967,6 @@ local endpoint_sections = {
         "get_secret_scanning_scan_history",
         secret_scanning_not_implemented,
       },
-
     },
   },
   {
@@ -2012,7 +2079,6 @@ local endpoint_sections = {
         "delete_repo_dependabot_secret",
         dependabot_not_implemented,
       },
-
     },
   },
   {
@@ -2034,7 +2100,6 @@ local endpoint_sections = {
         "post_repo_dependency_graph_snapshots",
         dependency_graph_not_implemented,
       },
-
     },
   },
   {
@@ -2163,7 +2228,6 @@ local endpoint_sections = {
         "projects_list_view_items_for_user",
         projects_list_empty,
       },
-
     },
   },
   {
@@ -2236,15 +2300,22 @@ local endpoint_sections = {
         "POST /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
         "restore_users_package_version",
       },
-
     },
   },
   {
     "interactions",
     {
       -- Interactions (https://docs.github.com/en/rest/interactions)
-      { "GET /orgs/{org}/interaction-limits", "get_org_interaction_limits", interaction_limits_empty },
-      { "PUT /orgs/{org}/interaction-limits", "put_org_interaction_limits", interaction_limits_put },
+      {
+        "GET /orgs/{org}/interaction-limits",
+        "get_org_interaction_limits",
+        interaction_limits_empty,
+      },
+      {
+        "PUT /orgs/{org}/interaction-limits",
+        "put_org_interaction_limits",
+        interaction_limits_put,
+      },
       {
         "DELETE /orgs/{org}/interaction-limits",
         "delete_org_interaction_limits",
@@ -2272,7 +2343,6 @@ local endpoint_sections = {
         "delete_user_interaction_limits",
         interaction_limits_delete,
       },
-
     },
   },
   {
@@ -2323,8 +2393,11 @@ local endpoint_sections = {
         "delete_user_migration_repo_lock",
         migration_not_found,
       },
-      { "GET /user/migrations/{migration_id}/repositories", "get_user_migration_repos", empty_list },
-
+      {
+        "GET /user/migrations/{migration_id}/repositories",
+        "get_user_migration_repos",
+        empty_list,
+      },
     },
   },
   {
@@ -2336,7 +2409,11 @@ local endpoint_sections = {
       { "PUT /repos/{owner}/{repo}/pages", "put_repo_pages", pages_not_implemented },
       { "DELETE /repos/{owner}/{repo}/pages", "delete_repo_pages", pages_not_implemented },
       { "GET /repos/{owner}/{repo}/pages/builds", "get_repo_pages_builds", empty_list },
-      { "POST /repos/{owner}/{repo}/pages/builds", "post_repo_pages_builds", pages_not_implemented },
+      {
+        "POST /repos/{owner}/{repo}/pages/builds",
+        "post_repo_pages_builds",
+        pages_not_implemented,
+      },
       {
         "GET /repos/{owner}/{repo}/pages/builds/latest",
         "get_repo_pages_build_latest",
@@ -2381,7 +2458,6 @@ local endpoint_sections = {
         source_import_gone,
       },
       { "PATCH /repos/{owner}/{repo}/import/lfs", "patch_repo_import_lfs", source_import_gone },
-
     },
   },
   {
@@ -2390,7 +2466,6 @@ local endpoint_sections = {
       -- Markdown (https://docs.github.com/en/rest/markdown)
       { "POST /markdown", "render_markdown", markdown_not_implemented },
       { "POST /markdown/raw", "render_markdown_raw", markdown_not_implemented },
-
     },
   },
   {
@@ -2459,7 +2534,11 @@ local endpoint_sections = {
       },
 
       -- Organization cache
-      { "GET /orgs/{org}/actions/cache/usage", "get_org_actions_cache_usage", actions_not_implemented },
+      {
+        "GET /orgs/{org}/actions/cache/usage",
+        "get_org_actions_cache_usage",
+        actions_not_implemented,
+      },
       {
         "GET /orgs/{org}/actions/cache/usage-by-repository",
         "get_org_actions_cache_usage_by_repo",
@@ -2576,8 +2655,16 @@ local endpoint_sections = {
       },
 
       -- Organization permissions
-      { "GET /orgs/{org}/actions/permissions", "get_org_actions_permissions", actions_not_implemented },
-      { "PUT /orgs/{org}/actions/permissions", "put_org_actions_permissions", actions_not_implemented },
+      {
+        "GET /orgs/{org}/actions/permissions",
+        "get_org_actions_permissions",
+        actions_not_implemented,
+      },
+      {
+        "PUT /orgs/{org}/actions/permissions",
+        "put_org_actions_permissions",
+        actions_not_implemented,
+      },
       {
         "GET /orgs/{org}/actions/permissions/artifact-and-log-retention",
         "get_org_actions_artifact_log_retention",
@@ -2608,7 +2695,11 @@ local endpoint_sections = {
         "put_org_actions_fork_pr_private_repos",
         actions_not_implemented,
       },
-      { "GET /orgs/{org}/actions/permissions/repositories", "get_org_actions_perm_repos", empty_list },
+      {
+        "GET /orgs/{org}/actions/permissions/repositories",
+        "get_org_actions_perm_repos",
+        empty_list,
+      },
       {
         "PUT /orgs/{org}/actions/permissions/repositories",
         "put_org_actions_perm_repos",
@@ -2753,7 +2844,11 @@ local endpoint_sections = {
         "get_org_actions_runners",
         make_empty_collection("runners"),
       },
-      { "GET /orgs/{org}/actions/runners/downloads", "get_org_actions_runner_downloads", empty_list },
+      {
+        "GET /orgs/{org}/actions/runners/downloads",
+        "get_org_actions_runner_downloads",
+        empty_list,
+      },
       {
         "POST /orgs/{org}/actions/runners/generate-jitconfig",
         "post_org_actions_runner_jitconfig",
@@ -2858,7 +2953,11 @@ local endpoint_sections = {
         "get_org_actions_variables",
         make_empty_collection("variables"),
       },
-      { "POST /orgs/{org}/actions/variables", "post_org_actions_variable", actions_not_implemented },
+      {
+        "POST /orgs/{org}/actions/variables",
+        "post_org_actions_variable",
+        actions_not_implemented,
+      },
       {
         "GET /orgs/{org}/actions/variables/{name}",
         "get_org_actions_variable",
@@ -3326,7 +3425,6 @@ local endpoint_sections = {
         "get_repo_actions_workflow_timing",
         actions_not_implemented,
       },
-
     },
   },
   {
@@ -3339,7 +3437,11 @@ local endpoint_sections = {
 
       -- Commits
       { "POST /repos/{owner}/{repo}/git/commits", "create_git_commit", git_not_implemented },
-      { "GET /repos/{owner}/{repo}/git/commits/{commit_sha}", "get_git_commit", git_not_implemented },
+      {
+        "GET /repos/{owner}/{repo}/git/commits/{commit_sha}",
+        "get_git_commit",
+        git_not_implemented,
+      },
 
       -- Refs
       {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -32,6 +32,7 @@ globals = {
   "proxy_json_paged",
   "proxy_json_created",
   "proxy_health_check",
+  "proxy_204",
   "rewrite_link_header",
   "append_page_params",
   "make_fetch_opts",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -31,6 +31,7 @@ globals = {
   "proxy_json",
   "proxy_json_paged",
   "proxy_json_created",
+  "proxy_health_check",
   "rewrite_link_header",
   "append_page_params",
   "make_fetch_opts",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -33,6 +33,7 @@ globals = {
   "proxy_json_created",
   "proxy_health_check",
   "proxy_204",
+  "proxy_json_list",
   "rewrite_link_header",
   "append_page_params",
   "make_fetch_opts",

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -352,12 +352,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, ado_url(config.base_url .. "/_apis/connectionData"), auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, ado_url(config.base_url .. "/_apis/connectionData"), auth()))
   end,
   get_repo = function(owner, repo_name)
     proxy_json(translate_ado_repo, fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name)))

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -1212,15 +1212,10 @@ backend_impl = {
     opts.body = EncodeJson(patch)
     opts.headers = opts.headers or {}
     opts.headers["Content-Type"] = "application/json-patch+json"
-    local cok, cstatus, _, cbody =
+    proxy_json_created(
+      translate_ado_workitem,
       pcall(Fetch, ado_url(config.base_url .. "/" .. owner .. "/_apis/wit/workitems/$Issue"), opts)
-    if cok and (cstatus == 200 or cstatus == 201) then
-      respond_json(201, translate_ado_workitem(DecodeJson(cbody) or {}))
-    elseif cok then
-      respond_json(cstatus, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   patch_repo_issue = function(owner, _repo_name, issue_number)

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -384,14 +384,7 @@ backend_impl = {
     local repo_id = repo.id or repo_name
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local dok, dstatus = pcall(Fetch, ado_url(repos_base(owner) .. "/" .. repo_id), dopts)
-    if dok and (dstatus == 204 or dstatus == 200) then
-      SetStatus(204, "No Content")
-    elseif dok then
-      respond_json(dstatus, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, ado_url(repos_base(owner) .. "/" .. repo_id), dopts))
   end,
 
   get_user_repos = function()
@@ -759,18 +752,14 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(
-      Fetch,
-      ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id),
-      dopts
+    proxy_204(
+      { 200 },
+      pcall(
+        Fetch,
+        ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id),
+        dopts
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_org_team_members = function(org, slug)
@@ -941,20 +930,16 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(
-      Fetch,
-      ado_url(
-        config.base_url .. "/_apis/projects/" .. (t.projectName or "") .. "/teams/" .. team_id
-      ),
-      dopts
+    proxy_204(
+      { 200 },
+      pcall(
+        Fetch,
+        ado_url(
+          config.base_url .. "/_apis/projects/" .. (t.projectName or "") .. "/teams/" .. team_id
+        ),
+        dopts
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_team_members = function(team_id)
@@ -1974,12 +1959,5 @@ _b.delete_git_ref = function(owner, repo_name, ref)
   local del_body = EncodeJson({
     { name = full_ref, newObjectId = ZERO_SHA, oldObjectId = old_sha },
   })
-  local ok2, status2 = fetch_json(url, "POST", del_body)
-  if ok2 and status2 == 200 then
-    SetStatus(204, "No Content")
-  elseif ok2 then
-    respond_json(status2, {})
-  else
-    respond_json(503, {})
-  end
+  proxy_204({ 200 }, fetch_json(url, "POST", del_body))
 end

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -635,12 +635,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/user", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/user", auth()))
   end,
 
   get_repo = proxy_handler(translate_bb_repo, function(o, r)

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -619,20 +619,6 @@ local function snippet_url(gist_id)
   return base() .. "/snippets/" .. ws .. "/" .. eid
 end
 
--- Like proxy_json but ensures empty results are written as "[]" not "{}".
-local function proxy_list(translate, ok, status, _headers, body)
-  if ok and status == 200 then
-    local data = DecodeJson(body) or {}
-    local result = translate(data)
-    set_preamble()
-    Write(#result > 0 and EncodeJson(result) or "[]")
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
-end
-
 backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/user", auth()))
@@ -1771,14 +1757,17 @@ backend_impl = {
   -- e.g. gist_id = "octocat~pHANT4" → /2.0/snippets/octocat/pHANT4
 
   get_gists = function()
-    proxy_list(
+    proxy_json_list(
       translate_bb_snippets,
       fetch_json(append_page_params(base() .. "/snippets?role=owner", PAGES))
     )
   end,
 
   get_gists_public = function()
-    proxy_list(translate_bb_snippets, fetch_json(append_page_params(base() .. "/snippets", PAGES)))
+    proxy_json_list(
+      translate_bb_snippets,
+      fetch_json(append_page_params(base() .. "/snippets", PAGES))
+    )
   end,
 
   post_gists = function()
@@ -1837,7 +1826,7 @@ backend_impl = {
   get_gist_comments = function(gist_id)
     local url = snippet_url(gist_id)
     if url then
-      proxy_list(
+      proxy_json_list(
         translate_bb_snippet_comments,
         fetch_json(append_page_params(url .. "/comments", PAGES))
       )
@@ -1892,7 +1881,7 @@ backend_impl = {
   get_gist_commits = function(gist_id)
     local url = snippet_url(gist_id)
     if url then
-      proxy_list(
+      proxy_json_list(
         translate_bb_snippet_commits,
         fetch_json(append_page_params(url .. "/commits", PAGES))
       )
@@ -1902,7 +1891,7 @@ backend_impl = {
   get_gist_forks = function(gist_id)
     local url = snippet_url(gist_id)
     if url then
-      proxy_list(translate_bb_snippets, fetch_json(append_page_params(url .. "/forks", PAGES)))
+      proxy_json_list(translate_bb_snippets, fetch_json(append_page_params(url .. "/forks", PAGES)))
     end
   end,
 
@@ -1951,7 +1940,7 @@ backend_impl = {
   end,
 
   get_user_gists = function(username)
-    proxy_list(
+    proxy_json_list(
       translate_bb_snippets,
       fetch_json(append_page_params(base() .. "/snippets/" .. username, PAGES))
     )

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -657,14 +657,7 @@ backend_impl = {
     local url = base() .. "/repositories/" .. owner .. "/" .. repo_name
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, url, dopts))
   end,
 
   get_user_repos = function()
@@ -1085,14 +1078,7 @@ backend_impl = {
     local url = base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/deploy-keys/" .. key_id
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, url, dopts))
   end,
 
   -- Webhooks ------------------------------------------------------------------
@@ -1157,14 +1143,7 @@ backend_impl = {
       .. "}"
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, url, dopts))
   end,
 
   -- Users ---------------------------------------------------------------------
@@ -1334,13 +1313,7 @@ backend_impl = {
       "POST",
       EncodeJson(bb)
     )
-    if ok and status == 200 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
@@ -1746,14 +1719,7 @@ backend_impl = {
       .. name
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, url, dopts))
   end,
 
   -- Activity (Bitbucket Watchers) ---------------------------------------------
@@ -1865,14 +1831,7 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and status == 204 then
-      set_preamble(204)
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, url, dopts))
   end,
 
   get_gist_comments = function(gist_id)
@@ -1927,14 +1886,7 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url .. "/comments/" .. comment_id, dopts)
-    if ok and status == 204 then
-      set_preamble(204)
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, url .. "/comments/" .. comment_id, dopts))
   end,
 
   get_gist_commits = function(gist_id)
@@ -1978,14 +1930,7 @@ backend_impl = {
     end
     local wopts = auth() or {}
     wopts.method = "PUT"
-    local ok, status = pcall(Fetch, url .. "/watch", wopts)
-    if ok and (status == 200 or status == 204) then
-      set_preamble(204)
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, url .. "/watch", wopts))
   end,
 
   delete_gist_star = function(gist_id)
@@ -1995,14 +1940,7 @@ backend_impl = {
     end
     local wopts = auth() or {}
     wopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url .. "/watch", wopts)
-    if ok and status == 204 then
-      set_preamble(204)
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, url .. "/watch", wopts))
   end,
 
   get_gist_revision = function(gist_id, sha)

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -404,14 +404,7 @@ backend_impl = {
   delete_repo = function(owner, repo_name)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, repo_path(owner, repo_name), dopts)
-    if ok and (status == 202 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 202 }, pcall(Fetch, repo_path(owner, repo_name), dopts))
   end,
 
   -- GET /user/repos — DC: GET /repos (all repos visible to the auth'd user)
@@ -639,14 +632,7 @@ backend_impl = {
   delete_repo_key = function(owner, repo_name, key_id)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, repo_path(owner, repo_name) .. "/ssh/" .. key_id, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, repo_path(owner, repo_name) .. "/ssh/" .. key_id, dopts))
   end,
 
   -- Webhooks -------------------------------------------------------------------
@@ -690,14 +676,7 @@ backend_impl = {
   delete_repo_hook = function(owner, repo_name, hook_id)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, repo_path(owner, repo_name) .. "/webhooks/" .. hook_id, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, repo_path(owner, repo_name) .. "/webhooks/" .. hook_id, dopts))
   end,
 
   get_repo_hook_config = proxy_handler(function(h)
@@ -853,14 +832,7 @@ backend_impl = {
     if req.commit_message then
       dc.message = req.commit_message
     end
-    local mok, mstatus = fetch_json(pr_url .. "/merge", "POST", EncodeJson(dc))
-    if mok and (mstatus == 200 or mstatus == 204) then
-      SetStatus(204, "No Content")
-    elseif mok then
-      respond_json(mstatus, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, fetch_json(pr_url .. "/merge", "POST", EncodeJson(dc)))
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
@@ -1410,12 +1382,5 @@ _b.delete_git_ref = function(owner, repo_name, ref)
     dopts.headers = dopts.headers or {}
     dopts.headers["Content-Type"] = "application/json"
   end
-  local ok, status = pcall(Fetch, url, dopts)
-  if ok and (status == 204 or status == 200 or status == 202) then
-    SetStatus(204, "No Content")
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
+  proxy_204({ 200, 202 }, pcall(Fetch, url, dopts))
 end

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -388,12 +388,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/repos", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
   end,
 
   get_repo = proxy_handler(translate_bbs_repo, function(owner, repo_name)

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -793,7 +793,8 @@ backend_impl = {
   end),
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- Returns 204 if PR is merged, 404 otherwise.
+  -- Cannot use proxy_json: DC always returns 200 with a PR object; the response
+  -- status (204 merged / 404 not merged) is synthesised from the body's state field.
   get_pull_merge = function(owner, repo_name, pull_number)
     local ok, status, _, body =
       fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -98,12 +98,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/repos", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
   end,
 
   -- GET /repos/{owner}/{repo}: owner must be "codecommit".

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -247,6 +247,9 @@ backend_impl = {
   end),
 
   -- Users ---------------------------------------------------------------------
+  -- These handlers cannot use proxy_json: Gerrit prefixes every JSON response
+  -- with ")]}'\n" to prevent XSS cross-domain reads.  gerrit_decode strips that
+  -- prefix before passing the body to DecodeJson.
 
   -- GET /user — authenticated user
   get_user = function()
@@ -302,7 +305,8 @@ backend_impl = {
   -- default empty-list / 404 handlers defined in .init.lua.
 
   -- Contents ------------------------------------------------------------------
-  -- Gerrit returns raw base64-encoded content at /branches/{branch}/files/{path}/content
+  -- Cannot use proxy_json: Gerrit returns the raw base64-encoded file bytes
+  -- directly (no JSON envelope), so DecodeJson is not applicable.
 
   get_repo_content = function(owner, repo_name, path)
     local ref = GetParam("ref") or "HEAD"

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -113,12 +113,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, config.base_url .. "/config/server/version", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, config.base_url .. "/config/server/version", auth()))
   end,
   get_repo = proxy_handler(translate_gerrit_repo, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name)

--- a/backends/gitblit.lua
+++ b/backends/gitblit.lua
@@ -117,12 +117,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, rpc() .. "?req=LIST_REPOSITORIES", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, rpc() .. "?req=LIST_REPOSITORIES", auth()))
   end,
 
   get_repo = function(owner, repo_name)

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -17,14 +17,7 @@ local proxy_handler_created = _t.proxy_handler_created
 local function set_204_or_error(method, url)
   local opts = auth() or {}
   opts.method = method
-  local ok, status = pcall(Fetch, url, opts)
-  if ok and status == 204 then
-    SetStatus(204, "No Content")
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
+  proxy_204(nil, pcall(Fetch, url, opts))
 end
 
 backend_impl = {
@@ -53,14 +46,7 @@ backend_impl = {
     local url = base() .. "/repos/" .. owner .. "/" .. repo_name
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, url, dopts))
   end,
 
   get_user_repos = proxy_handler(nil, function()
@@ -363,32 +349,24 @@ backend_impl = {
   end,
 
   put_repo_collaborator = function(owner, repo_name, username)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-      "PUT",
-      GetBody()
+    proxy_204(
+      { 201 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+        "PUT",
+        GetBody()
+      )
     )
-    if ok and (status == 204 or status == 201) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   delete_repo_collaborator = function(owner, repo_name, username)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_repo_collaborator_permission = proxy_handler(nil, function(o, r, username)
@@ -443,17 +421,13 @@ backend_impl = {
   end,
 
   delete_repo_release = function(owner, repo_name, release_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_repo_release_assets = proxy_handler(nil, function(o, r, id)
@@ -496,17 +470,13 @@ backend_impl = {
   end,
 
   delete_repo_release_asset = function(owner, repo_name, asset_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- Deploy keys ---------------------------------------------------------------
@@ -526,15 +496,10 @@ backend_impl = {
   end),
 
   delete_repo_key = function(owner, repo_name, key_id)
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- Webhooks ------------------------------------------------------------------
@@ -565,15 +530,10 @@ backend_impl = {
   end,
 
   delete_repo_hook = function(owner, repo_name, hook_id)
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   get_repo_hook_config = proxy_handler(function(h)
@@ -605,31 +565,23 @@ backend_impl = {
   end,
 
   post_repo_hook_ping = function(owner, repo_name, hook_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/pings",
-      "POST"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/pings",
+        "POST"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   post_repo_hook_test = function(owner, repo_name, hook_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
-      "POST"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
+        "POST"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- Commit comments -----------------------------------------------------------
@@ -653,17 +605,13 @@ backend_impl = {
   end,
 
   delete_repo_comment = function(owner, repo_name, comment_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_commit_comments = proxy_handler(nil, function(o, r, sha)
@@ -772,14 +720,7 @@ backend_impl = {
     opts.body = GetBody()
     opts.headers = opts.headers or {}
     opts.headers["Content-Type"] = "application/json"
-    local ok, status = pcall(Fetch, base() .. "/user/emails", opts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/user/emails", opts))
   end,
 
   get_user_keys = proxy_handler(nil, function()
@@ -797,14 +738,7 @@ backend_impl = {
   delete_user_key = function(key_id)
     local opts = auth() or {}
     opts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/user/keys/" .. key_id, opts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/user/keys/" .. key_id, opts))
   end,
 
   get_users_keys = proxy_handler(nil, function(username)
@@ -830,14 +764,7 @@ backend_impl = {
   end,
 
   delete_org_team = function(org, slug)
-    local ok, status = fetch_json(base() .. "/orgs/" .. org .. "/teams/" .. slug, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, fetch_json(base() .. "/orgs/" .. org .. "/teams/" .. slug, "DELETE"))
   end,
 
   get_org_team_invitations = proxy_handler(nil, function(org, slug)
@@ -867,17 +794,13 @@ backend_impl = {
   end,
 
   delete_org_team_membership = function(org, slug, username)
-    local ok, status = fetch_json(
-      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_org_team_repos = proxy_handler(nil, function(org, slug)
@@ -889,32 +812,24 @@ backend_impl = {
   end),
 
   put_org_team_repo = function(org, slug, owner, repo_name)
-    local ok, status = fetch_json(
-      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
-      "PUT",
-      GetBody()
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
+        "PUT",
+        GetBody()
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   delete_org_team_repo = function(org, slug, owner, repo_name)
-    local ok, status = fetch_json(
-      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_org_team_children = proxy_handler(nil, function(org, slug)
@@ -952,17 +867,13 @@ backend_impl = {
   end),
 
   delete_repo_issue_comment = function(owner, repo_name, comment_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_repo_issue_events = proxy_handler(nil, function(o, r)
@@ -1007,39 +918,31 @@ backend_impl = {
   end),
 
   delete_issue_labels = function(owner, repo_name, issue_number)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   delete_issue_label = function(owner, repo_name, issue_number, label_name)
-    local ok, status = fetch_json(
-      base()
-        .. "/repos/"
-        .. owner
-        .. "/"
-        .. repo_name
-        .. "/issues/"
-        .. issue_number
-        .. "/labels/"
-        .. label_name,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base()
+          .. "/repos/"
+          .. owner
+          .. "/"
+          .. repo_name
+          .. "/issues/"
+          .. issue_number
+          .. "/labels/"
+          .. label_name,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   post_issue_assignees = proxy_handler(nil, function(o, r, n)
@@ -1075,17 +978,13 @@ backend_impl = {
   end),
 
   delete_repo_label = function(owner, repo_name, label_name)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. label_name,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. label_name,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_repo_milestones = proxy_handler(nil, function(o, r)
@@ -1118,14 +1017,7 @@ backend_impl = {
   end,
 
   delete_team = function(team_id)
-    local ok, status = fetch_json(base() .. "/teams/" .. team_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, fetch_json(base() .. "/teams/" .. team_id, "DELETE"))
   end,
 
   get_team_invitations = proxy_handler(nil, function(team_id)
@@ -1168,15 +1060,10 @@ backend_impl = {
   end,
 
   delete_team_membership = function(team_id, username)
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/teams/" .. team_id .. "/memberships/" .. username, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   get_team_repos = proxy_handler(nil, function(team_id)
@@ -1188,30 +1075,21 @@ backend_impl = {
   end),
 
   put_team_repo = function(team_id, owner, repo_name)
-    local ok, status = fetch_json(
-      base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name,
-      "PUT",
-      GetBody()
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name,
+        "PUT",
+        GetBody()
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   delete_team_repo = function(team_id, owner, repo_name)
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   get_team_children = proxy_handler(nil, function(team_id)
@@ -1278,18 +1156,14 @@ backend_impl = {
   end,
 
   put_pull_merge = function(owner, repo_name, pull_number)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
-      "PUT",
-      GetBody()
+    proxy_204(
+      nil,
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
+        "PUT",
+        GetBody()
+      )
     )
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   get_pull_requested_reviewers = proxy_handler(nil, function(o, r, n)

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -29,12 +29,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/rate_limit", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/rate_limit", auth()))
   end,
 
   get_rate_limit = proxy_handler(function(data)

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -823,12 +823,7 @@ end
 backend_impl = {
   -- Health check
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/version", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
   end,
 
   get_rate_limit = proxy_handler(function(data)

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -46,14 +46,7 @@ end
 local function set_204_or_error(method, url)
   local opts = auth() or {}
   opts.method = method
-  local ok, status = pcall(Fetch, url, opts)
-  if ok and status == 204 then
-    SetStatus(204, "No Content")
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
+  proxy_204(nil, pcall(Fetch, url, opts))
 end
 
 local function proxy_users_follow_list(username, rel)
@@ -783,18 +776,6 @@ local function proxy_actions_list(key, translate_fn, url)
   )
 end
 
--- Forward mutating request body to Gitea and return 204 No Content on success.
-local function proxy_204(method, url)
-  local ok, status = fetch_json(url, method, GetBody())
-  if ok and status == 204 then
-    SetStatus(204, "No Content")
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
-end
-
 -- Given a synthesized GitHub reaction_id, extract the content string or nil.
 -- Gitea DELETE reactions takes a JSON body {"content":"..."} rather than an ID.
 local function reaction_content_from_id(reaction_id)
@@ -810,14 +791,7 @@ local function delete_gitea_reaction(url, reaction_id)
     respond_json(404, { message = "Not Found" })
     return
   end
-  local ok, status = fetch_json(url, "DELETE", '{"content":"' .. content .. '"}')
-  if ok and (status == 200 or status == 204) then
-    SetStatus(204, "No Content")
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
+  proxy_204({ 200 }, fetch_json(url, "DELETE", '{"content":"' .. content .. '"}'))
 end
 
 backend_impl = {
@@ -891,14 +865,7 @@ backend_impl = {
     local url = base() .. "/repos/" .. owner .. "/" .. repo_name
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, url, dopts))
   end,
 
   -- GET /user/repos
@@ -1191,33 +1158,25 @@ backend_impl = {
 
   -- PUT /repos/{owner}/{repo}/collaborators/{username}
   put_repo_collaborator = function(owner, repo_name, username)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-      "PUT",
-      GetBody()
+    proxy_204(
+      { 201 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+        "PUT",
+        GetBody()
+      )
     )
-    if ok and (status == 204 or status == 201) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- DELETE /repos/{owner}/{repo}/collaborators/{username}
   delete_repo_collaborator = function(owner, repo_name, username)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/collaborators/{username}/permission
@@ -1317,17 +1276,13 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/releases/{release_id}
   delete_repo_release = function(owner, repo_name, release_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/releases/{release_id}/assets
@@ -1395,17 +1350,13 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}
   delete_repo_release_asset = function(owner, repo_name, asset_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- Deploy keys ---------------------------------------------------------------
@@ -1439,15 +1390,10 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/keys/{key_id}
   delete_repo_key = function(owner, repo_name, key_id)
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- Webhooks ------------------------------------------------------------------
@@ -1493,15 +1439,10 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/hooks/{hook_id}
   delete_repo_hook = function(owner, repo_name, hook_id)
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- GET /repos/{owner}/{repo}/hooks/{hook_id}/config
@@ -1539,17 +1480,13 @@ backend_impl = {
 
   -- POST /repos/{owner}/{repo}/hooks/{hook_id}/tests
   post_repo_hook_test = function(owner, repo_name, hook_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
-      "POST"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
+        "POST"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- Users' repos --------------------------------------------------------------
@@ -1605,17 +1542,13 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/comments/{comment_id}
   delete_repo_comment = function(owner, repo_name, comment_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/commits/{commit_sha}/comments
@@ -1741,14 +1674,7 @@ backend_impl = {
 
   -- DELETE /user/keys/{key_id}
   delete_user_key = function(key_id)
-    local ok, status = fetch_json(base() .. "/user/keys/" .. key_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, fetch_json(base() .. "/user/keys/" .. key_id, "DELETE"))
   end,
 
   -- GET /users/{username}/keys
@@ -1775,14 +1701,7 @@ backend_impl = {
 
   -- DELETE /user/gpg_keys/{gpg_key_id}
   delete_user_gpg_key = function(gpg_key_id)
-    local ok, status = fetch_json(base() .. "/user/gpg_keys/" .. gpg_key_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, fetch_json(base() .. "/user/gpg_keys/" .. gpg_key_id, "DELETE"))
   end,
 
   -- GET /users/{username}/gpg_keys
@@ -1809,14 +1728,7 @@ backend_impl = {
     opts.body = GetBody()
     opts.headers = opts.headers or {}
     opts.headers["Content-Type"] = "application/json"
-    local ok, status = pcall(Fetch, base() .. "/user/emails", opts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/user/emails", opts))
   end,
 
   -- GET /user/public_emails — Gitea has no separate endpoint; filter verified from /user/emails
@@ -1897,14 +1809,7 @@ backend_impl = {
     end
     local opts = auth() or {}
     opts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/teams/" .. id, opts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, base() .. "/teams/" .. id, opts))
   end,
 
   -- GET /orgs/{org}/teams/{team_slug}/members
@@ -1966,14 +1871,7 @@ backend_impl = {
     end
     local opts = auth() or {}
     opts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, opts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, opts))
   end,
 
   -- GET /orgs/{org}/teams/{team_slug}/repos
@@ -2019,15 +1917,10 @@ backend_impl = {
     end
     local opts = auth() or {}
     opts.method = "PUT"
-    local ok, status =
+    proxy_204(
+      nil,
       pcall(Fetch, base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name, opts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
@@ -2039,15 +1932,10 @@ backend_impl = {
     end
     local opts = auth() or {}
     opts.method = "DELETE"
-    local ok, status =
+    proxy_204(
+      nil,
       pcall(Fetch, base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name, opts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- Issues -------------------------------------------------------------------
@@ -2089,17 +1977,13 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}
   delete_repo_issue_comment = function(owner, repo_name, comment_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
@@ -2249,17 +2133,13 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels  (remove all)
   delete_issue_labels = function(owner, repo_name, issue_number)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
@@ -2270,25 +2150,21 @@ backend_impl = {
       respond_json(404, { message = "Label not found" })
       return
     end
-    local ok, status = fetch_json(
-      base()
-        .. "/repos/"
-        .. owner
-        .. "/"
-        .. repo_name
-        .. "/issues/"
-        .. issue_number
-        .. "/labels/"
-        .. id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base()
+          .. "/repos/"
+          .. owner
+          .. "/"
+          .. repo_name
+          .. "/issues/"
+          .. issue_number
+          .. "/labels/"
+          .. id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- PUT /repos/{owner}/{repo}/issues/{issue_number}/lock
@@ -2298,18 +2174,14 @@ backend_impl = {
     opts.body = GetBody()
     opts.headers = opts.headers or {}
     opts.headers["Content-Type"] = "application/json"
-    local ok, status = pcall(
-      Fetch,
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/lock",
-      opts
+    proxy_204(
+      nil,
+      pcall(
+        Fetch,
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/lock",
+        opts
+      )
     )
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock
@@ -2414,15 +2286,10 @@ backend_impl = {
       respond_json(404, { message = "Label not found" })
       return
     end
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- Milestones ----------------------------------------------------------------
@@ -2449,17 +2316,13 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
   delete_repo_milestone = function(owner, repo_name, milestone_number)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/milestones/" .. milestone_number,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/milestones/" .. milestone_number,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels
@@ -2535,14 +2398,10 @@ backend_impl = {
   put_team_member = function(team_id, username)
     local opts = auth() or {}
     opts.method = "PUT"
-    local ok, status = pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, opts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(
+      { 200 },
+      pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, opts)
+    )
   end,
 
   -- DELETE /teams/{team_id}/members/{username} — deprecated legacy endpoint
@@ -2612,15 +2471,10 @@ backend_impl = {
   put_team_repo = function(team_id, owner, repo_name)
     local opts = auth() or {}
     opts.method = "PUT"
-    local ok, status =
+    proxy_204(
+      nil,
       pcall(Fetch, base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name, opts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- DELETE /teams/{team_id}/repos/{owner}/{repo}
@@ -2689,18 +2543,14 @@ backend_impl = {
   -- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
   -- GitHub uses PUT; Gitea uses POST.
   put_pull_merge = function(owner, repo_name, pull_number)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
-      "POST",
-      GetBody()
+    proxy_204(
+      nil,
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
+        "POST",
+        GetBody()
+      )
     )
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
@@ -2717,25 +2567,21 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
   delete_pull_requested_reviewers = function(owner, repo_name, pull_number)
-    local ok, status = fetch_json(
-      base()
-        .. "/repos/"
-        .. owner
-        .. "/"
-        .. repo_name
-        .. "/pulls/"
-        .. pull_number
-        .. "/requested_reviewers",
-      "DELETE",
-      GetBody()
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base()
+          .. "/repos/"
+          .. owner
+          .. "/"
+          .. repo_name
+          .. "/pulls/"
+          .. pull_number
+          .. "/requested_reviewers",
+        "DELETE",
+        GetBody()
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
@@ -2758,25 +2604,21 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
   delete_pull_review = function(owner, repo_name, pull_number, review_id)
-    local ok, status = fetch_json(
-      base()
-        .. "/repos/"
-        .. owner
-        .. "/"
-        .. repo_name
-        .. "/pulls/"
-        .. pull_number
-        .. "/reviews/"
-        .. review_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base()
+          .. "/repos/"
+          .. owner
+          .. "/"
+          .. repo_name
+          .. "/pulls/"
+          .. pull_number
+          .. "/reviews/"
+          .. review_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
@@ -3154,7 +2996,14 @@ backend_impl = {
     )
   end,
   patch_repo_actions_variable = function(owner, repo, name)
-    proxy_204("PUT", base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name)
+    proxy_204(
+      nil,
+      fetch_json(
+        base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name,
+        "PUT",
+        GetBody()
+      )
+    )
   end,
   delete_repo_actions_variable = function(owner, repo, name)
     set_204_or_error(
@@ -3183,7 +3032,10 @@ backend_impl = {
     )
   end,
   patch_org_actions_variable = function(org, name)
-    proxy_204("PUT", base() .. "/orgs/" .. org .. "/actions/variables/" .. name)
+    proxy_204(
+      nil,
+      fetch_json(base() .. "/orgs/" .. org .. "/actions/variables/" .. name, "PUT", GetBody())
+    )
   end,
   delete_org_actions_variable = function(org, name)
     set_204_or_error("DELETE", base() .. "/orgs/" .. org .. "/actions/variables/" .. name)

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -560,12 +560,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/version", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
   end,
 
   get_repo = proxy_handler(translate_gl_repo, function(owner, repo_name)

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -582,15 +582,8 @@ backend_impl = {
     local url = base() .. "/projects/" .. project_id(owner, repo_name)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
     -- GitLab returns 202 Accepted for async deletion
-    if ok and (status == 202 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 202 }, pcall(Fetch, url, dopts))
   end,
 
   get_user_repos = proxy_handler_paged(translate_gl_projects, function()
@@ -1146,11 +1139,7 @@ backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
       "DELETE"
     )
-    if ok2 and (status2 == 200 or status2 == 204) then
-      SetStatus(204, "No Content")
-    else
-      respond_json(status2 or 503, {})
-    end
+    proxy_204({ 200 }, ok2, status2)
   end,
 
   get_repo_collaborator_permission = function(owner, repo_name, username)
@@ -1322,13 +1311,7 @@ backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
       "DELETE"
     )
-    if ok and (status == 200 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   get_repo_release_assets = function(owner, repo_name, release_id)
@@ -1443,13 +1426,7 @@ backend_impl = {
         .. asset_id,
       "DELETE"
     )
-    if ok and (status == 200 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   -- Deploy keys ---------------------------------------------------------------
@@ -1487,13 +1464,7 @@ backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys/" .. key_id,
       "DELETE"
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   -- Webhooks ------------------------------------------------------------------
@@ -1537,13 +1508,7 @@ backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id,
       "DELETE"
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   get_repo_hook_config = proxy_handler(function(h)
@@ -1671,14 +1636,7 @@ backend_impl = {
   delete_user_key = function(key_id)
     local opts = auth() or {}
     opts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/user/keys/" .. key_id, opts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, base() .. "/user/keys/" .. key_id, opts))
   end,
 
   -- GET /users/{username}/keys
@@ -1712,14 +1670,7 @@ backend_impl = {
   delete_user_gpg_key = function(gpg_key_id)
     local opts = auth() or {}
     opts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/user/gpg_keys/" .. gpg_key_id, opts)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204(nil, pcall(Fetch, base() .. "/user/gpg_keys/" .. gpg_key_id, opts))
   end,
 
   -- GET /users/{username}/gpg_keys
@@ -1801,14 +1752,7 @@ backend_impl = {
     local gid = (DecodeJson(body) or {}).id
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local dok, dstatus = pcall(Fetch, base() .. "/groups/" .. gid, dopts)
-    if dok and (dstatus == 202 or dstatus == 204) then
-      SetStatus(204, "No Content")
-    elseif dok then
-      respond_json(dstatus, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. gid, dopts))
   end,
 
   -- GET /orgs/{org}/teams/{team_slug}/members
@@ -1897,14 +1841,7 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local dok, dstatus = pcall(Fetch, base() .. "/groups/" .. gid .. "/members/" .. uid, dopts)
-    if dok and (dstatus == 204 or dstatus == 200) then
-      SetStatus(204, "No Content")
-    elseif dok then
-      respond_json(dstatus, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. gid .. "/members/" .. uid, dopts))
   end,
 
   -- GET /orgs/{org}/teams/{team_slug}/repos
@@ -1962,13 +1899,7 @@ backend_impl = {
       "POST",
       EncodeJson({ group_id = gid, group_access = access })
     )
-    if pok and (pstatus == 200 or pstatus == 201) then
-      SetStatus(204, "No Content")
-    elseif pok then
-      respond_json(pstatus, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200, 201 }, pok, pstatus)
   end,
 
   -- DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
@@ -1982,14 +1913,7 @@ backend_impl = {
     local pid = project_id(owner, repo_name)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local dok, dstatus = pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. gid, dopts)
-    if dok and (dstatus == 204 or dstatus == 200) then
-      SetStatus(204, "No Content")
-    elseif dok then
-      respond_json(dstatus, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. gid, dopts))
   end,
 
   -- GET /orgs/{org}/teams/{team_slug}/teams — list sub-subgroups
@@ -2048,14 +1972,7 @@ backend_impl = {
   delete_team = function(team_id)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/groups/" .. team_id, dopts)
-    if ok and (status == 202 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. team_id, dopts))
   end,
 
   -- GET /teams/{team_id}/members
@@ -2102,13 +2019,7 @@ backend_impl = {
       "POST",
       EncodeJson({ user_id = uid, access_level = 30 })
     )
-    if ok and (status == 200 or status == 201) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200, 201 }, ok, status)
   end,
 
   -- DELETE /teams/{team_id}/members/{username} — deprecated legacy
@@ -2120,14 +2031,7 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
   end,
 
   -- GET /teams/{team_id}/memberships/{username}
@@ -2181,14 +2085,7 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
   end,
 
   -- GET /teams/{team_id}/repos
@@ -2227,13 +2124,7 @@ backend_impl = {
       "POST",
       EncodeJson({ group_id = team_id, group_access = access })
     )
-    if ok and (status == 200 or status == 201) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200, 201 }, ok, status)
   end,
 
   -- DELETE /teams/{team_id}/repos/{owner}/{repo}
@@ -2241,14 +2132,7 @@ backend_impl = {
     local pid = project_id(owner, repo_name)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. team_id, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. team_id, dopts))
   end,
 
   -- GET /teams/{team_id}/teams — sub-subgroups
@@ -2438,18 +2322,14 @@ backend_impl = {
 
   -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels  (remove all)
   delete_issue_labels = function(owner, repo_name, issue_number)
-    local ok, status = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-      "PUT",
-      EncodeJson({ labels = {} })
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+        "PUT",
+        EncodeJson({ labels = {} })
+      )
     )
-    if ok and (status == 200 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
@@ -2474,13 +2354,7 @@ backend_impl = {
       "PUT",
       EncodeJson({ labels = labels })
     )
-    if upok and (upstatus == 200 or upstatus == 204) then
-      SetStatus(204, "No Content")
-    elseif upok then
-      respond_json(upstatus, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, upok, upstatus)
   end,
 
   -- GET /repos/{owner}/{repo}/labels
@@ -2537,13 +2411,7 @@ backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id,
       dopts
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   -- Milestones ----------------------------------------------------------------
@@ -2602,13 +2470,7 @@ backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones/" .. milestone_number,
       dopts
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   -- Assignees -----------------------------------------------------------------
@@ -2781,13 +2643,7 @@ backend_impl = {
       "PUT",
       EncodeJson(gl)
     )
-    if ok and status == 200 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, ok, status)
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
@@ -3801,14 +3657,7 @@ end
 local function delete_snippet(url)
   local opts = auth() or {}
   opts.method = "DELETE"
-  local ok, status = pcall(Fetch, url, opts)
-  if ok and (status == 204 or status == 200) then
-    set_preamble(204)
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
+  proxy_204({ 200 }, pcall(Fetch, url, opts))
 end
 
 _b.get_gists = function()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -3641,19 +3641,6 @@ local function gl_snippet_req(req)
   return EncodeJson(gl)
 end
 
-local function proxy_list_gl(translate, ok, status, _headers, body)
-  if ok and status == 200 then
-    local data = DecodeJson(body) or {}
-    local result = translate(data)
-    set_preamble()
-    Write(#result > 0 and EncodeJson(result) or "[]")
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
-end
-
 local function delete_snippet(url)
   local opts = auth() or {}
   opts.method = "DELETE"
@@ -3661,11 +3648,11 @@ local function delete_snippet(url)
 end
 
 _b.get_gists = function()
-  proxy_list_gl(translate_gl_snippets, fetch_json(base() .. "/snippets"))
+  proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets"))
 end
 
 _b.get_gists_public = function()
-  proxy_list_gl(translate_gl_snippets, fetch_json(base() .. "/snippets/public"))
+  proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets/public"))
 end
 
 _b.post_gists = function()
@@ -3693,7 +3680,7 @@ _b.delete_gist = function(id)
 end
 
 _b.get_gist_comments = function(id)
-  proxy_list_gl(translate_gl_snippet_notes, fetch_json(base() .. "/snippets/" .. id .. "/notes"))
+  proxy_json_list(translate_gl_snippet_notes, fetch_json(base() .. "/snippets/" .. id .. "/notes"))
 end
 
 _b.post_gist_comment = function(id)
@@ -3733,7 +3720,7 @@ end
 
 _b.get_user_gists = function(_username)
   -- GitLab doesn't expose per-user public snippet lists; approximate with own snippets.
-  proxy_list_gl(translate_gl_snippets, fetch_json(base() .. "/snippets"))
+  proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets"))
 end
 
 -- ── Reactions (GitLab award emoji) ────────────────────────────────────────────

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -186,12 +186,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base(), auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base(), auth()))
   end,
 
   get_repo = proxy_handler(translate_harness_repo, function(owner, repo_name)

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -208,14 +208,7 @@ backend_impl = {
     local url = base() .. "/repos/" .. repo_ref(owner, repo_name)
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, url, dopts))
   end,
 
   get_user_repos = proxy_handler(translate_harness_repos, function()
@@ -425,15 +418,10 @@ backend_impl = {
   end),
 
   delete_repo_key = function(owner, repo_name, key_id)
-    local ok, status =
+    proxy_204(
+      { 200 },
       fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys/" .. key_id, "DELETE")
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    )
   end,
 
   -- Webhooks ------------------------------------------------------------------
@@ -480,17 +468,13 @@ backend_impl = {
   end,
 
   delete_repo_hook = function(owner, repo_name, hook_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id,
-      "DELETE"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id,
+        "DELETE"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- Hook config ---------------------------------------------------------------
@@ -525,17 +509,13 @@ backend_impl = {
   end,
 
   post_repo_hook_test = function(owner, repo_name, hook_id)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id .. "/test",
-      "POST"
+    proxy_204(
+      { 200 },
+      fetch_json(
+        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id .. "/test",
+        "POST"
+      )
     )
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
   end,
 
   -- Languages -----------------------------------------------------------------

--- a/backends/kallithea.lua
+++ b/backends/kallithea.lua
@@ -1,12 +1,7 @@
 -- Kallithea backend handler overrides.
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer"))
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
   end,
 
   -- Issues -----------------------------------------------------------------------

--- a/backends/launchpad.lua
+++ b/backends/launchpad.lua
@@ -92,12 +92,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, config.base_url .. "/devel/")
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, config.base_url .. "/devel/"))
   end,
 
   -- Issues --------------------------------------------------------------------

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -242,14 +242,7 @@ backend_impl = {
     end
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, base() .. "/projects/" .. id, dopts)
-    if ok and (status == 200 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. id, dopts))
   end,
 
   get_user_repos = function()

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -210,12 +210,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/server-version", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/server-version", auth()))
   end,
 
   get_repo = function(owner, repo_name)

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -189,12 +189,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/version", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
   end,
 
   get_repo = proxy_handler(translate_pagure_repo, function(owner, repo_name)

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -216,14 +216,7 @@ backend_impl = {
   delete_repo = function(owner, repo_name)
     -- Pagure: delete project via POST /api/0/{owner}/{repo}/delete
     local url = base() .. "/" .. owner .. "/" .. repo_name .. "/delete"
-    local ok, status = fetch_json(url, "POST", "{}")
-    if ok and (status == 200 or status == 204) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, fetch_json(url, "POST", "{}"))
   end,
 
   get_user_repos = function()

--- a/backends/phabricator.lua
+++ b/backends/phabricator.lua
@@ -206,12 +206,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, config.base_url .. "/api/conduit.ping")
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, config.base_url .. "/api/conduit.ping"))
   end,
 
   -- Issues --------------------------------------------------------------------

--- a/backends/radicle.lua
+++ b/backends/radicle.lua
@@ -97,12 +97,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base(), auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base(), auth()))
   end,
 
   -- GET /repos/{owner}/{rid} — owner is ignored; repo = RID

--- a/backends/rhodecode.lua
+++ b/backends/rhodecode.lua
@@ -1,12 +1,7 @@
 -- RhodeCode backend handler overrides.
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer"))
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
   end,
 
   -- Issues -----------------------------------------------------------------------

--- a/backends/sourceforge.lua
+++ b/backends/sourceforge.lua
@@ -4,12 +4,7 @@ if config.base_url == "" then
 end
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, config.base_url .. "/rest/p")
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, config.base_url .. "/rest/p"))
   end,
 
   -- Issues -----------------------------------------------------------------------

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -261,14 +261,7 @@ backend_impl = {
     local url = base() .. "/~" .. owner .. "/repos/" .. repo_name
     local dopts = auth() or {}
     dopts.method = "DELETE"
-    local ok, status = pcall(Fetch, url, dopts)
-    if ok and (status == 204 or status == 200) then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_204({ 200 }, pcall(Fetch, url, dopts))
   end,
 
   get_user_repos = function()

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -511,21 +511,14 @@ backend_impl = {
   post_repo_issues = function(owner, repo_name)
     local req = DecodeJson(GetBody() or "{}")
     local payload = EncodeJson({ title = req.title or "", description = req.body or "" })
-    local ok, status, _, body = fetch_json(
-      todo_base() .. "/~" .. owner .. "/trackers/" .. repo_name .. "/tickets",
-      "POST",
-      payload
+    proxy_json_created(
+      translate_srht_ticket,
+      fetch_json(
+        todo_base() .. "/~" .. owner .. "/trackers/" .. repo_name .. "/tickets",
+        "POST",
+        payload
+      )
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 and status ~= 201 then
-      respond_json(status, {})
-      return
-    end
-    local ticket = DecodeJson(body)
-    respond_json(201, translate_srht_ticket(ticket))
   end,
 
   -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
@@ -566,18 +559,9 @@ backend_impl = {
       .. "/tickets/"
       .. issue_number
       .. "/events"
-    local ok, status, _, body = fetch_json(url, "POST", payload)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 and status ~= 201 then
-      respond_json(status, {})
-      return
-    end
-    local event = DecodeJson(body)
-    local comment = translate_srht_event_comment(event)
-    respond_json(201, comment or {})
+    proxy_json_created(function(e)
+      return translate_srht_event_comment(e) or {}
+    end, fetch_json(url, "POST", payload))
   end,
 
   -- Checks (via builds.sr.ht jobs) --------------------------------------------

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -238,12 +238,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, config.base_url .. "/api/version", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, config.base_url .. "/api/version", auth()))
   end,
 
   get_repo = proxy_handler(translate_srht_repo, function(owner, repo_name)

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -482,6 +482,8 @@ backend_impl = {
   end,
 
   -- GET /repos/{owner}/{repo}/issues/{issue_number}
+  -- Cannot use proxy_json: todo.sr.ht returns a 404 body with tracker-specific
+  -- error text; we emit a clean GitHub-shaped { message = "Not Found" } instead.
   get_repo_issue = function(owner, repo_name, issue_number)
     local url = todo_base()
       .. "/~"

--- a/backends/tuleap.lua
+++ b/backends/tuleap.lua
@@ -137,12 +137,7 @@ end
 
 backend_impl = {
   get_root = function()
-    local ok, status = pcall(Fetch, base() .. "/projects?limit=1", auth())
-    if ok and status == 200 then
-      respond_json(200, {})
-    else
-      respond_json(503, {})
-    end
+    proxy_health_check(pcall(Fetch, base() .. "/projects?limit=1", auth()))
   end,
 
   -- GET /repos/{owner}/{repo}: owner = project shortname, repo = git repo name.

--- a/test/test-integration.sh
+++ b/test/test-integration.sh
@@ -5,7 +5,7 @@
 #   sh confusio.com -- gitea https://codeberg.org
 set -euo pipefail
 
-CONFUSIO_PORT=18080
+CONFUSIO_PORT=18200
 TMPDIR_INT=$(mktemp -d)
 trap "rm -rf $TMPDIR_INT" EXIT
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -634,6 +634,46 @@ proxy_204({ 200, 201 }, false, nil)
 eq(_last_status, 503, "proxy_204({200,201}): pcall failure → 503")
 
 -- ============================================================
+-- proxy_json_list
+-- ============================================================
+
+local function identity_list(x)
+  return x
+end
+
+reset_response()
+proxy_json_list(identity_list, true, 200, {}, '[{"a":1},{"b":2}]')
+eq(_last_status, 200, "proxy_json_list: upstream 200 → 200")
+ok(
+  _last_body == '[{"a":1},{"b":2}]' or _last_body == '[{"b":2},{"a":1}]',
+  "proxy_json_list: non-empty array body"
+)
+
+reset_response()
+proxy_json_list(identity_list, true, 200, {}, "[]")
+eq(_last_status, 200, "proxy_json_list: upstream empty array → 200")
+eq(_last_body, "[]", "proxy_json_list: upstream empty array → [] body")
+
+reset_response()
+proxy_json_list(identity_list, true, 404, {}, "{}")
+eq(_last_status, 404, "proxy_json_list: upstream non-200 forwarded")
+
+reset_response()
+proxy_json_list(identity_list, false, nil, nil, nil)
+eq(_last_status, 503, "proxy_json_list: pcall failure → 503")
+
+reset_response()
+proxy_json_list(function(data)
+  local out = {}
+  for i, x in ipairs(data) do
+    out[i] = { v = (x.v or 0) * 2 }
+  end
+  return out
+end, true, 200, {}, '[{"v":3}]')
+eq(_last_status, 200, "proxy_json_list: translate applied")
+ok(_last_body:find('"v":6') ~= nil, "proxy_json_list: translate doubles value")
+
+-- ============================================================
 -- make_proxy_handler
 -- ============================================================
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -585,6 +585,55 @@ proxy_health_check(false, nil)
 eq(_last_status, 503, "proxy_health_check: pcall failure → 503")
 
 -- ============================================================
+-- proxy_204
+-- ============================================================
+
+-- 204-only (also_ok = nil)
+reset_response()
+proxy_204(nil, true, 204)
+eq(_last_status, 204, "proxy_204: upstream 204 → 204")
+eq(_last_body, "", "proxy_204: upstream 204 → no body")
+
+reset_response()
+proxy_204(nil, true, 404)
+eq(_last_status, 404, "proxy_204: upstream 404 forwarded")
+
+reset_response()
+proxy_204(nil, false, nil)
+eq(_last_status, 503, "proxy_204: pcall failure → 503")
+
+-- also_ok = {200}
+reset_response()
+proxy_204({ 200 }, true, 200)
+eq(_last_status, 204, "proxy_204({200}): upstream 200 → 204")
+
+reset_response()
+proxy_204({ 200 }, true, 204)
+eq(_last_status, 204, "proxy_204({200}): upstream 204 → 204")
+
+reset_response()
+proxy_204({ 200 }, true, 422)
+eq(_last_status, 422, "proxy_204({200}): upstream 422 forwarded")
+
+-- also_ok = {202}
+reset_response()
+proxy_204({ 202 }, true, 202)
+eq(_last_status, 204, "proxy_204({202}): upstream 202 → 204")
+
+-- also_ok = {200, 201}
+reset_response()
+proxy_204({ 200, 201 }, true, 201)
+eq(_last_status, 204, "proxy_204({200,201}): upstream 201 → 204")
+
+reset_response()
+proxy_204({ 200, 201 }, true, 204)
+eq(_last_status, 204, "proxy_204({200,201}): upstream 204 → 204")
+
+reset_response()
+proxy_204({ 200, 201 }, false, nil)
+eq(_last_status, 503, "proxy_204({200,201}): pcall failure → 503")
+
+-- ============================================================
 -- make_proxy_handler
 -- ============================================================
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -564,6 +564,27 @@ eq(_last_status, 201, "proxy_json_created: translate fn applied")
 ok(_last_body:find("created") ~= nil, "proxy_json_created: translated body emitted")
 
 -- ============================================================
+-- proxy_health_check
+-- ============================================================
+
+reset_response()
+proxy_health_check(true, 200)
+eq(_last_status, 200, "proxy_health_check: upstream 200 → 200")
+eq(_last_body, "{}", "proxy_health_check: upstream 200 → empty object body")
+
+reset_response()
+proxy_health_check(true, 404)
+eq(_last_status, 503, "proxy_health_check: upstream non-200 → 503")
+
+reset_response()
+proxy_health_check(true, 503)
+eq(_last_status, 503, "proxy_health_check: upstream 503 → 503")
+
+reset_response()
+proxy_health_check(false, nil)
+eq(_last_status, 503, "proxy_health_check: pcall failure → 503")
+
+-- ============================================================
 -- make_proxy_handler
 -- ============================================================
 


### PR DESCRIPTION
Introduces shared proxy helpers (`proxy_health_check`, `proxy_204`, `proxy_json_list`, `proxy_json_created`) in `.init.lua` and migrates backend handlers across Gitea, GitLab, GitBucket, Azure DevOps, Bitbucket, and the remaining backends to use them. Also documents any custom proxy branches that remain with rationale comments.

Fixes #115.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (13)</summary>

- [x] Add proxy_health_check helper to .init.lua <!-- type:spec -->
- [x] Migrate backend get_root handlers to proxy_health_check <!-- type:spec -->
- [x] Promote proxy_204 to shared helper with extra success statuses <!-- type:spec -->
- [x] Migrate Gitea 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitLab 202/204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitBucket 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate Azure DevOps 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate remaining backends' 204 mutation paths to shared proxy_204 <!-- type:spec -->
- [x] Add proxy_json_list helper rendering empty arrays as [] <!-- type:spec -->
- [x] Migrate Bitbucket and GitLab list helpers to proxy_json_list <!-- type:spec -->
- [x] Migrate 200-or-201 create paths to proxy_json_created helper <!-- type:spec -->
- [x] Migrate decode-and-reshape handlers to proxy_json translate <!-- type:spec -->
- [x] Document remaining custom proxy branches with rationale comments <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->