### PR TITLE
Standardize shared proxy and error-handling usage across backends (closes #115)

### DIFF
--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -1305,43 +1305,33 @@ backend_impl = {
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
   -- Bitbucket: participants with role=REVIEWER and not yet approved.
   get_pull_requested_reviewers = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+    proxy_json(
+      function(pr)
+        local users = {}
+        for _, p in ipairs(pr.participants or {}) do
+          if p.role == "REVIEWER" and not p.approved then
+            users[#users + 1] = translate_bb_user(p.user)
+          end
+        end
+        return { users = users, teams = {} }
+      end,
+      fetch_json(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+      )
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    local users = {}
-    for _, p in ipairs(pr.participants or {}) do
-      if p.role == "REVIEWER" and not p.approved then
-        users[#users + 1] = translate_bb_user(p.user)
-      end
-    end
-    respond_json(200, { users = users, teams = {} })
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
   -- Bitbucket: participants with role=REVIEWER and approved=true → APPROVED reviews.
   get_pull_reviews = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+    proxy_json(
+      function(pr)
+        return translate_bb_participants_to_reviews(pr.participants)
+      end,
+      fetch_json(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+      )
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    respond_json(200, translate_bb_participants_to_reviews(pr.participants))
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
@@ -1370,69 +1360,59 @@ backend_impl = {
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
   -- Bitbucket has no per-review inline comments; return all inline PR comments.
   get_pull_review_comments = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      append_page_params(
-        base()
-          .. "/repositories/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pullrequests/"
-          .. pull_number
-          .. "/comments",
-        PAGES
+    proxy_json(
+      function(data)
+        local result = {}
+        for _, c in ipairs(data.values or {}) do
+          if c.inline then
+            result[#result + 1] = translate_bb_pr_comment(c)
+          end
+        end
+        return result
+      end,
+      fetch_json(
+        append_page_params(
+          base()
+            .. "/repositories/"
+            .. owner
+            .. "/"
+            .. repo_name
+            .. "/pullrequests/"
+            .. pull_number
+            .. "/comments",
+          PAGES
+        )
       )
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local result = {}
-    for _, c in ipairs(data.values or {}) do
-      if c.inline then
-        result[#result + 1] = translate_bb_pr_comment(c)
-      end
-    end
-    respond_json(200, result)
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
   -- Bitbucket inline PR comments (those with an "inline" field).
   get_pull_comments = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      append_page_params(
-        base()
-          .. "/repositories/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pullrequests/"
-          .. pull_number
-          .. "/comments",
-        PAGES
+    proxy_json(
+      function(data)
+        local result = {}
+        for _, c in ipairs(data.values or {}) do
+          if c.inline then
+            result[#result + 1] = translate_bb_pr_comment(c)
+          end
+        end
+        return result
+      end,
+      fetch_json(
+        append_page_params(
+          base()
+            .. "/repositories/"
+            .. owner
+            .. "/"
+            .. repo_name
+            .. "/pullrequests/"
+            .. pull_number
+            .. "/comments",
+          PAGES
+        )
       )
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local result = {}
-    for _, c in ipairs(data.values or {}) do
-      if c.inline then
-        result[#result + 1] = translate_bb_pr_comment(c)
-      end
-    end
-    respond_json(200, result)
   end,
 
   -- Search -----------------------------------------------------------------------
@@ -1553,49 +1533,44 @@ backend_impl = {
   -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
   -- Uses Bitbucket commit statuses.
   get_commit_check_runs = function(owner, repo_name, ref)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commit/" .. ref .. "/statuses"
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
     local bb_to_gh = {
       INPROGRESS = { status = "in_progress", conclusion = nil },
       SUCCESSFUL = { status = "completed", conclusion = "success" },
       FAILED = { status = "completed", conclusion = "failure" },
       STOPPED = { status = "completed", conclusion = "cancelled" },
     }
-    local runs = {}
-    for i, s in ipairs(data.values or {}) do
-      local mapped = bb_to_gh[s.state] or { status = "completed", conclusion = "failure" }
-      runs[i] = {
-        id = i,
-        node_id = "",
-        head_sha = ref,
-        name = s.key or s.name or "",
-        status = mapped.status,
-        conclusion = mapped.conclusion,
-        started_at = s.created_on,
-        completed_at = mapped.status == "completed" and s.updated_on or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.url or "",
-        details_url = s.url or "",
-      }
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
+    proxy_json(
+      function(data)
+        local runs = {}
+        for i, s in ipairs(data.values or {}) do
+          local mapped = bb_to_gh[s.state] or { status = "completed", conclusion = "failure" }
+          runs[i] = {
+            id = i,
+            node_id = "",
+            head_sha = ref,
+            name = s.key or s.name or "",
+            status = mapped.status,
+            conclusion = mapped.conclusion,
+            started_at = s.created_on,
+            completed_at = mapped.status == "completed" and s.updated_on or nil,
+            output = {
+              title = s.description or "",
+              summary = s.description or "",
+              text = "",
+              annotations_count = 0,
+              annotations_url = "",
+            },
+            url = "",
+            html_url = s.url or "",
+            details_url = s.url or "",
+          }
+        end
+        return { total_count = #runs, check_runs = runs }
+      end,
+      fetch_json(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commit/" .. ref .. "/statuses"
+      )
+    )
   end,
 
   -- Check suites have no Bitbucket equivalent; all suite endpoints fall back


### PR DESCRIPTION
Audits each remaining forge backend (bitbucket, bitbucket_datacenter, gitbucket, codecommit, gerrit, pagure, launchpad, gitea, gitlab, azuredevops, onedev, sourcehut, radicle) and migrates any proxy branches that match shared helper patterns. Documents the custom proxy branches that are retained and updates CLAUDE.md with guidance on when to reach for the shared helpers.

Fixes #115.

---

## Work queue

<!-- WORK_QUEUE_START -->
- [ ] Audit bitbucket_datacenter backend and migrate matching proxy branches to shared helpers **→ next** <!-- type:spec -->
- [ ] Audit gitbucket backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit codecommit backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit gerrit backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit pagure backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit launchpad backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit gitea backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit gitlab backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit azuredevops backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Audit onedev, sourcehut, and radicle backends and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [ ] Document retained custom proxy branches and update CLAUDE.md helper guidance <!-- type:spec -->

<details><summary>Completed (14)</summary>

- [x] Add proxy_health_check helper to .init.lua <!-- type:spec -->
- [x] Migrate backend get_root handlers to proxy_health_check <!-- type:spec -->
- [x] Promote proxy_204 to shared helper with extra success statuses <!-- type:spec -->
- [x] Migrate Gitea 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitLab 202/204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitBucket 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate Azure DevOps 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate remaining backends' 204 mutation paths to shared proxy_204 <!-- type:spec -->
- [x] Add proxy_json_list helper rendering empty arrays as [] <!-- type:spec -->
- [x] Migrate Bitbucket and GitLab list helpers to proxy_json_list <!-- type:spec -->
- [x] Migrate 200-or-201 create paths to proxy_json_created helper <!-- type:spec -->
- [x] Migrate decode-and-reshape handlers to proxy_json translate <!-- type:spec -->
- [x] Document remaining custom proxy branches with rationale comments <!-- type:spec -->
- [x] Audit bitbucket backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->