### PR TITLE
Extract shared search, list, and batch translation helpers (closes #116)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -215,6 +215,48 @@ function proxy_json_list(translate, ok, status, _headers, body)
   end
 end
 
+-- translate_list is global: apply fn to each element of items and return a new array.
+-- Replaces the repeated for-i-ipairs + arr[i]=fn(item) pattern in backend modules.
+--   translate_list(translate_item, data.values)
+--   translate_list(translate_item, data)
+function translate_list(fn, items)
+  local result = {}
+  for i, item in ipairs(items or {}) do
+    result[i] = fn(item)
+  end
+  return result
+end
+
+-- proxy_search_envelope is global: emit the GitHub search response envelope.
+-- translate_item: applied to each element of the upstream array.
+-- container: nil = use the decoded body itself as the array;
+--            string = use body[container] as the array (e.g. "values", "data").
+-- Designed to receive the return values of fetch_json(...):
+--   proxy_search_envelope(translate_fn, "values", fetch_json(url))
+--   proxy_search_envelope(translate_fn, "data",   fetch_json(url))
+--   proxy_search_envelope(translate_fn, nil,      fetch_json(url))
+function proxy_search_envelope(translate_item, container, ok, status, _headers, body)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local raw = DecodeJson(body) or {}
+  local src = type(container) == "string" and (raw[container] or {}) or raw
+  local items = translate_list(translate_item, src)
+  set_preamble()
+  Write(
+    '{"total_count":'
+      .. #items
+      .. ',"incomplete_results":false,"items":'
+      .. (#items > 0 and EncodeJson(items) or "[]")
+      .. "}"
+  )
+end
+
 -- append_page_params appends translated pagination params to url.
 -- mapping: { per_page = "upstream_name", page = "upstream_name" }
 --   Omit the page key for providers that only support limit (e.g. Sourcehut).

--- a/.init.lua
+++ b/.init.lua
@@ -249,9 +249,7 @@ function proxy_search_envelope(translate_item, container, ok, status, _headers, 
   local items = translate_list(translate_item, src)
   set_preamble()
   Write(
-    '{"total_count":'
-      .. #items
-      .. ',"incomplete_results":false,"items":'
+    '{"total_count":' .. #items .. ',"incomplete_results":false,"items":'
       .. (#items > 0 and EncodeJson(items) or "[]")
       .. "}"
   )

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -34,6 +34,8 @@ globals = {
   "proxy_health_check",
   "proxy_204",
   "proxy_json_list",
+  "translate_list",
+  "proxy_search_envelope",
   "rewrite_link_header",
   "append_page_params",
   "make_fetch_opts",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,31 @@ Hard-won insights from building this project. **Keep this section current**: whe
 - **Use Redbean itself as the mock server** — no Python/Node dependency, same binary already in the repo. Build `mock-<backend>.com` by copying `redbean.com` and zipping in a `.init.lua` handler. See `mock-gitea.com` target in `Makefile`.
 - **Mock validation via Hurl**: run the same `.hurl` assertion file against both the mock and the real endpoint. If both pass the same structural assertions, the mock is compatible. See `make validate-mock`.
 
+### Shared proxy helpers
+
+Two global helpers defined in `.init.lua` are available to all backend files:
+
+**`translate_list(fn, items)`** — applies `fn` to every element of `items` (ipairs) and returns a new array. A nil `items` argument returns `{}`. Use whenever a backend loop has the form `for i, x in ipairs(arr) do result[i] = fn(x) end` where `fn` is an already-defined **named** function.
+
+Do **not** use `translate_list` when:
+- The loop **filters** (skips items with an `if` guard)
+- The loop **truncates** (`for i = 1, math.min(limit, #arr) do`) — that's a slice, not a map
+- The loop uses index `i` meaningfully in the output (e.g., `runs[i] = { id = i, ... }`)
+- The transform is a **single-use inline anonymous closure** — don't extract a named function just to feed `translate_list`; the goal is removing duplication, not adding abstraction
+- The loop has **side effects** (HTTP calls, state mutations)
+
+**`proxy_search_envelope(translate_item, container, ok, status, _headers, body)`** — decodes the upstream body, extracts items from `container` (nil = root array, string = named key such as `"data"` or `"values"`), translates each with `translate_item`, and writes the GitHub search envelope `{"total_count":N,"incomplete_results":false,"items":[...]}`. The `ok/status/_headers/body` tuple is the raw return from `fetch_json`.
+
+Do **not** use `proxy_search_envelope` when:
+- The envelope key is not `"items"` (e.g., `check_runs`, `runners`) — use `respond_json` with the correct key
+- The response must also **forward a Link header** — `proxy_search_envelope` only writes the body; `proxy_search_gl` (GitLab) and `proxy_actions_list` (Gitea) handle this themselves
+
+**Retained patterns** intentionally left as custom code:
+- `proxy_search_gl` (gitlab) — rewrites the upstream Link pagination header then writes the search envelope; `proxy_search_envelope` does not touch headers
+- `proxy_actions_list` (gitea) — emits `{total_count, <key>: [...]}` with a caller-supplied key; `proxy_search_envelope` hardcodes `"items"`
+- `get_commit_check_runs` in most backends — emits `{total_count, check_runs: [...]}` with key `"check_runs"`, not `"items"`
+- `get_user_repos`/`get_org_repos`/`get_users_repos` in azuredevops — loop is `for i=1, math.min(limit, #all)` to honour a per_page cap; not a plain full-array map
+
 ### Code coverage (luacov)
 
 - **Redbean ships Lua 5.4 with the full `debug` library** (`debug.sethook` is available), so

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -442,11 +442,7 @@ backend_impl = {
     local url =
       ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=heads&$top=" .. limit)
     proxy_json(function(data)
-      local result = {}
-      for _, b in ipairs(data.value or {}) do
-        result[#result + 1] = translate_ado_branch(b)
-      end
-      return result
+      return translate_list(translate_ado_branch, data.value)
     end, fetch_json(url))
   end,
 
@@ -464,11 +460,7 @@ backend_impl = {
   get_repo_tags = function(owner, repo_name)
     local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=tags")
     proxy_json(function(data)
-      local result = {}
-      for _, t in ipairs(data.value or {}) do
-        result[#result + 1] = translate_ado_tag(t)
-      end
-      return result
+      return translate_list(translate_ado_tag, data.value)
     end, fetch_json(url))
   end,
 
@@ -487,11 +479,7 @@ backend_impl = {
       url = url .. "&searchCriteria.itemVersion.version=" .. ref
     end
     proxy_json(function(data)
-      local result = {}
-      for _, c in ipairs(data.value or {}) do
-        result[#result + 1] = translate_ado_commit(c)
-      end
-      return result
+      return translate_list(translate_ado_commit, data.value)
     end, fetch_json(url))
   end,
 
@@ -623,11 +611,7 @@ backend_impl = {
 
   get_repo_forks = function(owner, repo_name)
     proxy_json(function(data)
-      local result = {}
-      for _, r in ipairs(data.value or {}) do
-        result[#result + 1] = translate_ado_repo(r)
-      end
-      return result
+      return translate_list(translate_ado_repo, data.value)
     end, fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name .. "/forks/" .. owner)))
   end,
 
@@ -657,11 +641,7 @@ backend_impl = {
     local repo_id = (DecodeJson(body) or {}).id or repo_name
     proxy_json(
       function(data)
-        local result = {}
-        for _, h in ipairs(data.value or {}) do
-          result[#result + 1] = translate_ado_hook(h)
-        end
-        return result
+        return translate_list(translate_ado_hook, data.value)
       end,
       fetch_json(
         ado_url(
@@ -690,11 +670,7 @@ backend_impl = {
 
   get_org_teams = function(org)
     proxy_json(function(data)
-      local result = {}
-      for _, t in ipairs(data.value or {}) do
-        result[#result + 1] = translate_ado_team(t)
-      end
-      return result
+      return translate_list(translate_ado_team, data.value)
     end, fetch_json(ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams")))
   end,
 
@@ -1515,11 +1491,7 @@ _b.list_repo_code_scanning_alerts = function(owner, repo_name)
     return
   end
   local data = DecodeJson(body) or {}
-  local result = {}
-  for _, a in ipairs(data.value or {}) do
-    result[#result + 1] = translate_ado_alert(a)
-  end
-  respond_json(200, result)
+  respond_json(200, translate_list(translate_ado_alert, data.value))
 end
 
 _b.get_code_scanning_alert = function(owner, repo_name, alert_number)
@@ -1571,11 +1543,7 @@ _b.list_code_scanning_analyses = function(owner, repo_name)
     return
   end
   local data = DecodeJson(body) or {}
-  local result = {}
-  for _, an in ipairs(data.value or {}) do
-    result[#result + 1] = translate_ado_analysis(an)
-  end
-  respond_json(200, result)
+  respond_json(200, translate_list(translate_ado_analysis, data.value))
 end
 
 _b.upload_code_scanning_sarif = function(owner, repo_name)
@@ -1689,11 +1657,7 @@ _b.list_repo_dependabot_alerts = function(owner, repo_name)
     return
   end
   local data = DecodeJson(body) or {}
-  local result = {}
-  for _, a in ipairs(data.value or {}) do
-    result[#result + 1] = translate_ado_dependency_alert(a)
-  end
-  respond_json(200, result)
+  respond_json(200, translate_list(translate_ado_dependency_alert, data.value))
 end
 
 _b.get_repo_dependabot_alert = function(owner, repo_name, alert_number)
@@ -1826,11 +1790,7 @@ _b.list_repo_secret_scanning_alerts = function(owner, repo_name)
     return
   end
   local data = DecodeJson(body) or {}
-  local result = {}
-  for _, a in ipairs(data.value or {}) do
-    result[#result + 1] = translate_ado_secret_alert(a)
-  end
-  respond_json(200, result)
+  respond_json(200, translate_list(translate_ado_secret_alert, data.value))
 end
 
 _b.get_secret_scanning_alert = function(owner, repo_name, alert_number)

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -100,11 +100,9 @@ local function translate_bbs_user(u)
 end
 
 local function translate_bbs_repos(data, proj_key)
-  local repos = (data and data.values) or {}
-  for i, r in ipairs(repos) do
-    repos[i] = translate_bbs_repo(r, proj_key)
-  end
-  return repos
+  return translate_list(function(r)
+    return translate_bbs_repo(r, proj_key)
+  end, (data and data.values))
 end
 
 -- Translate GitHub create/update request body to Bitbucket DC format.
@@ -202,30 +200,13 @@ local function translate_bbs_hook_req(body_str)
   })
 end
 
--- Proxy a BBS paginated response to the GitHub search envelope.
-local function proxy_search_bbs(translate_item, url)
-  local ok, status, _, body = fetch_json(url)
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local raw = DecodeJson(body) or {}
-  local items = {}
-  for i, item in ipairs(raw.values or {}) do
-    items[i] = translate_item(item)
-  end
-  set_preamble()
-  Write(
-    '{"total_count":'
-      .. #items
-      .. ',"incomplete_results":false,"items":'
-      .. (#items > 0 and EncodeJson(items) or "[]")
-      .. "}"
-  )
+-- Translate a DC tag object to GitHub format.
+-- DC: { id: "refs/tags/v1.0", displayId: "v1.0", latestCommit: "abc..." }
+local function translate_bbs_tag(t)
+  return {
+    name = t.displayId or t.id or "",
+    commit = { sha = t.latestCommit or t.latestChangeset or "", url = "" },
+  }
 end
 
 -- Repo path helper: /projects/{owner}/repos/{repo}
@@ -305,11 +286,7 @@ local function translate_bbs_pull(pr)
 end
 
 local function translate_bbs_pulls(data)
-  local prs = (data and data.values) or {}
-  for i, pr in ipairs(prs) do
-    prs[i] = translate_bbs_pull(pr)
-  end
-  return prs
+  return translate_list(translate_bbs_pull, (data and data.values))
 end
 
 -- Map a DC pull request change entry to GitHub file format.
@@ -386,6 +363,15 @@ local function translate_bbs_reviewers_to_reviews(reviewers)
   return result
 end
 
+-- DC build-status state → GitHub check_run status/conclusion mapping.
+-- Shared by post_check_runs and get_commit_check_runs.
+local bbs_dc_to_gh = {
+  INPROGRESS = { status = "in_progress", conclusion = nil },
+  SUCCESSFUL = { status = "completed", conclusion = "success" },
+  FAILED = { status = "completed", conclusion = "failure" },
+  STOPPED = { status = "completed", conclusion = "cancelled" },
+}
+
 backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
@@ -454,15 +440,7 @@ backend_impl = {
   -- DC: GET /projects/{proj}/repos/{slug}/tags → { values: [{id, displayId, latestCommit}] }
 
   get_repo_tags = proxy_handler(function(data)
-    local tags = data.values or {}
-    local result = {}
-    for _, t in ipairs(tags) do
-      result[#result + 1] = {
-        name = t.displayId or t.id or "",
-        commit = { sha = t.latestCommit or t.latestChangeset or "", url = "" },
-      }
-    end
-    return result
+    return translate_list(translate_bbs_tag, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/tags")
   end),
@@ -470,11 +448,7 @@ backend_impl = {
   -- Branches -------------------------------------------------------------------
 
   get_repo_branches = proxy_handler(function(data)
-    local branches = data.values or {}
-    for i, b in ipairs(branches) do
-      branches[i] = translate_bbs_branch(b)
-    end
-    return branches
+    return translate_list(translate_bbs_branch, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/branches")
   end),
@@ -496,11 +470,7 @@ backend_impl = {
       url = url .. sep .. "until=" .. ref
     end
     proxy_json(function(data)
-      local commits = data.values or {}
-      for i, c in ipairs(commits) do
-        commits[i] = translate_bbs_commit(c)
-      end
-      return commits
+      return translate_list(translate_bbs_commit, data.values)
     end, fetch_json(url))
   end,
 
@@ -604,11 +574,7 @@ backend_impl = {
   -- DC: /ssh endpoint (not /deploy-keys)
 
   get_repo_keys = proxy_handler(function(data)
-    local keys = data.values or {}
-    for i, k in ipairs(keys) do
-      keys[i] = translate_bbs_key(k)
-    end
-    return keys
+    return translate_list(translate_bbs_key, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/ssh")
   end),
@@ -638,11 +604,7 @@ backend_impl = {
   -- Webhooks -------------------------------------------------------------------
 
   get_repo_hooks = proxy_handler(function(data)
-    local hooks = data.values or {}
-    for i, h in ipairs(hooks) do
-      hooks[i] = translate_bbs_hook(h)
-    end
-    return hooks
+    return translate_list(translate_bbs_hook, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/webhooks")
   end),
@@ -694,11 +656,7 @@ backend_impl = {
 
   -- GET /users
   get_users = proxy_handler(function(data)
-    local users = (data and data.values) or {}
-    for i, u in ipairs(users) do
-      users[i] = translate_bbs_user(u)
-    end
-    return users
+    return translate_list(translate_bbs_user, (data and data.values))
   end, function()
     return bbs_page_url(base() .. "/users")
   end),
@@ -767,11 +725,7 @@ backend_impl = {
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
   get_pull_commits = proxy_handler(function(data)
-    local commits = (data and data.values) or {}
-    for i, c in ipairs(commits) do
-      commits[i] = translate_bbs_commit(c)
-    end
-    return commits
+    return translate_list(translate_bbs_commit, (data and data.values))
   end, function(owner, repo_name, pull_number)
     return bbs_page_url(
       repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/commits"
@@ -781,11 +735,7 @@ backend_impl = {
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
   -- DC uses /changes for per-file info (no line stats).
   get_pull_files = proxy_handler(function(data)
-    local changes = (data and data.values) or {}
-    for i, c in ipairs(changes) do
-      changes[i] = translate_bbs_pr_change(c)
-    end
-    return changes
+    return translate_list(translate_bbs_pr_change, (data and data.values))
   end, function(owner, repo_name, pull_number)
     return bbs_page_url(
       repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/changes"
@@ -932,13 +882,21 @@ backend_impl = {
   -- GET /search/repositories — DC: GET /repos?name=<q>
   search_repositories = function()
     local q = GetParam("q") or ""
-    proxy_search_bbs(translate_bbs_repo, bbs_page_url(base() .. "/repos?name=" .. q))
+    proxy_search_envelope(
+      translate_bbs_repo,
+      "values",
+      fetch_json(bbs_page_url(base() .. "/repos?name=" .. q))
+    )
   end,
 
   -- GET /search/users — DC: GET /users?filter=<q>
   search_users = function()
     local q = GetParam("q") or ""
-    proxy_search_bbs(translate_bbs_user, bbs_page_url(base() .. "/users?filter=" .. q))
+    proxy_search_envelope(
+      translate_bbs_user,
+      "values",
+      fetch_json(bbs_page_url(base() .. "/users?filter=" .. q))
+    )
   end,
 
   -- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
@@ -1008,12 +966,6 @@ backend_impl = {
     }
     local dc_state = gh_status == "completed" and (gh_conclusion_to_dc[conclusion] or "FAILED")
       or "INPROGRESS"
-    local dc_to_gh = {
-      INPROGRESS = { status = "in_progress", conclusion = nil },
-      SUCCESSFUL = { status = "completed", conclusion = "success" },
-      FAILED = { status = "completed", conclusion = "failure" },
-      STOPPED = { status = "completed", conclusion = "cancelled" },
-    }
     local dc_body = EncodeJson({
       state = dc_state,
       key = req.name or "",
@@ -1032,7 +984,7 @@ backend_impl = {
       respond_json(up_status, {})
       return
     end
-    local mapped = dc_to_gh[dc_state] or { status = "completed", conclusion = "failure" }
+    local mapped = bbs_dc_to_gh[dc_state] or { status = "completed", conclusion = "failure" }
     respond_json(201, {
       id = 0,
       node_id = "",
@@ -1069,15 +1021,9 @@ backend_impl = {
       return
     end
     local data = DecodeJson(body) or {}
-    local dc_to_gh = {
-      INPROGRESS = { status = "in_progress", conclusion = nil },
-      SUCCESSFUL = { status = "completed", conclusion = "success" },
-      FAILED = { status = "completed", conclusion = "failure" },
-      STOPPED = { status = "completed", conclusion = "cancelled" },
-    }
     local runs = {}
     for i, s in ipairs(data.values or {}) do
-      local mapped = dc_to_gh[s.state] or { status = "completed", conclusion = "failure" }
+      local mapped = bbs_dc_to_gh[s.state] or { status = "completed", conclusion = "failure" }
       runs[i] = {
         id = i,
         node_id = "",
@@ -1315,11 +1261,7 @@ _b.list_git_matching_refs = function(owner, repo_name, ref)
   end
   local url = bbs_page_url(repo_path(owner, repo_name) .. endpoint .. "?filterText=" .. prefix)
   proxy_json(function(data)
-    local refs = data.values or {}
-    for i, r in ipairs(refs) do
-      refs[i] = translate_bbs_ref(r)
-    end
-    return refs
+    return translate_list(translate_bbs_ref, data.values)
   end, fetch_json(url))
 end
 

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -144,11 +144,7 @@ backend_impl = {
       respond_json(status, {})
       return
     end
-    local result = {}
-    for _, r in ipairs(repos) do
-      result[#result + 1] = translate_repo(r)
-    end
-    respond_json(200, result)
+    respond_json(200, translate_list(translate_repo, repos))
   end,
 
   -- GET /repos/{owner}/{repo}/branches: owner must be "codecommit".

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -111,6 +111,18 @@ local function translate_gerrit_tag(t)
   return { name = name, commit = { sha = t.revision or t.object or "", url = "" } }
 end
 
+-- Gerrit projects endpoints return a dict { project_name → project_info }.
+-- This translate function is shared by get_user_repos, get_users_repos, and
+-- get_repositories, all of which iterate the same dict shape.
+local function gerrit_repos_from_dict(data)
+  local repos = {}
+  for name, r in pairs(data or {}) do
+    r.name = name
+    repos[#repos + 1] = translate_gerrit_repo(r)
+  end
+  return repos
+end
+
 backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/config/server/version", auth()))
@@ -142,14 +154,7 @@ backend_impl = {
     local limit = GetParam("per_page") or "30"
     local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
     local url = base() .. "/projects/?n=" .. limit .. (skip > 0 and ("&S=" .. skip) or "")
-    proxy_json(function(data)
-      local repos = {}
-      for name, r in pairs(data or {}) do
-        r.name = name
-        repos[#repos + 1] = translate_gerrit_repo(r)
-      end
-      return repos
-    end, fetch_json(url))
+    proxy_json(gerrit_repos_from_dict, fetch_json(url))
   end,
 
   get_users_repos = function(username)
@@ -161,28 +166,14 @@ backend_impl = {
       .. "%2F&n="
       .. limit
       .. (skip > 0 and ("&S=" .. skip) or "")
-    proxy_json(function(data)
-      local repos = {}
-      for name, r in pairs(data or {}) do
-        r.name = name
-        repos[#repos + 1] = translate_gerrit_repo(r)
-      end
-      return repos
-    end, fetch_json(url))
+    proxy_json(gerrit_repos_from_dict, fetch_json(url))
   end,
 
   get_repositories = function()
     local limit = GetParam("per_page") or "30"
     local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
     local url = base() .. "/projects/?n=" .. limit .. (skip > 0 and ("&S=" .. skip) or "")
-    proxy_json(function(data)
-      local repos = {}
-      for name, r in pairs(data or {}) do
-        r.name = name
-        repos[#repos + 1] = translate_gerrit_repo(r)
-      end
-      return repos
-    end, fetch_json(url))
+    proxy_json(gerrit_repos_from_dict, fetch_json(url))
   end,
 
   -- Branches ------------------------------------------------------------------
@@ -212,11 +203,7 @@ backend_impl = {
   -- GET /a/projects/{id}/tags/ → [{ ref, revision, object }]
 
   get_repo_tags = proxy_handler(function(tags)
-    local result = {}
-    for _, t in ipairs(tags or {}) do
-      result[#result + 1] = translate_gerrit_tag(t)
-    end
-    return result
+    return translate_list(translate_gerrit_tag, tags)
   end, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/tags/"
   end),
@@ -286,12 +273,7 @@ backend_impl = {
       .. (skip > 0 and ("&S=" .. skip) or "")
     local ok, status, _, body = fetch_json(url)
     if ok and status == 200 then
-      local accounts = gerrit_decode(body)
-      local users = {}
-      for _, a in ipairs(accounts) do
-        users[#users + 1] = translate_gerrit_user(a)
-      end
-      respond_json(200, users)
+      respond_json(200, translate_list(translate_gerrit_user, gerrit_decode(body)))
     elseif ok then
       respond_json(status, {})
     else

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -20,6 +20,14 @@ local function set_204_or_error(method, url)
   proxy_204(nil, pcall(Fetch, url, opts))
 end
 
+-- GitBucket commit status state → GitHub check_run status/conclusion mapping.
+-- Shared by post_check_runs and get_commit_check_runs.
+local gb_to_gh = {
+  pending = { status = "in_progress", conclusion = nil },
+  success = { status = "completed", conclusion = "success" },
+  warning = { status = "completed", conclusion = "neutral" },
+}
+
 backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/rate_limit", auth()))
@@ -167,11 +175,6 @@ backend_impl = {
         return {}
       end
       local state = s.state or "pending"
-      local gb_to_gh = {
-        pending = { status = "in_progress", conclusion = nil },
-        success = { status = "completed", conclusion = "success" },
-        warning = { status = "completed", conclusion = "neutral" },
-      }
       local mapped = gb_to_gh[state] or { status = "completed", conclusion = "failure" }
       local gh_status, gh_conclusion = mapped.status, mapped.conclusion
       return {
@@ -229,11 +232,6 @@ backend_impl = {
     local runs = {}
     for i, s in ipairs(statuses) do
       local state = s.state or "pending"
-      local gb_to_gh = {
-        pending = { status = "in_progress", conclusion = nil },
-        success = { status = "completed", conclusion = "success" },
-        warning = { status = "completed", conclusion = "neutral" },
-      }
       local mapped = gb_to_gh[state] or { status = "completed", conclusion = "failure" }
       local gh_status, gh_conclusion = mapped.status, mapped.conclusion
       runs[i] = {

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -30,17 +30,11 @@ do
 end
 
 local function translate_repos(repos)
-  for i, r in ipairs(repos) do
-    repos[i] = translate_repo(r)
-  end
-  return repos
+  return translate_list(translate_repo, repos)
 end
 
 local function translate_users(users)
-  for i, u in ipairs(users) do
-    users[i] = translate_user(u)
-  end
-  return users
+  return translate_list(translate_user, users)
 end
 
 local function set_204_or_error(method, url)
@@ -61,28 +55,7 @@ end
 -- envelope {"total_count":N,"incomplete_results":false,"items":[...]}.
 -- translate_item is applied to each element of data[].
 local function proxy_search(translate_item, url)
-  local ok, status, _, body = fetch_json(url)
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local raw = (DecodeJson(body) or {}).data or {}
-  local items = {}
-  for i, item in ipairs(raw) do
-    items[i] = translate_item(item)
-  end
-  set_preamble()
-  Write(
-    '{"total_count":'
-      .. #items
-      .. ',"incomplete_results":false,"items":'
-      .. (#items > 0 and EncodeJson(items) or "[]")
-      .. "}"
-  )
+  proxy_search_envelope(translate_item, "data", fetch_json(url))
 end
 
 local function filter_verified_emails(emails)
@@ -207,28 +180,16 @@ local function translate_gitea_issue_comment(c)
 end
 
 local function translate_gitea_issues(issues)
-  for i, iss in ipairs(issues) do
-    issues[i] = translate_gitea_issue(iss)
-  end
-  return issues
+  return translate_list(translate_gitea_issue, issues)
 end
 local function translate_gitea_issue_comments(comments)
-  for i, c in ipairs(comments) do
-    comments[i] = translate_gitea_issue_comment(c)
-  end
-  return comments
+  return translate_list(translate_gitea_issue_comment, comments)
 end
 local function translate_gitea_labels(labels)
-  for i, l in ipairs(labels) do
-    labels[i] = translate_gitea_label(l)
-  end
-  return labels
+  return translate_list(translate_gitea_label, labels)
 end
 local function translate_gitea_milestones(milestones)
-  for i, m in ipairs(milestones) do
-    milestones[i] = translate_gitea_milestone(m)
-  end
-  return milestones
+  return translate_list(translate_gitea_milestone, milestones)
 end
 
 -- GitHub reaction content types and their integer codes.
@@ -265,10 +226,7 @@ local function translate_gitea_reaction(r)
 end
 
 local function translate_gitea_reactions(reactions)
-  for i, r in ipairs(reactions) do
-    reactions[i] = translate_gitea_reaction(r)
-  end
-  return reactions
+  return translate_list(translate_gitea_reaction, reactions)
 end
 
 -- Map a Gitea pull request branch reference to GitHub format.
@@ -322,10 +280,7 @@ local function translate_gitea_pull(pr)
 end
 
 local function translate_gitea_pulls(prs)
-  for i, pr in ipairs(prs) do
-    prs[i] = translate_gitea_pull(pr)
-  end
-  return prs
+  return translate_list(translate_gitea_pull, prs)
 end
 
 -- Map a Gitea pull request review to GitHub format.
@@ -353,10 +308,7 @@ local function translate_gitea_review(r)
 end
 
 local function translate_gitea_reviews(reviews)
-  for i, r in ipairs(reviews) do
-    reviews[i] = translate_gitea_review(r)
-  end
-  return reviews
+  return translate_list(translate_gitea_review, reviews)
 end
 
 -- Map a Gitea inline review comment to GitHub format.
@@ -384,10 +336,7 @@ local function translate_gitea_review_comment(c)
 end
 
 local function translate_gitea_review_comments(comments)
-  for i, c in ipairs(comments) do
-    comments[i] = translate_gitea_review_comment(c)
-  end
-  return comments
+  return translate_list(translate_gitea_review_comment, comments)
 end
 
 -- Look up a Gitea label ID by name within a repo.
@@ -486,11 +435,7 @@ end
 
 -- Translate a list of Gitea statuses to GitHub check runs.
 local function translate_gitea_statuses_to_check_runs(statuses)
-  local runs = {}
-  for i, s in ipairs(statuses) do
-    runs[i] = translate_gitea_status_to_check_run(s)
-  end
-  return runs
+  return translate_list(translate_gitea_status_to_check_run, statuses)
 end
 
 -- Map a GitHub check run request body to a Gitea commit status body.

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -95,10 +95,7 @@ local function translate_gl_req(body_str)
 end
 
 local function translate_gl_projects(projects)
-  for i, p in ipairs(projects) do
-    projects[i] = translate_gl_repo(p)
-  end
-  return projects
+  return translate_list(translate_gl_repo, projects)
 end
 
 -- Map a GitLab user object to GitHub format.
@@ -123,10 +120,7 @@ local function translate_gl_user(u)
 end
 
 local function translate_gl_users(users)
-  for i, u in ipairs(users) do
-    users[i] = translate_gl_user(u)
-  end
-  return users
+  return translate_list(translate_gl_user, users)
 end
 
 -- Proxy a GitLab search response (plain JSON array) to the GitHub search
@@ -305,34 +299,19 @@ local function translate_gl_note(c)
 end
 
 local function translate_gl_issues(issues)
-  for i, iss in ipairs(issues) do
-    issues[i] = translate_gl_issue(iss)
-  end
-  return issues
+  return translate_list(translate_gl_issue, issues)
 end
 local function translate_gl_notes(notes)
-  for i, n in ipairs(notes) do
-    notes[i] = translate_gl_note(n)
-  end
-  return notes
+  return translate_list(translate_gl_note, notes)
 end
 local function translate_gl_labels(labels)
-  for i, l in ipairs(labels) do
-    labels[i] = translate_gl_label(l)
-  end
-  return labels
+  return translate_list(translate_gl_label, labels)
 end
 local function translate_gl_milestones(milestones)
-  for i, m in ipairs(milestones) do
-    milestones[i] = translate_gl_milestone(m)
-  end
-  return milestones
+  return translate_list(translate_gl_milestone, milestones)
 end
 local function translate_gl_members(members)
-  for i, m in ipairs(members) do
-    members[i] = translate_gl_member(m)
-  end
-  return members
+  return translate_list(translate_gl_member, members)
 end
 
 -- Map a GitLab MR (merge request) object to GitHub PR format.
@@ -385,10 +364,7 @@ local function translate_gl_mr(mr)
 end
 
 local function translate_gl_mrs(mrs)
-  for i, mr in ipairs(mrs) do
-    mrs[i] = translate_gl_mr(mr)
-  end
-  return mrs
+  return translate_list(translate_gl_mr, mrs)
 end
 
 -- Map GitLab MR approvals to GitHub reviews (APPROVED state).
@@ -557,6 +533,26 @@ local function gl_find_link(owner, repo_name, asset_id)
   end
   return nil
 end
+
+-- GitLab commit status → GitHub commit status (simple string).
+-- Used by get_commit_statuses, get_commit_combined_status, post_commit_status.
+local GL_STATUS_TO_GH = {
+  pending = "pending",
+  running = "pending",
+  success = "success",
+  failed = "failure",
+  canceled = "error",
+}
+
+-- GitLab commit status → GitHub check run status/conclusion.
+-- Used by post_check_runs and get_commit_check_runs.
+local GL_STATUS_TO_CHECK_RUN = {
+  pending = { status = "queued", conclusion = nil },
+  running = { status = "in_progress", conclusion = nil },
+  success = { status = "completed", conclusion = "success" },
+  failed = { status = "completed", conclusion = "failure" },
+  canceled = { status = "completed", conclusion = "cancelled" },
+}
 
 backend_impl = {
   get_root = function()
@@ -739,20 +735,13 @@ backend_impl = {
 
   -- GitLab status mapping: running→pending, failed→failure, canceled→error
   get_commit_statuses = function(owner, repo_name, ref)
-    local gl_to_gh = {
-      pending = "pending",
-      running = "pending",
-      success = "success",
-      failed = "failure",
-      canceled = "error",
-    }
     proxy_json_paged(
       function(statuses)
         local result = {}
         for _, s in ipairs(statuses or {}) do
           result[#result + 1] = {
             id = s.id,
-            state = gl_to_gh[s.status] or s.status,
+            state = GL_STATUS_TO_GH[s.status] or s.status,
             description = s.description,
             target_url = s.target_url,
             context = s.name,
@@ -780,19 +769,12 @@ backend_impl = {
   get_commit_combined_status = function(owner, repo_name, ref)
     -- GitLab has no single-object combined status; return the list as-is
     -- and wrap in a GitHub-style combined status object.
-    local gl_to_gh = {
-      pending = "pending",
-      running = "pending",
-      success = "success",
-      failed = "failure",
-      canceled = "error",
-    }
     proxy_json(
       function(statuses)
         local state = "success"
         local result = {}
         for _, s in ipairs(statuses or {}) do
-          local gh_state = gl_to_gh[s.status] or s.status
+          local gh_state = GL_STATUS_TO_GH[s.status] or s.status
           if gh_state == "failure" or gh_state == "error" then
             state = gh_state
           end
@@ -832,16 +814,9 @@ backend_impl = {
     })
     proxy_json_created(
       function(s)
-        local gl_to_gh = {
-          pending = "pending",
-          running = "pending",
-          success = "success",
-          failed = "failure",
-          canceled = "error",
-        }
         return {
           id = s.id,
-          state = gl_to_gh[s.status] or s.status,
+          state = GL_STATUS_TO_GH[s.status] or s.status,
           description = s.description,
           target_url = s.target_url,
           context = s.name,
@@ -2911,14 +2886,8 @@ backend_impl = {
       if not s then
         return {}
       end
-      local gl_to_gh = {
-        pending = { status = "queued", conclusion = nil },
-        running = { status = "in_progress", conclusion = nil },
-        success = { status = "completed", conclusion = "success" },
-        failed = { status = "completed", conclusion = "failure" },
-        canceled = { status = "completed", conclusion = "cancelled" },
-      }
-      local mapped = gl_to_gh[s.status] or { status = "completed", conclusion = "failure" }
+      local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
+        or { status = "completed", conclusion = "failure" }
       return {
         id = s.id,
         node_id = "",
@@ -2970,16 +2939,10 @@ backend_impl = {
       return
     end
     local statuses = DecodeJson(body) or {}
-    local gl_to_gh = {
-      pending = { status = "queued", conclusion = nil },
-      running = { status = "in_progress", conclusion = nil },
-      success = { status = "completed", conclusion = "success" },
-      failed = { status = "completed", conclusion = "failure" },
-      canceled = { status = "completed", conclusion = "cancelled" },
-    }
     local runs = {}
     for i, s in ipairs(statuses) do
-      local mapped = gl_to_gh[s.status] or { status = "completed", conclusion = "failure" }
+      local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
+        or { status = "completed", conclusion = "failure" }
       runs[i] = {
         id = s.id,
         node_id = "",
@@ -3590,11 +3553,7 @@ local function translate_gl_snippet(s)
 end
 
 local function translate_gl_snippets(data)
-  local out = {}
-  for i, s in ipairs(data) do
-    out[i] = translate_gl_snippet(s)
-  end
-  return out
+  return translate_list(translate_gl_snippet, data)
 end
 
 local function translate_gl_snippet_note(n)
@@ -3613,11 +3572,7 @@ local function translate_gl_snippet_note(n)
 end
 
 local function translate_gl_snippet_notes(data)
-  local out = {}
-  for i, n in ipairs(data) do
-    out[i] = translate_gl_snippet_note(n)
-  end
-  return out
+  return translate_list(translate_gl_snippet_note, data)
 end
 
 -- Convert a GitHub gist create/update request body to GitLab snippet format.
@@ -3761,10 +3716,7 @@ local function translate_gl_award(a)
 end
 
 local function translate_gl_awards(awards)
-  for i, a in ipairs(awards) do
-    awards[i] = translate_gl_award(a)
-  end
-  return awards
+  return translate_list(translate_gl_award, awards)
 end
 
 -- Issue reactions: GitLab has full award_emoji support on issues.

--- a/backends/launchpad.lua
+++ b/backends/launchpad.lua
@@ -119,12 +119,7 @@ backend_impl = {
         .. "&status=New&status=Incomplete&status=Confirmed&status=Triaged&status=In+Progress"
     end
     proxy_json(function(data)
-      local entries = data.entries or {}
-      local result = {}
-      for _, t in ipairs(entries) do
-        result[#result + 1] = translate_lp_task(t)
-      end
-      return result
+      return translate_list(translate_lp_task, data.entries)
     end, fetch_json(url))
   end,
 

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -98,11 +98,7 @@ local function translate_onedev_req(body_str)
 end
 
 local function translate_onedev_repos(repos)
-  repos = repos or {}
-  for i, r in ipairs(repos) do
-    repos[i] = translate_onedev_repo(r)
-  end
-  return repos
+  return translate_list(translate_onedev_repo, repos)
 end
 
 local function translate_onedev_user(u)
@@ -308,11 +304,7 @@ backend_impl = {
     local page = tonumber(GetParam("page")) or 1
     proxy_json(
       function(branches)
-        branches = branches or {}
-        for i, b in ipairs(branches) do
-          branches[i] = translate_onedev_branch(b)
-        end
-        return branches
+        return translate_list(translate_onedev_branch, branches)
       end,
       fetch_json(
         base()
@@ -367,11 +359,7 @@ backend_impl = {
       url = url .. "&revision=" .. ref
     end
     proxy_json(function(commits)
-      commits = commits or {}
-      for i, c in ipairs(commits) do
-        commits[i] = translate_onedev_commit(c)
-      end
-      return commits
+      return translate_list(translate_onedev_commit, commits)
     end, fetch_json(url))
   end,
 
@@ -499,11 +487,7 @@ backend_impl = {
     local page = tonumber(GetParam("page")) or 1
     local offset = (page - 1) * (tonumber(count) or 30)
     proxy_json(function(users)
-      users = users or {}
-      for i, u in ipairs(users) do
-        users[i] = translate_onedev_user(u)
-      end
-      return users
+      return translate_list(translate_onedev_user, users)
     end, fetch_json(base() .. "/users?offset=" .. offset .. "&count=" .. count))
   end,
 
@@ -531,11 +515,7 @@ backend_impl = {
     end
     proxy_json(
       function(issues)
-        issues = issues or {}
-        for i, iss in ipairs(issues) do
-          issues[i] = translate_onedev_issue(iss)
-        end
-        return issues
+        return translate_list(translate_onedev_issue, issues)
       end,
       fetch_json(
         base()
@@ -615,11 +595,7 @@ backend_impl = {
     local cq = "%22Issue%22+is+%22" .. issue_id .. "%22"
     proxy_json(
       function(comments)
-        comments = comments or {}
-        for i, c in ipairs(comments) do
-          comments[i] = translate_onedev_issue_comment(c)
-        end
-        return comments
+        return translate_list(translate_onedev_issue_comment, comments)
       end,
       fetch_json(
         base()

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -180,12 +180,15 @@ local function translate_pagure_commit(c)
 end
 
 local function translate_pagure_issues(data)
-  local issues = data.issues or {}
-  for i, iss in ipairs(issues) do
-    issues[i] = translate_pagure_issue(iss)
-  end
-  return issues
+  return translate_list(translate_pagure_issue, data.issues)
 end
+
+-- Map Pagure flag statuses to GitHub check-run status/conclusion.
+local pagure_to_gh = {
+  pending = { status = "in_progress", conclusion = nil },
+  success = { status = "completed", conclusion = "success" },
+  canceled = { status = "completed", conclusion = "cancelled" },
+}
 
 backend_impl = {
   get_root = function()
@@ -229,11 +232,7 @@ backend_impl = {
     local me = DecodeJson(ubody)
     local username = me.username or me.name or ""
     proxy_json(function(data)
-      local projects = data.projects or {}
-      for i, p in ipairs(projects) do
-        projects[i] = translate_pagure_repo(p)
-      end
-      return projects
+      return translate_list(translate_pagure_repo, data.projects)
     end, fetch_json(append_page_params(base() .. "/user/" .. username .. "/projects", PAGES)))
   end,
 
@@ -251,11 +250,7 @@ backend_impl = {
   end,
 
   get_org_repos = proxy_handler(function(data)
-    local projects = data.projects or {}
-    for i, p in ipairs(projects) do
-      projects[i] = translate_pagure_repo(p)
-    end
-    return projects
+    return translate_list(translate_pagure_repo, data.projects)
   end, function(namespace)
     return append_page_params(base() .. "/projects?namespace=" .. namespace, PAGES)
   end),
@@ -295,11 +290,7 @@ backend_impl = {
   -- No commit SHAs in branch list response.
 
   get_repo_branches = proxy_handler(function(data)
-    local branches = {}
-    for _, name in ipairs(data.branches or {}) do
-      branches[#branches + 1] = translate_pagure_branch(name)
-    end
-    return branches
+    return translate_list(translate_pagure_branch, data.branches)
   end, function(owner, repo_name)
     return base() .. "/" .. owner .. "/" .. repo_name .. "/git/branches"
   end),
@@ -326,11 +317,7 @@ backend_impl = {
       url = url .. "&branch=" .. branch
     end
     proxy_json(function(data)
-      local commits = data.commits or {}
-      for i, c in ipairs(commits) do
-        commits[i] = translate_pagure_commit(c)
-      end
-      return commits
+      return translate_list(translate_pagure_commit, data.commits)
     end, fetch_json(url))
   end,
 
@@ -405,11 +392,7 @@ backend_impl = {
   -- Pagure: POST /api/0/fork with form body
 
   get_repo_forks = proxy_handler(function(data)
-    local forks = {}
-    for _, f in ipairs(data.forks or {}) do
-      forks[#forks + 1] = translate_pagure_repo(f)
-    end
-    return forks
+    return translate_list(translate_pagure_repo, data.forks)
   end, function(owner, repo_name)
     return base() .. "/" .. owner .. "/" .. repo_name
   end),
@@ -500,11 +483,7 @@ backend_impl = {
   -- Users' repos --------------------------------------------------------------
 
   get_users_repos = proxy_handler(function(data)
-    local projects = data.repos or data.projects or {}
-    for i, p in ipairs(projects) do
-      projects[i] = translate_pagure_repo(p)
-    end
-    return projects
+    return translate_list(translate_pagure_repo, data.repos or data.projects)
   end, function(username)
     return append_page_params(base() .. "/user/" .. username .. "/projects", PAGES)
   end),
@@ -513,11 +492,7 @@ backend_impl = {
 
   get_repositories = function()
     proxy_json(function(data)
-      local projects = data.projects or {}
-      for i, p in ipairs(projects) do
-        projects[i] = translate_pagure_repo(p)
-      end
-      return projects
+      return translate_list(translate_pagure_repo, data.projects)
     end, fetch_json(append_page_params(base() .. "/repos", PAGES)))
   end,
 
@@ -545,11 +520,7 @@ backend_impl = {
       return
     end
     local issue = DecodeJson(body or "{}") or {}
-    local comments = {}
-    for _, c in ipairs(issue.comments or {}) do
-      comments[#comments + 1] = translate_pagure_comment(c)
-    end
-    respond_json(200, comments)
+    respond_json(200, translate_list(translate_pagure_comment, issue.comments))
   end,
 
   get_repo_labels = function(_owner, _repo_name)
@@ -608,11 +579,6 @@ backend_impl = {
         return {}
       end
       local s = f.status or "pending"
-      local pagure_to_gh = {
-        pending = { status = "in_progress", conclusion = nil },
-        success = { status = "completed", conclusion = "success" },
-        canceled = { status = "completed", conclusion = "cancelled" },
-      }
       local mapped = pagure_to_gh[s] or { status = "completed", conclusion = "failure" }
       local gh_status, gh_conclusion = mapped.status, mapped.conclusion
       return {
@@ -667,11 +633,6 @@ backend_impl = {
     local runs = {}
     for i, f in ipairs(flags) do
       local s = f.status or "pending"
-      local pagure_to_gh = {
-        pending = { status = "in_progress", conclusion = nil },
-        success = { status = "completed", conclusion = "success" },
-        canceled = { status = "completed", conclusion = "cancelled" },
-      }
       local mapped = pagure_to_gh[s] or { status = "completed", conclusion = "failure" }
       local gh_status, gh_conclusion = mapped.status, mapped.conclusion
       runs[i] = {

--- a/backends/radicle.lua
+++ b/backends/radicle.lua
@@ -88,11 +88,7 @@ local function translate_radicle_req(body_str)
 end
 
 local function translate_radicle_repos(repos)
-  repos = repos or {}
-  for i, r in ipairs(repos) do
-    repos[i] = translate_radicle_repo(r)
-  end
-  return repos
+  return translate_list(translate_radicle_repo, repos)
 end
 
 backend_impl = {

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -275,11 +275,7 @@ backend_impl = {
     local canonical = user.canonical_name or ("~" .. (user.name or ""))
     proxy_json(
       function(data)
-        local repos = data.results or {}
-        for i, r in ipairs(repos) do
-          repos[i] = translate_srht_repo(r)
-        end
-        return repos
+        return translate_list(translate_srht_repo, data.results)
       end,
       -- Sourcehut uses cursor-based pagination; only limit is supported for page size
       fetch_json(append_page_params(base() .. "/" .. canonical .. "/repos", PAGES))
@@ -355,11 +351,7 @@ backend_impl = {
     end
     url = append_page_params(url, PAGES)
     proxy_json(function(data)
-      local commits = data.results or {}
-      for i, c in ipairs(commits) do
-        commits[i] = translate_srht_commit(c)
-      end
-      return commits
+      return translate_list(translate_srht_commit, data.results)
     end, fetch_json(url))
   end,
 
@@ -432,11 +424,7 @@ backend_impl = {
 
   get_users_repos = function(username)
     proxy_json(function(data)
-      local repos = data.results or {}
-      for i, r in ipairs(repos) do
-        repos[i] = translate_srht_repo(r)
-      end
-      return repos
+      return translate_list(translate_srht_repo, data.results)
     end, fetch_json(append_page_params(base() .. "/~" .. username .. "/repos", PAGES)))
   end,
 
@@ -472,12 +460,7 @@ backend_impl = {
     local url = todo_base() .. "/~" .. owner .. "/trackers/" .. repo_name .. "/tickets"
     url = append_page_params(url, PAGES)
     proxy_json(function(data)
-      local tickets = data.results or {}
-      local result = {}
-      for _, t in ipairs(tickets) do
-        result[#result + 1] = translate_srht_ticket(t)
-      end
-      return result
+      return translate_list(translate_srht_ticket, data.results)
     end, fetch_json(url))
   end,
 
@@ -587,11 +570,7 @@ backend_impl = {
       return
     end
     local data = DecodeJson(body) or {}
-    local jobs = data.results or {}
-    local runs = {}
-    for _, j in ipairs(jobs) do
-      runs[#runs + 1] = translate_srht_job_to_check_run(j)
-    end
+    local runs = translate_list(translate_srht_job_to_check_run, data.results)
     respond_json(200, { total_count = #runs, check_runs = runs })
   end,
 }

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -674,6 +674,72 @@ eq(_last_status, 200, "proxy_json_list: translate applied")
 ok(_last_body:find('"v":6') ~= nil, "proxy_json_list: translate doubles value")
 
 -- ============================================================
+-- translate_list
+-- ============================================================
+
+local tl = translate_list(function(x)
+  return x * 2
+end, { 1, 2, 3 })
+eq(#tl, 3, "translate_list: length preserved")
+eq(tl[1], 2, "translate_list: first element doubled")
+eq(tl[3], 6, "translate_list: third element doubled")
+
+local tl_empty = translate_list(function(x)
+  return x
+end, {})
+eq(#tl_empty, 0, "translate_list: empty input → empty output")
+
+local tl_nil = translate_list(function(x)
+  return x
+end, nil)
+eq(#tl_nil, 0, "translate_list: nil input → empty output")
+
+-- ============================================================
+-- proxy_search_envelope
+-- ============================================================
+
+reset_response()
+proxy_search_envelope(function(x)
+  return { id = x.id * 10 }
+end, nil, true, 200, {}, '[{"id":1},{"id":2}]')
+eq(_last_status, 200, "proxy_search_envelope(nil container): 200")
+ok(_last_body:find('"total_count":2') ~= nil, "proxy_search_envelope(nil container): total_count")
+ok(
+  _last_body:find('"incomplete_results":false') ~= nil,
+  "proxy_search_envelope: incomplete_results false"
+)
+ok(_last_body:find('"id":10') ~= nil, "proxy_search_envelope: translate_item applied")
+
+reset_response()
+proxy_search_envelope(function(x)
+  return { v = x.v }
+end, "values", true, 200, {}, '{"values":[{"v":7}],"size":1}')
+eq(_last_status, 200, "proxy_search_envelope(string container): 200")
+ok(
+  _last_body:find('"total_count":1') ~= nil,
+  "proxy_search_envelope(string container): total_count 1"
+)
+ok(_last_body:find('"v":7') ~= nil, "proxy_search_envelope(string container): item translated")
+
+reset_response()
+proxy_search_envelope(function(x)
+  return x
+end, nil, true, 200, {}, "[]")
+ok(_last_body:find('"items":%[%]') ~= nil, "proxy_search_envelope: empty array → items:[]")
+
+reset_response()
+proxy_search_envelope(function(x)
+  return x
+end, nil, true, 404, {}, "{}")
+eq(_last_status, 404, "proxy_search_envelope: upstream non-200 forwarded")
+
+reset_response()
+proxy_search_envelope(function(x)
+  return x
+end, nil, false, nil, nil, nil)
+eq(_last_status, 503, "proxy_search_envelope: pcall failure → 503")
+
+-- ============================================================
 -- make_proxy_handler
 -- ============================================================
 


### PR DESCRIPTION
Audits the remaining Git hosting backends (Bitbucket Data Center, GitBucket, CodeCommit, Gerrit, Pagure, Launchpad, Gitea, GitLab, Azure DevOps, OneDev, Sourcehut, Radicle) and migrates their proxy branches onto shared helpers, retiring per-backend duplicates where the shapes match. Adds shared \`translate_list\` and \`proxy_search_envelope\` helpers and migrates all backends onto them, then documents which custom proxy branches are intentionally retained.

Fixes #116.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (33)</summary>

- [x] Add proxy_health_check helper to .init.lua <!-- type:spec -->
- [x] Migrate backend get_root handlers to proxy_health_check <!-- type:spec -->
- [x] Promote proxy_204 to shared helper with extra success statuses <!-- type:spec -->
- [x] Migrate Gitea 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitLab 202/204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitBucket 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate Azure DevOps 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate remaining backends' 204 mutation paths to shared proxy_204 <!-- type:spec -->
- [x] Add proxy_json_list helper rendering empty arrays as [] <!-- type:spec -->
- [x] Migrate Bitbucket and GitLab list helpers to proxy_json_list <!-- type:spec -->
- [x] Migrate 200-or-201 create paths to proxy_json_created helper <!-- type:spec -->
- [x] Migrate decode-and-reshape handlers to proxy_json translate <!-- type:spec -->
- [x] Document remaining custom proxy branches with rationale comments <!-- type:spec -->
- [x] Audit bitbucket backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit bitbucket_datacenter backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gitbucket backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit codecommit backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gerrit backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit pagure backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit launchpad backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gitea backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gitlab backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit azuredevops backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit onedev, sourcehut, and radicle backends and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Document retained custom proxy branches and update CLAUDE.md helper guidance <!-- type:spec -->
- [x] Add shared translate_list helper for batch item translation <!-- type:spec -->
- [x] Add shared proxy_search_envelope helper (plain + paged) for GitHub search responses <!-- type:spec -->
- [x] Add shared proxy_collection_envelope helper for {total_count, <key>: []} responses <!-- type:spec -->
- [x] Migrate Gitea to shared translate_list, proxy_search_envelope, and proxy_collection_envelope <!-- type:spec -->
- [x] Migrate GitLab to shared search envelope (paged) and list translator helpers <!-- type:spec -->
- [x] Migrate Bitbucket and Bitbucket Data Center to shared search envelope and list translators <!-- type:spec -->
- [x] Migrate remaining backends emitting check_runs/check_suites envelopes to shared helper <!-- type:spec -->
- [x] Migrate remaining per-backend translate_<plurals> helpers to shared translate_list <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->

<details><summary>Completed (32)</summary>

- [x] Add proxy_health_check helper to .init.lua <!-- type:spec -->
- [x] Migrate backend get_root handlers to proxy_health_check <!-- type:spec -->
- [x] Promote proxy_204 to shared helper with extra success statuses <!-- type:spec -->
- [x] Migrate Gitea 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitLab 202/204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate GitBucket 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate Azure DevOps 204 mutation paths to shared proxy_204 helper <!-- type:spec -->
- [x] Migrate remaining backends' 204 mutation paths to shared proxy_204 <!-- type:spec -->
- [x] Add proxy_json_list helper rendering empty arrays as [] <!-- type:spec -->
- [x] Migrate Bitbucket and GitLab list helpers to proxy_json_list <!-- type:spec -->
- [x] Migrate 200-or-201 create paths to proxy_json_created helper <!-- type:spec -->
- [x] Migrate decode-and-reshape handlers to proxy_json translate <!-- type:spec -->
- [x] Document remaining custom proxy branches with rationale comments <!-- type:spec -->
- [x] Audit bitbucket backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit bitbucket_datacenter backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gitbucket backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit codecommit backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gerrit backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit pagure backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit launchpad backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gitea backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit gitlab backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit azuredevops backend and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Audit onedev, sourcehut, and radicle backends and migrate matching proxy branches to shared helpers <!-- type:spec -->
- [x] Add shared translate_list helper for batch item translation <!-- type:spec -->
- [x] Add shared proxy_search_envelope helper for GitHub search responses <!-- type:spec -->
- [x] Migrate Gitea to shared translate_list and proxy_search_envelope <!-- type:spec -->
- [x] Migrate GitLab to shared translate_list and extract GL_STATUS maps <!-- type:spec -->
- [x] Migrate remaining per-backend translate_plural helpers to shared translate_list <!-- type:spec -->
- [x] Document shared proxy helpers and retained patterns in CLAUDE.md <!-- type:spec -->
- [x] proxy_collection_envelope — not implemented; check_runs/runners envelopes use non-"items" keys and are intentionally left as custom respond_json calls <!-- type:spec -->
- [x] Migrate remaining backends emitting check_runs envelopes — not applicable; proxy_search_envelope hardcodes "items" key <!-- type:spec -->

</details>