### PR TITLE
fix broken gh-pages workflow (closes #130)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,11 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
-      - name: Generate compatibility matrix
-        run: |
-          mkdir -p _site
-          cp -r site/. _site/
-          python3 scripts/gen-matrix.py site/compatibility.csv site/index.html _site/index.html
+      - uses: ./.github/actions/setup
+      - run: make site
       - uses: actions/upload-pages-artifact@v3
         with:
           path: _site


### PR DESCRIPTION
Updates pages.yml to use `make site` so the catalog JSON is piped through correctly during the GitHub Pages build.

Fixes #130.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Fix pages.yml to use make site so catalog JSON is piped correctly <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->