### PR TITLE
GraphQL: GQL-03 - Implement schema loader and type validation API (closes #141)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -23,6 +23,8 @@ dofile("/zip/internal/proxy.lua")
 dofile("/zip/internal/transport.lua")
 dofile("/zip/internal/translators.lua")
 dofile("/zip/internal/graphql_parser.lua")
+dofile("/zip/internal/graphql_schema_data.lua")
+dofile("/zip/internal/graphql_schema.lua")
 dofile("/zip/internal/families.lua")
 
 -- backend_impl is global: set by backends/<name>.lua at startup.

--- a/internal/graphql_parser.lua
+++ b/internal/graphql_parser.lua
@@ -78,33 +78,27 @@ local function block_string_value(raw)
 end
 
 -- ============================================================
--- Lexer
+-- Character class predicates
 -- ============================================================
 
--- Character predicates.
+local function is_digit(b)
+  return b ~= nil and b >= 48 and b <= 57
+end
+
 local function is_name_start(b)
-  if not b then
-    return false
-  end
-  return b == 95 or (b >= 65 and b <= 90) or (b >= 97 and b <= 122)
+  return b ~= nil and (b == 95 or (b >= 65 and b <= 90) or (b >= 97 and b <= 122))
 end
 
 local function is_name_char(b)
-  if not b then
-    return false
-  end
-  return b == 95 or (b >= 65 and b <= 90) or (b >= 97 and b <= 122) or (b >= 48 and b <= 57)
+  return is_name_start(b) or is_digit(b)
 end
 
-local function is_digit(b)
-  if not b then
-    return false
-  end
-  return b >= 48 and b <= 57
-end
+-- ============================================================
+-- Lexer tables
+-- ============================================================
 
--- Lookup table for single-character string escape sequences.
-local escape_map = {
+-- Single-character escape sequences (GraphQL spec §2.1.9).
+local simple_escapes = {
   [34] = '"',
   [47] = "/",
   [92] = "\\",
@@ -115,47 +109,96 @@ local escape_map = {
   [116] = "\t",
 }
 
+-- Single-character punctuation (GraphQL spec §2.1.8): ! $ & ( ) : = @ [ ] { | }
+local punct_bytes = {
+  [33] = true,
+  [36] = true,
+  [38] = true,
+  [40] = true,
+  [41] = true,
+  [58] = true,
+  [61] = true,
+  [64] = true,
+  [91] = true,
+  [93] = true,
+  [123] = true,
+  [124] = true,
+  [125] = true,
+}
+
+-- ============================================================
+-- Lexer
+-- ============================================================
+
 local function make_lexer(source)
+  local src = source
   local lex = { src = source, pos = 1, line = 1, col = 1, _peeked = nil }
+
+  -- ---- Error reporting ----
 
   function lex:error(msg)
     error(self.line .. ":" .. self.col .. ": " .. msg, 0)
   end
 
-  -- Advance one non-newline character.
+  -- ---- Character inspection ----
+
+  function lex:at_end()
+    return self.pos > #src
+  end
+
+  function lex:byte()
+    return src:byte(self.pos)
+  end
+
+  function lex:char()
+    return src:sub(self.pos, self.pos)
+  end
+
+  function lex:match(s)
+    return src:sub(self.pos, self.pos + #s - 1) == s
+  end
+
+  -- ---- Position advancement ----
+
   function lex:advance()
     self.pos = self.pos + 1
     self.col = self.col + 1
   end
 
-  -- Advance n non-newline characters.
   function lex:advance_by(n)
     self.pos = self.pos + n
     self.col = self.col + n
   end
 
-  -- Handle a \n line terminator.
-  function lex:newline_lf()
+  function lex:newline()
     self.line = self.line + 1
     self.col = 1
     self.pos = self.pos + 1
   end
 
-  -- Handle a \r (or \r\n) line terminator.
-  function lex:newline_cr()
-    self.line = self.line + 1
-    self.col = 1
-    self.pos = self.pos + 1
-    if self.src:byte(self.pos) == 10 then
-      self.pos = self.pos + 1
+  -- ---- Skip helpers ----
+
+  -- Consume \n, \r, or \r\n.  Return true if a line terminator was consumed.
+  function lex:skip_line_terminator()
+    local b = self:byte()
+    if b == 10 then
+      self:newline()
+      return true
+    elseif b == 13 then
+      self:newline()
+      if self:byte() == 10 then
+        self.pos = self.pos + 1
+      end
+      return true
     end
+    return false
   end
 
-  -- Skip a # comment to end of line.
+  -- Skip from # through end of line.
   function lex:skip_comment()
-    self:advance() -- consume #
-    while self.pos <= #self.src do
-      local b = self.src:byte(self.pos)
+    self:advance()
+    while not self:at_end() do
+      local b = self:byte()
       if b == 10 or b == 13 then
         break
       end
@@ -163,77 +206,72 @@ local function make_lexer(source)
     end
   end
 
-  -- Skip all ignored tokens: whitespace, commas, line terminators, comments.
+  -- Skip whitespace, commas, line terminators, and comments.
   function lex:skip_ignored()
-    while self.pos <= #self.src do
-      local b = self.src:byte(self.pos)
-      if b == 9 or b == 32 or b == 44 then -- tab, space, comma
+    while not self:at_end() do
+      local b = self:byte()
+      if b == 9 or b == 32 or b == 44 then
         self:advance()
-      elseif b == 10 then
-        self:newline_lf()
-      elseif b == 13 then
-        self:newline_cr()
       elseif b == 35 then
         self:skip_comment()
-      else
+      elseif not self:skip_line_terminator() then
         break
       end
     end
   end
 
-  -- Consume all digits at the current position (no col tracking).
-  function lex:consume_digits()
-    while is_digit(self.src:byte(self.pos)) do
-      self.pos = self.pos + 1
-    end
-  end
+  -- ---- Token readers ----
 
-  -- Read a NAME token; pos is at the first name character.
   function lex:read_name(tline, tcol)
     local s = self.pos
     self.pos = self.pos + 1
-    while is_name_char(self.src:byte(self.pos)) do
+    while is_name_char(self:byte()) do
       self.pos = self.pos + 1
     end
-    local value = self.src:sub(s, self.pos - 1)
+    local value = src:sub(s, self.pos - 1)
     self.col = tcol + #value
     return { kind = "NAME", value = value, line = tline, col = tcol }
   end
 
-  -- Read an INT_VALUE or FLOAT_VALUE token; pos is at - or first digit.
-  function lex:read_number(tline, tcol)
-    local src = self.src
-    local s = self.pos
-    if src:byte(self.pos) == 45 then -- optional leading minus
+  function lex:read_digits()
+    while is_digit(self:byte()) do
       self.pos = self.pos + 1
-      if not is_digit(src:byte(self.pos)) then
+    end
+  end
+
+  function lex:read_number(tline, tcol)
+    local s = self.pos
+    if self:byte() == 45 then -- optional leading minus
+      self.pos = self.pos + 1
+      if not is_digit(self:byte()) then
         self:error("invalid number: expected digit after '-'")
       end
     end
-    self:consume_digits()
+    self:read_digits()
     local is_float = false
-    if src:byte(self.pos) == 46 then -- fractional part
+    if self:byte() == 46 then -- fractional part
       is_float = true
       self.pos = self.pos + 1
-      if not is_digit(src:byte(self.pos)) then
+      if not is_digit(self:byte()) then
         self:error("invalid float: expected digit after '.'")
       end
-      self:consume_digits()
+      self:read_digits()
     end
-    local b = src:byte(self.pos)
-    if b == 69 or b == 101 then -- exponent part (E or e)
+    local eb = self:byte()
+    if eb == 69 or eb == 101 then -- exponent part (E or e)
       is_float = true
       self.pos = self.pos + 1
-      local sb = src:byte(self.pos)
-      if sb == 43 or sb == 45 then -- optional sign
+      local sb = self:byte()
+      if sb == 43 or sb == 45 then -- optional +/-
         self.pos = self.pos + 1
       end
-      if not is_digit(src:byte(self.pos)) then
+      if not is_digit(self:byte()) then
         self:error("invalid float: expected digit in exponent")
       end
-      self:consume_digits()
+      self:read_digits()
     end
-    if is_name_char(src:byte(self.pos)) then
+    -- Number must not be immediately followed by a name/digit character.
+    if is_name_char(self:byte()) then
       self:error("invalid number literal: unexpected character after digits")
     end
     local value = src:sub(s, self.pos - 1)
@@ -246,39 +284,37 @@ local function make_lexer(source)
     }
   end
 
-  -- Read one escape sequence; pos is at the backslash.
   function lex:read_escape()
     self.pos = self.pos + 1 -- skip backslash
-    local eb = self.src:byte(self.pos)
-    local ch = escape_map[eb]
+    local eb = self:byte()
+    local ch = simple_escapes[eb]
     if ch then
       self.pos = self.pos + 1
       self.col = self.col + 2
       return ch
-    elseif eb == 117 then -- \uXXXX
+    end
+    if eb == 117 then -- \uXXXX
       self.pos = self.pos + 1
-      local hex = self.src:sub(self.pos, self.pos + 3)
-      if #hex < 4 or not hex:match("^[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]$") then
+      local hex = src:sub(self.pos, self.pos + 3)
+      if #hex < 4 or not hex:match("^%x%x%x%x$") then
         self:error("invalid unicode escape \\u" .. hex)
       end
-      local result = utf8.char(tonumber(hex, 16))
+      local codepoint = tonumber(hex, 16)
       self.pos = self.pos + 4
-      self.col = self.col + 6 -- \uXXXX = 6 source chars
-      return result
-    else
-      self:error("invalid escape sequence '\\" .. string.char(eb) .. "'")
+      self.col = self.col + 6
+      return utf8.char(codepoint)
     end
+    self:error("invalid escape sequence '\\" .. string.char(eb) .. "'")
   end
 
-  -- Read a single-line string token; pos is at the opening ".
   function lex:read_string(tline, tcol)
-    self:advance() -- consume opening "
+    self:advance() -- skip opening "
     local parts = {}
     while true do
-      if self.pos > #self.src then
+      if self:at_end() then
         self:error("unterminated string")
       end
-      local b = self.src:byte(self.pos)
+      local b = self:byte()
       if b == 10 or b == 13 then
         self:error("line terminator inside string")
       elseif b == 34 then -- closing "
@@ -287,52 +323,43 @@ local function make_lexer(source)
       elseif b == 92 then -- backslash escape
         parts[#parts + 1] = self:read_escape()
       else
-        parts[#parts + 1] = self.src:sub(self.pos, self.pos)
+        parts[#parts + 1] = self:char()
         self:advance()
       end
     end
     return { kind = "STRING_VALUE", value = table.concat(parts), line = tline, col = tcol }
   end
 
-  -- Consume one raw character into parts, tracking line state (for block strings).
-  function lex:block_char(parts)
-    local src = self.src
-    local b = src:byte(self.pos)
-    if b == 10 then
-      parts[#parts + 1] = "\n"
-      self:newline_lf()
-    elseif b == 13 then
-      parts[#parts + 1] = "\r"
-      self.line = self.line + 1
-      self.col = 1
-      self.pos = self.pos + 1
-      if src:byte(self.pos) == 10 then -- \r\n: consume and capture the \n too
-        parts[#parts + 1] = "\n"
-        self.pos = self.pos + 1
-      end
-    else
-      parts[#parts + 1] = src:sub(self.pos, self.pos)
-      self:advance()
-    end
-  end
-
-  -- Read a block string token; pos is at the opening """.
   function lex:read_block_string(tline, tcol)
-    local src = self.src
-    self:advance_by(3) -- consume opening """
+    self:advance_by(3) -- skip opening """
     local parts = {}
     while true do
-      if self.pos > #src then
+      if self:at_end() then
         self:error("unterminated block string")
       end
-      if src:sub(self.pos, self.pos + 2) == '"""' then
+      if self:match('"""') then
         self:advance_by(3)
         break
-      elseif src:sub(self.pos, self.pos + 3) == '\\"""' then -- escaped triple-quote
+      end
+      if self:match('\\"""') then -- escaped triple-quote
         parts[#parts + 1] = '"""'
         self:advance_by(4)
       else
-        self:block_char(parts)
+        local ch = self:char()
+        parts[#parts + 1] = ch
+        if ch == "\n" then
+          self:newline()
+        elseif ch == "\r" then
+          -- Cannot delegate to skip_line_terminator here because we must
+          -- also append the \n to parts when consuming a \r\n pair.
+          self:newline()
+          if self:byte() == 10 then
+            parts[#parts + 1] = "\n"
+            self.pos = self.pos + 1
+          end
+        else
+          self:advance()
+        end
       end
     end
     return {
@@ -343,71 +370,52 @@ local function make_lexer(source)
     }
   end
 
-  -- Read and return the next meaningful token, advancing position.
-  function lex:read_token()
-    self:skip_ignored()
+  function lex:read_punct(tline, tcol)
+    local ch = self:char()
+    self:advance()
+    return { kind = "PUNCT", value = ch, line = tline, col = tcol }
+  end
 
-    local tline = self.line
-    local tcol = self.col
-
-    if self.pos > #self.src then
-      return { kind = "EOF", value = "", line = tline, col = tcol }
-    end
-
-    local src = self.src
-    local b = src:byte(self.pos)
-
-    -- Single-character punctuation.
-    if
-      b == 33
-      or b == 36
-      or b == 38
-      or b == 40
-      or b == 41
-      or b == 58
-      or b == 61
-      or b == 64
-      or b == 91
-      or b == 93
-      or b == 123
-      or b == 124
-      or b == 125
-    then
-      local ch = src:sub(self.pos, self.pos)
-      self:advance()
-      return { kind = "PUNCT", value = ch, line = tline, col = tcol }
-    end
-
-    -- ... spread operator (one or two dots alone is a lexer error).
-    if b == 46 then
-      if src:sub(self.pos, self.pos + 2) == "..." then
-        self:advance_by(3)
-        return { kind = "PUNCT", value = "...", line = tline, col = tcol }
-      end
+  function lex:read_spread(tline, tcol)
+    if not self:match("...") then
       self:error("unexpected character '.'")
     end
+    self:advance_by(3)
+    return { kind = "PUNCT", value = "...", line = tline, col = tcol }
+  end
 
-    -- NAME: [_A-Za-z][_0-9A-Za-z]*
+  -- ---- Main tokenizer ----
+
+  function lex:read_token()
+    self:skip_ignored()
+    local tline = self.line
+    local tcol = self.col
+    if self:at_end() then
+      return { kind = "EOF", value = "", line = tline, col = tcol }
+    end
+    local b = self:byte()
+    if punct_bytes[b] then
+      return self:read_punct(tline, tcol)
+    end
+    if b == 46 then
+      return self:read_spread(tline, tcol)
+    end
     if is_name_start(b) then
       return self:read_name(tline, tcol)
     end
-
-    -- INT_VALUE or FLOAT_VALUE
     if b == 45 or is_digit(b) then
       return self:read_number(tline, tcol)
     end
-
-    -- STRING_VALUE: single-line or block (triple-quoted).
     if b == 34 then
-      if src:sub(self.pos, self.pos + 2) == '"""' then
+      if self:match('"""') then
         return self:read_block_string(tline, tcol)
-      else
-        return self:read_string(tline, tcol)
       end
+      return self:read_string(tline, tcol)
     end
-
-    self:error("unexpected character '" .. src:sub(self.pos, self.pos) .. "'")
+    self:error("unexpected character '" .. self:char() .. "'")
   end
+
+  -- ---- Public interface ----
 
   function lex:next()
     if self._peeked then

--- a/internal/graphql_schema.lua
+++ b/internal/graphql_schema.lua
@@ -1,0 +1,138 @@
+-- internal/graphql_schema.lua
+-- Runtime API for the GraphQL type registry.
+-- Depends on graphql_schema_data (loaded first).
+-- Exports six globals: graphql_schema_type, graphql_schema_field,
+-- graphql_schema_base_type, graphql_schema_is_leaf, graphql_schema_is_nonnull,
+-- graphql_schema_expand_type.
+-- luacheck: globals graphql_schema_type graphql_schema_field graphql_schema_base_type
+-- luacheck: globals graphql_schema_is_leaf graphql_schema_is_nonnull graphql_schema_expand_type
+
+-- ---------------------------------------------------------------------------
+-- graphql_schema_type(name)
+-- Returns the type definition table for the named type, or nil if unknown.
+-- ---------------------------------------------------------------------------
+function graphql_schema_type(name) -- luacheck: globals graphql_schema_type
+  return graphql_schema_data.types[name]
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_schema_base_type(type_ref)
+-- Extracts the innermost named type from a type-reference string.
+--   "String!"       → "String"
+--   "[Issue!]!"     → "Issue"
+-- ---------------------------------------------------------------------------
+function graphql_schema_base_type(type_ref) -- luacheck: globals graphql_schema_base_type
+  return type_ref:match("[_%a][_%w]*")
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_schema_is_nonnull(type_ref)
+-- True if the outermost wrapper is non-null (trailing "!").
+-- ---------------------------------------------------------------------------
+function graphql_schema_is_nonnull(type_ref) -- luacheck: globals graphql_schema_is_nonnull
+  return type_ref:sub(-1) == "!"
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_schema_is_leaf(type_ref)
+-- True if the resolved base type is a scalar or enum (leaf node).
+-- ---------------------------------------------------------------------------
+function graphql_schema_is_leaf(type_ref) -- luacheck: globals graphql_schema_is_leaf
+  local base = graphql_schema_base_type(type_ref)
+  local t = graphql_schema_type(base)
+  if t == nil then
+    return false
+  end
+  return t.kind == "SCALAR" or t.kind == "ENUM"
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_schema_expand_type(type_ref)
+-- Expands a type-reference string to the nested table form used by introspection.
+--   "String!"    → { kind="NON_NULL", name=nil, ofType={ kind="SCALAR", name="String", ofType=nil } }
+--   "[Issue!]!"  → NON_NULL → LIST → NON_NULL → OBJECT{name="Issue"}
+-- ---------------------------------------------------------------------------
+function graphql_schema_expand_type(type_ref) -- luacheck: globals graphql_schema_expand_type
+  if type_ref:sub(-1) == "!" then
+    return {
+      kind = "NON_NULL",
+      name = nil,
+      ofType = graphql_schema_expand_type(type_ref:sub(1, -2)),
+    }
+  elseif type_ref:sub(1, 1) == "[" then
+    return {
+      kind = "LIST",
+      name = nil,
+      ofType = graphql_schema_expand_type(type_ref:sub(2, -2)),
+    }
+  else
+    local t = graphql_schema_type(type_ref)
+    return { kind = (t and t.kind or "SCALAR"), name = type_ref, ofType = nil }
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Synthetic meta-field definitions (injected by graphql_schema_field).
+-- ---------------------------------------------------------------------------
+
+local META_TYPENAME = {
+  name = "__typename",
+  type = "String!",
+  description = "The name of the current type.",
+  args = {},
+}
+local META_SCHEMA = {
+  name = "__schema",
+  type = "__Schema!",
+  description = "Access the current type schema of this server.",
+  args = {},
+}
+local META_TYPE = {
+  name = "__type",
+  type = "__Type",
+  description = "Request the type information of a single type.",
+  args = {
+    { name = "name", type = "String!", description = "The name of the type.", default_value = nil },
+  },
+}
+
+-- ---------------------------------------------------------------------------
+-- graphql_schema_field(type_name, field_name)
+-- Returns the field definition for field_name on the named type, or nil.
+-- Injects synthetic meta-fields (__typename, __schema, __type) automatically.
+-- ---------------------------------------------------------------------------
+function graphql_schema_field(type_name, field_name) -- luacheck: globals graphql_schema_field
+  -- __typename is available on every object and interface type.
+  if field_name == "__typename" then
+    local t = graphql_schema_type(type_name)
+    if t and (t.kind == "OBJECT" or t.kind == "INTERFACE") then
+      return META_TYPENAME
+    end
+    return nil
+  end
+
+  -- __schema and __type are available only on the root Query type.
+  if field_name == "__schema" and type_name == graphql_schema_data.query_type then
+    return META_SCHEMA
+  end
+  if field_name == "__type" and type_name == graphql_schema_data.query_type then
+    return META_TYPE
+  end
+
+  local t = graphql_schema_type(type_name)
+  if t == nil then
+    return nil
+  end
+
+  -- Search the fields array (OBJECT, INTERFACE) or input_fields (INPUT_OBJECT).
+  local fields = t.fields or t.input_fields
+  if fields == nil then
+    return nil
+  end
+  for _, f in ipairs(fields) do
+    if f.name == field_name then
+      return f
+    end
+  end
+  return nil
+end

--- a/internal/graphql_schema.lua
+++ b/internal/graphql_schema.lua
@@ -1,11 +1,12 @@
 -- internal/graphql_schema.lua
 -- Runtime API for the GraphQL type registry.
 -- Depends on graphql_schema_data (loaded first).
--- Exports six globals: graphql_schema_type, graphql_schema_field,
+-- Exports eight globals: graphql_schema_type, graphql_schema_field,
 -- graphql_schema_base_type, graphql_schema_is_leaf, graphql_schema_is_nonnull,
--- graphql_schema_expand_type.
+-- graphql_schema_expand_type, graphql_introspect_schema, graphql_introspect_type.
 -- luacheck: globals graphql_schema_type graphql_schema_field graphql_schema_base_type
 -- luacheck: globals graphql_schema_is_leaf graphql_schema_is_nonnull graphql_schema_expand_type
+-- luacheck: globals graphql_introspect_schema graphql_introspect_type
 
 -- ---------------------------------------------------------------------------
 -- graphql_schema_type(name)
@@ -135,4 +136,152 @@ function graphql_schema_field(type_name, field_name) -- luacheck: globals graphq
     end
   end
   return nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Introspection helpers (internal).
+-- ---------------------------------------------------------------------------
+
+-- Convert a stored arg/input-field definition to an __InputValue introspection table.
+local function introspect_input_value(iv)
+  return {
+    name = iv.name,
+    description = iv.description,
+    type = graphql_schema_expand_type(iv.type),
+    defaultValue = iv.default_value,
+  }
+end
+
+-- Convert a stored field definition to a __Field introspection table.
+local function introspect_field(f)
+  local args = {}
+  for i, a in ipairs(f.args or {}) do
+    args[i] = introspect_input_value(a)
+  end
+  return {
+    name = f.name,
+    description = f.description,
+    args = args,
+    type = graphql_schema_expand_type(f.type),
+    isDeprecated = f.is_deprecated or false,
+    deprecationReason = f.deprecation_reason,
+  }
+end
+
+-- Convert a stored type definition to a __Type introspection table.
+local function introspect_type_def(t)
+  if t == nil then
+    return nil
+  end
+  local result = {
+    kind = t.kind,
+    name = t.name,
+    description = t.description,
+  }
+
+  -- fields: OBJECT and INTERFACE only
+  if t.kind == "OBJECT" or t.kind == "INTERFACE" then
+    local fields = {}
+    for i, f in ipairs(t.fields or {}) do
+      fields[i] = introspect_field(f)
+    end
+    result.fields = fields
+  end
+
+  -- interfaces: OBJECT only
+  if t.kind == "OBJECT" then
+    local ifaces = {}
+    for i, iname in ipairs(t.interfaces or {}) do
+      ifaces[i] = { kind = "INTERFACE", name = iname, ofType = nil }
+    end
+    result.interfaces = ifaces
+  end
+
+  -- possibleTypes: INTERFACE and UNION
+  if t.kind == "INTERFACE" or t.kind == "UNION" then
+    local pts = {}
+    for i, ptname in ipairs(t.possible_types or {}) do
+      pts[i] = { kind = "OBJECT", name = ptname, ofType = nil }
+    end
+    result.possibleTypes = pts
+  end
+
+  -- enumValues: ENUM only
+  if t.kind == "ENUM" then
+    local evs = {}
+    for i, ev in ipairs(t.values or {}) do
+      evs[i] = {
+        name = ev.name,
+        description = ev.description,
+        isDeprecated = ev.is_deprecated or false,
+        deprecationReason = ev.deprecation_reason,
+      }
+    end
+    result.enumValues = evs
+  end
+
+  -- inputFields: INPUT_OBJECT only
+  if t.kind == "INPUT_OBJECT" then
+    local ifields = {}
+    for i, f in ipairs(t.input_fields or {}) do
+      ifields[i] = introspect_input_value(f)
+    end
+    result.inputFields = ifields
+  end
+
+  return result
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_introspect_type(name)
+-- Returns the __Type introspection table for the named type, or nil if unknown.
+-- ---------------------------------------------------------------------------
+function graphql_introspect_type(name) -- luacheck: globals graphql_introspect_type
+  return introspect_type_def(graphql_schema_type(name))
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_introspect_schema()
+-- Returns the full __schema introspection response table.
+-- ---------------------------------------------------------------------------
+function graphql_introspect_schema() -- luacheck: globals graphql_introspect_schema
+  -- Collect all types as __Type objects, sorted by name for stability.
+  local type_names = {}
+  for name in pairs(graphql_schema_data.types) do
+    type_names[#type_names + 1] = name
+  end
+  table.sort(type_names)
+
+  local types = {}
+  for i, name in ipairs(type_names) do
+    types[i] = introspect_type_def(graphql_schema_data.types[name])
+  end
+
+  -- Convert stored directive definitions to __Directive introspection tables.
+  local directives = {}
+  for i, d in ipairs(graphql_schema_data.directives or {}) do
+    local args = {}
+    for j, a in ipairs(d.args or {}) do
+      args[j] = introspect_input_value(a)
+    end
+    directives[i] = {
+      name = d.name,
+      description = d.description,
+      isRepeatable = d.is_repeatable or false,
+      locations = d.locations,
+      args = args,
+    }
+  end
+
+  local qt = graphql_schema_data.query_type
+  local mt = graphql_schema_data.mutation_type
+  local st = graphql_schema_data.subscription_type
+
+  return {
+    types = types,
+    queryType = qt and { name = qt } or nil,
+    mutationType = mt and { name = mt } or nil,
+    subscriptionType = st and { name = st } or nil,
+    directives = directives,
+  }
 end

--- a/test/unit-graphql.lua
+++ b/test/unit-graphql.lua
@@ -1,5 +1,4 @@
--- Unit tests for the GraphQL lexer and recursive-descent parser
--- (internal/graphql_parser.lua).
+-- Unit tests for the GraphQL lexer, parser, and schema loader.
 -- Run from project root: sh redbean.com -i test/unit-graphql.lua
 -- ============================================================
 
@@ -13,8 +12,10 @@ function dofile(path) -- luacheck: globals dofile
   return _real_dofile(path)
 end
 
--- Load module under test.
+-- Load modules under test.
 dofile("internal/graphql_parser.lua")
+dofile("internal/graphql_schema_data.lua")
+dofile("internal/graphql_schema.lua")
 
 dofile = _real_dofile -- luacheck: globals dofile
 
@@ -621,6 +622,140 @@ end
 
 do -- bad unicode escape (not 4 hex digits)
   must_fail('{ field(x: "\\u00GG") { id } }', "bad unicode escape")
+end
+
+-- luacheck: globals graphql_schema_type graphql_schema_field graphql_schema_base_type
+-- luacheck: globals graphql_schema_is_leaf graphql_schema_is_nonnull graphql_schema_expand_type
+
+-- ============================================================
+-- graphql_schema_type
+-- ============================================================
+
+do
+  local t = graphql_schema_type("Repository")
+  ok(t ~= nil, "schema_type: Repository is found")
+  eq(t and t.kind, "OBJECT", "schema_type: Repository.kind is OBJECT")
+end
+
+do
+  local t = graphql_schema_type("IssueState")
+  ok(t ~= nil, "schema_type: IssueState is found")
+  eq(t and t.kind, "ENUM", "schema_type: IssueState.kind is ENUM")
+end
+
+do
+  local t = graphql_schema_type("NonExistent")
+  ok(t == nil, "schema_type: NonExistent returns nil")
+end
+
+-- ============================================================
+-- graphql_schema_field
+-- ============================================================
+
+do
+  local f = graphql_schema_field("Repository", "issues")
+  ok(f ~= nil, "schema_field: Repository.issues is found")
+  eq(f and f.type, "IssueConnection!", "schema_field: Repository.issues type is IssueConnection!")
+end
+
+do -- meta-field __schema on Query
+  local f = graphql_schema_field("Query", "__schema")
+  ok(f ~= nil, "schema_field: Query.__schema returns synthetic meta-field")
+  eq(f and f.name, "__schema", "schema_field: Query.__schema name")
+  eq(f and f.type, "__Schema!", "schema_field: Query.__schema type is __Schema!")
+end
+
+do -- meta-field __type on Query
+  local f = graphql_schema_field("Query", "__type")
+  ok(f ~= nil, "schema_field: Query.__type returns synthetic meta-field")
+  eq(f and f.name, "__type", "schema_field: Query.__type name")
+  eq(f and f.type, "__Type", "schema_field: Query.__type type is __Type")
+end
+
+do -- meta-field __typename on any object
+  local f = graphql_schema_field("Repository", "__typename")
+  ok(f ~= nil, "schema_field: Repository.__typename returns synthetic meta-field")
+  eq(f and f.name, "__typename", "schema_field: Repository.__typename name")
+  eq(f and f.type, "String!", "schema_field: Repository.__typename type is String!")
+end
+
+do -- __schema not available on non-Query types
+  local f = graphql_schema_field("Repository", "__schema")
+  ok(f == nil, "schema_field: __schema is nil on non-Query type")
+end
+
+do -- unknown field returns nil
+  local f = graphql_schema_field("Repository", "doesNotExist")
+  ok(f == nil, "schema_field: unknown field returns nil")
+end
+
+do -- unknown type returns nil
+  local f = graphql_schema_field("NoSuchType", "field")
+  ok(f == nil, "schema_field: unknown type returns nil")
+end
+
+-- ============================================================
+-- graphql_schema_base_type
+-- ============================================================
+
+do
+  eq(graphql_schema_base_type("[Issue!]!"), "Issue", "base_type: [Issue!]! → Issue")
+  eq(graphql_schema_base_type("String!"), "String", "base_type: String! → String")
+  eq(
+    graphql_schema_base_type("[IssueState]!"),
+    "IssueState",
+    "base_type: [IssueState]! → IssueState"
+  )
+  eq(graphql_schema_base_type("Repository"), "Repository", "base_type: Repository → Repository")
+end
+
+-- ============================================================
+-- graphql_schema_is_nonnull
+-- ============================================================
+
+do
+  ok(graphql_schema_is_nonnull("String!") == true, "is_nonnull: String! is non-null")
+  ok(graphql_schema_is_nonnull("String") == false, "is_nonnull: String is nullable")
+  ok(graphql_schema_is_nonnull("[Issue!]!") == true, "is_nonnull: [Issue!]! is non-null")
+  ok(graphql_schema_is_nonnull("[Issue!]") == false, "is_nonnull: [Issue!] is nullable")
+end
+
+-- ============================================================
+-- graphql_schema_is_leaf
+-- ============================================================
+
+do
+  ok(graphql_schema_is_leaf("String!") == true, "is_leaf: String! is a leaf (scalar)")
+  ok(graphql_schema_is_leaf("Repository!") == false, "is_leaf: Repository! is not a leaf (object)")
+  ok(graphql_schema_is_leaf("IssueState") == true, "is_leaf: IssueState is a leaf (enum)")
+  ok(
+    graphql_schema_is_leaf("IssueConnection!") == false,
+    "is_leaf: IssueConnection! is not a leaf (object)"
+  )
+  ok(graphql_schema_is_leaf("UnknownType") == false, "is_leaf: unknown type is not a leaf")
+end
+
+-- ============================================================
+-- graphql_schema_expand_type
+-- ============================================================
+
+do -- "String!" → NON_NULL → SCALAR
+  local e = graphql_schema_expand_type("String!")
+  eq(e.kind, "NON_NULL", "expand_type String!: outer kind is NON_NULL")
+  ok(e.name == nil, "expand_type String!: outer name is nil")
+  ok(e.ofType ~= nil, "expand_type String!: ofType present")
+  eq(e.ofType.kind, "SCALAR", "expand_type String!: inner kind is SCALAR")
+  eq(e.ofType.name, "String", "expand_type String!: inner name is String")
+  ok(e.ofType.ofType == nil, "expand_type String!: inner ofType is nil")
+end
+
+do -- "[Issue!]!" → NON_NULL → LIST → NON_NULL → OBJECT
+  local e = graphql_schema_expand_type("[Issue!]!")
+  eq(e.kind, "NON_NULL", "expand_type [Issue!]!: level 1 NON_NULL")
+  eq(e.ofType.kind, "LIST", "expand_type [Issue!]!: level 2 LIST")
+  eq(e.ofType.ofType.kind, "NON_NULL", "expand_type [Issue!]!: level 3 NON_NULL")
+  eq(e.ofType.ofType.ofType.kind, "OBJECT", "expand_type [Issue!]!: level 4 OBJECT")
+  eq(e.ofType.ofType.ofType.name, "Issue", "expand_type [Issue!]!: leaf name Issue")
 end
 
 -- ============================================================

--- a/test/unit-graphql.lua
+++ b/test/unit-graphql.lua
@@ -626,6 +626,7 @@ end
 
 -- luacheck: globals graphql_schema_type graphql_schema_field graphql_schema_base_type
 -- luacheck: globals graphql_schema_is_leaf graphql_schema_is_nonnull graphql_schema_expand_type
+-- luacheck: globals graphql_introspect_schema graphql_introspect_type
 
 -- ============================================================
 -- graphql_schema_type
@@ -756,6 +757,142 @@ do -- "[Issue!]!" → NON_NULL → LIST → NON_NULL → OBJECT
   eq(e.ofType.ofType.kind, "NON_NULL", "expand_type [Issue!]!: level 3 NON_NULL")
   eq(e.ofType.ofType.ofType.kind, "OBJECT", "expand_type [Issue!]!: level 4 OBJECT")
   eq(e.ofType.ofType.ofType.name, "Issue", "expand_type [Issue!]!: leaf name Issue")
+end
+
+-- ============================================================
+-- graphql_introspect_type
+-- ============================================================
+
+do -- ENUM type
+  local t = graphql_introspect_type("IssueState")
+  ok(t ~= nil, "introspect_type: IssueState returns a table")
+  eq(t and t.kind, "ENUM", "introspect_type: IssueState.kind is ENUM")
+  eq(t and t.name, "IssueState", "introspect_type: IssueState.name")
+  ok(t and t.enumValues ~= nil, "introspect_type: IssueState.enumValues present")
+  local found_open = false
+  for _, ev in ipairs(t and t.enumValues or {}) do
+    if ev.name == "OPEN" then
+      found_open = true
+    end
+  end
+  ok(found_open, "introspect_type: IssueState.enumValues contains OPEN")
+  local found_closed = false
+  for _, ev in ipairs(t and t.enumValues or {}) do
+    if ev.name == "CLOSED" then
+      found_closed = true
+    end
+  end
+  ok(found_closed, "introspect_type: IssueState.enumValues contains CLOSED")
+end
+
+do -- OBJECT type
+  local t = graphql_introspect_type("Repository")
+  ok(t ~= nil, "introspect_type: Repository returns a table")
+  eq(t and t.kind, "OBJECT", "introspect_type: Repository.kind is OBJECT")
+  eq(t and t.name, "Repository", "introspect_type: Repository.name")
+  ok(t and t.fields ~= nil, "introspect_type: Repository.fields present")
+  ok(t and t.interfaces ~= nil, "introspect_type: Repository.interfaces present")
+  -- fields should be __Field introspection tables (have .type as expanded table)
+  local found_name_field = false
+  for _, f in ipairs(t and t.fields or {}) do
+    if f.name == "name" then
+      found_name_field = true
+      ok(type(f.type) == "table", "introspect_type: Repository.name field.type is a table")
+    end
+  end
+  ok(found_name_field, "introspect_type: Repository.fields contains 'name'")
+end
+
+do -- SCALAR type
+  local t = graphql_introspect_type("String")
+  ok(t ~= nil, "introspect_type: String returns a table")
+  eq(t and t.kind, "SCALAR", "introspect_type: String.kind is SCALAR")
+  eq(t and t.name, "String", "introspect_type: String.name")
+  ok(t and t.fields == nil, "introspect_type: String.fields is nil (not an object)")
+end
+
+do -- INPUT_OBJECT type
+  local t = graphql_introspect_type("CreateIssueInput")
+  ok(t ~= nil, "introspect_type: CreateIssueInput returns a table")
+  eq(t and t.kind, "INPUT_OBJECT", "introspect_type: CreateIssueInput.kind is INPUT_OBJECT")
+  ok(t and t.inputFields ~= nil, "introspect_type: CreateIssueInput.inputFields present")
+end
+
+do -- unknown type returns nil
+  local t = graphql_introspect_type("NoSuchType")
+  ok(t == nil, "introspect_type: unknown type returns nil")
+end
+
+-- ============================================================
+-- graphql_introspect_schema
+-- ============================================================
+
+do
+  local s = graphql_introspect_schema()
+  ok(s ~= nil, "introspect_schema: returns a table")
+  ok(s.queryType ~= nil, "introspect_schema: queryType present")
+  eq(s.queryType and s.queryType.name, "Query", "introspect_schema: queryType.name is Query")
+  ok(s.mutationType ~= nil, "introspect_schema: mutationType present")
+  eq(
+    s.mutationType and s.mutationType.name,
+    "Mutation",
+    "introspect_schema: mutationType.name is Mutation"
+  )
+  ok(s.subscriptionType == nil, "introspect_schema: subscriptionType is nil")
+  ok(s.types ~= nil, "introspect_schema: types present")
+  ok(type(s.types) == "table", "introspect_schema: types is a table")
+  ok(#s.types > 0, "introspect_schema: types is non-empty")
+  ok(s.directives ~= nil, "introspect_schema: directives present")
+  ok(type(s.directives) == "table", "introspect_schema: directives is a table")
+end
+
+do -- types array contains introspect_type-shaped entries
+  local s = graphql_introspect_schema()
+  -- Find Repository in the types list
+  local repo_type = nil
+  for _, t in ipairs(s.types or {}) do
+    if t.name == "Repository" then
+      repo_type = t
+      break
+    end
+  end
+  ok(repo_type ~= nil, "introspect_schema: types contains Repository")
+  eq(
+    repo_type and repo_type.kind,
+    "OBJECT",
+    "introspect_schema: Repository in types has kind OBJECT"
+  )
+end
+
+do -- types array is sorted by name (stable)
+  local s = graphql_introspect_schema()
+  local prev = ""
+  local sorted = true
+  for _, t in ipairs(s.types or {}) do
+    if t.name < prev then
+      sorted = false
+      break
+    end
+    prev = t.name
+  end
+  ok(sorted, "introspect_schema: types array is sorted by name")
+end
+
+do -- directives array entries have required __Directive fields
+  local s = graphql_introspect_schema()
+  local found_skip = false
+  for _, d in ipairs(s.directives or {}) do
+    if d.name == "skip" then
+      found_skip = true
+      ok(d.locations ~= nil, "introspect_schema: skip directive has locations")
+      ok(d.args ~= nil, "introspect_schema: skip directive has args")
+      ok(
+        type(d.isRepeatable) == "boolean",
+        "introspect_schema: skip directive.isRepeatable is boolean"
+      )
+    end
+  end
+  ok(found_skip, "introspect_schema: directives contains @skip")
 end
 
 -- ============================================================


### PR DESCRIPTION
Fixes #141.

Implements the schema loader and type validation API for GQL-03. Adds `internal/graphql_schema.lua` with six core lookup/validation functions (type lookup, field lookup with meta-field injection, base type extraction, leaf detection, non-null checking, type expansion) plus full introspection support (`__schema` and `__type` queries), wired into the `.init.lua` load order with unit tests.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add schema loader with core type validation API and unit tests <!-- type:spec -->
- [x] Add introspection API and unit tests <!-- type:spec -->
- [x] [PR comment: Refactor lexer into Wirth/Oberon style helper methods](https://github.com/rhencke/confusio/pull/167#discussion_r3082790683) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->