### PR TITLE
GraphQL: GQL-07 - Implement error model, path tracking, and null propagation (closes #145)

### DIFF
--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -294,6 +294,12 @@ end
 local execute_selection_set
 local complete_value
 
+-- PROPAGATE is a unique sentinel returned by complete_value when a Non-Null field
+-- resolves to null.  The parent complete_value propagates it upward until a nullable
+-- type stops it (returning nil) or execute_selection_set converts it to nil in the
+-- result table.  Identity comparison only — never serialised or exposed to resolvers.
+local PROPAGATE = {}
+
 -- execute_field: resolves one field and returns the raw (uncompleted) value.
 local function execute_field(field_node, type_name, parent, ctx)
   local field_name = field_node.name.value
@@ -336,13 +342,23 @@ complete_value = function(value, type_ref, field_node, type_name, ctx)
   if graphql_schema_is_nonnull(type_ref) then
     local inner_ref = type_ref:sub(1, -2) -- strip trailing "!"
     local inner = complete_value(value, inner_ref, field_node, type_name, ctx)
-    if inner == nil then
-      local response_key = (field_node.alias and field_node.alias.value) or field_node.name.value
-      append_error(ctx, "non-null field returned null: " .. response_key, field_node)
+    if inner == nil or inner == PROPAGATE then
+      -- Non-null contract violated; bubble upward so the nearest nullable ancestor
+      -- becomes null (execute_selection_set converts PROPAGATE → nil in the result).
+      graphql_error(
+        ctx,
+        "non-null field resolved to null: " .. (field_node and field_node.name.value or "?"),
+        field_node
+      )
+      return PROPAGATE
     end
     return inner
   end
 
+  -- Nullable: absorb any upward-propagating null here.
+  if value == PROPAGATE then
+    return nil
+  end
   if value == nil then
     return nil
   end
@@ -360,7 +376,12 @@ complete_value = function(value, type_ref, field_node, type_name, ctx)
     local len = rawget(value, "n") or #value
     for i = 1, len do
       ctx.path[#ctx.path + 1] = i - 1 -- push 0-based index per spec
-      result[i] = complete_value(value[i], inner_ref, field_node, type_name, ctx)
+      local item = complete_value(value[i], inner_ref, field_node, type_name, ctx)
+      -- Do not use `item and nil or item` — the ternary idiom breaks when nil is
+      -- the "truthy" branch.  An explicit if keeps PROPAGATE out of the result.
+      if item ~= PROPAGATE then
+        result[i] = item
+      end
       ctx.path[#ctx.path] = nil -- pop
     end
     return result
@@ -400,7 +421,13 @@ execute_selection_set = function(sel_set, type_name, parent, ctx)
     local raw = execute_field(field_node, type_name, parent, ctx)
     local field_def = graphql_schema_field(type_name, field_name)
     local type_ref = (field_def and field_def.type) or "String"
-    result[response_key] = complete_value(raw, type_ref, field_node, type_name, ctx)
+    local completed = complete_value(raw, type_ref, field_node, type_name, ctx)
+    -- PROPAGATE means a non-null field resolved to null; the field becomes null
+    -- (nil in Lua) in the result.  Do not use the `a and b or c` ternary here —
+    -- it breaks when b is nil (falsy), causing PROPAGATE to leak into the result.
+    if completed ~= PROPAGATE then
+      result[response_key] = completed
+    end
     ctx.path[#ctx.path] = nil -- pop
   end
   return result

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -480,6 +480,20 @@ end
 -- graphql_validate: Phase 1 field-existence and leaf/composite checks
 -- ---------------------------------------------------------------------------
 
+-- graphql_validate_error: builds a validation error table (VALIDATION_ERROR code).
+-- Simpler than graphql_error — no ctx needed since validation runs before execution.
+-- name_node is a NameNode with optional line/col from the parser, or nil.
+local function graphql_validate_error(message, name_node)
+  local err = {
+    message = message,
+    extensions = { code = "VALIDATION_ERROR" },
+  }
+  if name_node and name_node.line then
+    err.locations = { { line = name_node.line, column = name_node.col } }
+  end
+  return err
+end
+
 -- validate_selection_set: recursively validate field existence and structure.
 -- Returns an array of error objects (empty means valid).
 local function validate_selection_set(sel_set, type_name, doc, seen_frags, errors)
@@ -490,29 +504,22 @@ local function validate_selection_set(sel_set, type_name, doc, seen_frags, error
       if field_name ~= "__typename" and field_name ~= "__schema" and field_name ~= "__type" then
         local field_def = graphql_schema_field(type_name, field_name)
         if not field_def then
-          errors[#errors + 1] = {
-            message = "Field '" .. field_name .. "' does not exist on type '" .. type_name .. "'",
-            locations = sel.name.line and { { line = sel.name.line, column = sel.name.col } }
-              or nil,
-          }
+          errors[#errors + 1] = graphql_validate_error(
+            "Field '" .. field_name .. "' does not exist on type '" .. type_name .. "'",
+            sel.name
+          )
         else
           local is_leaf = graphql_schema_is_leaf(field_def.type)
           if is_leaf and sel.selection_set then
-            errors[#errors + 1] = {
-              message = "Field '"
-                .. field_name
-                .. "' is a leaf type and must not have sub-selections",
-              locations = sel.name.line and { { line = sel.name.line, column = sel.name.col } }
-                or nil,
-            }
+            errors[#errors + 1] = graphql_validate_error(
+              "Field '" .. field_name .. "' is a leaf type and must not have sub-selections",
+              sel.name
+            )
           elseif not is_leaf and not sel.selection_set then
-            errors[#errors + 1] = {
-              message = "Field '"
-                .. field_name
-                .. "' is a composite type and must have sub-selections",
-              locations = sel.name.line and { { line = sel.name.line, column = sel.name.col } }
-                or nil,
-            }
+            errors[#errors + 1] = graphql_validate_error(
+              "Field '" .. field_name .. "' is a composite type and must have sub-selections",
+              sel.name
+            )
           elseif sel.selection_set then
             local base = graphql_schema_base_type(field_def.type)
             validate_selection_set(sel.selection_set, base, doc, seen_frags, errors)
@@ -551,7 +558,9 @@ local function graphql_validate(doc, op)
   elseif op.operation == "mutation" then
     root_type = graphql_schema_data.mutation_type
   else
-    return { { message = "Unsupported operation type: " .. tostring(op.operation) } }
+    return {
+      graphql_validate_error("Unsupported operation type: " .. tostring(op.operation), nil),
+    }
   end
   local errors = {}
   validate_selection_set(op.selection_set, root_type, doc, {}, errors)
@@ -640,10 +649,12 @@ function graphql_handler() -- luacheck: globals graphql_handler
   local raw = GetBody() or ""
   local req = DecodeJson(raw)
   if not req or type(req.query) ~= "string" then
-    respond_graphql(
-      nil,
-      { { message = "POST /graphql requires a JSON body with a 'query' field" } }
-    )
+    respond_graphql(nil, {
+      {
+        message = "POST /graphql requires a JSON body with a 'query' field",
+        extensions = { code = "BAD_USER_INPUT" },
+      },
+    })
     return
   end
   local source = req.query
@@ -653,14 +664,24 @@ function graphql_handler() -- luacheck: globals graphql_handler
   -- Step 2: parse.
   local doc, parse_err = graphql_parse(source)
   if not doc then
-    respond_graphql(nil, { { message = parse_err } })
+    respond_graphql(nil, {
+      {
+        message = parse_err,
+        extensions = { code = "PARSE_ERROR" },
+      },
+    })
     return
   end
 
   -- Step 3: select operation.
   local op, sel_err = select_operation(doc, op_name)
   if not op then
-    respond_graphql(nil, { { message = sel_err } })
+    respond_graphql(nil, {
+      {
+        message = sel_err,
+        extensions = { code = "BAD_USER_INPUT" },
+      },
+    })
     return
   end
 

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -359,7 +359,9 @@ complete_value = function(value, type_ref, field_node, type_name, ctx)
     -- Query.nodes where some entries are nil/null) to preserve the correct length.
     local len = rawget(value, "n") or #value
     for i = 1, len do
+      ctx.path[#ctx.path + 1] = i - 1 -- push 0-based index per spec
       result[i] = complete_value(value[i], inner_ref, field_node, type_name, ctx)
+      ctx.path[#ctx.path] = nil -- pop
     end
     return result
   end
@@ -394,10 +396,12 @@ execute_selection_set = function(sel_set, type_name, parent, ctx)
     local field_nodes = field_map[response_key]
     local field_node = field_nodes[1]
     local field_name = field_node.name.value
+    ctx.path[#ctx.path + 1] = response_key -- push
     local raw = execute_field(field_node, type_name, parent, ctx)
     local field_def = graphql_schema_field(type_name, field_name)
     local type_ref = (field_def and field_def.type) or "String"
     result[response_key] = complete_value(raw, type_ref, field_node, type_name, ctx)
+    ctx.path[#ctx.path] = nil -- pop
   end
   return result
 end
@@ -645,6 +649,7 @@ function graphql_handler() -- luacheck: globals graphql_handler
     doc = doc,
     variables = variables,
     errors = {},
+    path = {},
   }
   -- Build variable_defs lookup: name → VariableDefinitionNode (for default values).
   ctx.variable_defs = {}

--- a/internal/graphql_translators.lua
+++ b/internal/graphql_translators.lua
@@ -9,6 +9,7 @@
 --   decode_node_id(encoded)
 --   graphql_fetch(fetch_json, path[, method[, body]])
 --   graphql_fetch_with_headers(fetch_json, path[, method[, body]])
+--   graphql_fetch_or_error(fetch_json, path, ctx, field_node[, method[, body]])
 --   graphql_page_to_cursor(page)
 --   graphql_cursor_to_page(cursor)
 --   graphql_cursor_url(url_base, args, param_names)
@@ -146,6 +147,35 @@ function graphql_fetch_with_headers(fetch_json, path, method, body) -- luacheck:
     return nil, nil, "invalid JSON from upstream for " .. path
   end
   return decoded, headers or {}, nil
+end
+
+-- graphql_fetch_or_error is global: like graphql_fetch but records an error in ctx on
+-- failure and returns nil, so callers can write `if not data then return nil end` instead
+-- of repeating the HTTP-status → error-code mapping in every resolver.
+--
+-- fetch_json:  the backend's fetch function (from make_backend_transport)
+-- path:        full URL to request
+-- ctx:         GraphQL execution context (errors array)
+-- field_node:  FieldNode being resolved (for location tracking), or nil
+-- method:      HTTP method string, or nil for GET
+-- body:        request body (JSON-encoded string) or nil
+--
+-- Returns decoded_table on success, nil on failure (error already in ctx.errors).
+function graphql_fetch_or_error(fetch_json, path, ctx, field_node, method, body) -- luacheck: globals graphql_fetch_or_error
+  local data, err = graphql_fetch(fetch_json, path, method, body)
+  if not data then
+    local code = "INTERNAL_ERROR"
+    if err:find("not found") then
+      code = "NOT_FOUND"
+    elseif err:find("40[13]") then
+      code = "FORBIDDEN"
+    elseif err:find("429") then
+      code = "RATE_LIMITED"
+    end
+    graphql_error(ctx, err, field_node, code)
+    return nil
+  end
+  return data
 end
 
 -- ---------------------------------------------------------------------------

--- a/test/unit-graphql.lua
+++ b/test/unit-graphql.lua
@@ -1398,6 +1398,50 @@ do -- subscription operation: unsupported op type → null data (execute_operati
 end
 
 -- ============================================================
+-- ctx.path tracking: path appears in errors during execution
+-- ============================================================
+
+do -- path recorded for nested non-null field error
+  -- Query.repository → Repository.id (ID!) with id=nil triggers a non-null error.
+  -- The error path should be ["repository", "id"].
+  with_resolvers({
+    ["Query.repository"] = function(_parent, _args, _ctx)
+      return { id = nil, __typename = "Repository" }
+    end,
+  }, function()
+    local r = call_handler({ query = '{ repository(name: "x") { id } }' })
+    ok(r.errors and #r.errors > 0, "path tracking: nested field error recorded")
+    local err = r.errors[1]
+    ok(err.path ~= nil, "path tracking: path is present on field error")
+    eq(err.path[1], "repository", "path tracking: path[1] is 'repository'")
+    eq(err.path[2], "id", "path tracking: path[2] is 'id'")
+    eq(#err.path, 2, "path tracking: path has exactly 2 segments")
+  end)
+end
+
+do -- path includes 0-based list index for error inside a list item
+  -- Query.codesOfConduct returns [CodeOfConduct]; CodeOfConduct.id is ID! (non-null).
+  -- The second item has id=nil → error path should be ["codesOfConduct", 1, "id"].
+  with_resolvers({
+    ["Query.codesOfConduct"] = function(_parent, _args, _ctx)
+      return {
+        { __typename = "CodeOfConduct", id = "coc:mit", key = "mit", name = "MIT" },
+        { __typename = "CodeOfConduct", id = nil, key = "cc0-1.0", name = "CC0" },
+      }
+    end,
+  }, function()
+    local r = call_handler({ query = "{ codesOfConduct { id } }" })
+    ok(r.errors and #r.errors > 0, "path tracking: list item error recorded")
+    local err = r.errors[1]
+    ok(err.path ~= nil, "path tracking: path present for list item error")
+    eq(err.path[1], "codesOfConduct", "path tracking: list path[1] is field name")
+    eq(err.path[2], 1, "path tracking: list path[2] is 0-based index (1 = second item)")
+    eq(err.path[3], "id", "path tracking: list path[3] is 'id'")
+    eq(#err.path, 3, "path tracking: list error path has 3 segments")
+  end)
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 

--- a/test/unit-graphql.lua
+++ b/test/unit-graphql.lua
@@ -41,6 +41,7 @@ dofile("internal/graphql_schema_data.lua")
 dofile("internal/graphql_schema.lua")
 dofile("internal/http.lua")
 dofile("internal/graphql_executor.lua")
+dofile("internal/graphql_translators.lua") -- graphql_fetch, graphql_fetch_or_error, etc.
 
 dofile = _real_dofile -- luacheck: globals dofile
 
@@ -1558,6 +1559,96 @@ do -- PROPAGATE in a list: non-null item failure becomes nil in the list, not th
       "propagate in list: second item id is null (not sentinel)"
     )
   end)
+end
+
+-- ============================================================
+-- graphql_fetch_or_error: HTTP-status → error-code mapping
+-- ============================================================
+
+-- luacheck: globals graphql_fetch_or_error
+
+-- make_fetch_stub: returns a fetch_json stub that produces (ok, status, {}, json_body).
+-- Pass status=nil to simulate a network failure (ok=false).
+local function make_fetch_stub(status, json_body)
+  return function(_path, _method, _body)
+    if status == nil then
+      return false, nil, nil, nil -- network failure
+    end
+    return true, status, {}, json_body or '{"key":"value"}'
+  end
+end
+
+do -- success: returns decoded data, no error added to ctx
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(200, '{"login":"fido"}')
+  local data = graphql_fetch_or_error(fetch, "/user", ctx, nil)
+  ok(data ~= nil, "fetch_or_error: 200 → data returned")
+  eq(data.login, "fido", "fetch_or_error: 200 → decoded body accessible")
+  eq(#ctx.errors, 0, "fetch_or_error: 200 → no errors added")
+end
+
+do -- 404 → NOT_FOUND code, nil returned
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(404)
+  local data = graphql_fetch_or_error(fetch, "/repos/x/y", ctx, nil)
+  ok(data == nil, "fetch_or_error: 404 → nil returned")
+  eq(#ctx.errors, 1, "fetch_or_error: 404 → one error added")
+  eq(ctx.errors[1].extensions.code, "NOT_FOUND", "fetch_or_error: 404 → NOT_FOUND code")
+end
+
+do -- 401 → FORBIDDEN code
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(401, "")
+  -- graphql_fetch produces "upstream error 401 fetching /path" which matches "40[13]"
+  local data = graphql_fetch_or_error(fetch, "/user", ctx, nil)
+  ok(data == nil, "fetch_or_error: 401 → nil returned")
+  eq(ctx.errors[1].extensions.code, "FORBIDDEN", "fetch_or_error: 401 → FORBIDDEN code")
+end
+
+do -- 403 → FORBIDDEN code
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(403, "")
+  local data = graphql_fetch_or_error(fetch, "/user", ctx, nil)
+  ok(data == nil, "fetch_or_error: 403 → nil returned")
+  eq(ctx.errors[1].extensions.code, "FORBIDDEN", "fetch_or_error: 403 → FORBIDDEN code")
+end
+
+do -- 429 → RATE_LIMITED code
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(429, "")
+  local data = graphql_fetch_or_error(fetch, "/user", ctx, nil)
+  ok(data == nil, "fetch_or_error: 429 → nil returned")
+  eq(ctx.errors[1].extensions.code, "RATE_LIMITED", "fetch_or_error: 429 → RATE_LIMITED code")
+end
+
+do -- 500 → INTERNAL_ERROR code
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(500, "")
+  local data = graphql_fetch_or_error(fetch, "/user", ctx, nil)
+  ok(data == nil, "fetch_or_error: 500 → nil returned")
+  eq(ctx.errors[1].extensions.code, "INTERNAL_ERROR", "fetch_or_error: 500 → INTERNAL_ERROR code")
+end
+
+do -- network failure → INTERNAL_ERROR code
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(nil) -- ok=false
+  local data = graphql_fetch_or_error(fetch, "/user", ctx, nil)
+  ok(data == nil, "fetch_or_error: network failure → nil returned")
+  eq(
+    ctx.errors[1].extensions.code,
+    "INTERNAL_ERROR",
+    "fetch_or_error: network failure → INTERNAL_ERROR code"
+  )
+end
+
+do -- error message forwarded to ctx.errors[1].message
+  local ctx = { errors = {}, path = {} }
+  local fetch = make_fetch_stub(404)
+  graphql_fetch_or_error(fetch, "/repos/owner/repo", ctx, nil)
+  ok(
+    ctx.errors[1].message:find("not found"),
+    "fetch_or_error: error message forwarded from graphql_fetch"
+  )
 end
 
 -- ============================================================

--- a/test/unit-graphql.lua
+++ b/test/unit-graphql.lua
@@ -1097,6 +1097,64 @@ do -- validation error: unknown field
   )
 end
 
+-- ============================================================
+-- extensions.code on request-level and validation errors
+-- ============================================================
+
+do -- invalid body → extensions.code = BAD_USER_INPUT
+  reset_response()
+  _req_body = "not json"
+  graphql_handler()
+  local r = DecodeJson(_last_body)
+  ok(
+    r.errors and r.errors[1].extensions and r.errors[1].extensions.code == "BAD_USER_INPUT",
+    "error codes: invalid body → BAD_USER_INPUT"
+  )
+end
+
+do -- missing query field → extensions.code = BAD_USER_INPUT
+  reset_response()
+  _req_body = '{"notQuery": "x"}'
+  graphql_handler()
+  local r = DecodeJson(_last_body)
+  ok(
+    r.errors and r.errors[1].extensions and r.errors[1].extensions.code == "BAD_USER_INPUT",
+    "error codes: missing query field → BAD_USER_INPUT"
+  )
+end
+
+do -- parse error → extensions.code = PARSE_ERROR
+  local r = call_handler({ query = "{ unclosed_brace" })
+  ok(
+    r.errors and r.errors[1].extensions and r.errors[1].extensions.code == "PARSE_ERROR",
+    "error codes: parse error → PARSE_ERROR"
+  )
+end
+
+do -- unknown operationName → extensions.code = BAD_USER_INPUT
+  local r = call_handler({ query = "query A { __typename }", operationName = "B" })
+  ok(
+    r.errors and r.errors[1].extensions and r.errors[1].extensions.code == "BAD_USER_INPUT",
+    "error codes: unknown operationName → BAD_USER_INPUT"
+  )
+end
+
+do -- ambiguous document (no operationName) → extensions.code = BAD_USER_INPUT
+  local r = call_handler({ query = "query A { __typename } query B { __typename }" })
+  ok(
+    r.errors and r.errors[1].extensions and r.errors[1].extensions.code == "BAD_USER_INPUT",
+    "error codes: ambiguous document → BAD_USER_INPUT"
+  )
+end
+
+do -- validation error: unknown field → extensions.code = VALIDATION_ERROR
+  local r = call_handler({ query = "{ nonexistentField123 }" })
+  ok(
+    r.errors and r.errors[1].extensions and r.errors[1].extensions.code == "VALIDATION_ERROR",
+    "error codes: unknown field → VALIDATION_ERROR"
+  )
+end
+
 do -- __typename meta-field — no resolver needed
   with_resolvers({}, function()
     local r = call_handler({ query = "{ __typename }" })

--- a/test/unit-graphql.lua
+++ b/test/unit-graphql.lua
@@ -1442,6 +1442,67 @@ do -- path includes 0-based list index for error inside a list item
 end
 
 -- ============================================================
+-- PROPAGATE sentinel and null propagation
+-- ============================================================
+
+do -- non-null field with nil value: error message uses new wording, exactly one error
+  -- complete_value(nil, "ID!") should record exactly one "non-null field resolved to null"
+  -- error and store nil for that field in data.
+  with_resolvers({
+    ["Query.repository"] = function(_parent, _args, _ctx)
+      return { id = nil, __typename = "Repository" }
+    end,
+  }, function()
+    local r = call_handler({ query = '{ repository(name: "x") { id } }' })
+    eq(#r.errors, 1, "propagate: exactly one error for one non-null violation")
+    ok(
+      r.errors[1].message:find("non%-null field resolved to null"),
+      "propagate: error message is 'non-null field resolved to null: ...'"
+    )
+    -- The field is null (nil in Lua → null in JSON), not the PROPAGATE sentinel.
+    ok(r.data.repository ~= nil, "propagate: Repository object is still present")
+    ok(r.data.repository.id == nil, "propagate: id field is null (PROPAGATE converted to nil)")
+  end)
+end
+
+do -- PROPAGATE stops at nullable: the nullable parent is not null, only the non-null field inside
+  -- Repository.name is "String!" (non-null); Query.repository is "Repository" (nullable).
+  -- When name is nil, null propagates to name but stops there — repository stays non-null.
+  with_resolvers({
+    ["Query.repository"] = function(_parent, _args, _ctx)
+      return { name = nil, __typename = "Repository" }
+    end,
+  }, function()
+    local r = call_handler({ query = '{ repository(name: "x") { name } }' })
+    eq(#r.errors, 1, "propagate stops at nullable: exactly one error")
+    ok(r.data.repository ~= nil, "propagate stops at nullable: Repository field is not null")
+    ok(r.data.repository.name == nil, "propagate stops at nullable: name field is null")
+  end)
+end
+
+do -- PROPAGATE in a list: non-null item failure becomes nil in the list, not the sentinel
+  -- Query.codesOfConduct is [CodeOfConduct]; CodeOfConduct.id is ID! (non-null).
+  -- Second item has id=nil → data.codesOfConduct[2].id must be nil, not a table/object.
+  with_resolvers({
+    ["Query.codesOfConduct"] = function(_parent, _args, _ctx)
+      return {
+        { __typename = "CodeOfConduct", id = "coc:mit", key = "mit", name = "MIT" },
+        { __typename = "CodeOfConduct", id = nil, key = "cc0-1.0", name = "CC0" },
+      }
+    end,
+  }, function()
+    local r = call_handler({ query = "{ codesOfConduct { id } }" })
+    ok(r.errors and #r.errors == 1, "propagate in list: exactly one error")
+    -- First item succeeds; second item's id is null (not the PROPAGATE sentinel object).
+    eq(r.data.codesOfConduct[1].id, "coc:mit", "propagate in list: first item id intact")
+    ok(
+      r.data.codesOfConduct[2].id == nil,
+      "propagate in list: second item id is null (not sentinel)"
+    )
+  end)
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 


### PR DESCRIPTION
Fixes #145.

Implements the GraphQL error model from doc 09: path tracking during field and list execution, null propagation via a PROPAGATE sentinel, extension codes on validation/request errors, and a `graphql_fetch_or_error` helper for resolvers.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add ctx.path tracking to execute_selection_set and complete_value <!-- type:spec -->
- [x] Add PROPAGATE sentinel and null propagation in complete_value <!-- type:spec -->
- [x] Add extensions.code to validation and request-level errors <!-- type:spec -->
- [x] Add graphql_fetch_or_error helper to graphql_translators.lua <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->