### PR TITLE
GraphQL: GQL-09 - Implement cost-limit enforcement and batch/APQ rejection (closes #147)

### DIFF
--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -9,6 +9,7 @@
 --   graphql_handler()            — HTTP handler for POST /graphql; registered in catalog
 --   respond_graphql(data, errs)  — null-safe GraphQL response writer
 --   graphql_error(ctx, ...)      — error-recording helper called by resolvers
+--   graphql_cached(ctx, key, fn) — request-scoped cache helper for resolvers
 --   estimate_query_cost(op, vars) — query cost estimator; exposed for unit tests
 
 -- ---------------------------------------------------------------------------
@@ -79,6 +80,40 @@ function graphql_error(ctx, message, field_node, code) -- luacheck: globals grap
 
   ctx.errors[#ctx.errors + 1] = err
   return nil
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_cached
+-- ---------------------------------------------------------------------------
+
+-- Unique sentinel: distinguishes "key not yet fetched" (nil table entry) from
+-- "key was fetched and result was nil" (CACHE_MISS entry).
+local CACHE_MISS = {}
+
+-- Call fetch_fn() and cache the result under cache_key for this request.
+-- Returns the cached result on subsequent calls with the same key.
+--
+-- fetch_fn may return nil (e.g. resource not found); nil is cached via the
+-- CACHE_MISS sentinel so a second call does not re-invoke fetch_fn.
+--
+-- Cache key convention: "TypeName:local_id"  (e.g. "User:octocat",
+-- "Repository:octocat/hello-world").  Connection results (paginated lists)
+-- are not cached — their content varies by pagination args.
+--
+-- ctx.cache is created fresh per graphql_handler invocation; there is no
+-- cross-request cache.
+function graphql_cached(ctx, cache_key, fetch_fn) -- luacheck: globals graphql_cached
+  local hit = ctx.cache[cache_key]
+  if hit == nil then
+    -- Not yet fetched.
+    local result = fetch_fn()
+    ctx.cache[cache_key] = (result == nil) and CACHE_MISS or result
+    return result
+  elseif hit == CACHE_MISS then
+    return nil -- previously fetched, was nil
+  else
+    return hit
+  end
 end
 
 -- ---------------------------------------------------------------------------
@@ -807,6 +842,7 @@ function graphql_handler() -- luacheck: globals graphql_handler
     variables = variables,
     errors = {},
     path = {},
+    cache = {}, -- request-scoped cache; see graphql_cached
   }
   -- Build variable_defs lookup: name → VariableDefinitionNode (for default values).
   ctx.variable_defs = {}

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -732,6 +732,26 @@ function graphql_handler() -- luacheck: globals graphql_handler
   -- Step 1: decode request body.
   local raw = GetBody() or ""
   local req = DecodeJson(raw)
+  -- Step 1a: array body → batch request (rejected in Phase 1).
+  if type(req) == "table" and req[1] ~= nil then
+    respond_json(400, {
+      errors = {
+        { message = "GraphQL request batching is not supported; send one operation per request." },
+      },
+    })
+    return
+  end
+  -- Step 1b: APQ body → persisted queries not supported.
+  if type(req) == "table" and type(req.extensions) == "table" and req.extensions.persistedQuery then
+    respond_graphql(nil, {
+      {
+        message = "Persisted queries are not supported; send the full query string.",
+        extensions = { code = "PERSISTED_QUERY_NOT_SUPPORTED" },
+      },
+    })
+    return
+  end
+  -- Step 1c: missing or non-string query field.
   if not req or type(req.query) ~= "string" then
     respond_graphql(nil, {
       {

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -639,13 +639,19 @@ graphql_resolvers["Query.nodes"] = function(_parent, args, ctx)
 end
 
 -- ---------------------------------------------------------------------------
--- estimate_query_cost
+-- estimate_query_cost / GRAPHQL_MAX_COST
 -- ---------------------------------------------------------------------------
+
+-- Maximum allowed estimated query cost.  Queries whose estimated cost exceeds
+-- this value are rejected before execution.  The default (10000) is enough for
+-- practical GitHub CLI and Octokit queries; override in Phase 2 via SCRIPTARGS.
+local GRAPHQL_MAX_COST = 10000
 
 -- Lightweight pre-execution cost estimator.  Walks the operation's selection
 -- set counting connection argument values (first/last), multiplying for nested
 -- connections.  The result is stored in ctx.rate_cost before execution so that
--- the Query.rateLimit resolver can report a non-zero cost value.
+-- the Query.rateLimit resolver can report a non-zero cost value, and so that
+-- the cost-limit gate can reject runaway queries before execution begins.
 --
 -- Cost rules (mirrors GitHub's documented model):
 --   - Each field with a first/last argument contributes (multiplier × value).
@@ -654,8 +660,7 @@ end
 --   - Minimum returned value is 1 (math.max(1, total)).
 --
 -- This is best-effort: fragment spreads are not walked in Phase 1, and
--- @skip/@include directives are not applied.  The value is used only to
--- populate rateLimit.cost for observability; it has no enforcement effect.
+-- @skip/@include directives are not applied.
 function estimate_query_cost(op, variables) -- luacheck: globals estimate_query_cost
   local cost = 0
   -- We need a minimal ctx for coerce_value (Variable nodes require variables +
@@ -810,6 +815,23 @@ function graphql_handler() -- luacheck: globals graphql_handler
   end
   -- Estimate query cost before execution so rateLimit.cost reflects this query.
   ctx.rate_cost = estimate_query_cost(op, variables)
+  -- Step 5a: reject queries that exceed the cost ceiling.
+  if ctx.rate_cost > GRAPHQL_MAX_COST then
+    respond_graphql(nil, {
+      {
+        message = "query cost "
+          .. tostring(ctx.rate_cost)
+          .. " exceeds maximum allowed cost of "
+          .. tostring(GRAPHQL_MAX_COST),
+        extensions = {
+          code = "BAD_USER_INPUT",
+          estimatedCost = ctx.rate_cost,
+          maxAllowedCost = GRAPHQL_MAX_COST,
+        },
+      },
+    })
+    return
+  end
   local data = execute_operation(op, ctx)
 
   -- Step 6: write response.

--- a/internal/http.lua
+++ b/internal/http.lua
@@ -8,6 +8,7 @@ local HTTP_STATUS_TEXT = {
   [201] = "Created",
   [204] = "No Content",
   [302] = "Found",
+  [400] = "Bad Request",
   [401] = "Unauthorized",
   [404] = "Not Found",
   [405] = "Method Not Allowed",

--- a/test/graphql-batching-caching.lua
+++ b/test/graphql-batching-caching.lua
@@ -140,6 +140,76 @@ do -- APQ body that also includes a query field is still rejected
 end
 
 -- ============================================================
+-- Cost-limit enforcement
+-- ============================================================
+
+-- Helper: parse source and return the first OperationDefinition.
+local function parse_op(src)
+  local doc, err = graphql_parse(src) -- luacheck: globals graphql_parse
+  if not doc then
+    error("parse failed: " .. tostring(err))
+  end
+  return doc.definitions[1]
+end
+
+do -- 100×100 nested connection → cost 10100 (100 outer + 100*100 inner)
+  -- outer first:100 → 100; inner first:100 per outer item → 100*100 = 10000; total = 10100
+  local op =
+    parse_op("{ repositories(first: 100) { nodes { issues(first: 100) { nodes { title } } } } }")
+  local cost = estimate_query_cost(op, {}) -- luacheck: globals estimate_query_cost
+  ok(
+    cost > 10000,
+    "cost: 100×100 nested connection exceeds GRAPHQL_MAX_COST (got " .. tostring(cost) .. ")"
+  )
+end
+
+do -- cost enforcement gate: query over ceiling → data:null, BAD_USER_INPUT, estimatedCost
+  -- Stub estimate_query_cost to return 10001 so validation (run first) can pass on a
+  -- simple schema-valid query, while the cost gate still fires as intended.
+  local _saved = estimate_query_cost -- luacheck: globals estimate_query_cost
+  estimate_query_cost = function(_op, _vars)
+    return 10001
+  end -- luacheck: globals estimate_query_cost
+  local status, r = run_handler(EncodeJson({ query = "{ rateLimit { cost } }" }))
+  estimate_query_cost = _saved -- luacheck: globals estimate_query_cost
+  eq(status, 200, "cost-limit: HTTP 200 (GraphQL-layer rejection)")
+  ok(r ~= nil, "cost-limit: response is valid JSON")
+  ok(r.errors ~= nil and #r.errors == 1, "cost-limit: exactly one error")
+  eq(r.errors[1].extensions.code, "BAD_USER_INPUT", "cost-limit: error code BAD_USER_INPUT")
+  eq(r.errors[1].extensions.estimatedCost, 10001, "cost-limit: estimatedCost is 10001")
+  eq(r.errors[1].extensions.maxAllowedCost, 10000, "cost-limit: maxAllowedCost is 10000")
+  ok(
+    type(r.errors[1].message) == "string" and r.errors[1].message:find("exceeds") ~= nil,
+    "cost-limit: message mentions exceeds"
+  )
+end
+
+do -- cost enforcement gate: cost exactly at ceiling (==10000) is allowed through
+  local _saved = estimate_query_cost -- luacheck: globals estimate_query_cost
+  estimate_query_cost = function(_op, _vars)
+    return 10000
+  end -- luacheck: globals estimate_query_cost
+  local status, r = run_handler(EncodeJson({ query = "{ rateLimit { cost } }" }))
+  estimate_query_cost = _saved -- luacheck: globals estimate_query_cost
+  eq(status, 200, "cost-limit: cost==10000 → HTTP 200")
+  ok(
+    r.errors == nil or #r.errors == 0 or r.errors[1].extensions.code ~= "BAD_USER_INPUT",
+    "cost-limit: cost==10000 allowed through (not rejected as cost-limit error)"
+  )
+end
+
+do -- introspection query has cost 1, well below ceiling → allowed
+  local body = EncodeJson({ query = "{ __schema { types { name } } }" })
+  local status, r = run_handler(body)
+  eq(status, 200, "cost-limit: introspection → HTTP 200")
+  ok(
+    r.errors == nil or #r.errors == 0 or r.errors[1].extensions.code ~= "BAD_USER_INPUT",
+    "cost-limit: introspection not rejected by cost enforcement"
+  )
+  ok(r.data ~= nil, "cost-limit: introspection returns data")
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 

--- a/test/graphql-batching-caching.lua
+++ b/test/graphql-batching-caching.lua
@@ -210,6 +210,90 @@ do -- introspection query has cost 1, well below ceiling → allowed
 end
 
 -- ============================================================
+-- graphql_cached
+-- ============================================================
+-- luacheck: globals graphql_cached
+
+-- Build a minimal ctx with an empty cache (mirrors graphql_handler's ctx init).
+local function make_cache_ctx()
+  return { errors = {}, path = {}, cache = {} }
+end
+
+do -- first call invokes fetch_fn and returns its result
+  local calls = 0
+  local ctx = make_cache_ctx()
+  local result = graphql_cached(ctx, "User:fido", function()
+    calls = calls + 1
+    return { login = "fido" }
+  end)
+  eq(calls, 1, "graphql_cached: first call invokes fetch_fn once")
+  ok(result ~= nil and result.login == "fido", "graphql_cached: first call returns fetch result")
+end
+
+do -- second call with same key returns cached value without re-invoking fetch_fn
+  local calls = 0
+  local ctx = make_cache_ctx()
+  local function fetch()
+    calls = calls + 1
+    return { login = "fido" }
+  end
+  graphql_cached(ctx, "User:fido", fetch)
+  local result2 = graphql_cached(ctx, "User:fido", fetch)
+  eq(calls, 1, "graphql_cached: second call does not invoke fetch_fn again")
+  ok(result2 ~= nil and result2.login == "fido", "graphql_cached: second call returns cached value")
+end
+
+do -- nil result is cached via CACHE_MISS sentinel; second call returns nil without fetch
+  local calls = 0
+  local ctx = make_cache_ctx()
+  local function fetch()
+    calls = calls + 1
+    return nil
+  end
+  local r1 = graphql_cached(ctx, "User:ghost", fetch)
+  local r2 = graphql_cached(ctx, "User:ghost", fetch)
+  eq(calls, 1, "graphql_cached: nil result cached; fetch_fn not called again")
+  ok(r1 == nil, "graphql_cached: first call returns nil when fetch_fn returns nil")
+  ok(r2 == nil, "graphql_cached: second call returns nil (from cache, not re-fetch)")
+end
+
+do -- different keys are independent; each invokes its own fetch_fn
+  local calls_a, calls_b = 0, 0
+  local ctx = make_cache_ctx()
+  graphql_cached(ctx, "User:alice", function()
+    calls_a = calls_a + 1
+    return { login = "alice" }
+  end)
+  graphql_cached(ctx, "User:bob", function()
+    calls_b = calls_b + 1
+    return { login = "bob" }
+  end)
+  eq(calls_a, 1, "graphql_cached: key alice fetched once")
+  eq(calls_b, 1, "graphql_cached: key bob fetched once (independent)")
+end
+
+do -- request-scoped isolation: two separate ctx tables share no cache state
+  local calls = 0
+  local function fetch()
+    calls = calls + 1
+    return { login = "fido" }
+  end
+  local ctx1 = make_cache_ctx()
+  local ctx2 = make_cache_ctx()
+  graphql_cached(ctx1, "User:fido", fetch)
+  graphql_cached(ctx2, "User:fido", fetch)
+  eq(calls, 2, "graphql_cached: separate ctx tables each invoke fetch_fn (no cross-request bleed)")
+end
+
+do -- ctx.cache is initialised by graphql_handler (verified via a handler round-trip)
+  -- The handler sets ctx.cache = {}; resolvers that call graphql_cached must not panic.
+  -- Use the rateLimit query (no backend needed) to exercise the full handler path.
+  local status, r = run_handler(EncodeJson({ query = "{ rateLimit { cost } }" }))
+  eq(status, 200, "graphql_cached: handler initialises ctx.cache (rateLimit round-trip → 200)")
+  ok(r ~= nil and r.data ~= nil, "graphql_cached: handler response has data")
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 

--- a/test/graphql-batching-caching.lua
+++ b/test/graphql-batching-caching.lua
@@ -1,0 +1,149 @@
+-- Unit tests for batch/APQ rejection, cost-limit enforcement, and request-scoped cache.
+-- Run: sh redbean.com -i test/graphql-batching-caching.lua
+-- ============================================================
+
+-- Stub Redbean HTTP context APIs needed by http.lua and graphql_executor.lua.
+-- luacheck: push
+-- luacheck: globals SetStatus SetHeader Write GetBody
+SetStatus = function(_code, _reason) end
+SetHeader = function(_k, _v) end
+Write = function(_s) end
+GetBody = function()
+  return nil
+end
+-- luacheck: pop
+
+-- Redirect /zip/internal/ → internal/ so tests run without a Redbean zip context.
+local _real_dofile = dofile
+function dofile(path) -- luacheck: globals dofile
+  if path and path:match("^/zip/internal/") then
+    return _real_dofile(path:sub(6))
+  end
+  return _real_dofile(path)
+end
+
+dofile("internal/graphql_parser.lua")
+dofile("internal/graphql_schema_data.lua")
+dofile("internal/graphql_schema.lua")
+dofile("internal/http.lua")
+dofile("internal/graphql_translators.lua")
+dofile("internal/graphql_executor.lua")
+
+dofile = _real_dofile -- luacheck: globals dofile
+
+-- ============================================================
+-- Assertion helpers
+-- ============================================================
+
+local PASS, FAIL = 0, 0
+
+local function ok(cond, msg)
+  if cond then
+    PASS = PASS + 1
+    io.write("PASS  " .. msg .. "\n")
+  else
+    FAIL = FAIL + 1
+    io.write("FAIL  " .. msg .. "\n")
+  end
+end
+
+local function eq(a, b, msg)
+  ok(a == b, msg .. " (got " .. tostring(a) .. ", want " .. tostring(b) .. ")")
+end
+
+-- run_handler: invoke graphql_handler() with a given request body, capturing
+-- the HTTP status code and response body.  Returns (status, decoded_body).
+local function run_handler(body_str)
+  local captured_status = nil
+  local captured_body = ""
+  local saved_set_status = SetStatus -- luacheck: globals SetStatus
+  local saved_write = Write -- luacheck: globals Write
+  local saved_get_body = GetBody -- luacheck: globals GetBody
+  SetStatus = function(code, _reason)
+    captured_status = code
+  end -- luacheck: globals SetStatus
+  Write = function(s)
+    captured_body = captured_body .. tostring(s)
+  end -- luacheck: globals Write
+  GetBody = function()
+    return body_str
+  end -- luacheck: globals GetBody
+  graphql_handler() -- luacheck: globals graphql_handler
+  SetStatus = saved_set_status -- luacheck: globals SetStatus
+  Write = saved_write -- luacheck: globals Write
+  GetBody = saved_get_body -- luacheck: globals GetBody
+  return captured_status, DecodeJson(captured_body)
+end
+
+-- ============================================================
+-- Batch rejection
+-- ============================================================
+
+do -- array body → HTTP 400, batching-not-supported message
+  local body = '[{"query":"{ viewer { login } }"},{"query":"{ rateLimit { cost } }"}]'
+  local status, r = run_handler(body)
+  eq(status, 400, "batch: array body → HTTP 400")
+  ok(r ~= nil, "batch: response is valid JSON")
+  ok(r.errors ~= nil and #r.errors == 1, "batch: exactly one error in response")
+  ok(
+    type(r.errors[1].message) == "string" and r.errors[1].message:find("batching") ~= nil,
+    "batch: error message mentions batching"
+  )
+end
+
+do -- single-element array body also rejected (still a batch)
+  local body = '[{"query":"{ viewer { login } }"}]'
+  local status, r = run_handler(body)
+  eq(status, 400, "batch: single-element array → HTTP 400")
+  ok(r.errors ~= nil and #r.errors == 1, "batch: single-element array → one error")
+end
+
+-- ============================================================
+-- APQ rejection
+-- ============================================================
+
+do -- APQ body (no query, has extensions.persistedQuery) → PERSISTED_QUERY_NOT_SUPPORTED
+  local body = EncodeJson({
+    extensions = {
+      persistedQuery = { version = 1, sha256Hash = "abc123deadbeef" },
+    },
+  })
+  local status, r = run_handler(body)
+  eq(status, 200, "APQ: HTTP 200 (GraphQL-layer error)")
+  ok(r ~= nil, "APQ: response is valid JSON")
+  ok(r.errors ~= nil and #r.errors == 1, "APQ: exactly one error in response")
+  eq(
+    r.errors[1].extensions.code,
+    "PERSISTED_QUERY_NOT_SUPPORTED",
+    "APQ: error code is PERSISTED_QUERY_NOT_SUPPORTED"
+  )
+  ok(
+    type(r.errors[1].message) == "string" and r.errors[1].message:find("Persisted") ~= nil,
+    "APQ: message mentions persisted queries"
+  )
+end
+
+do -- APQ body that also includes a query field is still rejected
+  local body = EncodeJson({
+    query = "{ viewer { login } }",
+    extensions = {
+      persistedQuery = { version = 1, sha256Hash = "abc123deadbeef" },
+    },
+  })
+  local status, r = run_handler(body)
+  eq(status, 200, "APQ+query: HTTP 200 (GraphQL-layer error)")
+  eq(
+    r.errors[1].extensions.code,
+    "PERSISTED_QUERY_NOT_SUPPORTED",
+    "APQ+query: still rejected with PERSISTED_QUERY_NOT_SUPPORTED"
+  )
+end
+
+-- ============================================================
+-- Summary
+-- ============================================================
+
+io.write(string.format("\n%d passed, %d failed\n", PASS, FAIL))
+if FAIL > 0 then
+  os.exit(1)
+end


### PR DESCRIPTION
Fixes #147.

Implements GQL-09: batch request rejection (HTTP 400 for array bodies), APQ rejection with standard `PERSISTED_QUERY_NOT_SUPPORTED` fallback code, cost-limit enforcement via a `GRAPHQL_MAX_COST` ceiling that gates execution, and a request-scoped `graphql_cached` helper for deduplicating REST calls within a single query.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Reject batch requests and APQ payloads in graphql_handler <!-- type:spec -->
- [x] Add cost-limit enforcement with GRAPHQL_MAX_COST ceiling <!-- type:spec -->
- [x] Add request-scoped cache with graphql_cached helper <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->