### PR TITLE
GraphQL: GQL-10 - Register Gitea GraphQL resolvers (closes #148)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -113,4 +113,5 @@ globals = {
 -- Exclude auto-generated files from linting
 exclude_files = {
   "internal/graphql_schema_data.lua",
+  ".claude/",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -106,6 +106,7 @@ globals = {
   "graphql_translate_commit",
   "graphql_translate_ref",
   "graphql_translate_release",
+  "graphql_translate_review",
   "graphql_translate_reaction",
 }
 

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3357,6 +3357,123 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
   return graphql_translate_label(translate_gitea_label(data), owner, repo)
 end
 
+-- ---------------------------------------------------------------------------
+-- Repository connection sub-resolvers
+-- ---------------------------------------------------------------------------
+-- Local helper: build a paginated Relay Connection from a Gitea list endpoint.
+-- Fetches page from graphql_cursor_url(base_suffix, args, {per_page="limit", page="page"}),
+-- reads X-Total / X-Total-Count for totalCount, translates items with translate_fn(item),
+-- and delegates to make_conn(nodes, args, total, ctx).
+local function gitea_repo_connection(owner, repo, suffix, args, ctx, translate_fn, make_conn)
+  local url = graphql_cursor_url(
+    base() .. "/repos/" .. owner .. "/" .. repo .. suffix,
+    args,
+    { per_page = "limit", page = "page" }
+  )
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  local nodes = {}
+  for _, item in ipairs(data) do
+    nodes[#nodes + 1] = translate_fn(item)
+  end
+  return make_conn(nodes, args, total, ctx)
+end
+
+-- Repository.issues: paginated list of issues (excluding pull requests).
+-- Passes type=issues so Gitea omits PRs from the response.
+graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gitea_repo_connection(owner, name, "/issues?type=issues", args, ctx, function(i)
+    return graphql_translate_issue(translate_gitea_issue(i), owner, name)
+  end, graphql_issues_connection)
+end
+
+-- Repository.pullRequests: paginated list of pull requests.
+graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gitea_repo_connection(owner, name, "/pulls", args, ctx, function(p)
+    return graphql_translate_pr(translate_gitea_pull(p), owner, name)
+  end, graphql_prs_connection)
+end
+
+-- Repository.releases: paginated list of releases.
+-- Gitea release objects are already GitHub-REST-compatible; no intermediate translator needed.
+graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gitea_repo_connection(owner, name, "/releases", args, ctx, function(r)
+    return graphql_translate_release(r, owner, name)
+  end, function(n, a, t, c)
+    return graphql_make_connection("Release", n, a, t, c)
+  end)
+end
+
+-- Repository.labels: paginated list of labels.
+graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gitea_repo_connection(owner, name, "/labels", args, ctx, function(l)
+    return graphql_translate_label(translate_gitea_label(l), owner, name)
+  end, graphql_labels_connection)
+end
+
+-- Repository.milestones: paginated list of milestones.
+graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gitea_repo_connection(owner, name, "/milestones", args, ctx, function(m)
+    return graphql_translate_milestone(translate_gitea_milestone(m), owner, name)
+  end, function(n, a, t, c)
+    return graphql_make_connection("Milestone", n, a, t, c)
+  end)
+end
+
+-- Repository.refs: paginated list of branches as Ref objects.
+-- Gitea branch objects use commit.id for the SHA; we normalise to commit.sha before
+-- passing to graphql_translate_ref (which uses r.commit.sha).
+graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gitea_repo_connection(owner, name, "/branches", args, ctx, function(b)
+    if b.commit then
+      b.commit.sha = b.commit.id
+    end
+    return graphql_translate_ref(b, parent)
+  end, graphql_refs_connection)
+end
+
+-- Repository.collaborators: paginated list of collaborators as Users.
+graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gitea_repo_connection(owner, name, "/collaborators", args, ctx, function(u)
+    return graphql_translate_user(translate_user(u))
+  end, function(n, a, t, c)
+    return graphql_make_connection("RepositoryCollaborator", n, a, t, c)
+  end)
+end
+
 -- Repository.defaultBranchRef: enrich the inline stub with full branch data.
 -- The parent already carries {__typename="Ref",name="main"} from graphql_translate_repo.
 -- This resolver makes a second call to get the commit SHA.

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3640,3 +3640,97 @@ graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
     edges = edges,
   }
 end
+
+-- ---------------------------------------------------------------------------
+-- Query.search
+-- ---------------------------------------------------------------------------
+
+-- search_fetch: fetch a Gitea search endpoint and return the item array.
+-- Gitea repo/user search wraps results in {"data":[...]}: pass container="data".
+-- Gitea issue search returns a plain array: pass container=nil.
+local function search_fetch(url, container)
+  local data, _, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    return nil, err
+  end
+  if container then
+    return type(data[container]) == "table" and data[container] or {}, nil
+  end
+  return type(data) == "table" and data or {}, nil
+end
+
+-- Query.search: map GitHub GraphQL search to Gitea search endpoints.
+-- Supports REPOSITORY, USER, and ISSUE types; all others return empty.
+graphql_resolvers["Query.search"] = function(_parent, args, ctx)
+  local query = args.query or ""
+  local search_type = args.type or "REPOSITORY"
+  local per_page = args.first or 30
+  local q = EscapeParam(query)
+
+  local nodes = {}
+  local repo_count, user_count, issue_count = 0, 0, 0
+
+  if search_type == "REPOSITORY" then
+    local list, err =
+      search_fetch(base() .. "/repos/search?q=" .. q .. "&limit=" .. per_page, "data")
+    if not list then
+      graphql_error(ctx, err)
+    else
+      for _, r in ipairs(list) do
+        nodes[#nodes + 1] = graphql_translate_repo(translate_repo(r))
+      end
+      repo_count = #nodes
+    end
+  elseif search_type == "USER" then
+    local list, err =
+      search_fetch(base() .. "/users/search?q=" .. q .. "&limit=" .. per_page, "data")
+    if not list then
+      graphql_error(ctx, err)
+    else
+      for _, u in ipairs(list) do
+        nodes[#nodes + 1] = graphql_translate_user(translate_user(u))
+      end
+      user_count = #nodes
+    end
+  elseif search_type == "ISSUE" then
+    local list, err = search_fetch(
+      base() .. "/repos/issues/search?q=" .. q .. "&type=issues&limit=" .. per_page,
+      nil
+    )
+    if not list then
+      graphql_error(ctx, err)
+    else
+      for _, i in ipairs(list) do
+        nodes[#nodes + 1] = graphql_translate_issue(translate_gitea_issue(i))
+      end
+      issue_count = #nodes
+    end
+  end
+
+  local edges = {}
+  for _, node in ipairs(nodes) do
+    edges[#edges + 1] = {
+      __typename = "SearchResultItemEdge",
+      cursor = graphql_page_to_cursor(1),
+      node = node,
+    }
+  end
+  return {
+    __typename = "SearchResultItemConnection",
+    nodes = nodes,
+    edges = edges,
+    pageInfo = {
+      __typename = "PageInfo",
+      hasNextPage = false,
+      hasPreviousPage = false,
+      startCursor = #nodes > 0 and graphql_page_to_cursor(1) or nil,
+      endCursor = #nodes > 0 and graphql_page_to_cursor(1) or nil,
+    },
+    repositoryCount = repo_count,
+    userCount = user_count,
+    issueCount = issue_count,
+    codeCount = 0,
+    discussionCount = 0,
+    wikiCount = 0,
+  }
+end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3286,3 +3286,73 @@ graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
   end
   return graphql_translate_comment(translate_gitea_issue_comment(data), owner, repo)
 end
+
+-- Query.user: look up a User by login.
+-- Returns nil (and no error) when the user does not exist.
+graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "user requires a login argument")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. args.login)
+  if not data then
+    return nil
+  end
+  return graphql_translate_user(translate_user(data))
+end
+
+-- Query.organization: look up an Organization by login.
+-- Returns nil (and no error) when the organization does not exist.
+graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "organization requires a login argument")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/orgs/" .. args.login)
+  if not data then
+    return nil
+  end
+  return graphql_translate_org(data)
+end
+
+-- Query.repository: look up a Repository by owner login and repo name.
+-- Returns nil (and no error) when the repository does not exist.
+graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+  if not args.owner or not args.name then
+    graphql_error(ctx, "repository requires owner and name arguments")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/repos/" .. args.owner .. "/" .. args.name)
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_repo(data))
+end
+
+-- node.Release: fetch a release by "owner/repo/release_id" local ID.
+graphql_resolvers["node.Release"] = function(local_id, _ctx)
+  local owner, repo, rid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/releases/" .. rid)
+  if not data then
+    return nil
+  end
+  return graphql_translate_release(data, owner, repo)
+end
+
+-- node.Label: fetch a label by "owner/repo/label_id" local ID.
+graphql_resolvers["node.Label"] = function(local_id, _ctx)
+  local owner, repo, lid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/labels/" .. lid)
+  if not data then
+    return nil
+  end
+  return graphql_translate_label(translate_gitea_label(data), owner, repo)
+end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3492,6 +3492,75 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   return graphql_make_connection("IssueComment", nodes, args, total, ctx)
 end
 
+-- PullRequest.commits: paginated commit list for a pull request.
+-- Decodes the PullRequest node ID (PullRequest:owner/repo/number) for coordinates,
+-- then fetches /api/v1/repos/{owner}/{repo}/pulls/{number}/commits.
+graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local url = graphql_cursor_url(
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits",
+    args,
+    { per_page = "limit", page = "page" }
+  )
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  -- PullRequest.commits returns PullRequestCommitConnection, whose nodes are
+  -- PullRequestCommit objects (not bare Commit objects).  Each PullRequestCommit
+  -- wraps the Commit so clients can query commits { nodes { commit { oid } } }.
+  local nodes = {}
+  for _, c in ipairs(data) do
+    local sha = c.sha or (c.commit and c.commit.id) or ""
+    nodes[#nodes + 1] = {
+      __typename = "PullRequestCommit",
+      id = encode_node_id("PullRequestCommit", sha),
+      commit = graphql_translate_commit(c),
+      url = c.html_url,
+    }
+  end
+  return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
+end
+
+-- PullRequest.reviews: paginated review list for a pull request.
+graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local url = graphql_cursor_url(
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/reviews",
+    args,
+    { per_page = "limit", page = "page" }
+  )
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  local nodes = {}
+  for _, r in ipairs(data) do
+    nodes[#nodes + 1] = graphql_translate_review(translate_gitea_review(r), owner, repo)
+  end
+  return graphql_make_connection("PullRequestReview", nodes, args, total, ctx)
+end
+
 -- Repository.collaborators: paginated list of collaborators as Users.
 graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3356,3 +3356,70 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
   end
   return graphql_translate_label(translate_gitea_label(data), owner, repo)
 end
+
+-- Repository.defaultBranchRef: enrich the inline stub with full branch data.
+-- The parent already carries {__typename="Ref",name="main"} from graphql_translate_repo.
+-- This resolver makes a second call to get the commit SHA.
+-- Gitea branch objects use commit.id for the SHA; we normalise to commit.sha before
+-- passing to graphql_translate_ref.
+graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
+  local branch = parent.defaultBranchRef and parent.defaultBranchRef.name
+  if not branch then
+    return nil
+  end
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. name .. "/branches/" .. branch)
+  if not data then
+    return nil
+  end
+  if data.commit then
+    data.commit.sha = data.commit.id
+  end
+  return graphql_translate_ref(data, parent)
+end
+
+-- Repository.languages: fetch language byte-count breakdown as a LanguageConnection.
+-- Gitea returns {"Language": bytes, ...}; we convert to the Relay Connection shape.
+-- Language colours are not available from Gitea's API; color is always nil.
+graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. name .. "/languages")
+  if not data then
+    return nil
+  end
+  local nodes, edges = {}, {}
+  local total_size = 0
+  for lang_name, size in pairs(data) do
+    total_size = total_size + size
+    local node = {
+      __typename = "Language",
+      id = encode_node_id("Language", lang_name),
+      name = lang_name,
+      color = nil,
+    }
+    nodes[#nodes + 1] = node
+    edges[#edges + 1] = { cursor = "", node = node, size = size }
+  end
+  return {
+    __typename = "LanguageConnection",
+    totalCount = #nodes,
+    totalSize = total_size,
+    pageInfo = {
+      __typename = "PageInfo",
+      hasNextPage = false,
+      hasPreviousPage = false,
+      startCursor = nil,
+      endCursor = nil,
+    },
+    nodes = nodes,
+    edges = edges,
+  }
+end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3461,6 +3461,37 @@ graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
   end, graphql_refs_connection)
 end
 
+-- Issue.comments: paginated list of comments for a single issue.
+-- Decodes the Issue node ID to extract owner/repo/number, then fetches
+-- /api/v1/repos/{owner}/{repo}/issues/{number}/comments.
+graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local url = graphql_cursor_url(
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments",
+    args,
+    { per_page = "limit", page = "page" }
+  )
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  local nodes = {}
+  for _, c in ipairs(data) do
+    nodes[#nodes + 1] = graphql_translate_comment(translate_gitea_issue_comment(c), owner, repo)
+  end
+  return graphql_make_connection("IssueComment", nodes, args, total, ctx)
+end
+
 -- Repository.collaborators: paginated list of collaborators as Users.
 graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")

--- a/internal/graphql_translators.lua
+++ b/internal/graphql_translators.lua
@@ -33,6 +33,7 @@
 --   graphql_translate_commit(c)
 --   graphql_translate_ref(r, repo)
 --   graphql_translate_release(r[, owner, repo])
+--   graphql_translate_review(r[, owner, repo])
 --   graphql_translate_reaction(r)
 
 -- ---------------------------------------------------------------------------
@@ -671,6 +672,34 @@ function graphql_translate_pr(p, owner, repo) -- luacheck: globals graphql_trans
     createdAt = p.created_at,
     updatedAt = p.updated_at,
     closedAt = p.closed_at,
+  }
+end
+
+-- graphql_translate_review is global: converts a GitHub REST pull request review to GraphQL shape.
+-- owner and repo are optional; when provided they give the review a resolvable node ID.
+-- GitHub REST uses state "COMMENT" but GraphQL enum uses "COMMENTED"; normalised here.
+function graphql_translate_review(r, owner, repo) -- luacheck: globals graphql_translate_review
+  if not r then
+    return nil
+  end
+  local local_id
+  if owner and repo then
+    local_id = owner .. "/" .. repo .. "/" .. tostring(r.id or "")
+  else
+    local_id = tostring(r.id or "")
+  end
+  local state = r.state or "COMMENTED"
+  if state == "COMMENT" then
+    state = "COMMENTED"
+  end
+  return {
+    __typename = "PullRequestReview",
+    id = encode_node_id("PullRequestReview", local_id),
+    body = (r.body and r.body ~= "") and r.body or nil,
+    state = state,
+    author = r.user and graphql_translate_user(r.user) or nil,
+    submittedAt = r.submitted_at,
+    url = r.html_url,
   }
 end
 

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -126,3 +126,83 @@ HTTP 200
 jsonpath "$.data.repository.languages.totalCount" == 2
 jsonpath "$.data.repository.languages.totalSize" == 19134
 jsonpath "$.data.repository.languages.nodes" isCollection
+
+# POST /graphql — Repository.issues returns an IssueConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues { nodes { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.issues.nodes" isCollection
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+jsonpath "$.data.repository.issues.nodes[0].title" == "Found a bug"
+jsonpath "$.data.repository.issues.nodes[0].state" == "OPEN"
+
+# POST /graphql — Repository.pullRequests returns a PullRequestConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { pullRequests { nodes { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.pullRequests.nodes" isCollection
+jsonpath "$.data.repository.pullRequests.nodes[0].number" == 1
+jsonpath "$.data.repository.pullRequests.nodes[0].title" == "A great PR"
+jsonpath "$.data.repository.pullRequests.nodes[0].state" == "OPEN"
+
+# POST /graphql — Repository.releases returns a ReleaseConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { releases { nodes { tagName name isDraft isPrerelease } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.releases.nodes" isCollection
+jsonpath "$.data.repository.releases.nodes[0].tagName" == "v1.0"
+jsonpath "$.data.repository.releases.nodes[0].name" == "Release 1.0"
+jsonpath "$.data.repository.releases.nodes[0].isDraft" == false
+jsonpath "$.data.repository.releases.nodes[0].isPrerelease" == false
+
+# POST /graphql — Repository.labels returns a LabelConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { labels { nodes { name color } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.labels.nodes" isCollection
+jsonpath "$.data.repository.labels.nodes[0].name" == "bug"
+jsonpath "$.data.repository.labels.nodes[0].color" == "d73a4a"
+
+# POST /graphql — Repository.milestones returns a MilestoneConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { milestones { nodes { title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.milestones.nodes" isCollection
+jsonpath "$.data.repository.milestones.nodes[0].title" == "v1.0"
+jsonpath "$.data.repository.milestones.nodes[0].state" == "OPEN"
+
+# POST /graphql — Repository.refs returns a RefConnection (branches)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { refs { nodes { name target { oid } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.refs.nodes" isCollection
+jsonpath "$.data.repository.refs.nodes[0].name" == "main"
+jsonpath "$.data.repository.refs.nodes[0].target.oid" == "abc123def456"
+
+# POST /graphql — Repository.collaborators returns a RepositoryCollaboratorConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { collaborators { nodes { login } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.collaborators.nodes" isCollection
+jsonpath "$.data.repository.collaborators.nodes[0].login" == "octocat"

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -36,3 +36,63 @@ jsonpath "$.data.viewer.websiteUrl" == "https://github.blog"
 jsonpath "$.data.viewer.url" == "http://localhost/octocat"
 jsonpath "$.data.viewer.isViewer" == true
 jsonpath "$.data.viewer.isSiteAdmin" == false
+
+# POST /graphql — Query.user returns a user by login
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ user(login: \"octocat\") { login name email location websiteUrl url } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.user.login" == "octocat"
+jsonpath "$.data.user.name" == "The Octocat"
+jsonpath "$.data.user.email" == "octocat@github.com"
+jsonpath "$.data.user.location" == "San Francisco"
+jsonpath "$.data.user.websiteUrl" == "https://github.blog"
+jsonpath "$.data.user.url" == "http://localhost/octocat"
+
+# POST /graphql — Query.organization returns an organization by login
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ organization(login: \"testorg\") { login name description } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.organization.login" == "testorg"
+jsonpath "$.data.organization.name" == "Test Organization"
+jsonpath "$.data.organization.description" == "A test org"
+
+# POST /graphql — Query.repository returns a repository by owner and name
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { name nameWithOwner description } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.name" == "hello-world"
+jsonpath "$.data.repository.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.repository.description" == "My first repo"
+
+# POST /graphql — node(Release) fetches a release by encoded node ID
+# Node ID for Release:octocat/hello-world/1 = UmVsZWFzZTpvY3RvY2F0L2hlbGxvLXdvcmxkLzE=
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"UmVsZWFzZTpvY3RvY2F0L2hlbGxvLXdvcmxkLzE=\") { ... on Release { tagName name isDraft isPrerelease } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.tagName" == "v1.0"
+jsonpath "$.data.node.name" == "Release 1.0"
+jsonpath "$.data.node.isDraft" == false
+jsonpath "$.data.node.isPrerelease" == false
+
+# POST /graphql — node(Label) fetches a label by encoded node ID
+# Node ID for Label:octocat/hello-world/1 = TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x\") { ... on Label { name color } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "bug"
+jsonpath "$.data.node.color" == "d73a4a"

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -241,3 +241,39 @@ jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes" isCollection
 jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].state" == "APPROVED"
 jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].body" == "Looks good!"
 jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].author.login" == "octocat"
+
+# POST /graphql — Query.search REPOSITORY returns a SearchResultItemConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ search(query: \"hello\", type: REPOSITORY, first: 5) { repositoryCount nodes { ... on Repository { name nameWithOwner } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.search.repositoryCount" == 1
+jsonpath "$.data.search.nodes" isCollection
+jsonpath "$.data.search.nodes[0].name" == "hello-world"
+jsonpath "$.data.search.nodes[0].nameWithOwner" == "octocat/hello-world"
+
+# POST /graphql — Query.search USER returns a SearchResultItemConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ search(query: \"octocat\", type: USER, first: 5) { userCount nodes { ... on User { login } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.search.userCount" == 1
+jsonpath "$.data.search.nodes" isCollection
+jsonpath "$.data.search.nodes[0].login" == "octocat"
+
+# POST /graphql — Query.search ISSUE returns a SearchResultItemConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ search(query: \"bug\", type: ISSUE, first: 5) { issueCount nodes { ... on Issue { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.search.issueCount" == 1
+jsonpath "$.data.search.nodes" isCollection
+jsonpath "$.data.search.nodes[0].number" == 1
+jsonpath "$.data.search.nodes[0].title" == "Found a bug"
+jsonpath "$.data.search.nodes[0].state" == "OPEN"

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -197,6 +197,18 @@ jsonpath "$.data.repository.refs.nodes" isCollection
 jsonpath "$.data.repository.refs.nodes[0].name" == "main"
 jsonpath "$.data.repository.refs.nodes[0].target.oid" == "abc123def456"
 
+# POST /graphql — Issue.comments returns an IssueCommentConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues { nodes { number comments { nodes { body author { login } } } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes" isCollection
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes[0].body" == "This is a comment"
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes[0].author.login" == "octocat"
+
 # POST /graphql — Repository.collaborators returns a RepositoryCollaboratorConnection
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -218,3 +218,26 @@ HTTP 200
 [Asserts]
 jsonpath "$.data.repository.collaborators.nodes" isCollection
 jsonpath "$.data.repository.collaborators.nodes[0].login" == "octocat"
+
+# POST /graphql — PullRequest.commits returns a CommitConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { pullRequests { nodes { number commits { nodes { commit { oid } } } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.pullRequests.nodes[0].number" == 1
+jsonpath "$.data.repository.pullRequests.nodes[0].commits.nodes" isCollection
+
+# POST /graphql — PullRequest.reviews returns a PullRequestReviewConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { pullRequests { nodes { number reviews { nodes { state body author { login } } } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.pullRequests.nodes[0].number" == 1
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes" isCollection
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].state" == "APPROVED"
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].body" == "Looks good!"
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].author.login" == "octocat"

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -96,3 +96,33 @@ HTTP 200
 [Asserts]
 jsonpath "$.data.node.name" == "bug"
 jsonpath "$.data.node.color" == "d73a4a"
+
+# POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { owner { login } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.owner.login" == "octocat"
+
+# POST /graphql — Repository.defaultBranchRef enriches the inline stub with commit SHA
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { defaultBranchRef { name target { oid } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.defaultBranchRef.name" == "main"
+jsonpath "$.data.repository.defaultBranchRef.target.oid" == "abc123def456"
+
+# POST /graphql — Repository.languages returns a LanguageConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { languages { totalCount totalSize nodes { name } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.languages.totalCount" == 2
+jsonpath "$.data.repository.languages.totalSize" == 19134
+jsonpath "$.data.repository.languages.nodes" isCollection

--- a/test/mock-gitea.lua
+++ b/test/mock-gitea.lua
@@ -31,6 +31,10 @@ function OnHttpRequest()
     .. '"location":"San Francisco","website":"https://github.blog",'
     .. '"followers_count":100,"following_count":5,"created":"2011-01-25T18:44:36Z"}'
 
+  local ORG = '{"login":"testorg","id":2,"avatar_url":"","html_url":"http://localhost/testorg",'
+    .. '"name":"Test Organization","description":"A test org","email":"","location":"",'
+    .. '"blog":"","created_at":"2020-01-01T00:00:00Z","updated_at":"2020-01-01T00:00:00Z"}'
+
   local FOLLOWER = '[{"login":"hubot","id":2,"avatar_url":"","html_url":"","full_name":"Hubot",'
     .. '"email":"","is_admin":false,"location":"","website":"","followers_count":0,'
     .. '"following_count":0,"created":"2020-01-01T00:00:00Z"}]'
@@ -272,6 +276,9 @@ function OnHttpRequest()
       200,
       '{"id":1,"body":"Nice commit","user":{"login":"octocat"},"created_at":"2020-01-01T00:00:00Z"}',
     },
+
+    -- Orgs
+    ["/api/v1/orgs/testorg"] = { 200, ORG },
 
     -- Users
     ["GET /api/v1/user"] = { 200, USER },

--- a/test/mock-gitea.lua
+++ b/test/mock-gitea.lua
@@ -418,6 +418,7 @@ function OnHttpRequest()
     -- Search
     ["/api/v1/repos/search"] = { 200, '{"data":[' .. REPO .. '],"ok":true}' },
     ["/api/v1/users/search"] = { 200, '{"data":[' .. USER .. '],"ok":true}' },
+    ["/api/v1/repos/issues/search"] = { 200, "[" .. ISSUE .. "]" },
 
     -- Gitignore templates
     ["/api/v1/gitignores"] = { 200, '["C","Go","Python"]' },


### PR DESCRIPTION
Fixes #148.

Registers Gitea GraphQL resolvers for all GQL-10 deliverables: root queries (user, organization, repository, search), repository sub-resolvers (connections + scalars), issue/PR nested field resolvers, and the remaining node resolvers (Release, Label). Each resolver chains through the existing Gitea REST translators into the shared GraphQL translators, with hurl tests against the mock.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Add root query resolvers (user, organization, repository) and node.Release, node.Label <!-- type:spec -->
- [x] Add Repository scalar sub-resolvers (owner, defaultBranchRef, languages) <!-- type:spec -->
- [x] Add Repository connection sub-resolvers (issues, PRs, releases, labels, milestones, refs, collaborators) <!-- type:spec -->
- [x] Add Issue sub-resolvers (comments, labels, assignees, author, milestone) <!-- type:spec -->
- [x] Add PullRequest sub-resolvers (commits, reviews, labels, assignees) <!-- type:spec -->
- [x] Add Query.search resolver with repo, user, and issue type support <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->