### PR TITLE
GraphQL: GQL-11 - Add GraphQL catalog group, CSV row, and site integration (closes #149)

### DIFF
--- a/scripts/gen-matrix.py
+++ b/scripts/gen-matrix.py
@@ -51,6 +51,7 @@ PROVIDER_NAMES = {
 }
 
 GROUP_NAMES = {
+    "graphql":              "GraphQL",
     "meta":                 "Meta",
     "gitignore":            "Gitignore",
     "licenses":             "Licenses",

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,5 +1,5 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
-POST /graphql,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~,~
+POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and issues work,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~repository and issues; no pull requests,n,n,n,n,~repository only; issues/PRs absent,n
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n


### PR DESCRIPTION
Fixes #149.

Adds the `"graphql": "GraphQL"` group name to `gen-matrix.py` and updates the `POST /graphql` CSV row from placeholder all-`~` values to actual per-backend support levels per the design doc. Everything else the issue calls for (catalog entry, validate-claims exemption, stub hurl tests) already landed on main.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Add GraphQL group to gen-matrix.py and update CSV support values <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->