### PR TITLE
GraphQL Phase 1 - Query engine (closes #135)

### DIFF
--- a/test/integration-graphql.hurl
+++ b/test/integration-graphql.hurl
@@ -1,0 +1,67 @@
+# GraphQL smoke tests for the live Gitea integration suite.
+# All queries here must work without authentication and without
+# depending on specific repository data existing on gitea.com.
+
+# POST /graphql — __typename always resolves
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ __typename }"}
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.data.__typename" == "Query"
+jsonpath "$.errors" not exists
+
+# POST /graphql �� rateLimit is synthesized by confusio (no upstream call)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ rateLimit { limit remaining cost resetAt } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.rateLimit.limit" isInteger
+jsonpath "$.data.rateLimit.remaining" isInteger
+jsonpath "$.data.rateLimit.cost" isInteger
+jsonpath "$.data.rateLimit.resetAt" isString
+jsonpath "$.errors" not exists
+
+# POST /graphql — introspection answered from vendored schema
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ __schema { queryType { name } mutationType { name } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.__schema.queryType.name" == "Query"
+jsonpath "$.data.__schema.mutationType.name" == "Mutation"
+jsonpath "$.errors" not exists
+
+# POST /graphql �� parse error returns PARSE_ERROR
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ broken!!!"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data" == null
+jsonpath "$.errors[0].extensions.code" == "PARSE_ERROR"
+
+# POST /graphql — validation error returns VALIDATION_ERROR
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ fieldThatDoesNotExistAnywhere }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data" == null
+jsonpath "$.errors[0].extensions.code" == "VALIDATION_ERROR"
+
+# POST /graphql — batch rejection
+POST http://{{host}}/graphql
+Content-Type: application/json
+[{"query": "{ __typename }"}]
+
+HTTP 400
+[Asserts]
+jsonpath "$.errors[0].message" contains "batching is not supported"

--- a/test/stub-graphql.hurl
+++ b/test/stub-graphql.hurl
@@ -1,7 +1,6 @@
 # GraphQL API — executor is always active; all backends use graphql_handler.
-# Resolvers are not yet registered for any backend, so fields that require a
-# REST call return null. The meta-field __typename is handled directly by the
-# executor without any resolver and works for all backends.
+# These tests cover request-level and schema-level errors that are backend-agnostic:
+# they do not depend on any resolver and run for every backend.
 
 # POST /graphql — __typename on the Query root is always resolved
 POST http://{{host}}/graphql
@@ -10,9 +9,29 @@ Content-Type: application/json
 
 HTTP 200
 [Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.data.__typename" == "Query"
 
-# POST /graphql — parse error returns {"data":null,"errors":[...]}
+# POST /graphql — batch request rejected with HTTP 400
+POST http://{{host}}/graphql
+Content-Type: application/json
+[{"query": "{ __typename }"}]
+
+HTTP 400
+[Asserts]
+jsonpath "$.errors[0].message" isString
+
+# POST /graphql — invalid body (not JSON) → BAD_USER_INPUT
+POST http://{{host}}/graphql
+Content-Type: application/json
+`not json`
+
+HTTP 200
+[Asserts]
+jsonpath "$.data" == null
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — parse error returns PARSE_ERROR extension code
 POST http://{{host}}/graphql
 Content-Type: application/json
 {"query": "{ unclosed_brace"}
@@ -20,4 +39,14 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.data" == null
-jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "PARSE_ERROR"
+
+# POST /graphql — unknown field returns VALIDATION_ERROR extension code
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ fieldThatDoesNotExistAnywhere }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data" == null
+jsonpath "$.errors[0].extensions.code" == "VALIDATION_ERROR"

--- a/test/stub-graphql.hurl
+++ b/test/stub-graphql.hurl
@@ -11,17 +11,29 @@ HTTP 200
 [Asserts]
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.data.__typename" == "Query"
+jsonpath "$.errors" not exists
 
-# POST /graphql — batch request rejected with HTTP 400
+# POST /graphql — batch request rejected with HTTP 400 (Phase 1: doc 12)
 POST http://{{host}}/graphql
 Content-Type: application/json
 [{"query": "{ __typename }"}]
 
 HTTP 400
 [Asserts]
-jsonpath "$.errors[0].message" isString
+jsonpath "$.errors[0].message" contains "batching is not supported"
 
-# POST /graphql — invalid body (not JSON) → BAD_USER_INPUT
+# POST /graphql — APQ request rejected (Phase 1: doc 12)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"extensions": {"persistedQuery": {"sha256Hash": "abc123"}}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data" == null
+jsonpath "$.errors[0].message" contains "Persisted queries are not supported"
+jsonpath "$.errors[0].extensions.code" == "PERSISTED_QUERY_NOT_SUPPORTED"
+
+# POST /graphql — invalid body (not JSON) → BAD_USER_INPUT (doc 09)
 POST http://{{host}}/graphql
 Content-Type: application/json
 `not json`
@@ -29,9 +41,21 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.data" == null
+jsonpath "$.errors[0].message" contains "'query' field"
 jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
 
-# POST /graphql — parse error returns PARSE_ERROR extension code
+# POST /graphql — valid JSON but missing query field → BAD_USER_INPUT (doc 09)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"variables": {"x": 1}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data" == null
+jsonpath "$.errors[0].message" contains "'query' field"
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — parse error returns PARSE_ERROR extension code (doc 09)
 POST http://{{host}}/graphql
 Content-Type: application/json
 {"query": "{ unclosed_brace"}
@@ -39,9 +63,10 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.data" == null
+jsonpath "$.errors[0].message" isString
 jsonpath "$.errors[0].extensions.code" == "PARSE_ERROR"
 
-# POST /graphql — unknown field returns VALIDATION_ERROR extension code
+# POST /graphql — unknown field returns VALIDATION_ERROR extension code (doc 09)
 POST http://{{host}}/graphql
 Content-Type: application/json
 {"query": "{ fieldThatDoesNotExistAnywhere }"}
@@ -49,4 +74,5 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.data" == null
+jsonpath "$.errors[0].message" contains "does not exist"
 jsonpath "$.errors[0].extensions.code" == "VALIDATION_ERROR"

--- a/test/test-integration.sh
+++ b/test/test-integration.sh
@@ -27,4 +27,5 @@ for _i in $(seq 1 150); do
 done
 
 ./hurl --retry 10 --retry-interval 200 --connect-timeout 5 --max-time 15 \
-  --variable host=localhost:$CONFUSIO_PORT test/gitea-root.hurl test/stub-apps.hurl
+  --variable host=localhost:$CONFUSIO_PORT test/gitea-root.hurl test/stub-apps.hurl \
+  test/integration-graphql.hurl


### PR DESCRIPTION
Fixes #135.
Fixes #178.

Closes out GraphQL Phase 1 by hardening the stub-graphql.hurl assertions to match the design doc (batch rejection, validation errors, malformed JSON) and adding GraphQL smoke tests to the live Gitea integration suite.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Harden stub-graphql.hurl with design-doc assertions <!-- type:spec -->
- [x] Add GraphQL smoke tests to live Gitea integration suite <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->