### PR TITLE
GraphQL: GQL-14 - GitBucket GraphQL resolvers (closes #152)

### DIFF
--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1324,3 +1324,524 @@ backend_impl = {
     return base() .. "/users/" .. user .. "/gists"
   end),
 }
+
+-- ---------------------------------------------------------------------------
+-- GraphQL resolvers
+-- ---------------------------------------------------------------------------
+
+-- Local pagination parameters for graphql_cursor_url.
+-- GitBucket uses GitHub-compatible per_page / page query parameters.
+local GQL_PAGES = { per_page = "per_page", page = "page" }
+
+-- Local helper: build a paginated Relay Connection from a GitBucket list endpoint.
+-- GitBucket may return X-Total / X-Total-Count headers; if absent, the connection
+-- builder falls back to the count == per_page heuristic for hasNextPage.
+local function gb_repo_connection(owner, repo_name, suffix, args, ctx, translate_fn, make_conn)
+  local url =
+    graphql_cursor_url(base() .. "/repos/" .. owner .. "/" .. repo_name .. suffix, args, GQL_PAGES)
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  local nodes = {}
+  for _, item in ipairs(data) do
+    nodes[#nodes + 1] = translate_fn(item)
+  end
+  return make_conn(nodes, args, total, ctx)
+end
+
+-- Query.repositoryOwner: look up a User or Organization by login.
+-- Tries /users/{login} first; falls back to /orgs/{login}.
+graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "repositoryOwner requires a login argument")
+    return nil
+  end
+  local udata, _ = graphql_fetch(fetch_json, base() .. "/users/" .. args.login)
+  if udata then
+    return graphql_translate_user(udata)
+  end
+  local odata, _ = graphql_fetch(fetch_json, base() .. "/orgs/" .. args.login)
+  if odata then
+    return graphql_translate_org(odata)
+  end
+  return nil
+end
+
+-- Query.viewer: resolve the authenticated user via GET /user.
+graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+  local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
+  if not data then
+    return nil
+  end
+  local u = graphql_translate_user(data)
+  u.isViewer = true
+  return u
+end
+
+-- Query.user: look up a User by login.
+graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "user requires a login argument")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. args.login)
+  if not data then
+    return nil
+  end
+  return graphql_translate_user(data)
+end
+
+-- Query.organization: look up an Organization by login.
+graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "organization requires a login argument")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/orgs/" .. args.login)
+  if not data then
+    return nil
+  end
+  return graphql_translate_org(data)
+end
+
+-- Query.repository: look up a Repository by owner and name.
+graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+  if not args.owner or not args.name then
+    graphql_error(ctx, "repository requires owner and name arguments")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/repos/" .. args.owner .. "/" .. args.name)
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(data)
+end
+
+-- node.Repository: fetch a repository by "owner/repo" local ID.
+graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+  local data, _ = graphql_fetch(fetch_json, base() .. "/repos/" .. local_id)
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(data)
+end
+
+-- node.User: fetch a user by login.
+graphql_resolvers["node.User"] = function(local_id, _ctx)
+  local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. local_id)
+  if not data then
+    return nil
+  end
+  return graphql_translate_user(data)
+end
+
+-- node.Organization: fetch an organization by login.
+graphql_resolvers["node.Organization"] = function(local_id, _ctx)
+  local data, _ = graphql_fetch(fetch_json, base() .. "/orgs/" .. local_id)
+  if not data then
+    return nil
+  end
+  return graphql_translate_org(data)
+end
+
+-- node.Issue: fetch an issue by "owner/repo/number" local ID.
+graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number)
+  if not data then
+    return nil
+  end
+  return graphql_translate_issue(data, owner, repo)
+end
+
+-- node.PullRequest: fetch a pull request by "owner/repo/number" local ID.
+graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number)
+  if not data then
+    return nil
+  end
+  return graphql_translate_pr(data, owner, repo)
+end
+
+-- node.IssueComment: fetch an issue comment by "owner/repo/comment_id" local ID.
+graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
+  local owner, repo, cid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(
+    fetch_json,
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/comments/" .. cid
+  )
+  if not data then
+    return nil
+  end
+  return graphql_translate_comment(data, owner, repo)
+end
+
+-- node.Release: fetch a release by "owner/repo/release_id" local ID.
+graphql_resolvers["node.Release"] = function(local_id, _ctx)
+  local owner, repo, rid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/releases/" .. rid)
+  if not data then
+    return nil
+  end
+  return graphql_translate_release(data, owner, repo)
+end
+
+-- node.Label: fetch a label by "owner/repo/label_id" local ID.
+graphql_resolvers["node.Label"] = function(local_id, _ctx)
+  local owner, repo, lid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/labels/" .. lid)
+  if not data then
+    return nil
+  end
+  return graphql_translate_label(data, owner, repo)
+end
+
+-- ---------------------------------------------------------------------------
+-- Repository connection sub-resolvers
+-- ---------------------------------------------------------------------------
+
+-- Repository.issues: paginated list of issues.
+-- GitBucket's issue list includes PRs (like GitHub); filter them out by checking
+-- the pull_request field.
+graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local url =
+    graphql_cursor_url(base() .. "/repos/" .. owner .. "/" .. name .. "/issues", args, GQL_PAGES)
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  local nodes = {}
+  for _, item in ipairs(data) do
+    if not item.pull_request then
+      nodes[#nodes + 1] = graphql_translate_issue(item, owner, name)
+    end
+  end
+  return graphql_issues_connection(nodes, args, total, ctx)
+end
+
+-- Repository.pullRequests: paginated list of pull requests.
+graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gb_repo_connection(owner, name, "/pulls", args, ctx, function(p)
+    return graphql_translate_pr(p, owner, name)
+  end, graphql_prs_connection)
+end
+
+-- Repository.releases: paginated list of releases.
+graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gb_repo_connection(owner, name, "/releases", args, ctx, function(r)
+    return graphql_translate_release(r, owner, name)
+  end, function(n, a, t, c)
+    return graphql_make_connection("Release", n, a, t, c)
+  end)
+end
+
+-- Repository.labels: paginated list of labels.
+graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gb_repo_connection(owner, name, "/labels", args, ctx, function(l)
+    return graphql_translate_label(l, owner, name)
+  end, graphql_labels_connection)
+end
+
+-- Repository.milestones: paginated list of milestones.
+graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gb_repo_connection(owner, name, "/milestones", args, ctx, function(m)
+    return graphql_translate_milestone(m, owner, name)
+  end, function(n, a, t, c)
+    return graphql_make_connection("Milestone", n, a, t, c)
+  end)
+end
+
+-- Repository.refs: paginated list of branches as Ref objects.
+-- GitBucket branch objects already include commit.sha (GitHub-compatible);
+-- no commit.id → commit.sha normalisation needed.
+graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gb_repo_connection(owner, name, "/branches", args, ctx, function(b)
+    return graphql_translate_ref(b, parent)
+  end, graphql_refs_connection)
+end
+
+-- Issue.comments: paginated list of comments for a single issue.
+graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local url = graphql_cursor_url(
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments",
+    args,
+    GQL_PAGES
+  )
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  local nodes = {}
+  for _, c in ipairs(data) do
+    nodes[#nodes + 1] = graphql_translate_comment(c, owner, repo)
+  end
+  return graphql_make_connection("IssueComment", nodes, args, total, ctx)
+end
+
+-- PullRequest.commits: paginated commit list for a pull request.
+graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local url = graphql_cursor_url(
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits",
+    args,
+    GQL_PAGES
+  )
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  -- PullRequest.commits returns PullRequestCommitConnection, whose nodes are
+  -- PullRequestCommit objects wrapping bare Commit objects.
+  local nodes = {}
+  for _, c in ipairs(data) do
+    local sha = c.sha or ""
+    nodes[#nodes + 1] = {
+      __typename = "PullRequestCommit",
+      id = encode_node_id("PullRequestCommit", sha),
+      commit = graphql_translate_commit(c),
+      url = c.html_url,
+    }
+  end
+  return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
+end
+
+-- PullRequest.reviews: paginated review list for a pull request.
+graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local url = graphql_cursor_url(
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/reviews",
+    args,
+    GQL_PAGES
+  )
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  local nodes = {}
+  for _, r in ipairs(data) do
+    nodes[#nodes + 1] = graphql_translate_review(r, owner, repo)
+  end
+  return graphql_make_connection("PullRequestReview", nodes, args, total, ctx)
+end
+
+-- Repository.collaborators: paginated list of collaborators as Users.
+graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return gb_repo_connection(owner, name, "/collaborators", args, ctx, function(u)
+    return graphql_translate_user(u)
+  end, function(n, a, t, c)
+    return graphql_make_connection("RepositoryCollaborator", n, a, t, c)
+  end)
+end
+
+-- Repository.defaultBranchRef: enrich the inline stub with full branch data.
+-- The parent already carries {__typename="Ref",name="main"} from graphql_translate_repo.
+graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
+  local branch = parent.defaultBranchRef and parent.defaultBranchRef.name
+  if not branch then
+    return nil
+  end
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. name .. "/branches/" .. branch)
+  if not data then
+    return nil
+  end
+  return graphql_translate_ref(data, parent)
+end
+
+-- Repository.languages: fetch language byte-count breakdown as a LanguageConnection.
+-- GitBucket returns {"Language": bytes, ...}; we convert to the Relay Connection shape.
+graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. name .. "/languages")
+  if not data then
+    return nil
+  end
+  local nodes, edges = {}, {}
+  local total_size = 0
+  for lang_name, size in pairs(data) do
+    total_size = total_size + size
+    local node = {
+      __typename = "Language",
+      id = encode_node_id("Language", lang_name),
+      name = lang_name,
+      color = nil,
+    }
+    nodes[#nodes + 1] = node
+    edges[#edges + 1] = { cursor = "", node = node, size = size }
+  end
+  return {
+    __typename = "LanguageConnection",
+    totalCount = #nodes,
+    totalSize = total_size,
+    pageInfo = {
+      __typename = "PageInfo",
+      hasNextPage = false,
+      hasPreviousPage = false,
+      startCursor = nil,
+      endCursor = nil,
+    },
+    nodes = nodes,
+    edges = edges,
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- Query.search
+-- ---------------------------------------------------------------------------
+
+-- Query.search: map GitHub GraphQL search to GitBucket search endpoints.
+-- GitBucket exposes GitHub-compatible /search/{repositories,users} returning
+-- the standard {total_count, items} envelope.
+-- ISSUE search is not supported (GitBucket has no /search/issues endpoint).
+graphql_resolvers["Query.search"] = function(_parent, args, _ctx)
+  local query = args.query or ""
+  local search_type = args.type or "REPOSITORY"
+  local per_page = args.first or 30
+  local q = EscapeParam(query)
+
+  local nodes = {}
+  local repo_count, user_count, issue_count = 0, 0, 0
+
+  if search_type == "REPOSITORY" then
+    local data, _ = graphql_fetch(
+      fetch_json,
+      base() .. "/search/repositories?q=" .. q .. "&per_page=" .. per_page
+    )
+    if data and data.items then
+      for _, r in ipairs(data.items) do
+        nodes[#nodes + 1] = graphql_translate_repo(r)
+      end
+      repo_count = data.total_count or #nodes
+    end
+  elseif search_type == "USER" then
+    local data, _ =
+      graphql_fetch(fetch_json, base() .. "/search/users?q=" .. q .. "&per_page=" .. per_page)
+    if data and data.items then
+      for _, u in ipairs(data.items) do
+        nodes[#nodes + 1] = graphql_translate_user(u)
+      end
+      user_count = data.total_count or #nodes
+    end
+  end
+
+  local edges = {}
+  for _, node in ipairs(nodes) do
+    edges[#edges + 1] = {
+      __typename = "SearchResultItemEdge",
+      cursor = graphql_page_to_cursor(1),
+      node = node,
+    }
+  end
+  return {
+    __typename = "SearchResultItemConnection",
+    nodes = nodes,
+    edges = edges,
+    pageInfo = {
+      __typename = "PageInfo",
+      hasNextPage = false,
+      hasPreviousPage = false,
+      startCursor = #nodes > 0 and graphql_page_to_cursor(1) or nil,
+      endCursor = #nodes > 0 and graphql_page_to_cursor(1) or nil,
+    },
+    repositoryCount = repo_count,
+    userCount = user_count,
+    issueCount = issue_count,
+    codeCount = 0,
+    discussionCount = 0,
+    wikiCount = 0,
+  }
+end

--- a/test/gitbucket-graphql.hurl
+++ b/test/gitbucket-graphql.hurl
@@ -1,0 +1,262 @@
+# GraphQL API — GitBucket backend.
+# Tests for Query root fields and resolvers backed by the GitBucket REST API.
+# GitBucket is GitHub-compatible (/api/v3), so responses pass through to the
+# shared graphql_translate_* helpers without intermediate REST translators.
+
+# POST /graphql — __typename on the Query root is always resolved
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ __typename }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.__typename" == "Query"
+
+# POST /graphql — parse error returns {"data":null,"errors":[...]}
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ unclosed_brace"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data" == null
+jsonpath "$.errors" isCollection
+
+# POST /graphql — Query.viewer returns the authenticated user
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "{ viewer { login name email isViewer isSiteAdmin } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.viewer.login" == "octocat"
+jsonpath "$.data.viewer.name" == "The Octocat"
+jsonpath "$.data.viewer.email" == "octocat@github.com"
+jsonpath "$.data.viewer.isViewer" == true
+jsonpath "$.data.viewer.isSiteAdmin" == false
+
+# POST /graphql — Query.user returns a user by login
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ user(login: \"octocat\") { login name } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.user.login" == "octocat"
+jsonpath "$.data.user.name" == "The Octocat"
+
+# POST /graphql — Query.organization returns an organization by login
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ organization(login: \"testorg\") { login name description } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.organization.login" == "testorg"
+jsonpath "$.data.organization.name" == "Test Organization"
+jsonpath "$.data.organization.description" == "A test org"
+
+# POST /graphql — Query.repository returns a repository by owner and name
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { name nameWithOwner description } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.name" == "hello-world"
+jsonpath "$.data.repository.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.repository.description" == "My first repo"
+
+# POST /graphql — node(Release) fetches a release by encoded node ID
+# Node ID for Release:octocat/hello-world/1 = UmVsZWFzZTpvY3RvY2F0L2hlbGxvLXdvcmxkLzE=
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"UmVsZWFzZTpvY3RvY2F0L2hlbGxvLXdvcmxkLzE=\") { ... on Release { tagName name isDraft isPrerelease } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.tagName" == "v1.0"
+jsonpath "$.data.node.name" == "Release 1.0"
+jsonpath "$.data.node.isDraft" == false
+jsonpath "$.data.node.isPrerelease" == false
+
+# POST /graphql — node(Label) fetches a label by encoded node ID
+# Node ID for Label:octocat/hello-world/1 = TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x\") { ... on Label { name color } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "bug"
+jsonpath "$.data.node.color" == "d73a4a"
+
+# POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { owner { login } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.owner.login" == "octocat"
+
+# POST /graphql — Repository.defaultBranchRef enriches the inline stub with commit SHA
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { defaultBranchRef { name target { oid } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.defaultBranchRef.name" == "main"
+jsonpath "$.data.repository.defaultBranchRef.target.oid" == "abc123def456"
+
+# POST /graphql — Repository.languages returns a LanguageConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { languages { totalCount totalSize nodes { name } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.languages.totalCount" == 2
+jsonpath "$.data.repository.languages.totalSize" == 19134
+jsonpath "$.data.repository.languages.nodes" isCollection
+
+# POST /graphql — Repository.issues returns an IssueConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues { nodes { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.issues.nodes" isCollection
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+jsonpath "$.data.repository.issues.nodes[0].title" == "Found a bug"
+jsonpath "$.data.repository.issues.nodes[0].state" == "OPEN"
+
+# POST /graphql — Repository.pullRequests returns a PullRequestConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { pullRequests { nodes { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.pullRequests.nodes" isCollection
+jsonpath "$.data.repository.pullRequests.nodes[0].number" == 1
+jsonpath "$.data.repository.pullRequests.nodes[0].title" == "A great PR"
+jsonpath "$.data.repository.pullRequests.nodes[0].state" == "MERGED"
+
+# POST /graphql — Repository.releases returns a ReleaseConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { releases { nodes { tagName name isDraft isPrerelease } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.releases.nodes" isCollection
+jsonpath "$.data.repository.releases.nodes[0].tagName" == "v1.0"
+jsonpath "$.data.repository.releases.nodes[0].name" == "Release 1.0"
+jsonpath "$.data.repository.releases.nodes[0].isDraft" == false
+jsonpath "$.data.repository.releases.nodes[0].isPrerelease" == false
+
+# POST /graphql — Repository.labels returns a LabelConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { labels { nodes { name color } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.labels.nodes" isCollection
+jsonpath "$.data.repository.labels.nodes[0].name" == "bug"
+jsonpath "$.data.repository.labels.nodes[0].color" == "d73a4a"
+
+# POST /graphql — Repository.milestones returns a MilestoneConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { milestones { nodes { title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.milestones.nodes" isCollection
+jsonpath "$.data.repository.milestones.nodes[0].title" == "v1.0"
+jsonpath "$.data.repository.milestones.nodes[0].state" == "OPEN"
+
+# POST /graphql — Repository.refs returns a RefConnection (branches)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { refs { nodes { name target { oid } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.refs.nodes" isCollection
+jsonpath "$.data.repository.refs.nodes[0].name" == "main"
+jsonpath "$.data.repository.refs.nodes[0].target.oid" == "abc123def456"
+
+# POST /graphql — Issue.comments returns an IssueCommentConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues { nodes { number comments { nodes { body author { login } } } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes" isCollection
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes[0].body" == "This is a comment"
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes[0].author.login" == "octocat"
+
+# POST /graphql — Repository.collaborators returns a RepositoryCollaboratorConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { collaborators { nodes { login } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.collaborators.nodes" isCollection
+jsonpath "$.data.repository.collaborators.nodes[0].login" == "octocat"
+
+# POST /graphql — PullRequest.commits returns a PullRequestCommitConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { pullRequests { nodes { number commits { nodes { commit { oid message } } } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.pullRequests.nodes[0].number" == 1
+jsonpath "$.data.repository.pullRequests.nodes[0].commits.nodes" isCollection
+jsonpath "$.data.repository.pullRequests.nodes[0].commits.nodes[0].commit.oid" == "abc123def456"
+
+# POST /graphql — PullRequest.reviews returns a PullRequestReviewConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { pullRequests { nodes { number reviews { nodes { state body author { login } } } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.pullRequests.nodes[0].number" == 1
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes" isCollection
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].state" == "APPROVED"
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].body" == "LGTM"
+jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].author.login" == "octocat"
+
+# POST /graphql — Query.search REPOSITORY returns a SearchResultItemConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ search(query: \"hello\", type: REPOSITORY, first: 5) { repositoryCount nodes { ... on Repository { name nameWithOwner } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.search.repositoryCount" == 1
+jsonpath "$.data.search.nodes" isCollection
+jsonpath "$.data.search.nodes[0].name" == "hello-world"
+jsonpath "$.data.search.nodes[0].nameWithOwner" == "octocat/hello-world"
+
+# POST /graphql — Query.search USER returns a SearchResultItemConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ search(query: \"octocat\", type: USER, first: 5) { userCount nodes { ... on User { login } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.search.userCount" == 1
+jsonpath "$.data.search.nodes" isCollection
+jsonpath "$.data.search.nodes[0].login" == "octocat"

--- a/test/mock-gitbucket.lua
+++ b/test/mock-gitbucket.lua
@@ -331,6 +331,11 @@ function OnHttpRequest()
     )
 
   -- Labels ------------------------------------------------------------------
+  elseif path == rb .. "/labels/1" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":1,"name":"bug","color":"d73a4a","description":"","default":false,"node_id":"","url":""}'
+    )
   elseif path == rb .. "/labels/nosuchlabel" then
     SetStatus(404, "Not Found")
     json('{"message":"Not Found"}')
@@ -423,6 +428,14 @@ function OnHttpRequest()
     SetStatus(200, "OK")
     json('[{"id":1,"key":"ssh-rsa AAAAB3N...","title":"my key"}]')
 
+  -- Orgs -------------------------------------------------------------------
+  elseif path == "/api/v3/orgs/testorg" then
+    SetStatus(200, "OK")
+    json(
+      '{"login":"testorg","id":2,"node_id":"","avatar_url":"","html_url":"",'
+        .. '"type":"Organization","name":"Test Organization","description":"A test org"}'
+    )
+
   -- Teams -------------------------------------------------------------------
   elseif path == "/api/v3/orgs/testorg/teams" then
     SetStatus(200, "OK")
@@ -513,7 +526,12 @@ function OnHttpRequest()
     json(PR)
   elseif path == rb .. "/pulls/1/commits" then
     SetStatus(200, "OK")
-    json("[]")
+    json(
+      '[{"sha":"abc123def456","html_url":"http://localhost/octocat/hello-world/commit/abc123def456",'
+        .. '"commit":{"message":"Initial commit","author":{"name":"Octocat",'
+        .. '"email":"octocat@github.com","date":"2011-01-26T19:01:12Z"},'
+        .. '"committer":{"name":"Octocat","email":"octocat@github.com","date":"2011-01-26T19:01:12Z"}}}]'
+    )
   elseif path == rb .. "/pulls/1/files" then
     SetStatus(200, "OK")
     json("[]")


### PR DESCRIPTION
Fixes #152.

Add GitBucket GraphQL resolvers, leveraging GitBucket's GitHub-compatible `/api/v3` API with the shared `graphql_translate_*` helpers. Includes mock routes and hurl tests validating all resolvers end-to-end.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add GitBucket GraphQL resolvers to backends/gitbucket.lua <!-- type:spec -->
- [x] Add GitBucket GraphQL mock routes and hurl tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->