### PR TITLE
GraphQL: GQL-16 - Partial resolvers for remaining backends (closes #154)

### DIFF
--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -1916,3 +1916,32 @@ _b.delete_git_ref = function(owner, repo_name, ref)
   })
   proxy_204({ 200 }, fetch_json(url, "POST", del_body))
 end
+
+-- GraphQL resolvers -----------------------------------------------------------
+-- Minimum foothold: Query.repository and node.Repository only.
+-- ADO has no GET /user, so Query.viewer returns null (handled by default).
+-- Work Items ≠ GitHub Issues, so issue resolvers are omitted.
+
+graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+  if not args.owner or not args.name then
+    graphql_error(ctx, "repository requires owner and name arguments")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, ado_url(repos_base(args.owner) .. "/" .. args.name))
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_ado_repo(data))
+end
+
+graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+  local owner, name = local_id:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, ado_url(repos_base(owner) .. "/" .. name))
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_ado_repo(data))
+end

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -1327,3 +1327,105 @@ _b.delete_git_ref = function(owner, repo_name, ref)
   end
   proxy_204({ 200, 202 }, pcall(Fetch, url, dopts))
 end
+
+-- GraphQL resolvers -----------------------------------------------------------
+-- BBS scope: Query.repository, Query.user, Repository.pullRequests.
+-- No GET /user → Query.viewer returns null (handled by default).
+-- No native issue tracker → issue resolvers omitted.
+
+-- Shared pagination helper for BBS /values arrays.
+-- BBS pagination uses start (offset) and limit (page size);
+-- graphql_cursor_url can't be used because BBS start = (page-1)*limit, not page number.
+local function bbs_repo_connection(owner, repo_name, suffix, args, ctx, translate_fn, make_conn)
+  local per_page = args.first or 30
+  local page = 1
+  if args.after then
+    local p = graphql_cursor_to_page(args.after)
+    if p then
+      page = p + 1
+    end
+  end
+  local start = (page - 1) * per_page
+  local url = repo_path(owner, repo_name) .. suffix
+  local sep = url:find("?", 1, true) and "&" or "?"
+  url = url .. sep .. "limit=" .. tostring(per_page)
+  if start > 0 then
+    url = url .. "&start=" .. tostring(start)
+  end
+  local data, _, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local nodes = {}
+  for _, item in ipairs(data.values or {}) do
+    nodes[#nodes + 1] = translate_fn(item)
+  end
+  return make_conn(nodes, args, nil, ctx)
+end
+
+graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+  if not args.owner or not args.name then
+    graphql_error(ctx, "repository requires owner and name arguments")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, repo_path(args.owner, args.name))
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_bbs_repo(data))
+end
+
+graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+  local owner, name = local_id:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, repo_path(owner, name))
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_bbs_repo(data))
+end
+
+graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "user requires a login argument")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. args.login)
+  if not data then
+    return nil
+  end
+  return graphql_translate_user(translate_bbs_user(data))
+end
+
+graphql_resolvers["node.User"] = function(local_id, _ctx)
+  local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. local_id)
+  if not data then
+    return nil
+  end
+  return graphql_translate_user(translate_bbs_user(data))
+end
+
+graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return bbs_repo_connection(owner, name, "/pull-requests", args, ctx, function(pr)
+    return graphql_translate_pr(translate_bbs_pull(pr), owner, name)
+  end, graphql_prs_connection)
+end
+
+graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, repo_path(owner, repo) .. "/pull-requests/" .. number)
+  if not data then
+    return nil
+  end
+  return graphql_translate_pr(translate_bbs_pull(data), owner, repo)
+end

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -662,3 +662,297 @@ backend_impl = {
   -- Check suites have no Pagure equivalent; all suite endpoints fall back to
   -- the route_defaults stubs defined in .init.lua.
 }
+
+-- ---------------------------------------------------------------------------
+-- GraphQL resolvers
+-- ---------------------------------------------------------------------------
+
+-- Query.viewer: resolve the authenticated user via whoami then /user/{username}.
+graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+  local whoami, _ = graphql_fetch(fetch_json, base() .. "/-/whoami")
+  if not whoami then
+    graphql_error(ctx, "could not determine authenticated user", nil, "FORBIDDEN")
+    return nil
+  end
+  local username = whoami.username or ""
+  if username == "" then
+    graphql_error(ctx, "empty username from whoami", nil, "FORBIDDEN")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/user/" .. username)
+  if not data then
+    return nil
+  end
+  local u = data.user or data
+  local gh_user = translate_pagure_user(u)
+  gh_user.email = (u.emails and u.emails[1]) or ""
+  local result = graphql_translate_user(gh_user)
+  result.isViewer = true
+  return result
+end
+
+-- Query.user: look up a User by login.
+graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "user requires a login argument")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/user/" .. args.login)
+  if not data then
+    return nil
+  end
+  local u = data.user or data
+  local gh_user = translate_pagure_user(u)
+  gh_user.email = (u.emails and u.emails[1]) or ""
+  return graphql_translate_user(gh_user)
+end
+
+-- Query.repositoryOwner: look up a user by login.
+-- Pagure has no organization concept; all owners are users.
+graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
+  if not args.login then
+    graphql_error(ctx, "repositoryOwner requires a login argument")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/user/" .. args.login)
+  if not data then
+    return nil
+  end
+  local u = data.user or data
+  local gh_user = translate_pagure_user(u)
+  gh_user.email = (u.emails and u.emails[1]) or ""
+  return graphql_translate_user(gh_user)
+end
+
+-- Query.repository: look up a Repository by owner and name.
+graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+  if not args.owner or not args.name then
+    graphql_error(ctx, "repository requires owner and name arguments")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/" .. args.owner .. "/" .. args.name)
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_pagure_repo(data))
+end
+
+-- node.Repository: fetch a repository by "owner/repo" local ID.
+graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+  local data, _ = graphql_fetch(fetch_json, base() .. "/" .. local_id)
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_pagure_repo(data))
+end
+
+-- node.User: fetch a user by login.
+graphql_resolvers["node.User"] = function(local_id, _ctx)
+  local data, _ = graphql_fetch(fetch_json, base() .. "/user/" .. local_id)
+  if not data then
+    return nil
+  end
+  local u = data.user or data
+  local gh_user = translate_pagure_user(u)
+  gh_user.email = (u.emails and u.emails[1]) or ""
+  return graphql_translate_user(gh_user)
+end
+
+-- node.Issue: fetch an issue by "owner/repo/number" local ID.
+-- Pagure uses /issue/{number} (singular) for individual issues.
+graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/" .. owner .. "/" .. repo .. "/issue/" .. number)
+  if not data then
+    return nil
+  end
+  return graphql_translate_issue(translate_pagure_issue(data), owner, repo)
+end
+
+-- node.IssueComment: fetch a comment by "owner/repo/issue_number/comment_id" local ID.
+-- Pagure embeds comments in the issue; we fetch the issue and find the comment by id.
+graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
+  local owner, repo, issue_num, cid = local_id:match("^([^/]+)/([^/]+)/(%d+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local cid_n = tonumber(cid)
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/" .. owner .. "/" .. repo .. "/issue/" .. issue_num)
+  if not data then
+    return nil
+  end
+  for _, c in ipairs(data.comments or {}) do
+    if c.id == cid_n then
+      local gh_comment = translate_pagure_comment(c)
+      local comment_node = graphql_translate_comment(gh_comment, owner, repo)
+      comment_node.id = encode_node_id(
+        "IssueComment",
+        owner .. "/" .. repo .. "/" .. issue_num .. "/" .. cid
+      )
+      return comment_node
+    end
+  end
+  return nil
+end
+
+-- Repository.issues: paginated list of issues.
+-- Pagure returns {"issues": [...], "total_issues": N}.
+graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local url = graphql_cursor_url(base() .. "/" .. owner .. "/" .. name .. "/issues", args, PAGES)
+  local data, _, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local items = (type(data) == "table") and (data.issues or {}) or {}
+  local total = (type(data) == "table") and data.total_issues or nil
+  local nodes = {}
+  for _, i in ipairs(items) do
+    nodes[#nodes + 1] = graphql_translate_issue(translate_pagure_issue(i), owner, name)
+  end
+  return graphql_issues_connection(nodes, args, total, ctx)
+end
+
+-- Repository.refs: paginated list of branches as Ref objects.
+-- Pagure returns {"branches": ["name1", ...], "total_branches": N} — no commit SHAs.
+graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local url =
+    graphql_cursor_url(base() .. "/" .. owner .. "/" .. name .. "/git/branches", args, PAGES)
+  local data, _, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local items = (type(data) == "table") and (data.branches or {}) or {}
+  local total = (type(data) == "table") and data.total_branches or nil
+  local nodes = {}
+  for _, b_name in ipairs(items) do
+    -- Pagure branch list returns only names; no commit SHA is available.
+    nodes[#nodes + 1] = graphql_translate_ref({ name = b_name }, parent)
+  end
+  return graphql_refs_connection(nodes, args, total, ctx)
+end
+
+-- Issue.comments: extract embedded comments from a Pagure issue.
+-- Pagure embeds all comments in the issue object; we re-fetch to get them.
+-- IssueComment node IDs use "owner/repo/issue_number/comment_id" for resolvability.
+graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/" .. owner .. "/" .. repo .. "/issue/" .. number)
+  if not data then
+    graphql_error(ctx, "could not fetch issue comments")
+    return nil
+  end
+  local comments = data.comments or {}
+  local nodes = {}
+  for _, c in ipairs(comments) do
+    local gh_comment = translate_pagure_comment(c)
+    local comment_node = graphql_translate_comment(gh_comment, owner, repo)
+    comment_node.id = encode_node_id(
+      "IssueComment",
+      owner .. "/" .. repo .. "/" .. number .. "/" .. tostring(c.id or "")
+    )
+    nodes[#nodes + 1] = comment_node
+  end
+  return graphql_make_connection("IssueComment", nodes, args, #nodes, ctx)
+end
+
+-- Query.search: map GitHub GraphQL search to Pagure search endpoints.
+-- REPOSITORY: GET /projects?search={query}
+-- USER: GET /users?username={query}  (returns name list; build minimal user objects)
+-- ISSUE: Pagure has no simple keyword issue search; returns empty.
+graphql_resolvers["Query.search"] = function(_parent, args, ctx)
+  local query = args.query or ""
+  local search_type = args.type or "REPOSITORY"
+  local per_page = args.first or 30
+  local q = EscapeParam(query)
+
+  local nodes = {}
+  local repo_count, user_count, issue_count = 0, 0, 0
+
+  if search_type == "REPOSITORY" then
+    local data, _, err = graphql_fetch_with_headers(
+      fetch_json,
+      base() .. "/projects?search=" .. q .. "&per_page=" .. per_page
+    )
+    if not data then
+      graphql_error(ctx, err)
+    else
+      local items = (type(data) == "table") and (data.projects or {}) or {}
+      for _, r in ipairs(items) do
+        nodes[#nodes + 1] = graphql_translate_repo(translate_pagure_repo(r))
+      end
+      repo_count = #nodes
+    end
+  elseif search_type == "USER" then
+    local data, _, err = graphql_fetch_with_headers(
+      fetch_json,
+      base() .. "/users?username=" .. q .. "&per_page=" .. per_page
+    )
+    if not data then
+      graphql_error(ctx, err)
+    else
+      -- Pagure /users returns an array of login names, not full user objects.
+      local items = (type(data) == "table") and (data.users or {}) or {}
+      for _, u_name in ipairs(items) do
+        nodes[#nodes + 1] = graphql_translate_user({
+          login = u_name,
+          name = nil,
+          email = "",
+          avatar_url = "",
+          html_url = config.base_url .. "/" .. u_name,
+          site_admin = false,
+        })
+      end
+      user_count = #nodes
+    end
+  end
+
+  local edges = {}
+  for _, node in ipairs(nodes) do
+    edges[#edges + 1] = {
+      __typename = "SearchResultItemEdge",
+      cursor = graphql_page_to_cursor(1),
+      node = node,
+    }
+  end
+  return {
+    __typename = "SearchResultItemConnection",
+    nodes = nodes,
+    edges = edges,
+    pageInfo = {
+      __typename = "PageInfo",
+      hasNextPage = false,
+      hasPreviousPage = false,
+      startCursor = #nodes > 0 and graphql_page_to_cursor(1) or nil,
+      endCursor = #nodes > 0 and graphql_page_to_cursor(1) or nil,
+    },
+    repositoryCount = repo_count,
+    userCount = user_count,
+    issueCount = issue_count,
+    codeCount = 0,
+    discussionCount = 0,
+    wikiCount = 0,
+  }
+end

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -790,10 +790,8 @@ graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
     if c.id == cid_n then
       local gh_comment = translate_pagure_comment(c)
       local comment_node = graphql_translate_comment(gh_comment, owner, repo)
-      comment_node.id = encode_node_id(
-        "IssueComment",
-        owner .. "/" .. repo .. "/" .. issue_num .. "/" .. cid
-      )
+      comment_node.id =
+        encode_node_id("IssueComment", owner .. "/" .. repo .. "/" .. issue_num .. "/" .. cid)
       return comment_node
     end
   end

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -72,7 +72,8 @@ local function translate_srht_repo(r)
     archived = false,
     disabled = false,
     open_issues_count = 0,
-    default_branch = r.HEAD and r.HEAD.name or "main",
+    default_branch = r.HEAD and ((r.HEAD.name or ""):match("^refs/heads/(.+)") or r.HEAD.name)
+      or "main",
     visibility = vis == "private" and "private" or "public",
     forks = 0,
     open_issues = 0,
@@ -578,3 +579,110 @@ backend_impl = {
 -- Code scanning: Sourcehut has no native code scanning API.
 -- All code scanning endpoints fall back to the default handlers in .init.lua:
 -- list endpoints return 200 empty, per-resource endpoints return 501.
+
+-- GraphQL resolvers --------------------------------------------------------
+-- Sourcehut scope: Query.repository, Query.viewer, Repository.issues.
+-- No Query.user (no endpoint to fetch an arbitrary user by login).
+-- No Repository.pullRequests (Sourcehut has no PR model).
+
+-- Translate a Sourcehut user (canonical_name/name) into a GitHub REST-shaped
+-- user table suitable for graphql_translate_user.
+local function translate_srht_user_for_graphql(u)
+  if not u then
+    return {}
+  end
+  local canonical = u.canonical_name or ""
+  local login = canonical:sub(1, 1) == "~" and canonical:sub(2) or canonical
+  return {
+    login = login,
+    id = 0,
+    node_id = "",
+    avatar_url = "",
+    html_url = config.base_url .. "/" .. canonical,
+    type = "User",
+    site_admin = false,
+    name = u.name or canonical,
+    email = u.email or "",
+    blog = u.url or "",
+  }
+end
+
+graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+  if not args.owner or not args.name then
+    graphql_error(ctx, "repository requires owner and name arguments")
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/~" .. args.owner .. "/repos/" .. args.name)
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_srht_repo(data))
+end
+
+graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+  local owner, name = local_id:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/~" .. owner .. "/repos/" .. name)
+  if not data then
+    return nil
+  end
+  return graphql_translate_repo(translate_srht_repo(data))
+end
+
+graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+  local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
+  if not data then
+    return nil
+  end
+  local u = graphql_translate_user(translate_srht_user_for_graphql(data))
+  u.isViewer = true
+  return u
+end
+
+-- Repository.issues: paginated list of issues via todo.sr.ht trackers.
+-- Sourcehut pagination uses cursor-based results with a `limit` param;
+-- graphql_cursor_url cannot be used (no page-number param), so we build
+-- the URL manually like bbs_repo_connection does.
+local function srht_issue_connection(owner, repo_name, args, ctx)
+  local per_page = args.first or 30
+  local url = todo_base()
+    .. "/~"
+    .. owner
+    .. "/trackers/"
+    .. repo_name
+    .. "/tickets?limit="
+    .. tostring(per_page)
+  local data, _, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  local nodes = {}
+  for _, t in ipairs(data.results or {}) do
+    nodes[#nodes + 1] = graphql_translate_issue(translate_srht_ticket(t), owner, repo_name)
+  end
+  return graphql_issues_connection(nodes, args, nil, ctx)
+end
+
+graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+  local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  return srht_issue_connection(owner, name, args, ctx)
+end
+
+graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local url = todo_base() .. "/~" .. owner .. "/trackers/" .. repo .. "/tickets/" .. number
+  local data, _ = graphql_fetch(fetch_json, url)
+  if not data then
+    return nil
+  end
+  return graphql_translate_issue(translate_srht_ticket(data), owner, repo)
+end

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,5 +1,5 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
-POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~repository and issues; no pull requests,n,n,n,n,~no pull requests,n
+POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,5 +1,5 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
-POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~repository and issues; no pull requests,n,n,n,n,~repository only; issues/PRs absent,n
+POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~repository and issues; no pull requests,n,n,n,n,~no pull requests,n
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,5 +1,5 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
-POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and issues work,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~repository and issues; no pull requests,n,n,n,n,~repository only; issues/PRs absent,n
+POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~repository and issues; no pull requests,n,n,n,n,~repository only; issues/PRs absent,n
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n

--- a/test/azuredevops-graphql.hurl
+++ b/test/azuredevops-graphql.hurl
@@ -1,0 +1,55 @@
+# GraphQL API — Azure DevOps backend.
+# ADO scope: Query.repository only; no viewer (no GET /user), no issues
+# (Work Items are a fundamentally different model).
+
+# POST /graphql — __typename on the Query root is always resolved
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ __typename }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.__typename" == "Query"
+
+# POST /graphql — Query.repository returns a repository by owner and name
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { name nameWithOwner description } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.name" == "hello-world"
+jsonpath "$.data.repository.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.repository.description" == "Test project"
+
+# POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { owner { login } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.owner.login" == "octocat"
+
+# POST /graphql — Repository scalar fields
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { isPrivate isFork isArchived defaultBranchRef { name } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.isPrivate" == false
+jsonpath "$.data.repository.isFork" == false
+jsonpath "$.data.repository.isArchived" == false
+jsonpath "$.data.repository.defaultBranchRef.name" == "main"
+
+# POST /graphql — Query.viewer is not resolved (ADO has no GET /user)
+# When no Query.viewer resolver is registered, the GraphQL executor returns
+# null for the field. EncodeJson drops nil keys, so viewer is absent.
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ viewer { login } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.viewer" not exists

--- a/test/bitbucket_datacenter-graphql.hurl
+++ b/test/bitbucket_datacenter-graphql.hurl
@@ -1,0 +1,77 @@
+# GraphQL API — Bitbucket Data Center backend.
+# BBS scope: Query.repository, Query.user, Repository.pullRequests.
+# No viewer (no GET /user), no issues (BBS relies on Jira).
+
+# POST /graphql — __typename on the Query root is always resolved
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ __typename }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.__typename" == "Query"
+
+# POST /graphql — Query.repository returns a repository by owner and name
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { name nameWithOwner } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.name" == "hello-world"
+jsonpath "$.data.repository.nameWithOwner" == "octocat/hello-world"
+
+# POST /graphql — Repository.owner is inlined by the translator
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { owner { login } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.owner.login" == "octocat"
+
+# POST /graphql — Repository scalar fields
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { isPrivate isFork isArchived defaultBranchRef { name } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.isPrivate" == false
+jsonpath "$.data.repository.isFork" == false
+jsonpath "$.data.repository.isArchived" == false
+jsonpath "$.data.repository.defaultBranchRef.name" == "main"
+
+# POST /graphql — Query.user returns a user by login
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ user(login: \"octocat\") { login name } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.user.login" == "octocat"
+jsonpath "$.data.user.name" == "The Octocat"
+
+# POST /graphql — Repository.pullRequests returns a PullRequestConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { pullRequests { nodes { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.pullRequests.nodes" isCollection
+jsonpath "$.data.repository.pullRequests.nodes[0].number" == 1
+jsonpath "$.data.repository.pullRequests.nodes[0].title" == "A great PR"
+jsonpath "$.data.repository.pullRequests.nodes[0].state" == "MERGED"
+
+# POST /graphql — node(PullRequest) fetches a PR by encoded node ID
+# Node ID for PullRequest:octocat/hello-world/1 = UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\") { ... on PullRequest { number title state } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.number" == 1
+jsonpath "$.data.node.title" == "A great PR"
+jsonpath "$.data.node.state" == "MERGED"

--- a/test/mock-pagure.lua
+++ b/test/mock-pagure.lua
@@ -114,7 +114,17 @@ function OnHttpRequest()
     json('{"user":{"username":"octocat","fullname":"The Octocat","avatar_url":""}}')
   elseif path == "/api/0/users" then
     SetStatus(200, "OK")
-    json('{"users":["octocat","hubot"],"total_users":2}')
+    local ufilter = GetParam("username")
+    if ufilter and ufilter ~= "" then
+      -- Pagure filters by username prefix; simulate by returning only octocat when queried.
+      if ("octocat"):find(ufilter, 1, true) then
+        json('{"users":["octocat"],"total_users":1}')
+      else
+        json('{"users":[],"total_users":0}')
+      end
+    else
+      json('{"users":["octocat","hubot"],"total_users":2}')
+    end
 
   -- Users' repos -----------------------------------------------------------
   elseif path:find("^/api/0/user/") then

--- a/test/pagure-graphql.hurl
+++ b/test/pagure-graphql.hurl
@@ -1,0 +1,160 @@
+# GraphQL API — Pagure backend.
+# Pagure scope: Query.viewer, Query.user, Query.repository,
+# Repository.issues, Repository.refs, Issue.comments, Query.search.
+# No pull requests, reviews, releases, or labels (Pagure has no equivalent APIs).
+
+# POST /graphql — __typename on the Query root is always resolved
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ __typename }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.__typename" == "Query"
+
+# POST /graphql — Query.viewer returns the authenticated user
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "{ viewer { login name isViewer } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.viewer.login" == "octocat"
+jsonpath "$.data.viewer.name" == "The Octocat"
+jsonpath "$.data.viewer.isViewer" == true
+
+# POST /graphql — Query.user returns a user by login
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ user(login: \"octocat\") { login name } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.user.login" == "octocat"
+jsonpath "$.data.user.name" == "The Octocat"
+
+# POST /graphql — Query.repository returns a repository by owner and name
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { name nameWithOwner description } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.name" == "hello-world"
+jsonpath "$.data.repository.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.repository.description" == "My first repo"
+
+# POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { owner { login } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.owner.login" == "octocat"
+
+# POST /graphql — Repository scalar fields
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { isPrivate isFork isArchived defaultBranchRef { name } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.isPrivate" == false
+jsonpath "$.data.repository.isFork" == false
+jsonpath "$.data.repository.isArchived" == false
+jsonpath "$.data.repository.defaultBranchRef.name" == "main"
+
+# POST /graphql — node(Repository) fetches a repository by encoded node ID
+# Node ID for Repository:octocat/hello-world = UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\") { ... on Repository { name nameWithOwner } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "hello-world"
+jsonpath "$.data.node.nameWithOwner" == "octocat/hello-world"
+
+# POST /graphql — Repository.issues returns an IssueConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues { nodes { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.issues.nodes" isCollection
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+jsonpath "$.data.repository.issues.nodes[0].title" == "Found a bug"
+jsonpath "$.data.repository.issues.nodes[0].state" == "OPEN"
+
+# POST /graphql — node(Issue) fetches an issue by encoded node ID
+# Node ID for Issue:octocat/hello-world/1 = SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\") { ... on Issue { number title state } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.number" == 1
+jsonpath "$.data.node.title" == "Found a bug"
+jsonpath "$.data.node.state" == "OPEN"
+
+# POST /graphql — Issue.comments returns embedded comments
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues { nodes { number comments { nodes { body author { login } } } } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes" isCollection
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes[0].body" == "This is a comment"
+jsonpath "$.data.repository.issues.nodes[0].comments.nodes[0].author.login" == "octocat"
+
+# POST /graphql — node(IssueComment) fetches a comment by encoded node ID
+# Node ID for IssueComment:octocat/hello-world/1/1 = SXNzdWVDb21tZW50Om9jdG9jYXQvaGVsbG8td29ybGQvMS8x
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"SXNzdWVDb21tZW50Om9jdG9jYXQvaGVsbG8td29ybGQvMS8x\") { ... on IssueComment { body author { login } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.body" == "This is a comment"
+jsonpath "$.data.node.author.login" == "octocat"
+
+# POST /graphql — Repository.refs returns a RefConnection (branches)
+# Pagure branch list has no commit SHAs; target is absent.
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { refs { nodes { name } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.refs.nodes" isCollection
+jsonpath "$.data.repository.refs.nodes[0].name" == "main"
+
+# POST /graphql — Query.search REPOSITORY returns a SearchResultItemConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ search(query: \"hello\", type: REPOSITORY, first: 5) { repositoryCount nodes { ... on Repository { name nameWithOwner } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.search.repositoryCount" == 1
+jsonpath "$.data.search.nodes" isCollection
+jsonpath "$.data.search.nodes[0].name" == "hello-world"
+jsonpath "$.data.search.nodes[0].nameWithOwner" == "octocat/hello-world"
+
+# POST /graphql — Query.search USER returns a SearchResultItemConnection
+# Pagure /users returns login names only; no full profile is fetched per result.
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ search(query: \"octocat\", type: USER, first: 5) { userCount nodes { ... on User { login } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.search.userCount" == 1
+jsonpath "$.data.search.nodes" isCollection
+jsonpath "$.data.search.nodes[0].login" == "octocat"

--- a/test/sourcehut-graphql.hurl
+++ b/test/sourcehut-graphql.hurl
@@ -1,0 +1,79 @@
+# GraphQL API — Sourcehut backend.
+# Sourcehut scope: Query.repository, Query.viewer, Repository.issues.
+# No Query.user (no arbitrary-user lookup), no Repository.pullRequests.
+
+# POST /graphql — __typename on the Query root is always resolved
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ __typename }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.__typename" == "Query"
+
+# POST /graphql — Query.repository returns a repository by owner and name
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { name nameWithOwner description } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.name" == "hello-world"
+jsonpath "$.data.repository.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.repository.description" == "My first repo"
+
+# POST /graphql — Repository.owner is inlined by the translator
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { owner { login } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.owner.login" == "octocat"
+
+# POST /graphql — Repository scalar fields
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { isPrivate isFork isArchived defaultBranchRef { name } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.isPrivate" == false
+jsonpath "$.data.repository.isFork" == false
+jsonpath "$.data.repository.isArchived" == false
+jsonpath "$.data.repository.defaultBranchRef.name" == "main"
+
+# POST /graphql — Query.viewer returns the authenticated user
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ viewer { login name isViewer } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.viewer.login" == "octocat"
+jsonpath "$.data.viewer.name" == "octocat"
+jsonpath "$.data.viewer.isViewer" == true
+
+# POST /graphql — Repository.issues returns an IssueConnection
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues { nodes { number title state } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.repository.issues.nodes" isCollection
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+jsonpath "$.data.repository.issues.nodes[0].title" == "Found a bug"
+jsonpath "$.data.repository.issues.nodes[0].state" == "OPEN"
+
+# POST /graphql — node(Issue) fetches an issue by encoded node ID
+# Node ID for Issue:octocat/hello-world/1 = SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\") { ... on Issue { number title state } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.number" == 1
+jsonpath "$.data.node.title" == "Found a bug"
+jsonpath "$.data.node.state" == "OPEN"


### PR DESCRIPTION
Fixes #154.

Adds minimum GraphQL resolver coverage for the remaining backends that lack it: Sourcehut and Pagure. Each backend gets its own resolvers, hurl test file, and CSV claim update, completing GraphQL support across all providers.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Pagure: add GraphQL resolvers and tests <!-- type:spec -->
- [x] Bitbucket Data Center: add GraphQL resolvers and tests <!-- type:spec -->
- [x] Azure DevOps: add Query.repository GraphQL resolver and tests <!-- type:spec -->
- [x] Sourcehut: add GraphQL resolvers and tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->