### PR TITLE
GraphQL: GQL-19 - Issue mutations (create, update, close, reopen) (closes #157)

### DIFF
--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3855,3 +3855,168 @@ graphql_resolvers["Mutation.deleteRepository"] = function(_parent, args, ctx)
   end
   return { clientMutationId = cmid }
 end
+
+-- ---------------------------------------------------------------------------
+-- Issue mutations
+-- ---------------------------------------------------------------------------
+
+-- Mutation.createIssue: open a new issue in an existing repository.
+-- Input fields: repositoryId (required, Repository node ID), title (required),
+--   body, labelIds (array of Label node IDs), assigneeIds (array of User node IDs),
+--   milestoneId (Milestone node ID).
+-- Sends POST /repos/{owner}/{repo}/issues; returns the created issue.
+graphql_resolvers["Mutation.createIssue"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.repositoryId then
+    return graphql_error(ctx, "createIssue requires input.repositoryId", nil, "BAD_USER_INPUT")
+  end
+  if not input.title then
+    return graphql_error(ctx, "createIssue requires input.title", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.repositoryId)
+  if t ~= "Repository" then
+    return graphql_error(ctx, "createIssue: invalid repositoryId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo = lid:match("^([^/]+)/(.+)$")
+  if not owner then
+    return graphql_error(ctx, "createIssue: malformed repositoryId", nil, "BAD_USER_INPUT")
+  end
+  -- Decode labelIds: Label node local_id = "owner/repo/label_id"; extract integer id.
+  local labels = {}
+  for _, lid_encoded in ipairs(input.labelIds or {}) do
+    local lt, llid = decode_node_id(lid_encoded)
+    if lt == "Label" then
+      local _, _, label_id = llid:match("^([^/]+)/([^/]+)/(.+)$")
+      if label_id then
+        labels[#labels + 1] = tonumber(label_id)
+      end
+    end
+  end
+  -- Decode assigneeIds: User node local_id = login.
+  local assignees = {}
+  for _, aid_encoded in ipairs(input.assigneeIds or {}) do
+    local at, alid = decode_node_id(aid_encoded)
+    if at == "User" then
+      assignees[#assignees + 1] = alid
+    end
+  end
+  -- Decode milestoneId: Milestone node local_id = "owner/repo/id".
+  local milestone_id
+  if input.milestoneId then
+    local mt, mlid = decode_node_id(input.milestoneId)
+    if mt == "Milestone" then
+      local _, _, mid = mlid:match("^([^/]+)/([^/]+)/(.+)$")
+      milestone_id = mid and tonumber(mid) or nil
+    end
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues"
+  local body = EncodeJson({
+    title = input.title,
+    body = input.body,
+    labels = #labels > 0 and labels or nil,
+    assignees = #assignees > 0 and assignees or nil,
+    milestone = milestone_id,
+  })
+  local data = graphql_fetch_or_error(fetch_json, path, ctx, nil, "POST", body)
+  if not data then
+    return nil
+  end
+  return {
+    issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end
+
+-- Mutation.updateIssue: update title, body, or state of an existing issue.
+-- Input fields: id (required, Issue node ID), title, body, state (IssueState enum).
+-- Sends PATCH /repos/{owner}/{repo}/issues/{number} with only the supplied fields.
+-- Maps GraphQL IssueState enum (OPEN, CLOSED) to Gitea REST values (open, closed).
+graphql_resolvers["Mutation.updateIssue"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.id then
+    return graphql_error(ctx, "updateIssue requires input.id", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.id)
+  if t ~= "Issue" then
+    return graphql_error(ctx, "updateIssue: invalid id", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "updateIssue: malformed id", nil, "BAD_USER_INPUT")
+  end
+  local state_map = { OPEN = "open", CLOSED = "closed" }
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number
+  local body = EncodeJson({
+    title = input.title,
+    body = input.body,
+    state = input.state and state_map[input.state] or nil,
+  })
+  local data = graphql_fetch_or_error(fetch_json, path, ctx, nil, "PATCH", body)
+  if not data then
+    return nil
+  end
+  return {
+    issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end
+
+-- Mutation.closeIssue: close an open issue.
+-- Input fields: issueId (required, Issue node ID).
+-- Sends PATCH /repos/{owner}/{repo}/issues/{number} with state=closed.
+graphql_resolvers["Mutation.closeIssue"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.issueId then
+    return graphql_error(ctx, "closeIssue requires input.issueId", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.issueId)
+  if t ~= "Issue" then
+    return graphql_error(ctx, "closeIssue: invalid issueId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "closeIssue: malformed issueId", nil, "BAD_USER_INPUT")
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number
+  local body = EncodeJson({ state = "closed" })
+  local data = graphql_fetch_or_error(fetch_json, path, ctx, nil, "PATCH", body)
+  if not data then
+    return nil
+  end
+  return {
+    issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end
+
+-- Mutation.reopenIssue: reopen a closed issue.
+-- Input fields: issueId (required, Issue node ID).
+-- Sends PATCH /repos/{owner}/{repo}/issues/{number} with state=open.
+graphql_resolvers["Mutation.reopenIssue"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.issueId then
+    return graphql_error(ctx, "reopenIssue requires input.issueId", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.issueId)
+  if t ~= "Issue" then
+    return graphql_error(ctx, "reopenIssue: invalid issueId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "reopenIssue: malformed issueId", nil, "BAD_USER_INPUT")
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number
+  local body = EncodeJson({ state = "open" })
+  local data = graphql_fetch_or_error(fetch_json, path, ctx, nil, "PATCH", body)
+  if not data then
+    return nil
+  end
+  return {
+    issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -470,3 +470,224 @@ HTTP 200
 jsonpath "$.data.deleteRepository" not exists
 jsonpath "$.errors" isCollection
 jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createIssue creates an issue in the given repository
+# repositoryId "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk" = base64("Repository:octocat/hello-world")
+# → POST /api/v1/repos/octocat/hello-world/issues
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createIssue(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", title: \"Found a bug\" }) { issue { number title state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createIssue.issue.number" == 1
+jsonpath "$.data.createIssue.issue.title" == "Found a bug"
+jsonpath "$.data.createIssue.issue.state" == "OPEN"
+jsonpath "$.data.createIssue.clientMutationId" not exists
+
+# POST /graphql — Mutation.createIssue echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createIssue(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", title: \"Found a bug\", clientMutationId: \"relay-ci-1\" }) { issue { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createIssue.issue.number" == 1
+jsonpath "$.data.createIssue.clientMutationId" == "relay-ci-1"
+
+# POST /graphql — Mutation.createIssue without repositoryId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createIssue(input: { title: \"Found a bug\" }) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createIssue without title returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createIssue(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\" }) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createIssue with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createIssue(input: { repositoryId: \"VXNlcjpvY3RvY2F0\", title: \"Found a bug\" }) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.updateIssue updates an issue
+# issueId "SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x" = base64("Issue:octocat/hello-world/1")
+# → PATCH /api/v1/repos/octocat/hello-world/issues/1
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateIssue(input: { id: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\", title: \"Found a bug\" }) { issue { number title state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updateIssue.issue.number" == 1
+jsonpath "$.data.updateIssue.issue.title" == "Found a bug"
+jsonpath "$.data.updateIssue.issue.state" isString
+jsonpath "$.data.updateIssue.clientMutationId" not exists
+
+# POST /graphql — Mutation.updateIssue echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateIssue(input: { id: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\", title: \"Found a bug\", clientMutationId: \"relay-ui-1\" }) { issue { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updateIssue.issue.number" == 1
+jsonpath "$.data.updateIssue.clientMutationId" == "relay-ui-1"
+
+# POST /graphql — Mutation.updateIssue without id returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateIssue(input: { title: \"Found a bug\" }) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.updateIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.updateIssue with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateIssue(input: { id: \"VXNlcjpvY3RvY2F0\", title: \"Found a bug\" }) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.updateIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.closeIssue closes an issue
+# issueId "SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x" = base64("Issue:octocat/hello-world/1")
+# → PATCH /api/v1/repos/octocat/hello-world/issues/1 with state=closed
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { closeIssue(input: { issueId: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\" }) { issue { number state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.closeIssue.issue.number" == 1
+jsonpath "$.data.closeIssue.issue.state" isString
+jsonpath "$.data.closeIssue.clientMutationId" not exists
+
+# POST /graphql — Mutation.closeIssue echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { closeIssue(input: { issueId: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\", clientMutationId: \"relay-close-1\" }) { issue { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.closeIssue.issue.number" == 1
+jsonpath "$.data.closeIssue.clientMutationId" == "relay-close-1"
+
+# POST /graphql — Mutation.closeIssue without issueId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { closeIssue(input: {}) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.closeIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.closeIssue with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { closeIssue(input: { issueId: \"VXNlcjpvY3RvY2F0\" }) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.closeIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.reopenIssue reopens an issue
+# issueId "SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x" = base64("Issue:octocat/hello-world/1")
+# → PATCH /api/v1/repos/octocat/hello-world/issues/1 with state=open
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { reopenIssue(input: { issueId: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\" }) { issue { number state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.reopenIssue.issue.number" == 1
+jsonpath "$.data.reopenIssue.issue.state" isString
+jsonpath "$.data.reopenIssue.clientMutationId" not exists
+
+# POST /graphql — Mutation.reopenIssue echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { reopenIssue(input: { issueId: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\", clientMutationId: \"relay-reopen-1\" }) { issue { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.reopenIssue.issue.number" == 1
+jsonpath "$.data.reopenIssue.clientMutationId" == "relay-reopen-1"
+
+# POST /graphql — Mutation.reopenIssue without issueId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { reopenIssue(input: {}) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.reopenIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.reopenIssue with wrong node type returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { reopenIssue(input: { issueId: \"VXNlcjpvY3RvY2F0\" }) { issue { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.reopenIssue" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"

--- a/test/graphql-mutations.lua
+++ b/test/graphql-mutations.lua
@@ -229,3 +229,168 @@ do -- mutation validation error: unknown field on Mutation type
     "mutation: validation error → VALIDATION_ERROR code"
   )
 end
+
+-- ============================================================
+-- Issue mutation resolver dispatch
+-- ============================================================
+
+do -- createIssue resolver is dispatched and returns issue payload
+  local repo_id = encode_node_id("Repository", "octocat/hello-world")
+  with_resolvers({
+    ["Mutation.createIssue"] = function(_parent, _args, _ctx)
+      return {
+        issue = {
+          __typename = "Issue",
+          id = encode_node_id("Issue", "octocat/hello-world/1"),
+          number = 1,
+          title = "Found a bug",
+          state = "OPEN",
+        },
+        clientMutationId = nil,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = string.format(
+        [[mutation { createIssue(input: { repositoryId: "%s", title: "Found a bug" }) { issue { number title state } clientMutationId } }]],
+        repo_id
+      ),
+    })
+    ok(r.errors == nil or #r.errors == 0, "createIssue: resolver dispatched → no errors")
+    ok(r.data.createIssue ~= nil, "createIssue: resolver dispatched → payload present")
+    eq(r.data.createIssue.issue.number, 1, "createIssue: payload → issue.number")
+    eq(r.data.createIssue.issue.title, "Found a bug", "createIssue: payload → issue.title")
+    eq(r.data.createIssue.issue.state, "OPEN", "createIssue: payload → issue.state open")
+  end)
+end
+
+do -- updateIssue resolver is dispatched and returns updated issue
+  local issue_id = encode_node_id("Issue", "octocat/hello-world/1")
+  with_resolvers({
+    ["Mutation.updateIssue"] = function(_parent, _args, _ctx)
+      return {
+        issue = {
+          __typename = "Issue",
+          id = encode_node_id("Issue", "octocat/hello-world/1"),
+          number = 1,
+          title = "Updated title",
+          state = "OPEN",
+        },
+        clientMutationId = nil,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = string.format(
+        [[mutation { updateIssue(input: { id: "%s", title: "Updated title" }) { issue { number title state } } }]],
+        issue_id
+      ),
+    })
+    ok(r.errors == nil or #r.errors == 0, "updateIssue: resolver dispatched → no errors")
+    ok(r.data.updateIssue ~= nil, "updateIssue: resolver dispatched → payload present")
+    eq(r.data.updateIssue.issue.number, 1, "updateIssue: payload → issue.number")
+    eq(r.data.updateIssue.issue.title, "Updated title", "updateIssue: payload → issue.title")
+  end)
+end
+
+do -- closeIssue resolver is dispatched and returns closed issue
+  local issue_id = encode_node_id("Issue", "octocat/hello-world/1")
+  with_resolvers({
+    ["Mutation.closeIssue"] = function(_parent, _args, _ctx)
+      return {
+        issue = {
+          __typename = "Issue",
+          id = encode_node_id("Issue", "octocat/hello-world/1"),
+          number = 1,
+          title = "Found a bug",
+          state = "CLOSED",
+        },
+        clientMutationId = nil,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = string.format(
+        [[mutation { closeIssue(input: { issueId: "%s" }) { issue { number state } } }]],
+        issue_id
+      ),
+    })
+    ok(r.errors == nil or #r.errors == 0, "closeIssue: resolver dispatched → no errors")
+    ok(r.data.closeIssue ~= nil, "closeIssue: resolver dispatched → payload present")
+    eq(r.data.closeIssue.issue.state, "CLOSED", "closeIssue: payload → issue.state closed")
+  end)
+end
+
+do -- reopenIssue resolver is dispatched and returns open issue
+  local issue_id = encode_node_id("Issue", "octocat/hello-world/1")
+  with_resolvers({
+    ["Mutation.reopenIssue"] = function(_parent, _args, _ctx)
+      return {
+        issue = {
+          __typename = "Issue",
+          id = encode_node_id("Issue", "octocat/hello-world/1"),
+          number = 1,
+          title = "Found a bug",
+          state = "OPEN",
+        },
+        clientMutationId = nil,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = string.format(
+        [[mutation { reopenIssue(input: { issueId: "%s" }) { issue { number state } } }]],
+        issue_id
+      ),
+    })
+    ok(r.errors == nil or #r.errors == 0, "reopenIssue: resolver dispatched → no errors")
+    ok(r.data.reopenIssue ~= nil, "reopenIssue: resolver dispatched → payload present")
+    eq(r.data.reopenIssue.issue.state, "OPEN", "reopenIssue: payload → issue.state open")
+  end)
+end
+
+do -- createIssue: clientMutationId is echoed back in payload
+  local repo_id = encode_node_id("Repository", "octocat/hello-world")
+  with_resolvers({
+    ["Mutation.createIssue"] = function(_parent, args, _ctx)
+      local cmid = get_client_mutation_id(args)
+      return {
+        issue = {
+          __typename = "Issue",
+          id = encode_node_id("Issue", "octocat/hello-world/2"),
+          number = 2,
+          title = "New issue",
+          state = "OPEN",
+        },
+        clientMutationId = cmid,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = string.format(
+        [[mutation { createIssue(input: { repositoryId: "%s", title: "New issue", clientMutationId: "relay-issue-7" }) { issue { number } clientMutationId } }]],
+        repo_id
+      ),
+    })
+    ok(r.errors == nil or #r.errors == 0, "createIssue: clientMutationId round-trip → no errors")
+    eq(
+      r.data.createIssue.clientMutationId,
+      "relay-issue-7",
+      "createIssue: clientMutationId round-trip → value echoed back"
+    )
+  end)
+end
+
+do -- closeIssue: no resolver registered → null payload (no crash)
+  local issue_id = encode_node_id("Issue", "octocat/hello-world/1")
+  with_resolvers({}, function()
+    local r = call_handler({
+      query = string.format(
+        [[mutation { closeIssue(input: { issueId: "%s" }) { clientMutationId } }]],
+        issue_id
+      ),
+    })
+    ok(r.data ~= nil, "closeIssue: no resolver → data not null at root")
+    ok(r.data.closeIssue == nil, "closeIssue: no resolver → payload is null")
+  end)
+end

--- a/test/mock-gitea.lua
+++ b/test/mock-gitea.lua
@@ -369,7 +369,9 @@ function OnHttpRequest()
 
     -- Issues
     ["/api/v1/repos/octocat/hello-world/issues"] = { 200, "[" .. ISSUE .. "]" },
+    ["POST /api/v1/repos/octocat/hello-world/issues"] = { 201, ISSUE },
     ["/api/v1/repos/octocat/hello-world/issues/1"] = { 200, ISSUE },
+    ["PATCH /api/v1/repos/octocat/hello-world/issues/1"] = { 200, ISSUE },
     ["/api/v1/repos/octocat/hello-world/issues/comments"] = { 200, "[" .. ISSUE_COMMENT .. "]" },
     ["/api/v1/repos/octocat/hello-world/issues/comments/1"] = { 200, ISSUE_COMMENT },
     ["/api/v1/repos/octocat/hello-world/issues/events"] = { 200, "[" .. ISSUE_EVENT .. "]" },


### PR DESCRIPTION
Fixes #157.

Adds GraphQL issue mutations (createIssue, updateIssue, closeIssue, reopenIssue) to the Gitea backend, following the established resolver pattern from repository mutations. Includes mock routes for POST/PATCH issue endpoints, unit tests for resolver dispatch and input validation, and Hurl integration tests for the full mutation round-trip.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add unit tests for issue mutation resolvers in graphql-mutations.lua <!-- type:spec -->
- [x] Add Hurl tests for issue mutation GraphQL queries in gitea-graphql.hurl <!-- type:spec -->
- [x] Gitea: implement createIssue, updateIssue, closeIssue, reopenIssue GraphQL mutations <!-- type:spec -->
- [x] Add mock routes for issue create and update in mock-gitea.lua <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->