### PR TITLE
GraphQL: GQL-20 - Pull request mutations (closes #158)

### DIFF
--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -4023,3 +4023,154 @@ graphql_resolvers["Mutation.reopenIssue"] = function(_parent, args, ctx)
     clientMutationId = cmid,
   }
 end
+
+-- Mutation.createPullRequest: open a new pull request in a repository.
+-- Input fields: repositoryId (required, Repository node ID), title (required),
+--   body, headRefName (required, source branch), baseRefName (required, target branch).
+-- Sends POST /repos/{owner}/{repo}/pulls and returns the created pull request.
+graphql_resolvers["Mutation.createPullRequest"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.repositoryId then
+    return graphql_error(
+      ctx,
+      "createPullRequest requires input.repositoryId",
+      nil,
+      "BAD_USER_INPUT"
+    )
+  end
+  if not input.title then
+    return graphql_error(ctx, "createPullRequest requires input.title", nil, "BAD_USER_INPUT")
+  end
+  if not input.headRefName then
+    return graphql_error(ctx, "createPullRequest requires input.headRefName", nil, "BAD_USER_INPUT")
+  end
+  if not input.baseRefName then
+    return graphql_error(ctx, "createPullRequest requires input.baseRefName", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.repositoryId)
+  if t ~= "Repository" then
+    return graphql_error(ctx, "createPullRequest: invalid repositoryId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo = lid:match("^([^/]+)/(.+)$")
+  if not owner then
+    return graphql_error(ctx, "createPullRequest: malformed repositoryId", nil, "BAD_USER_INPUT")
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls"
+  local body = EncodeJson({
+    title = input.title,
+    body = input.body,
+    head = input.headRefName,
+    base = input.baseRefName,
+  })
+  local data = graphql_fetch_or_error(fetch_json, path, ctx, nil, "POST", body)
+  if not data then
+    return nil
+  end
+  return {
+    pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end
+
+-- Mutation.updatePullRequest: update the title, body, and/or base branch of a pull request.
+-- Input fields: pullRequestId (required, PullRequest node ID), title, body, baseRefName.
+-- Sends PATCH /repos/{owner}/{repo}/pulls/{number}.
+graphql_resolvers["Mutation.updatePullRequest"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.pullRequestId then
+    return graphql_error(
+      ctx,
+      "updatePullRequest requires input.pullRequestId",
+      nil,
+      "BAD_USER_INPUT"
+    )
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.pullRequestId)
+  if t ~= "PullRequest" then
+    return graphql_error(ctx, "updatePullRequest: invalid pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "updatePullRequest: malformed pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number
+  local body = EncodeJson({ title = input.title, body = input.body, base = input.baseRefName })
+  local data = graphql_fetch_or_error(fetch_json, path, ctx, nil, "PATCH", body)
+  if not data then
+    return nil
+  end
+  return {
+    pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end
+
+-- Mutation.closePullRequest: close an open pull request.
+-- Input fields: pullRequestId (required, PullRequest node ID).
+-- Sends PATCH /repos/{owner}/{repo}/pulls/{number} with state=closed.
+graphql_resolvers["Mutation.closePullRequest"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.pullRequestId then
+    return graphql_error(
+      ctx,
+      "closePullRequest requires input.pullRequestId",
+      nil,
+      "BAD_USER_INPUT"
+    )
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.pullRequestId)
+  if t ~= "PullRequest" then
+    return graphql_error(ctx, "closePullRequest: invalid pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "closePullRequest: malformed pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number
+  local data =
+    graphql_fetch_or_error(fetch_json, path, ctx, nil, "PATCH", EncodeJson({ state = "closed" }))
+  if not data then
+    return nil
+  end
+  return {
+    pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end
+
+-- Mutation.reopenPullRequest: reopen a closed pull request.
+-- Input fields: pullRequestId (required, PullRequest node ID).
+-- Sends PATCH /repos/{owner}/{repo}/pulls/{number} with state=open.
+graphql_resolvers["Mutation.reopenPullRequest"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.pullRequestId then
+    return graphql_error(
+      ctx,
+      "reopenPullRequest requires input.pullRequestId",
+      nil,
+      "BAD_USER_INPUT"
+    )
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.pullRequestId)
+  if t ~= "PullRequest" then
+    return graphql_error(ctx, "reopenPullRequest: invalid pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "reopenPullRequest: malformed pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number
+  local data =
+    graphql_fetch_or_error(fetch_json, path, ctx, nil, "PATCH", EncodeJson({ state = "open" }))
+  if not data then
+    return nil
+  end
+  return {
+    pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -4174,3 +4174,75 @@ graphql_resolvers["Mutation.reopenPullRequest"] = function(_parent, args, ctx)
     clientMutationId = cmid,
   }
 end
+
+-- Mutation.mergePullRequest: merge an open pull request.
+-- Input fields: pullRequestId (required, PullRequest node ID), mergeMethod
+--   (MERGE/SQUASH/REBASE; defaults to MERGE), commitHeadline, commitBody.
+-- Sends POST /repos/{owner}/{repo}/pulls/{number}/merge (Gitea uses POST; GitHub uses PUT).
+-- The merge endpoint returns 204 No Content, so the PR is re-fetched to populate the payload.
+graphql_resolvers["Mutation.mergePullRequest"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.pullRequestId then
+    return graphql_error(
+      ctx,
+      "mergePullRequest requires input.pullRequestId",
+      nil,
+      "BAD_USER_INPUT"
+    )
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.pullRequestId)
+  if t ~= "PullRequest" then
+    return graphql_error(ctx, "mergePullRequest: invalid pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "mergePullRequest: malformed pullRequestId", nil, "BAD_USER_INPUT")
+  end
+  -- Map GitHub mergeMethod enum to Gitea's Do field string.
+  local method_map = { MERGE = "merge", SQUASH = "squash", REBASE = "rebase" }
+  local do_method = method_map[input.mergeMethod or "MERGE"] or "merge"
+  local merge_path = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/merge"
+  local merge_body = EncodeJson({
+    Do = do_method,
+    MergeTitleField = input.commitHeadline,
+    MergeMessageField = input.commitBody,
+  })
+  -- POST to Gitea's merge endpoint; it returns 204 No Content on success.
+  local ok, status = fetch_json(merge_path, "POST", merge_body)
+  if not ok then
+    graphql_error(ctx, "network error merging pull request", nil, "INTERNAL_ERROR")
+    return nil
+  end
+  if status == 401 or status == 403 then
+    graphql_error(ctx, "not authorized to merge pull request", nil, "FORBIDDEN")
+    return nil
+  end
+  if status == 404 then
+    graphql_error(ctx, "pull request not found", nil, "NOT_FOUND")
+    return nil
+  end
+  if status == 405 then
+    graphql_error(ctx, "pull request is not mergeable", nil, "UNPROCESSABLE")
+    return nil
+  end
+  if status ~= 204 then
+    graphql_error(
+      ctx,
+      "upstream error " .. tostring(status) .. " merging pull request",
+      nil,
+      "INTERNAL_ERROR"
+    )
+    return nil
+  end
+  -- Re-fetch the PR to return in the payload (merge returns 204, no body).
+  local pr_path = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number
+  local pr_data = graphql_fetch_or_error(fetch_json, pr_path, ctx, nil)
+  if not pr_data then
+    return nil
+  end
+  return {
+    pullRequest = graphql_translate_pr(translate_gitea_pull(pr_data), owner, repo),
+    clientMutationId = cmid,
+  }
+end

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -662,3 +662,234 @@ HTTP 200
 jsonpath "$.data.reopenIssue" not exists
 jsonpath "$.errors" isCollection
 jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createPullRequest creates a pull request
+# Node ID for Repository:octocat/hello-world = UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk
+# → POST /api/v1/repos/octocat/hello-world/pulls
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createPullRequest(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", title: \"A great PR\", headRefName: \"feature\", baseRefName: \"main\" }) { pullRequest { number title state headRefName baseRefName } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createPullRequest.pullRequest.number" == 1
+jsonpath "$.data.createPullRequest.pullRequest.title" == "A great PR"
+jsonpath "$.data.createPullRequest.pullRequest.state" == "OPEN"
+jsonpath "$.data.createPullRequest.pullRequest.headRefName" == "feature"
+jsonpath "$.data.createPullRequest.pullRequest.baseRefName" == "main"
+jsonpath "$.data.createPullRequest.clientMutationId" not exists
+
+# POST /graphql — Mutation.createPullRequest echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createPullRequest(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", title: \"A great PR\", headRefName: \"feature\", baseRefName: \"main\", clientMutationId: \"pr-relay-1\" }) { pullRequest { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createPullRequest.pullRequest.number" == 1
+jsonpath "$.data.createPullRequest.clientMutationId" == "pr-relay-1"
+
+# POST /graphql — Mutation.createPullRequest without repositoryId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createPullRequest(input: { title: \"A great PR\", headRefName: \"feature\", baseRefName: \"main\" }) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createPullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createPullRequest without title returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createPullRequest(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", headRefName: \"feature\", baseRefName: \"main\" }) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createPullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createPullRequest with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createPullRequest(input: { repositoryId: \"VXNlcjpvY3RvY2F0\", title: \"A great PR\", headRefName: \"feature\", baseRefName: \"main\" }) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createPullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.updatePullRequest updates a pull request
+# Node ID for PullRequest:octocat/hello-world/1 = UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x
+# → PATCH /api/v1/repos/octocat/hello-world/pulls/1
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updatePullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\", title: \"Updated PR\" }) { pullRequest { number title state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updatePullRequest.pullRequest.number" == 1
+jsonpath "$.data.updatePullRequest.pullRequest.title" == "A great PR"
+jsonpath "$.data.updatePullRequest.pullRequest.state" == "OPEN"
+jsonpath "$.data.updatePullRequest.clientMutationId" not exists
+
+# POST /graphql — Mutation.updatePullRequest echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updatePullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\", clientMutationId: \"pr-relay-2\" }) { pullRequest { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updatePullRequest.clientMutationId" == "pr-relay-2"
+
+# POST /graphql — Mutation.updatePullRequest without pullRequestId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updatePullRequest(input: { title: \"Updated PR\" }) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.updatePullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.updatePullRequest with wrong node type returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updatePullRequest(input: { pullRequestId: \"VXNlcjpvY3RvY2F0\" }) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.updatePullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.closePullRequest closes a pull request
+# → PATCH /api/v1/repos/octocat/hello-world/pulls/1 (state=closed)
+# Mock returns the PR fixture unchanged (state stays "open"); tests the REST call path.
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { closePullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\" }) { pullRequest { number state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.closePullRequest.pullRequest.number" == 1
+jsonpath "$.data.closePullRequest.pullRequest.state" == "OPEN"
+jsonpath "$.data.closePullRequest.clientMutationId" not exists
+
+# POST /graphql — Mutation.closePullRequest echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { closePullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\", clientMutationId: \"close-pr-relay-1\" }) { pullRequest { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.closePullRequest.clientMutationId" == "close-pr-relay-1"
+
+# POST /graphql — Mutation.closePullRequest without pullRequestId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { closePullRequest(input: {}) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.closePullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.reopenPullRequest reopens a closed pull request
+# → PATCH /api/v1/repos/octocat/hello-world/pulls/1 (state=open)
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { reopenPullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\" }) { pullRequest { number state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.reopenPullRequest.pullRequest.number" == 1
+jsonpath "$.data.reopenPullRequest.pullRequest.state" == "OPEN"
+jsonpath "$.data.reopenPullRequest.clientMutationId" not exists
+
+# POST /graphql — Mutation.reopenPullRequest echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { reopenPullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\", clientMutationId: \"reopen-pr-relay-1\" }) { pullRequest { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.reopenPullRequest.clientMutationId" == "reopen-pr-relay-1"
+
+# POST /graphql — Mutation.reopenPullRequest without pullRequestId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { reopenPullRequest(input: {}) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.reopenPullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.mergePullRequest merges a pull request
+# → POST /api/v1/repos/octocat/hello-world/pulls/1/merge (Gitea uses POST; returns 204)
+# → GET /api/v1/repos/octocat/hello-world/pulls/1 (re-fetch; mock returns open PR)
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { mergePullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\" }) { pullRequest { number state } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.mergePullRequest.pullRequest.number" == 1
+jsonpath "$.data.mergePullRequest.pullRequest.state" == "OPEN"
+jsonpath "$.data.mergePullRequest.clientMutationId" not exists
+
+# POST /graphql — Mutation.mergePullRequest echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { mergePullRequest(input: { pullRequestId: \"UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x\", clientMutationId: \"merge-pr-relay-1\" }) { pullRequest { number } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.mergePullRequest.clientMutationId" == "merge-pr-relay-1"
+
+# POST /graphql — Mutation.mergePullRequest without pullRequestId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { mergePullRequest(input: {}) { pullRequest { number } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.mergePullRequest" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"

--- a/test/graphql-mutations.lua
+++ b/test/graphql-mutations.lua
@@ -373,3 +373,231 @@ do -- closeIssue and reopenIssue resolvers are dispatched
     eq(r.data.reopenIssue.issue.state, "OPEN", "reopenIssue: resolver dispatched → state OPEN")
   end)
 end
+
+-- ============================================================
+-- Pull request mutation dispatch
+-- ============================================================
+
+-- Node IDs used in tests:
+--   Repository:octocat/hello-world      = UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk
+--   PullRequest:octocat/hello-world/1   = UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x
+
+do -- createPullRequest resolver is dispatched and returns pullRequest payload
+  with_resolvers({
+    ["Mutation.createPullRequest"] = function(_parent, _args, _ctx)
+      return {
+        pullRequest = {
+          number = 1,
+          title = "A great PR",
+          state = "OPEN",
+          __typename = "PullRequest",
+        },
+        clientMutationId = nil,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          createPullRequest(input: {
+            repositoryId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk",
+            title: "A great PR",
+            headRefName: "feature",
+            baseRefName: "main"
+          }) {
+            pullRequest { number title state }
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "createPullRequest: resolver dispatched → no errors")
+    ok(
+      r.data.createPullRequest ~= nil,
+      "createPullRequest: resolver dispatched → payload present"
+    )
+    eq(
+      r.data.createPullRequest.pullRequest.title,
+      "A great PR",
+      "createPullRequest: resolver dispatched → title returned"
+    )
+    eq(
+      r.data.createPullRequest.pullRequest.state,
+      "OPEN",
+      "createPullRequest: resolver dispatched → state returned"
+    )
+  end)
+end
+
+do -- createPullRequest clientMutationId round-trip
+  with_resolvers({
+    ["Mutation.createPullRequest"] = function(_parent, args, _ctx)
+      return {
+        pullRequest = {
+          number = 1,
+          title = "A great PR",
+          state = "OPEN",
+          __typename = "PullRequest",
+        },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          createPullRequest(input: {
+            repositoryId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk",
+            title: "A great PR",
+            headRefName: "feature",
+            baseRefName: "main",
+            clientMutationId: "pr-relay-1"
+          }) {
+            pullRequest { number }
+            clientMutationId
+          }
+        }
+      ]],
+    })
+    ok(
+      r.errors == nil or #r.errors == 0,
+      "createPullRequest: clientMutationId round-trip → no errors"
+    )
+    eq(
+      r.data.createPullRequest.clientMutationId,
+      "pr-relay-1",
+      "createPullRequest: clientMutationId round-trip → value echoed back"
+    )
+  end)
+end
+
+do -- updatePullRequest resolver is dispatched and returns pullRequest payload
+  with_resolvers({
+    ["Mutation.updatePullRequest"] = function(_parent, _args, _ctx)
+      return {
+        pullRequest = {
+          number = 1,
+          title = "A great PR",
+          state = "OPEN",
+          __typename = "PullRequest",
+        },
+        clientMutationId = nil,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          updatePullRequest(input: {
+            pullRequestId: "UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x",
+            title: "Updated PR"
+          }) {
+            pullRequest { number title state }
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "updatePullRequest: resolver dispatched → no errors")
+    ok(
+      r.data.updatePullRequest ~= nil,
+      "updatePullRequest: resolver dispatched → payload present"
+    )
+    eq(
+      r.data.updatePullRequest.pullRequest.number,
+      1,
+      "updatePullRequest: resolver dispatched → number returned"
+    )
+  end)
+end
+
+do -- closePullRequest, reopenPullRequest, and mergePullRequest resolvers are dispatched
+  with_resolvers({
+    ["Mutation.closePullRequest"] = function(_parent, _args, _ctx)
+      return {
+        pullRequest = {
+          number = 1,
+          title = "A great PR",
+          state = "CLOSED",
+          __typename = "PullRequest",
+        },
+        clientMutationId = nil,
+      }
+    end,
+    ["Mutation.reopenPullRequest"] = function(_parent, _args, _ctx)
+      return {
+        pullRequest = {
+          number = 1,
+          title = "A great PR",
+          state = "OPEN",
+          __typename = "PullRequest",
+        },
+        clientMutationId = nil,
+      }
+    end,
+    ["Mutation.mergePullRequest"] = function(_parent, _args, _ctx)
+      return {
+        pullRequest = {
+          number = 1,
+          title = "A great PR",
+          state = "MERGED",
+          merged = true,
+          __typename = "PullRequest",
+        },
+        clientMutationId = nil,
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          closePullRequest(input: {
+            pullRequestId: "UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x"
+          }) {
+            pullRequest { number state }
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "closePullRequest: resolver dispatched → no errors")
+    eq(
+      r.data.closePullRequest.pullRequest.state,
+      "CLOSED",
+      "closePullRequest: resolver dispatched → state CLOSED"
+    )
+
+    r = call_handler({
+      query = [[
+        mutation {
+          reopenPullRequest(input: {
+            pullRequestId: "UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x"
+          }) {
+            pullRequest { number state }
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "reopenPullRequest: resolver dispatched → no errors")
+    eq(
+      r.data.reopenPullRequest.pullRequest.state,
+      "OPEN",
+      "reopenPullRequest: resolver dispatched → state OPEN"
+    )
+
+    r = call_handler({
+      query = [[
+        mutation {
+          mergePullRequest(input: {
+            pullRequestId: "UHVsbFJlcXVlc3Q6b2N0b2NhdC9oZWxsby13b3JsZC8x"
+          }) {
+            pullRequest { number state merged }
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "mergePullRequest: resolver dispatched → no errors")
+    eq(
+      r.data.mergePullRequest.pullRequest.state,
+      "MERGED",
+      "mergePullRequest: resolver dispatched → state MERGED"
+    )
+  end)
+end

--- a/test/mock-gitea.lua
+++ b/test/mock-gitea.lua
@@ -406,7 +406,9 @@ function OnHttpRequest()
 
     -- Pull Requests
     ["/api/v1/repos/octocat/hello-world/pulls"] = { 200, "[" .. PR .. "]" },
+    ["POST /api/v1/repos/octocat/hello-world/pulls"] = { 201, PR },
     ["/api/v1/repos/octocat/hello-world/pulls/1"] = { 200, PR },
+    ["PATCH /api/v1/repos/octocat/hello-world/pulls/1"] = { 200, PR },
     ["/api/v1/repos/octocat/hello-world/pulls/1/commits"] = { 200, "[]" },
     ["/api/v1/repos/octocat/hello-world/pulls/1/files"] = { 200, "[]" },
     ["/api/v1/repos/octocat/hello-world/pulls/1/merge"] = { 204, nil },


### PR DESCRIPTION
Fixes #158.

Implements the five pull request GraphQL mutations from GQL-20: createPullRequest, updatePullRequest, closePullRequest, reopenPullRequest, and mergePullRequest. Follows the same resolver pattern established by the issue mutations in GQL-19, with mergePullRequest handling the unique 204-response re-fetch and mergeMethod enum mapping.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Implement mergePullRequest mutation with mergeMethod enum mapping <!-- type:spec -->
- [x] Add unit tests and hurl assertions for all five PR mutations <!-- type:spec -->
- [x] Implement createPullRequest, updatePullRequest, closePullRequest, reopenPullRequest mutations <!-- type:spec -->
- [x] Add mock-gitea routes for PR mutation endpoints (POST, PATCH, PUT merge) <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->