### PR TITLE
GraphQL: GQL-22 - Label, star, and subscription mutations (closes #160)

### DIFF
--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -4367,3 +4367,103 @@ graphql_resolvers["Mutation.deleteIssueComment"] = function(_parent, args, ctx)
   end
   return { clientMutationId = cmid }
 end
+
+graphql_resolvers["Mutation.addStar"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.starrableId then
+    return graphql_error(ctx, "addStar requires input.starrableId", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.starrableId)
+  if t ~= "Repository" then
+    return graphql_error(ctx, "addStar: invalid starrableId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo = lid:match("^([^/]+)/(.+)$")
+  if not owner then
+    return graphql_error(ctx, "addStar: malformed starrableId", nil, "BAD_USER_INPUT")
+  end
+  local star_path = base() .. "/user/starred/" .. owner .. "/" .. repo
+  -- PUT returns 204 No Content on success.
+  local ok, status = fetch_json(star_path, "PUT")
+  if not ok then
+    graphql_error(ctx, "network error starring repository", nil, "INTERNAL_ERROR")
+    return nil
+  end
+  if status == 401 or status == 403 then
+    graphql_error(ctx, "not authorized to star repository", nil, "FORBIDDEN")
+    return nil
+  end
+  if status == 404 then
+    graphql_error(ctx, "repository not found", nil, "NOT_FOUND")
+    return nil
+  end
+  if status ~= 204 then
+    graphql_error(
+      ctx,
+      "upstream error " .. tostring(status) .. " starring repository",
+      nil,
+      "INTERNAL_ERROR"
+    )
+    return nil
+  end
+  -- Re-fetch the repository to return in the payload (star returns 204, no body).
+  local repo_path = base() .. "/repos/" .. owner .. "/" .. repo
+  local repo_data = graphql_fetch_or_error(fetch_json, repo_path, ctx, nil)
+  if not repo_data then
+    return nil
+  end
+  return {
+    starrable = graphql_translate_repo(translate_repo(repo_data)),
+    clientMutationId = cmid,
+  }
+end
+
+graphql_resolvers["Mutation.removeStar"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.starrableId then
+    return graphql_error(ctx, "removeStar requires input.starrableId", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.starrableId)
+  if t ~= "Repository" then
+    return graphql_error(ctx, "removeStar: invalid starrableId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo = lid:match("^([^/]+)/(.+)$")
+  if not owner then
+    return graphql_error(ctx, "removeStar: malformed starrableId", nil, "BAD_USER_INPUT")
+  end
+  local star_path = base() .. "/user/starred/" .. owner .. "/" .. repo
+  -- DELETE returns 204 No Content on success.
+  local ok, status = fetch_json(star_path, "DELETE")
+  if not ok then
+    graphql_error(ctx, "network error unstarring repository", nil, "INTERNAL_ERROR")
+    return nil
+  end
+  if status == 401 or status == 403 then
+    graphql_error(ctx, "not authorized to unstar repository", nil, "FORBIDDEN")
+    return nil
+  end
+  if status == 404 then
+    graphql_error(ctx, "repository not found", nil, "NOT_FOUND")
+    return nil
+  end
+  if status ~= 204 then
+    graphql_error(
+      ctx,
+      "upstream error " .. tostring(status) .. " unstarring repository",
+      nil,
+      "INTERNAL_ERROR"
+    )
+    return nil
+  end
+  -- Re-fetch the repository to return in the payload (unstar returns 204, no body).
+  local repo_path = base() .. "/repos/" .. owner .. "/" .. repo
+  local repo_data = graphql_fetch_or_error(fetch_json, repo_path, ctx, nil)
+  if not repo_data then
+    return nil
+  end
+  return {
+    starrable = graphql_translate_repo(translate_repo(repo_data)),
+    clientMutationId = cmid,
+  }
+end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -4467,3 +4467,72 @@ graphql_resolvers["Mutation.removeStar"] = function(_parent, args, ctx)
     clientMutationId = cmid,
   }
 end
+
+graphql_resolvers["Mutation.updateSubscription"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.subscribableId then
+    return graphql_error(
+      ctx,
+      "updateSubscription requires input.subscribableId",
+      nil,
+      "BAD_USER_INPUT"
+    )
+  end
+  if not input.state then
+    return graphql_error(ctx, "updateSubscription requires input.state", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.subscribableId)
+  if t ~= "Repository" then
+    return graphql_error(ctx, "updateSubscription: invalid subscribableId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo = lid:match("^([^/]+)/(.+)$")
+  if not owner then
+    return graphql_error(ctx, "updateSubscription: malformed subscribableId", nil, "BAD_USER_INPUT")
+  end
+  local sub_path = base() .. "/repos/" .. owner .. "/" .. repo .. "/subscription"
+  local ok, status
+  if input.state == "UNSUBSCRIBED" then
+    -- Unsubscribe uses DELETE, which returns 204 No Content.
+    ok, status = fetch_json(sub_path, "DELETE")
+  else
+    -- SUBSCRIBED and IGNORED both use PUT with a JSON body; returns 200.
+    local body = EncodeJson({
+      subscribed = input.state == "SUBSCRIBED",
+      ignored = input.state == "IGNORED",
+    })
+    ok, status = fetch_json(sub_path, "PUT", body)
+  end
+  if not ok then
+    graphql_error(ctx, "network error updating subscription", nil, "INTERNAL_ERROR")
+    return nil
+  end
+  if status == 401 or status == 403 then
+    graphql_error(ctx, "not authorized to update subscription", nil, "FORBIDDEN")
+    return nil
+  end
+  if status == 404 then
+    graphql_error(ctx, "repository not found", nil, "NOT_FOUND")
+    return nil
+  end
+  local expected_status = input.state == "UNSUBSCRIBED" and 204 or 200
+  if status ~= expected_status then
+    graphql_error(
+      ctx,
+      "upstream error " .. tostring(status) .. " updating subscription",
+      nil,
+      "INTERNAL_ERROR"
+    )
+    return nil
+  end
+  -- Re-fetch the repository to return in the payload.
+  local repo_path = base() .. "/repos/" .. owner .. "/" .. repo
+  local repo_data = graphql_fetch_or_error(fetch_json, repo_path, ctx, nil)
+  if not repo_data then
+    return nil
+  end
+  return {
+    subscribable = graphql_translate_repo(translate_repo(repo_data)),
+    clientMutationId = cmid,
+  }
+end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -4536,3 +4536,114 @@ graphql_resolvers["Mutation.updateSubscription"] = function(_parent, args, ctx)
     clientMutationId = cmid,
   }
 end
+
+graphql_resolvers["Mutation.createLabel"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.repositoryId then
+    return graphql_error(ctx, "createLabel requires input.repositoryId", nil, "BAD_USER_INPUT")
+  end
+  if not input.name then
+    return graphql_error(ctx, "createLabel requires input.name", nil, "BAD_USER_INPUT")
+  end
+  if not input.color then
+    return graphql_error(ctx, "createLabel requires input.color", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.repositoryId)
+  if t ~= "Repository" then
+    return graphql_error(ctx, "createLabel: invalid repositoryId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo = lid:match("^([^/]+)/(.+)$")
+  if not owner then
+    return graphql_error(ctx, "createLabel: malformed repositoryId", nil, "BAD_USER_INPUT")
+  end
+  local path = base() .. "/repos/" .. owner .. "/" .. repo .. "/labels"
+  -- GitHub sends color without '#'; Gitea expects '#' prefix.
+  local body = EncodeJson({
+    name = input.name,
+    color = "#" .. input.color,
+    description = input.description,
+  })
+  local data = graphql_fetch_or_error(fetch_json, path, ctx, nil, "POST", body)
+  if not data then
+    return nil
+  end
+  return {
+    label = graphql_translate_label(translate_gitea_label(data), owner, repo),
+    clientMutationId = cmid,
+  }
+end
+
+graphql_resolvers["Mutation.addLabelsToLabelable"] = function(_parent, args, ctx)
+  local input = args and args.input
+  if not input or not input.labelableId then
+    return graphql_error(
+      ctx,
+      "addLabelsToLabelable requires input.labelableId",
+      nil,
+      "BAD_USER_INPUT"
+    )
+  end
+  if not input.labelIds or #input.labelIds == 0 then
+    return graphql_error(ctx, "addLabelsToLabelable requires input.labelIds", nil, "BAD_USER_INPUT")
+  end
+  local cmid = get_client_mutation_id(args)
+  local t, lid = decode_node_id(input.labelableId)
+  if t ~= "Issue" and t ~= "PullRequest" then
+    return graphql_error(ctx, "addLabelsToLabelable: invalid labelableId", nil, "BAD_USER_INPUT")
+  end
+  local owner, repo, number = lid:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return graphql_error(ctx, "addLabelsToLabelable: malformed labelableId", nil, "BAD_USER_INPUT")
+  end
+  -- Decode each Label node ID and extract the Gitea integer label ID.
+  local label_ids = {}
+  for _, label_node_id in ipairs(input.labelIds) do
+    local lt, llid = decode_node_id(label_node_id)
+    if lt ~= "Label" then
+      return graphql_error(ctx, "addLabelsToLabelable: invalid labelId", nil, "BAD_USER_INPUT")
+    end
+    -- Label local_id is "owner/repo/integer_id"
+    local label_id = llid:match("/(%d+)$")
+    if not label_id then
+      return graphql_error(ctx, "addLabelsToLabelable: malformed labelId", nil, "BAD_USER_INPUT")
+    end
+    label_ids[#label_ids + 1] = tonumber(label_id)
+  end
+  -- Both issues and PRs share the /issues/{n}/labels endpoint in Gitea.
+  local labels_path = base()
+    .. "/repos/"
+    .. owner
+    .. "/"
+    .. repo
+    .. "/issues/"
+    .. number
+    .. "/labels"
+  local body = EncodeJson({ labels = label_ids })
+  -- POST returns 200 with the updated label list; we discard it and re-fetch the full item.
+  local labels_ok = graphql_fetch_or_error(fetch_json, labels_path, ctx, nil, "POST", body)
+  if labels_ok == nil then
+    return nil
+  end
+  -- Re-fetch the issue or PR to populate the labelable payload field.
+  local item_data
+  if t == "PullRequest" then
+    local pr_path = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number
+    local pr_data = graphql_fetch_or_error(fetch_json, pr_path, ctx, nil)
+    if not pr_data then
+      return nil
+    end
+    item_data = graphql_translate_pr(translate_gitea_pull(pr_data), owner, repo)
+  else
+    local issue_path = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number
+    local issue_data = graphql_fetch_or_error(fetch_json, issue_path, ctx, nil)
+    if not issue_data then
+      return nil
+    end
+    item_data = graphql_translate_issue(translate_gitea_issue(issue_data), owner, repo)
+  end
+  return {
+    labelable = item_data,
+    clientMutationId = cmid,
+  }
+end

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -1240,3 +1240,106 @@ HTTP 200
 jsonpath "$.data.updateSubscription" not exists
 jsonpath "$.errors" isCollection
 jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createLabel creates a label in a repository
+# Node ID for Repository:octocat/hello-world = UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk
+# → POST /api/v1/repos/octocat/hello-world/labels
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createLabel(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", name: \"bug\", color: \"d73a4a\" }) { label { name color } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createLabel.label.name" == "bug"
+jsonpath "$.data.createLabel.label.color" == "d73a4a"
+jsonpath "$.data.createLabel.clientMutationId" not exists
+
+# POST /graphql — Mutation.createLabel echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createLabel(input: { repositoryId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", name: \"bug\", color: \"d73a4a\", clientMutationId: \"label-relay-1\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createLabel.clientMutationId" == "label-relay-1"
+
+# POST /graphql — Mutation.createLabel without repositoryId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createLabel(input: { name: \"bug\", color: \"d73a4a\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createLabel" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.createLabel with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { createLabel(input: { repositoryId: \"VXNlcjpvY3RvY2F0\", name: \"bug\", color: \"d73a4a\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.createLabel" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.addLabelsToLabelable adds a label to an issue
+# Node ID for Issue:octocat/hello-world/1 = SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x
+# Node ID for Label:octocat/hello-world/1 = TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x
+# → POST /api/v1/repos/octocat/hello-world/issues/1/labels, then GET /api/v1/repos/octocat/hello-world/issues/1
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addLabelsToLabelable(input: { labelableId: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\", labelIds: [\"TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x\"] }) { labelable { ... on Issue { number title } } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.addLabelsToLabelable.labelable.number" == 1
+jsonpath "$.data.addLabelsToLabelable.labelable.title" isString
+jsonpath "$.data.addLabelsToLabelable.clientMutationId" not exists
+
+# POST /graphql — Mutation.addLabelsToLabelable echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addLabelsToLabelable(input: { labelableId: \"SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x\", labelIds: [\"TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x\"], clientMutationId: \"label-relay-2\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.addLabelsToLabelable.clientMutationId" == "label-relay-2"
+
+# POST /graphql — Mutation.addLabelsToLabelable without labelableId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addLabelsToLabelable(input: { labelIds: [\"TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x\"] }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.addLabelsToLabelable" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.addLabelsToLabelable with wrong labelable node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addLabelsToLabelable(input: { labelableId: \"VXNlcjpvY3RvY2F0\", labelIds: [\"TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x\"] }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.addLabelsToLabelable" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -1055,3 +1055,102 @@ HTTP 200
 jsonpath "$.data.deleteIssueComment" not exists
 jsonpath "$.errors" isCollection
 jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.addStar stars a repository
+# Node ID for Repository:octocat/hello-world = UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk
+# → PUT /api/v1/user/starred/octocat/hello-world, then GET /api/v1/repos/octocat/hello-world
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addStar(input: { starrableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\" }) { starrable { ... on Repository { nameWithOwner } } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.addStar.starrable.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.addStar.clientMutationId" not exists
+
+# POST /graphql — Mutation.addStar echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addStar(input: { starrableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", clientMutationId: \"star-relay-1\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.addStar.clientMutationId" == "star-relay-1"
+
+# POST /graphql — Mutation.addStar without starrableId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addStar(input: {}) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.addStar" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.addStar with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { addStar(input: { starrableId: \"VXNlcjpvY3RvY2F0\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.addStar" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.removeStar unstars a repository
+# → DELETE /api/v1/user/starred/octocat/hello-world, then GET /api/v1/repos/octocat/hello-world
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { removeStar(input: { starrableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\" }) { starrable { ... on Repository { nameWithOwner } } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.removeStar.starrable.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.removeStar.clientMutationId" not exists
+
+# POST /graphql — Mutation.removeStar echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { removeStar(input: { starrableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", clientMutationId: \"star-relay-2\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.removeStar.clientMutationId" == "star-relay-2"
+
+# POST /graphql — Mutation.removeStar without starrableId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { removeStar(input: {}) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.removeStar" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.removeStar with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { removeStar(input: { starrableId: \"VXNlcjpvY3RvY2F0\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.removeStar" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -1154,3 +1154,89 @@ HTTP 200
 jsonpath "$.data.removeStar" not exists
 jsonpath "$.errors" isCollection
 jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.updateSubscription subscribes to a repository (SUBSCRIBED)
+# Node ID for Repository:octocat/hello-world = UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk
+# → PUT /api/v1/repos/octocat/hello-world/subscription, then GET /api/v1/repos/octocat/hello-world
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateSubscription(input: { subscribableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", state: SUBSCRIBED }) { subscribable { ... on Repository { nameWithOwner } } clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updateSubscription.subscribable.nameWithOwner" == "octocat/hello-world"
+jsonpath "$.data.updateSubscription.clientMutationId" not exists
+
+# POST /graphql — Mutation.updateSubscription sets ignored state (IGNORED)
+# → PUT /api/v1/repos/octocat/hello-world/subscription
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateSubscription(input: { subscribableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", state: IGNORED }) { subscribable { ... on Repository { nameWithOwner } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updateSubscription.subscribable.nameWithOwner" == "octocat/hello-world"
+
+# POST /graphql — Mutation.updateSubscription unsubscribes (UNSUBSCRIBED)
+# → DELETE /api/v1/repos/octocat/hello-world/subscription, then GET /api/v1/repos/octocat/hello-world
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateSubscription(input: { subscribableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", state: UNSUBSCRIBED }) { subscribable { ... on Repository { nameWithOwner } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updateSubscription.subscribable.nameWithOwner" == "octocat/hello-world"
+
+# POST /graphql — Mutation.updateSubscription echoes back clientMutationId
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateSubscription(input: { subscribableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\", state: SUBSCRIBED, clientMutationId: \"sub-relay-1\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.updateSubscription.clientMutationId" == "sub-relay-1"
+
+# POST /graphql — Mutation.updateSubscription without subscribableId returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateSubscription(input: { state: SUBSCRIBED }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.updateSubscription" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.updateSubscription without state returns BAD_USER_INPUT
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateSubscription(input: { subscribableId: \"UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk\" }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.updateSubscription" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"
+
+# POST /graphql — Mutation.updateSubscription with wrong node type returns BAD_USER_INPUT
+# Node ID for User:octocat = VXNlcjpvY3RvY2F0
+POST http://{{host}}/graphql
+Authorization: token testtoken
+Content-Type: application/json
+{"query": "mutation { updateSubscription(input: { subscribableId: \"VXNlcjpvY3RvY2F0\", state: SUBSCRIBED }) { clientMutationId } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.updateSubscription" not exists
+jsonpath "$.errors" isCollection
+jsonpath "$.errors[0].extensions.code" == "BAD_USER_INPUT"

--- a/test/graphql-mutations.lua
+++ b/test/graphql-mutations.lua
@@ -888,3 +888,72 @@ do -- removeStar resolver is dispatched; payload contains starrable
     eq(r.data.removeStar.starrable.__typename, "Repository", "removeStar: starrable __typename")
   end)
 end
+
+do -- updateSubscription resolver is dispatched; payload contains subscribable
+  with_resolvers({
+    ["Mutation.updateSubscription"] = function(_parent, args, _ctx)
+      return {
+        subscribable = { __typename = "Repository" },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          updateSubscription(input: {
+            subscribableId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk",
+            state: SUBSCRIBED
+          }) {
+            subscribable { __typename }
+            clientMutationId
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "updateSubscription: resolver dispatched → no errors")
+    ok(
+      r.data.updateSubscription ~= nil,
+      "updateSubscription: resolver dispatched → payload present"
+    )
+    eq(
+      r.data.updateSubscription.subscribable.__typename,
+      "Repository",
+      "updateSubscription: subscribable __typename"
+    )
+  end)
+end
+
+do -- updateSubscription clientMutationId round-trip
+  with_resolvers({
+    ["Mutation.updateSubscription"] = function(_parent, args, _ctx)
+      return {
+        subscribable = { __typename = "Repository" },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          updateSubscription(input: {
+            subscribableId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk",
+            state: IGNORED,
+            clientMutationId: "sub-relay-1"
+          }) {
+            clientMutationId
+          }
+        }
+      ]],
+    })
+    ok(
+      r.errors == nil or #r.errors == 0,
+      "updateSubscription: clientMutationId round-trip → no errors"
+    )
+    eq(
+      r.data.updateSubscription.clientMutationId,
+      "sub-relay-1",
+      "updateSubscription: clientMutationId round-trip → value echoed back"
+    )
+  end)
+end

--- a/test/graphql-mutations.lua
+++ b/test/graphql-mutations.lua
@@ -957,3 +957,95 @@ do -- updateSubscription clientMutationId round-trip
     )
   end)
 end
+
+do -- createLabel resolver is dispatched; payload contains label
+  with_resolvers({
+    ["Mutation.createLabel"] = function(_parent, args, _ctx)
+      return {
+        label = { __typename = "Label", name = args.input.name },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          createLabel(input: {
+            repositoryId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk",
+            name: "bug",
+            color: "d73a4a"
+          }) {
+            label { name }
+            clientMutationId
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "createLabel: resolver dispatched → no errors")
+    ok(r.data.createLabel ~= nil, "createLabel: resolver dispatched → payload present")
+    eq(r.data.createLabel.label.name, "bug", "createLabel: label name returned")
+  end)
+end
+
+do -- createLabel clientMutationId round-trip
+  with_resolvers({
+    ["Mutation.createLabel"] = function(_parent, args, _ctx)
+      return {
+        label = { __typename = "Label", name = args.input.name },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          createLabel(input: {
+            repositoryId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk",
+            name: "bug",
+            color: "d73a4a",
+            clientMutationId: "label-relay-1"
+          }) {
+            clientMutationId
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "createLabel: clientMutationId round-trip → no errors")
+    eq(
+      r.data.createLabel.clientMutationId,
+      "label-relay-1",
+      "createLabel: clientMutationId round-trip → value echoed back"
+    )
+  end)
+end
+
+do -- addLabelsToLabelable resolver is dispatched; payload contains labelable
+  with_resolvers({
+    ["Mutation.addLabelsToLabelable"] = function(_parent, args, _ctx)
+      return {
+        labelable = { __typename = "Issue", number = 1 },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          addLabelsToLabelable(input: {
+            labelableId: "SXNzdWU6b2N0b2NhdC9oZWxsby13b3JsZC8x",
+            labelIds: ["TGFiZWw6b2N0b2NhdC9oZWxsby13b3JsZC8x"]
+          }) {
+            labelable { ... on Issue { number } }
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "addLabelsToLabelable: resolver dispatched → no errors")
+    ok(r.data.addLabelsToLabelable ~= nil, "addLabelsToLabelable: payload present")
+    eq(
+      r.data.addLabelsToLabelable.labelable.number,
+      1,
+      "addLabelsToLabelable: labelable.number returned"
+    )
+  end)
+end

--- a/test/graphql-mutations.lua
+++ b/test/graphql-mutations.lua
@@ -805,3 +805,86 @@ do -- deleteIssueComment clientMutationId round-trip
     )
   end)
 end
+
+do -- addStar resolver is dispatched; payload contains starrable
+  with_resolvers({
+    ["Mutation.addStar"] = function(_parent, args, _ctx)
+      return {
+        starrable = { __typename = "Repository" },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          addStar(input: {
+            starrableId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk"
+          }) {
+            starrable { __typename }
+            clientMutationId
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "addStar: resolver dispatched → no errors")
+    ok(r.data.addStar ~= nil, "addStar: resolver dispatched → payload present")
+    eq(r.data.addStar.starrable.__typename, "Repository", "addStar: starrable __typename")
+  end)
+end
+
+do -- addStar clientMutationId round-trip
+  with_resolvers({
+    ["Mutation.addStar"] = function(_parent, args, _ctx)
+      return {
+        starrable = { __typename = "Repository" },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          addStar(input: {
+            starrableId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk",
+            clientMutationId: "star-relay-1"
+          }) {
+            clientMutationId
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "addStar: clientMutationId round-trip → no errors")
+    eq(
+      r.data.addStar.clientMutationId,
+      "star-relay-1",
+      "addStar: clientMutationId round-trip → value echoed back"
+    )
+  end)
+end
+
+do -- removeStar resolver is dispatched; payload contains starrable
+  with_resolvers({
+    ["Mutation.removeStar"] = function(_parent, args, _ctx)
+      return {
+        starrable = { __typename = "Repository" },
+        clientMutationId = get_client_mutation_id(args),
+      }
+    end,
+  }, function()
+    local r = call_handler({
+      query = [[
+        mutation {
+          removeStar(input: {
+            starrableId: "UmVwb3NpdG9yeTpvY3RvY2F0L2hlbGxvLXdvcmxk"
+          }) {
+            starrable { __typename }
+          }
+        }
+      ]],
+    })
+    ok(r.errors == nil or #r.errors == 0, "removeStar: resolver dispatched → no errors")
+    ok(r.data.removeStar ~= nil, "removeStar: resolver dispatched → payload present")
+    eq(r.data.removeStar.starrable.__typename, "Repository", "removeStar: starrable __typename")
+  end)
+end

--- a/test/mock-gitea.lua
+++ b/test/mock-gitea.lua
@@ -397,6 +397,7 @@ function OnHttpRequest()
     -- Labels
     ["/api/v1/repos/octocat/hello-world/labels"] = { 200, "[" .. LABEL .. "]" },
     ["/api/v1/repos/octocat/hello-world/labels?limit=50"] = { 200, "[" .. LABEL .. "]" },
+    ["POST /api/v1/repos/octocat/hello-world/labels"] = { 201, LABEL },
     ["/api/v1/repos/octocat/hello-world/labels/1"] = { 200, LABEL },
 
     -- Milestones


### PR DESCRIPTION
Fixes #160.

Implements GQL-22: adds five GraphQL mutation resolvers to the Gitea backend for star operations (addStar, removeStar), subscription management (updateSubscription), and label handling (createLabel, addLabelsToLabelable). Each mutation follows the established pattern of node ID decoding, REST proxying via graphql_fetch_or_error, and payload translation with clientMutationId support.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Gitea: add updateSubscription GraphQL mutation resolver with tests <!-- type:spec -->
- [x] Gitea: add createLabel and addLabelsToLabelable GraphQL mutation resolvers with tests <!-- type:spec -->
- [x] Gitea: add addStar and removeStar GraphQL mutation resolvers with tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->