### PR TITLE
GraphQL: GQL-23 - Batch request support (closes #161)

### DIFF
--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -784,44 +784,40 @@ function get_client_mutation_id(args) -- luacheck: globals get_client_mutation_i
 end
 
 -- ---------------------------------------------------------------------------
--- graphql_handler
+-- execute_single
 -- ---------------------------------------------------------------------------
 
--- graphql_handler is registered in the catalog as the fixed handler for
--- POST /graphql.  Backends do NOT override this via backend_impl; they only
--- populate graphql_resolvers.
-function graphql_handler() -- luacheck: globals graphql_handler
-  -- Step 1: decode request body.
-  local raw = GetBody() or ""
-  local req = DecodeJson(raw)
-  -- Step 1a: array body → batch request (rejected in Phase 1).
-  if type(req) == "table" and req[1] ~= nil then
-    respond_json(400, {
-      errors = {
-        { message = "GraphQL request batching is not supported; send one operation per request." },
-      },
-    })
-    return
-  end
+-- Run one GraphQL operation object through the full pipeline and return a
+-- result table.  The caller is responsible for writing the HTTP response.
+--
+-- req    — decoded JSON table for a single operation (must not be a batch array).
+-- Returns { data = <table|nil>, errors = <array> }
+--   data   is nil for request/validation errors; a partial table for field errors.
+--   errors is always an array (possibly empty).
+local function execute_single(req)
   -- Step 1b: APQ body → persisted queries not supported.
   if type(req) == "table" and type(req.extensions) == "table" and req.extensions.persistedQuery then
-    respond_graphql(nil, {
-      {
-        message = "Persisted queries are not supported; send the full query string.",
-        extensions = { code = "PERSISTED_QUERY_NOT_SUPPORTED" },
+    return {
+      data = nil,
+      errors = {
+        {
+          message = "Persisted queries are not supported; send the full query string.",
+          extensions = { code = "PERSISTED_QUERY_NOT_SUPPORTED" },
+        },
       },
-    })
-    return
+    }
   end
   -- Step 1c: missing or non-string query field.
   if not req or type(req.query) ~= "string" then
-    respond_graphql(nil, {
-      {
-        message = "POST /graphql requires a JSON body with a 'query' field",
-        extensions = { code = "BAD_USER_INPUT" },
+    return {
+      data = nil,
+      errors = {
+        {
+          message = "POST /graphql requires a JSON body with a 'query' field",
+          extensions = { code = "BAD_USER_INPUT" },
+        },
       },
-    })
-    return
+    }
   end
   local source = req.query
   local variables = type(req.variables) == "table" and req.variables or {}
@@ -830,43 +826,48 @@ function graphql_handler() -- luacheck: globals graphql_handler
   -- Step 2: parse.
   local doc, parse_err = graphql_parse(source)
   if not doc then
-    respond_graphql(nil, {
-      {
-        message = parse_err,
-        extensions = { code = "PARSE_ERROR" },
+    return {
+      data = nil,
+      errors = {
+        {
+          message = parse_err,
+          extensions = { code = "PARSE_ERROR" },
+        },
       },
-    })
-    return
+    }
   end
 
   -- Step 3: select operation.
   local op, sel_err = select_operation(doc, op_name)
   if not op then
-    respond_graphql(nil, {
-      {
-        message = sel_err,
-        extensions = { code = "BAD_USER_INPUT" },
+    return {
+      data = nil,
+      errors = {
+        {
+          message = sel_err,
+          extensions = { code = "BAD_USER_INPUT" },
+        },
       },
-    })
-    return
+    }
   end
 
   -- Step 3a: reject subscription operations (not supported).
   if op.operation == "subscription" then
-    respond_graphql(nil, {
-      {
-        message = "subscriptions are not supported",
-        extensions = { code = "BAD_USER_INPUT" },
+    return {
+      data = nil,
+      errors = {
+        {
+          message = "subscriptions are not supported",
+          extensions = { code = "BAD_USER_INPUT" },
+        },
       },
-    })
-    return
+    }
   end
 
   -- Step 4: validate.
   local verrs = graphql_validate(doc, op)
   if #verrs > 0 then
-    respond_graphql(nil, verrs)
-    return
+    return { data = nil, errors = verrs }
   end
 
   -- Step 5: execute.
@@ -886,23 +887,50 @@ function graphql_handler() -- luacheck: globals graphql_handler
   ctx.rate_cost = estimate_query_cost(op, variables)
   -- Step 5a: reject queries that exceed the cost ceiling.
   if ctx.rate_cost > GRAPHQL_MAX_COST then
-    respond_graphql(nil, {
-      {
-        message = "query cost "
-          .. tostring(ctx.rate_cost)
-          .. " exceeds maximum allowed cost of "
-          .. tostring(GRAPHQL_MAX_COST),
-        extensions = {
-          code = "BAD_USER_INPUT",
-          estimatedCost = ctx.rate_cost,
-          maxAllowedCost = GRAPHQL_MAX_COST,
+    return {
+      data = nil,
+      errors = {
+        {
+          message = "query cost "
+            .. tostring(ctx.rate_cost)
+            .. " exceeds maximum allowed cost of "
+            .. tostring(GRAPHQL_MAX_COST),
+          extensions = {
+            code = "BAD_USER_INPUT",
+            estimatedCost = ctx.rate_cost,
+            maxAllowedCost = GRAPHQL_MAX_COST,
+          },
         },
+      },
+    }
+  end
+  local data = execute_operation(op, ctx)
+
+  -- Step 6: assemble result.
+  return { data = data, errors = ctx.errors }
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_handler
+-- ---------------------------------------------------------------------------
+
+-- graphql_handler is registered in the catalog as the fixed handler for
+-- POST /graphql.  Backends do NOT override this via backend_impl; they only
+-- populate graphql_resolvers.
+function graphql_handler() -- luacheck: globals graphql_handler
+  -- Step 1: decode request body.
+  local raw = GetBody() or ""
+  local req = DecodeJson(raw)
+  -- Step 1a: array body → batch request (rejected in Phase 1).
+  if type(req) == "table" and req[1] ~= nil then
+    respond_json(400, {
+      errors = {
+        { message = "GraphQL request batching is not supported; send one operation per request." },
       },
     })
     return
   end
-  local data = execute_operation(op, ctx)
-
-  -- Step 6: write response.
-  respond_graphql(data, ctx.errors)
+  -- Single operation: delegate to execute_single and write the response.
+  local result = execute_single(req)
+  respond_graphql(result.data, result.errors)
 end

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -914,6 +914,20 @@ end
 -- graphql_handler
 -- ---------------------------------------------------------------------------
 
+-- Render a single execute_single result table as a JSON object string.
+-- WHY MANUAL: EncodeJson({data = nil}) silently drops the key, producing
+-- {"errors":[...]} instead of the spec-required {"data":null,...}.
+-- Mirrors the same workaround used by respond_graphql for single-op responses.
+local function encode_result(result)
+  local data_json = (result.data ~= nil) and EncodeJson(result.data) or "null"
+  local errors = result.errors
+  if errors and #errors > 0 then
+    return '{"data":' .. data_json .. ',"errors":' .. EncodeJson(errors) .. "}"
+  else
+    return '{"data":' .. data_json .. "}"
+  end
+end
+
 -- graphql_handler is registered in the catalog as the fixed handler for
 -- POST /graphql.  Backends do NOT override this via backend_impl; they only
 -- populate graphql_resolvers.
@@ -921,13 +935,15 @@ function graphql_handler() -- luacheck: globals graphql_handler
   -- Step 1: decode request body.
   local raw = GetBody() or ""
   local req = DecodeJson(raw)
-  -- Step 1a: array body → batch request (rejected in Phase 1).
+  -- Step 1a: array body → batch request.  Execute each operation independently
+  -- and return a parallel array of {data, errors} result objects.
   if type(req) == "table" and req[1] ~= nil then
-    respond_json(400, {
-      errors = {
-        { message = "GraphQL request batching is not supported; send one operation per request." },
-      },
-    })
+    local parts = {}
+    for i, item in ipairs(req) do
+      parts[i] = encode_result(execute_single(item))
+    end
+    set_preamble(200)
+    Write("[" .. table.concat(parts, ",") .. "]")
     return
   end
   -- Single operation: delegate to execute_single and write the response.

--- a/test/graphql-batching-caching.lua
+++ b/test/graphql-batching-caching.lua
@@ -30,26 +30,25 @@ local function run_handler(body_str)
 end
 
 -- ============================================================
--- Batch rejection
+-- Batch execution (Phase 2)
 -- ============================================================
 
-do -- array body → HTTP 400, batching-not-supported message
-  local body = '[{"query":"{ viewer { login } }"},{"query":"{ rateLimit { cost } }"}]'
+do -- array body → HTTP 200, parallel array of result objects
+  local body = '[{"query":"{ rateLimit { cost } }"},{"query":"{ rateLimit { cost } }"}]'
   local status, r = run_handler(body)
-  eq(status, 400, "batch: array body → HTTP 400")
-  ok(r ~= nil, "batch: response is valid JSON")
-  ok(r.errors ~= nil and #r.errors == 1, "batch: exactly one error in response")
-  ok(
-    type(r.errors[1].message) == "string" and r.errors[1].message:find("batching") ~= nil,
-    "batch: error message mentions batching"
-  )
+  eq(status, 200, "batch: array body → HTTP 200")
+  ok(type(r) == "table", "batch: response decodes as a table (JSON array)")
+  ok(r[1] ~= nil and r[2] ~= nil, "batch: response has two elements")
+  ok(r[1].data ~= nil, "batch: first result has a data key")
+  ok(r[2].data ~= nil, "batch: second result has a data key")
 end
 
-do -- single-element array body also rejected (still a batch)
-  local body = '[{"query":"{ viewer { login } }"}]'
+do -- single-element array body → HTTP 200, one-element array result
+  local body = '[{"query":"{ rateLimit { cost } }"}]'
   local status, r = run_handler(body)
-  eq(status, 400, "batch: single-element array → HTTP 400")
-  ok(r.errors ~= nil and #r.errors == 1, "batch: single-element array → one error")
+  eq(status, 200, "batch: single-element array → HTTP 200")
+  ok(type(r) == "table" and r[1] ~= nil, "batch: single-element array → one result element")
+  ok(r[1].data ~= nil, "batch: single-element result has a data key")
 end
 
 -- ============================================================

--- a/test/graphql-batching-caching.lua
+++ b/test/graphql-batching-caching.lua
@@ -1,4 +1,4 @@
--- Unit tests for batch/APQ rejection, cost-limit enforcement, and request-scoped cache.
+-- Unit tests for batch execution (Phase 2), APQ rejection, cost-limit enforcement, and request-scoped cache.
 -- Loaded by test/unit-graphql.lua; relies on shared state from the driver.
 -- ============================================================
 
@@ -49,6 +49,91 @@ do -- single-element array body → HTTP 200, one-element array result
   eq(status, 200, "batch: single-element array → HTTP 200")
   ok(type(r) == "table" and r[1] ~= nil, "batch: single-element array → one result element")
   ok(r[1].data ~= nil, "batch: single-element result has a data key")
+end
+
+-- run_handler_raw: like run_handler but returns the raw (undecoded) body string.
+-- Used for tests that must inspect the literal JSON, e.g. asserting "data":null is present.
+local function run_handler_raw(body_str)
+  local captured_status = nil
+  local captured_body = ""
+  local saved_set_status = SetStatus -- luacheck: globals SetStatus
+  local saved_write = Write -- luacheck: globals Write
+  local saved_get_body = GetBody -- luacheck: globals GetBody
+  SetStatus = function(code, _reason)
+    captured_status = code
+  end -- luacheck: globals SetStatus
+  Write = function(s)
+    captured_body = captured_body .. tostring(s)
+  end -- luacheck: globals Write
+  GetBody = function()
+    return body_str
+  end -- luacheck: globals GetBody
+  graphql_handler() -- luacheck: globals graphql_handler
+  SetStatus = saved_set_status -- luacheck: globals SetStatus
+  Write = saved_write -- luacheck: globals Write
+  GetBody = saved_get_body -- luacheck: globals GetBody
+  return captured_status, captured_body
+end
+
+do -- per-operation error isolation: parse error in first op does not prevent second op
+  local body = '[{"query":"{ unclosed_brace"},{"query":"{ rateLimit { cost } }"}]'
+  local status, r = run_handler(body)
+  eq(status, 200, "batch isolation: HTTP 200")
+  ok(r[1] ~= nil and r[2] ~= nil, "batch isolation: two results returned")
+  ok(
+    r[1].errors ~= nil and #r[1].errors > 0,
+    "batch isolation: first result has errors (parse failure)"
+  )
+  eq(
+    r[1].errors[1].extensions.code,
+    "PARSE_ERROR",
+    "batch isolation: first item error code is PARSE_ERROR"
+  )
+  ok(r[1].data == nil, "batch isolation: first result data is nil")
+  ok(r[2].data ~= nil, "batch isolation: second result has data (unaffected by first)")
+  ok(r[2].errors == nil or #r[2].errors == 0, "batch isolation: second result has no errors")
+end
+
+do -- batch item with nil data contains literal "data":null in the raw JSON (not a missing key)
+  -- This verifies encode_result's manual nil-data workaround (EncodeJson drops nil keys).
+  local _, raw = run_handler_raw('[{"query":"{ unclosed_brace"}]')
+  ok(raw:find('"data":null') ~= nil, 'batch nil-data: raw response contains "data":null')
+end
+
+do -- per-operation cost enforcement: each op is independently checked against the ceiling
+  local call_count = 0
+  local _saved = estimate_query_cost -- luacheck: globals estimate_query_cost
+  estimate_query_cost = function(_op, _vars) -- luacheck: globals estimate_query_cost
+    call_count = call_count + 1
+    return call_count == 1 and 10001 or 1
+  end
+  local body = '[{"query":"{ rateLimit { cost } }"},{"query":"{ rateLimit { cost } }"}]'
+  local status, r = run_handler(body)
+  estimate_query_cost = _saved -- luacheck: globals estimate_query_cost
+  eq(status, 200, "batch cost: HTTP 200")
+  ok(r[1] ~= nil and r[2] ~= nil, "batch cost: two results")
+  ok(r[1].errors ~= nil and #r[1].errors > 0, "batch cost: first item exceeded cost ceiling")
+  eq(
+    r[1].errors[1].extensions.code,
+    "BAD_USER_INPUT",
+    "batch cost: first item has BAD_USER_INPUT error"
+  )
+  ok(r[1].data == nil, "batch cost: first item data is nil")
+  ok(r[2].data ~= nil, "batch cost: second item executes normally (independent cost)")
+end
+
+do -- ordering: three-element batch returns results in input order
+  local body =
+    '[{"query":"{ __typename }"},{"query":"mutation { __typename }"},{"query":"{ rateLimit { cost } }"}]'
+  local status, r = run_handler(body)
+  eq(status, 200, "batch ordering: HTTP 200")
+  ok(r[1] ~= nil and r[2] ~= nil and r[3] ~= nil, "batch ordering: three results")
+  eq(r[1].data.__typename, "Query", "batch ordering: result[1] is Query.__typename")
+  eq(r[2].data.__typename, "Mutation", "batch ordering: result[2] is Mutation.__typename")
+  ok(
+    r[3].data ~= nil and r[3].data.rateLimit ~= nil,
+    "batch ordering: result[3] is rateLimit query"
+  )
 end
 
 -- ============================================================

--- a/test/integration-graphql.hurl
+++ b/test/integration-graphql.hurl
@@ -57,11 +57,12 @@ HTTP 200
 jsonpath "$.data" == null
 jsonpath "$.errors[0].extensions.code" == "VALIDATION_ERROR"
 
-# POST /graphql — batch rejection
+# POST /graphql — single-element array batch executes (Phase 2: doc 12)
 POST http://{{host}}/graphql
 Content-Type: application/json
 [{"query": "{ __typename }"}]
 
-HTTP 400
+HTTP 200
 [Asserts]
-jsonpath "$.errors[0].message" contains "batching is not supported"
+jsonpath "$[0].data.__typename" == "Query"
+jsonpath "$[0].errors" not exists

--- a/test/stub-graphql.hurl
+++ b/test/stub-graphql.hurl
@@ -24,14 +24,15 @@ header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.data.__typename" == "Mutation"
 jsonpath "$.errors" not exists
 
-# POST /graphql — batch request rejected with HTTP 400 (Phase 1: doc 12)
+# POST /graphql — single-element array batch returns HTTP 200 with a parallel array (Phase 2: doc 12)
 POST http://{{host}}/graphql
 Content-Type: application/json
 [{"query": "{ __typename }"}]
 
-HTTP 400
+HTTP 200
 [Asserts]
-jsonpath "$.errors[0].message" contains "batching is not supported"
+jsonpath "$[0].data.__typename" == "Query"
+jsonpath "$[0].errors" not exists
 
 # POST /graphql — APQ request rejected (Phase 1: doc 12)
 POST http://{{host}}/graphql


### PR DESCRIPTION
Fixes #161.

Refactors `graphql_handler` to extract an `execute_single` helper, then replaces the Phase 1 batch-rejection guard with real array-body iteration so clients can send multiple GraphQL operations in a single POST. Adds unit tests covering parallel result arrays, per-operation error isolation, and edge cases.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add batch array-body detection and iteration in graphql_handler <!-- type:spec -->
- [x] Add batch unit tests for success, errors, and edge cases <!-- type:spec -->
- [x] Extract execute_single from graphql_handler body <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->