### PR TITLE
GraphQL: GQL-24 - Backward pagination (`last`/`before`) (closes #162)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -87,6 +87,7 @@ globals = {
   "graphql_page_to_cursor",
   "graphql_cursor_to_page",
   "graphql_cursor_url",
+  "graphql_prefetch_total_from_headers",
   "graphql_inline_connection",
   "graphql_make_connection",
   "graphql_issues_connection",

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -2248,8 +2248,14 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url_base =
-    base() .. "/repositories/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments"
+  local url_base = base()
+    .. "/repositories/"
+    .. owner
+    .. "/"
+    .. repo
+    .. "/issues/"
+    .. number
+    .. "/comments"
   local total
   if args.last and not args.before then
     local count_url = graphql_cursor_url(url_base, { first = 1 }, GQL_PAGES)
@@ -2282,8 +2288,14 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url_base =
-    base() .. "/repositories/" .. owner .. "/" .. repo .. "/pullrequests/" .. number .. "/commits"
+  local url_base = base()
+    .. "/repositories/"
+    .. owner
+    .. "/"
+    .. repo
+    .. "/pullrequests/"
+    .. number
+    .. "/commits"
   local total
   if args.last and not args.before then
     local count_url = graphql_cursor_url(url_base, { first = 1 }, GQL_PAGES)

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -1955,21 +1955,32 @@ backend_impl = {
 -- Bitbucket uses pagelen / page query parameters (not per_page).
 local GQL_PAGES = { per_page = "pagelen", page = "page" }
 
+-- Local helper: extract total from a Bitbucket paginated response body.
+local function bb_total(data)
+  return data.size and tonumber(data.size) or nil
+end
+
 -- Local helper: build a paginated Relay Connection from a Bitbucket list endpoint.
 -- Bitbucket wraps paginated responses in {"values":[...],"size":N,"pagelen":30,"page":1}.
 -- The total count comes from the response body's "size" field (not HTTP headers).
+-- For backward pagination (last without before), prefetches total via a pagelen=1 request.
 local function bb_repo_connection(owner, repo_name, suffix, args, ctx, translate_fn, make_conn)
-  local url = graphql_cursor_url(
-    base() .. "/repositories/" .. owner .. "/" .. repo_name .. suffix,
-    args,
-    GQL_PAGES
-  )
+  local url_base = base() .. "/repositories/" .. owner .. "/" .. repo_name .. suffix
+  local total
+  if args.last and not args.before then
+    local count_url = graphql_cursor_url(url_base, { first = 1 }, GQL_PAGES)
+    local pdata, _, _ = graphql_fetch_with_headers(fetch_json, count_url)
+    if pdata then
+      total = bb_total(pdata)
+    end
+  end
+  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
   local data, _, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = data.size and tonumber(data.size) or nil
+  total = bb_total(data) or total
   local nodes = {}
   for _, item in ipairs(data.values or {}) do
     nodes[#nodes + 1] = translate_fn(item)
@@ -2237,17 +2248,23 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/repositories/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments",
-    args,
-    GQL_PAGES
-  )
+  local url_base =
+    base() .. "/repositories/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments"
+  local total
+  if args.last and not args.before then
+    local count_url = graphql_cursor_url(url_base, { first = 1 }, GQL_PAGES)
+    local pdata, _, _ = graphql_fetch_with_headers(fetch_json, count_url)
+    if pdata then
+      total = bb_total(pdata)
+    end
+  end
+  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
   local data, _, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = data.size and tonumber(data.size) or nil
+  total = bb_total(data) or total
   local nodes = {}
   for _, c in ipairs(data.values or {}) do
     nodes[#nodes + 1] = graphql_translate_comment(translate_bb_issue_comment(c), owner, repo)
@@ -2265,17 +2282,23 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/repositories/" .. owner .. "/" .. repo .. "/pullrequests/" .. number .. "/commits",
-    args,
-    GQL_PAGES
-  )
+  local url_base =
+    base() .. "/repositories/" .. owner .. "/" .. repo .. "/pullrequests/" .. number .. "/commits"
+  local total
+  if args.last and not args.before then
+    local count_url = graphql_cursor_url(url_base, { first = 1 }, GQL_PAGES)
+    local pdata, _, _ = graphql_fetch_with_headers(fetch_json, count_url)
+    if pdata then
+      total = bb_total(pdata)
+    end
+  end
+  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
   local data, _, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = data.size and tonumber(data.size) or nil
+  total = bb_total(data) or total
   local nodes = {}
   for _, c in ipairs(data.values or {}) do
     local translated = translate_bb_commit(c)

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -1336,10 +1336,20 @@ end
 -- Shared pagination helper for BBS /values arrays.
 -- BBS pagination uses start (offset) and limit (page size);
 -- graphql_cursor_url can't be used because BBS start = (page-1)*limit, not page number.
+--
+-- Backward pagination (last/before):
+--   before: cursor(P) → page P-1, start (P-2)*limit (graphql_make_connection handles before(1))
+--   last: N without before → page 1 fallback (BBS has no total-count endpoint)
 local function bbs_repo_connection(owner, repo_name, suffix, args, ctx, translate_fn, make_conn)
-  local per_page = args.first or 30
+  local per_page = args.last or args.first or 30
   local page = 1
-  if args.after then
+  if args.before then
+    local before_page = graphql_cursor_to_page(args.before)
+    if before_page and before_page >= 2 then
+      page = before_page - 1
+    end
+    -- else: before page 1 or invalid → page 1; graphql_make_connection returns empty
+  elseif args.after then
     local p = graphql_cursor_to_page(args.after)
     if p then
       page = p + 1

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1333,19 +1333,33 @@ backend_impl = {
 -- GitBucket uses GitHub-compatible per_page / page query parameters.
 local GQL_PAGES = { per_page = "per_page", page = "page" }
 
+-- Headers GitBucket may return for the total item count (optional; absent on some endpoints).
+local GB_TOTAL_HEADERS = { "X-Total", "X-Total-Count" }
+
+-- Local helper: extract total from GitBucket response headers (nil when absent).
+local function gb_total(headers)
+  return (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+end
+
 -- Local helper: build a paginated Relay Connection from a GitBucket list endpoint.
 -- GitBucket may return X-Total / X-Total-Count headers; if absent, the connection
 -- builder falls back to the count == per_page heuristic for hasNextPage.
+-- For backward pagination (last without before), prefetches total via a per_page=1 request
+-- when headers are expected; falls back to heuristic when not available.
 local function gb_repo_connection(owner, repo_name, suffix, args, ctx, translate_fn, make_conn)
-  local url =
-    graphql_cursor_url(base() .. "/repos/" .. owner .. "/" .. repo_name .. suffix, args, GQL_PAGES)
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo_name .. suffix
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GQL_PAGES, GB_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gb_total(headers) or total
   local nodes = {}
   for _, item in ipairs(data) do
     nodes[#nodes + 1] = translate_fn(item)
@@ -1532,15 +1546,18 @@ graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url =
-    graphql_cursor_url(base() .. "/repos/" .. owner .. "/" .. name .. "/issues", args, GQL_PAGES)
+  local url_base = base() .. "/repos/" .. owner .. "/" .. name .. "/issues"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GQL_PAGES, GB_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gb_total(headers) or total
   local nodes = {}
   for _, item in ipairs(data) do
     if not item.pull_request then
@@ -1621,18 +1638,18 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments",
-    args,
-    GQL_PAGES
-  )
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GQL_PAGES, GB_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gb_total(headers) or total
   local nodes = {}
   for _, c in ipairs(data) do
     nodes[#nodes + 1] = graphql_translate_comment(c, owner, repo)
@@ -1650,18 +1667,18 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits",
-    args,
-    GQL_PAGES
-  )
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GQL_PAGES, GB_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gb_total(headers) or total
   -- PullRequest.commits returns PullRequestCommitConnection, whose nodes are
   -- PullRequestCommit objects wrapping bare Commit objects.
   local nodes = {}

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1638,7 +1638,14 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments"
+  local url_base = base()
+    .. "/repos/"
+    .. owner
+    .. "/"
+    .. repo
+    .. "/issues/"
+    .. number
+    .. "/comments"
   local total
   if args.last and not args.before then
     total = graphql_prefetch_total_from_headers(fetch_json, url_base, GQL_PAGES, GB_TOTAL_HEADERS)

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3378,7 +3378,8 @@ local function gitea_repo_connection(owner, repo, suffix, args, ctx, translate_f
   local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. suffix
   local total
   if args.last and not args.before then
-    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+    total =
+      graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
   end
   local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
@@ -3483,10 +3484,18 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments"
+  local url_base = base()
+    .. "/repos/"
+    .. owner
+    .. "/"
+    .. repo
+    .. "/issues/"
+    .. number
+    .. "/comments"
   local total
   if args.last and not args.before then
-    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+    total =
+      graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
   end
   local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
@@ -3517,7 +3526,8 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
   local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits"
   local total
   if args.last and not args.before then
-    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+    total =
+      graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
   end
   local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
@@ -3555,7 +3565,8 @@ graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
   local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/reviews"
   local total
   if args.last and not args.before then
-    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+    total =
+      graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
   end
   local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3360,23 +3360,33 @@ end
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------
+-- Local pagination parameters for graphql_cursor_url (Gitea uses limit / page).
+local GITEA_PAGES = { per_page = "limit", page = "page" }
+-- Headers Gitea uses for the total item count.
+local GITEA_TOTAL_HEADERS = { "X-Total", "X-Total-Count" }
+
+-- Local helper: extract total from Gitea response headers.
+local function gitea_total(headers)
+  return (headers["X-Total"] and tonumber(headers["X-Total"]))
+    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+end
+
 -- Local helper: build a paginated Relay Connection from a Gitea list endpoint.
--- Fetches page from graphql_cursor_url(base_suffix, args, {per_page="limit", page="page"}),
--- reads X-Total / X-Total-Count for totalCount, translates items with translate_fn(item),
--- and delegates to make_conn(nodes, args, total, ctx).
+-- For backward pagination (last without before), prefetches total via a limit=1 request
+-- so graphql_cursor_url can seek the correct last page on the subsequent full fetch.
 local function gitea_repo_connection(owner, repo, suffix, args, ctx, translate_fn, make_conn)
-  local url = graphql_cursor_url(
-    base() .. "/repos/" .. owner .. "/" .. repo .. suffix,
-    args,
-    { per_page = "limit", page = "page" }
-  )
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. suffix
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gitea_total(headers) or total
   local nodes = {}
   for _, item in ipairs(data) do
     nodes[#nodes + 1] = translate_fn(item)
@@ -3473,18 +3483,18 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments",
-    args,
-    { per_page = "limit", page = "page" }
-  )
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/issues/" .. number .. "/comments"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gitea_total(headers) or total
   local nodes = {}
   for _, c in ipairs(data) do
     nodes[#nodes + 1] = graphql_translate_comment(translate_gitea_issue_comment(c), owner, repo)
@@ -3504,18 +3514,18 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits",
-    args,
-    { per_page = "limit", page = "page" }
-  )
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gitea_total(headers) or total
   -- PullRequest.commits returns PullRequestCommitConnection, whose nodes are
   -- PullRequestCommit objects (not bare Commit objects).  Each PullRequestCommit
   -- wraps the Commit so clients can query commits { nodes { commit { oid } } }.
@@ -3542,18 +3552,18 @@ graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/reviews",
-    args,
-    { per_page = "limit", page = "page" }
-  )
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/reviews"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = (headers["X-Total"] and tonumber(headers["X-Total"]))
-    or (headers["X-Total-Count"] and tonumber(headers["X-Total-Count"]))
+  total = gitea_total(headers) or total
   local nodes = {}
   for _, r in ipairs(data) do
     nodes[#nodes + 1] = graphql_translate_review(translate_gitea_review(r), owner, repo)

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -3993,18 +3993,25 @@ end
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------
 
+-- Headers GitLab uses for the total item count.
+local GL_TOTAL_HEADERS = { "X-Total" }
+
 -- Local helper: build a paginated Relay Connection from a GitLab list endpoint.
--- Fetches page from graphql_cursor_url, reads X-Total for totalCount,
--- translates items with translate_fn, and delegates to make_conn.
+-- For backward pagination (last without before), prefetches total via a per_page=1 request
+-- so graphql_cursor_url can seek the correct last page on the subsequent full fetch.
 local function gitlab_repo_connection(owner, repo, suffix, args, ctx, translate_fn, make_conn)
-  local url =
-    graphql_cursor_url(base() .. "/projects/" .. project_id(owner, repo) .. suffix, args, PAGES)
+  local url_base = base() .. "/projects/" .. project_id(owner, repo) .. suffix
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, PAGES, GL_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = headers["X-Total"] and tonumber(headers["X-Total"])
+  total = (headers["X-Total"] and tonumber(headers["X-Total"])) or total
   local nodes = {}
   for _, item in ipairs(data) do
     nodes[#nodes + 1] = translate_fn(item)
@@ -4147,17 +4154,18 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/projects/" .. project_id(owner, repo) .. "/issues/" .. iid .. "/notes",
-    args,
-    PAGES
-  )
+  local url_base = base() .. "/projects/" .. project_id(owner, repo) .. "/issues/" .. iid .. "/notes"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, PAGES, GL_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = headers["X-Total"] and tonumber(headers["X-Total"])
+  total = (headers["X-Total"] and tonumber(headers["X-Total"])) or total
   local nodes = {}
   for _, n in ipairs(data) do
     if not n.system then
@@ -4182,17 +4190,19 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(
-    base() .. "/projects/" .. project_id(owner, repo) .. "/merge_requests/" .. iid .. "/commits",
-    args,
-    PAGES
-  )
+  local url_base =
+    base() .. "/projects/" .. project_id(owner, repo) .. "/merge_requests/" .. iid .. "/commits"
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(fetch_json, url_base, PAGES, GL_TOTAL_HEADERS)
+  end
+  local url = graphql_cursor_url(url_base, args, PAGES, total)
   local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
-  local total = headers["X-Total"] and tonumber(headers["X-Total"])
+  total = (headers["X-Total"] and tonumber(headers["X-Total"])) or total
   local nodes = {}
   for _, c in ipairs(data) do
     -- Translate GitLab's flat commit format to the REST shape graphql_translate_commit expects.

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -4154,7 +4154,12 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url_base = base() .. "/projects/" .. project_id(owner, repo) .. "/issues/" .. iid .. "/notes"
+  local url_base = base()
+    .. "/projects/"
+    .. project_id(owner, repo)
+    .. "/issues/"
+    .. iid
+    .. "/notes"
   local total
   if args.last and not args.before then
     total = graphql_prefetch_total_from_headers(fetch_json, url_base, PAGES, GL_TOTAL_HEADERS)
@@ -4190,8 +4195,12 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url_base =
-    base() .. "/projects/" .. project_id(owner, repo) .. "/merge_requests/" .. iid .. "/commits"
+  local url_base = base()
+    .. "/projects/"
+    .. project_id(owner, repo)
+    .. "/merge_requests/"
+    .. iid
+    .. "/commits"
   local total
   if args.last and not args.before then
     total = graphql_prefetch_total_from_headers(fetch_json, url_base, PAGES, GL_TOTAL_HEADERS)

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -805,14 +805,23 @@ graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url = graphql_cursor_url(base() .. "/" .. owner .. "/" .. name .. "/issues", args, PAGES)
+  local url_base = base() .. "/" .. owner .. "/" .. name .. "/issues"
+  local total
+  if args.last and not args.before then
+    local count_url = graphql_cursor_url(url_base, { first = 1 }, PAGES)
+    local pdata, _, _ = graphql_fetch_with_headers(fetch_json, count_url)
+    if pdata then
+      total = (type(pdata) == "table") and pdata.total_issues or nil
+    end
+  end
+  local url = graphql_cursor_url(url_base, args, PAGES, total)
   local data, _, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
   local items = (type(data) == "table") and (data.issues or {}) or {}
-  local total = (type(data) == "table") and data.total_issues or nil
+  total = ((type(data) == "table") and data.total_issues or nil) or total
   local nodes = {}
   for _, i in ipairs(items) do
     nodes[#nodes + 1] = graphql_translate_issue(translate_pagure_issue(i), owner, name)
@@ -827,15 +836,23 @@ graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
   if not owner then
     return nil
   end
-  local url =
-    graphql_cursor_url(base() .. "/" .. owner .. "/" .. name .. "/git/branches", args, PAGES)
+  local url_base = base() .. "/" .. owner .. "/" .. name .. "/git/branches"
+  local total
+  if args.last and not args.before then
+    local count_url = graphql_cursor_url(url_base, { first = 1 }, PAGES)
+    local pdata, _, _ = graphql_fetch_with_headers(fetch_json, count_url)
+    if pdata then
+      total = (type(pdata) == "table") and pdata.total_branches or nil
+    end
+  end
+  local url = graphql_cursor_url(url_base, args, PAGES, total)
   local data, _, err = graphql_fetch_with_headers(fetch_json, url)
   if not data then
     graphql_error(ctx, err)
     return nil
   end
   local items = (type(data) == "table") and (data.branches or {}) or {}
-  local total = (type(data) == "table") and data.total_branches or nil
+  total = ((type(data) == "table") and data.total_branches or nil) or total
   local nodes = {}
   for _, b_name in ipairs(items) do
     -- Pagure branch list returns only names; no commit SHA is available.

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -645,8 +645,10 @@ end
 -- Sourcehut pagination uses cursor-based results with a `limit` param;
 -- graphql_cursor_url cannot be used (no page-number param), so we build
 -- the URL manually like bbs_repo_connection does.
+-- Backward pagination (last/before): Sourcehut exposes no total count and no
+-- page-number addressing, so last: N returns the first N items (known limitation).
 local function srht_issue_connection(owner, repo_name, args, ctx)
-  local per_page = args.first or 30
+  local per_page = args.last or args.first or 30
   local url = todo_base()
     .. "/~"
     .. owner

--- a/docs/graphql/07-pagination.md
+++ b/docs/graphql/07-pagination.md
@@ -140,41 +140,146 @@ end
 
 ## Backward pagination (`last`/`before`)
 
-### Phase 1 limitation
+### Argument semantics
 
-Backward pagination requires either:
-- Backend support for reverse ordering, or
-- Knowing the total page count to seek from the end.
+| Arguments | Meaning | REST translation |
+|-----------|---------|-----------------|
+| `last: N` only | Last N items overall | two-pass: prefetch total → `per_page=N, page=ceil(total/N)` |
+| `last: N, before: cursor` | N items before cursor | `per_page=N, page=cursor_page-1` |
+| `before: cursor` only | Default page before cursor | `per_page=30, page=cursor_page-1` |
 
-Most REST backends support neither reliably.  Phase 1 returns an error for any request
-that uses `last` or `before`:
+### Two-pass total-prefetch strategy
+
+Seeking the last page requires knowing the total item count *before* building the REST URL.
+For `last: N` without a `before` cursor, resolvers use a two-pass approach:
+
+1. **Prefetch pass**: call `graphql_prefetch_total_from_headers` with `first: 1` to fetch
+   a single-item page and read the total-count header (`X-Total` / `X-Total-Count`).
+   This avoids downloading a full page of data we will discard.
+
+2. **Real pass**: call `graphql_cursor_url(url_base, args, param_names, total)` with the
+   fetched total so it computes `page = ceil(total / per_page)` and fetches the correct
+   last page.
 
 ```lua
-if args.last or args.before then
-  append_graphql_error(ctx,
-    "backward pagination (last/before) is not supported in this version")
-  return {
-    __typename  = typename .. "Connection",
-    total_count = 0,
-    page_info   = {
-      __typename         = "PageInfo",
-      has_next_page      = false,
-      has_previous_page  = false,
-      start_cursor       = nil,
-      end_cursor         = nil,
-    },
-    nodes = {},
-    edges = {},
-  }
+-- internal/graphql_translators.lua
+--
+-- Lightweight prefetch that returns the total item count from headers.
+-- Only call when args.last is set and args.before is absent.
+function graphql_prefetch_total_from_headers(fetch_json, url_base, param_names, header_names)
+  local count_url = graphql_cursor_url(url_base, { first = 1 }, param_names)
+  local _, headers, _ = graphql_fetch_with_headers(fetch_json, count_url)
+  if not headers then return nil end
+  for _, name in ipairs(header_names) do
+    local v = headers[name] and tonumber(headers[name])
+    if v then return v end
+  end
+  return nil
 end
 ```
 
-The error is added to `ctx.errors` and the field returns an empty connection (not `null`),
-so the rest of the query continues executing.  Clients that use only `first`/`after` are
-unaffected.
+Helper usage in a backend connection resolver:
 
-Backward pagination implementation is tracked as a Phase 2 item in
-[16-roadmap.md](16-roadmap.md).
+```lua
+local function gitea_repo_connection(owner, repo, suffix, args, ctx, translate_fn, make_conn)
+  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. suffix
+  local total
+  if args.last and not args.before then
+    total = graphql_prefetch_total_from_headers(
+      fetch_json, url_base, GITEA_PAGES, { "X-Total", "X-Total-Count" }
+    )
+  end
+  local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
+  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  total = gitea_total(headers) or total
+  -- translate + return make_conn(nodes, args, total, ctx)
+end
+```
+
+### URL construction for backward pagination
+
+`graphql_cursor_url` accepts an optional fourth argument `total`.  When `args.last` (or
+`args.before`) is detected, the backward-pagination branch runs:
+
+| Case | REST page |
+|------|-----------|
+| `last: N, before: cursor(P)` where P ≥ 2 | `page=P-1, per_page=N` |
+| `last: N, before: cursor(1)` or malformed cursor | `page=1, per_page=N` (edge: `make_connection` returns empty) |
+| `last: N` with `total` provided | `page=ceil(total/N), per_page=N` |
+| `last: N` without `total` | `page=1, per_page=N` (fallback; resolver uses two-pass) |
+
+### Connection assembly for backward pagination
+
+`graphql_make_connection` detects `args.last` or `args.before` and enters the backward
+branch:
+
+**`before: cursor(P)` where P ≥ 2 — one page before the cursor:**
+
+```lua
+local page = before_page - 1
+return {
+  pageInfo = {
+    hasNextPage     = true,  -- cursor page P proves items exist there
+    hasPreviousPage = page > 1,
+    startCursor     = graphql_page_to_cursor(page),
+    endCursor       = graphql_page_to_cursor(page),
+  },
+  totalCount = total or count,
+  nodes = nodes,
+  edges = edges,
+}
+```
+
+**`before: cursor(1)` or malformed cursor — nothing before the first page:**
+
+```lua
+return {
+  pageInfo = {
+    hasNextPage     = (before_page ~= nil and before_page >= 1),
+    hasPreviousPage = false,
+    startCursor     = nil,
+    endCursor       = nil,
+  },
+  totalCount = total or 0,
+  nodes = {},
+  edges = {},
+}
+```
+
+**`last: N` without `before` — last page overall:**
+
+```lua
+local page = total and math.max(1, math.ceil(total / per_page)) or 1
+local has_next = total ~= nil and (page * per_page) < total
+              or total == nil and count == per_page  -- heuristic fallback
+return {
+  pageInfo = {
+    hasNextPage     = has_next,
+    hasPreviousPage = page > 1,
+    ...
+  },
+  ...
+}
+```
+
+### Backends without total-count headers
+
+Backends that do not return `X-Total` / `X-Total-Count` (Bitbucket Cloud, Pagure,
+Sourcehut) cannot determine the total page count.  For `last: N` without `before`:
+
+- The two-pass prefetch returns `nil` (no header).
+- `graphql_cursor_url` falls back to `page=1`.
+- `graphql_make_connection` uses the page-full heuristic for `hasNextPage`.
+- `hasPreviousPage` is always `false` (page 1).
+
+Clients receive the first page of results when they ask for the last, which is incorrect
+but does not error.  This is documented in [14-backend-feasibility.md](14-backend-feasibility.md).
+
+`last: N, before: cursor` always works correctly (no total needed).
 
 ## `totalCount`
 
@@ -455,29 +560,59 @@ field names (camelCase) as their keys**, not REST field names (snake_case).
 
 ## Testing
 
-Unit tests in `test/graphql-pagination.lua`:
+### Unit tests — `test/graphql-pagination.lua`
+
+Forward pagination:
 
 - `graphql_page_to_cursor(1)` → deterministic base64 string.
 - `graphql_cursor_to_page(graphql_page_to_cursor(3))` → `3` (round-trip).
 - `graphql_cursor_to_page("invalid")` → `nil`.
-- `graphql_cursor_to_page(nil)` → `nil`.
 - `graphql_cursor_url(base, {first=10}, params)` → URL with `limit=10`, no `page` param.
 - `graphql_cursor_url(base, {first=10, after=cursor_for_page_2}, params)` → URL with
   `limit=10&page=3`.
 - `graphql_make_connection("Issue", nodes, {first=2}, nil)` where `#nodes==2`:
   `hasNextPage = true`, `hasPreviousPage = false`, `totalCount = 2`.
-- `graphql_make_connection("Issue", nodes, {first=5}, nil)` where `#nodes==3`:
-  `hasNextPage = false` (partial page).
 - `graphql_make_connection("Issue", nodes, {first=10, after=cursor_for_page_1}, 25)`:
-  page=2, `hasNextPage = (2*10)<25 = true`, `hasPreviousPage = true`.
-- `graphql_make_connection("Issue", nodes, {first=10, after=cursor_for_page_2}, 25)`:
-  page=3, `hasNextPage = (3*10)<25 = false`.
+  page=2, `hasNextPage = true`, `hasPreviousPage = true`.
+
+Backward pagination:
+
+- `graphql_cursor_url(base, {last=10}, params, 25)` → URL with `limit=10&page=3`
+  (`ceil(25/10)=3`).
+- `graphql_cursor_url(base, {last=10}, params)` (no total) → URL with `limit=10`, page 1
+  fallback.
+- `graphql_cursor_url(base, {last=10, before=cursor(3)}, params)` → URL with
+  `limit=10&page=2`.
+- `graphql_cursor_url(base, {last=5, before=cursor(1)}, params)` → URL with `limit=5`
+  (clamped to page 1; `make_connection` returns empty).
+- `graphql_make_connection("Issue", nodes, {last=10}, 25)`: page=3, `hasNextPage=false`,
+  `hasPreviousPage=true`.
+- `graphql_make_connection("Issue", nodes, {last=10}, 10)`: page=1, `hasNextPage=false`,
+  `hasPreviousPage=false`.
+- `graphql_make_connection("Issue", nodes, {last=3, before=cursor(3)}, 10)`: page=2,
+  `hasNextPage=true`, `hasPreviousPage=true`.
+- `graphql_make_connection("Issue", nodes, {last=3, before=cursor(1)}, 10)`: empty nodes,
+  `hasNextPage=true` (cursor(1) is valid), `hasPreviousPage=false`.
+- `graphql_make_connection("Issue", nodes, {before="notacursor"}, 10)`: empty nodes,
+  `hasNextPage=false` (malformed cursor), `hasPreviousPage=false`.
 - `graphql_inline_connection("Label", labels)`: `hasNextPage = false`,
   `hasPreviousPage = false`, `totalCount = #labels`.
-- Backward pagination: `graphql_make_connection` with `{last=5}` returns empty connection
-  and appends to `ctx.errors`.
 
-Integration: an executor test that selects
-`repository { issues(first: 2) { totalCount pageInfo { hasNextPage endCursor } nodes { title } } }`
-with a stub resolver returning 2 issues verifies the full connection shape is assembled and
-plucked correctly.
+### Unit tests — `test/gitea-graphql.hurl` (against mock)
+
+- `issues(last: 1)`: mock returns X-Total: 1 → two-pass resolves to page 1; 1 node,
+  `hasPreviousPage=false`, `hasNextPage=false`.
+- `issues(first: 1)` to capture `endCursor` (cursor for page 1), then
+  `issues(last: 1, before: endCursor)`: empty nodes (nothing before page 1),
+  `hasNextPage=true`, `hasPreviousPage=false`.
+
+### Integration tests — `test/integration-graphql-mutations.hurl` (live gitea.com)
+
+Run when `GITEA_TOKEN` is set.  Three issues are created inside `confusio-mutation-test`
+so the repo has enough data to exercise the two-pass path:
+
+- `issues(last: 1)` with total=3: prefetch returns 3, `last_page=3`; resolver fetches
+  page 3; `hasPreviousPage=true`, `hasNextPage=false`, `totalCount=3`.
+- `issues(first: 1)` to capture `endCursor` for page 1, then
+  `issues(last: 1, before: endCursor)`: empty nodes, `hasNextPage=true`,
+  `hasPreviousPage=false`, `totalCount=3`.

--- a/internal/graphql_translators.lua
+++ b/internal/graphql_translators.lua
@@ -12,7 +12,7 @@
 --   graphql_fetch_or_error(fetch_json, path, ctx, field_node[, method[, body]])
 --   graphql_page_to_cursor(page)
 --   graphql_cursor_to_page(cursor)
---   graphql_cursor_url(url_base, args, param_names)
+--   graphql_cursor_url(url_base, args, param_names[, total])
 --   graphql_inline_connection(typename, nodes)
 --   graphql_make_connection(typename, nodes, args, total[, ctx])
 --   graphql_issues_connection(nodes, args, total[, ctx])
@@ -204,17 +204,40 @@ end
 
 -- graphql_cursor_url is global: builds a paginated REST URL from GraphQL connection args.
 -- url_base:    base REST URL (may already contain a query string)
--- args:        GraphQL connection arguments table; reads args.first (default 30) and args.after
+-- args:        GraphQL connection arguments table; reads first/after (forward) or last/before (backward)
 -- param_names: table mapping REST parameter names, e.g. { per_page = "limit", page = "page" }.
 --              Keys present in param_names are appended; omitted keys are skipped.
 --              The page parameter is only appended when the resolved page is > 1.
-function graphql_cursor_url(url_base, args, param_names) -- luacheck: globals graphql_cursor_url
-  local per_page = args.first or 30
-  local page = 1
-  if args.after then
-    local p = graphql_cursor_to_page(args.after)
-    if p then
-      page = p + 1
+-- total:       optional total item count (from a prior X-Total header); used to compute the
+--              last-page number for backward pagination with last but no before cursor.
+--
+-- Backward pagination (last/before):
+--   last: N, before: cursor(P)  → page P-1, per_page N  (P-1 < 1 clamps to 1; make_connection handles empty)
+--   last: N  (no before)        → page ceil(total/N) when total provided; page 1 otherwise (fallback)
+function graphql_cursor_url(url_base, args, param_names, total) -- luacheck: globals graphql_cursor_url
+  local per_page, page
+  if args.last or args.before then
+    -- Backward pagination.
+    per_page = args.last or 30
+    if args.before then
+      local before_page = graphql_cursor_to_page(args.before)
+      -- Clamp to 1 when before_page is absent, malformed, or ≤ 1.
+      -- graphql_make_connection detects the degenerate case and returns an empty connection.
+      page = (before_page and before_page >= 2) and (before_page - 1) or 1
+    elseif total and total > 0 then
+      page = math.max(1, math.ceil(total / per_page))
+    else
+      page = 1 -- fallback: no total available; resolver must use two-pass strategy for accuracy
+    end
+  else
+    -- Forward pagination.
+    per_page = args.first or 30
+    page = 1
+    if args.after then
+      local p = graphql_cursor_to_page(args.after)
+      if p then
+        page = p + 1
+      end
     end
   end
   local sep = url_base:find("?", 1, true) and "&" or "?"
@@ -263,30 +286,94 @@ end
 -- nodes:    array of already-translated GraphQL objects for this page
 -- args:     GraphQL connection arguments (first, after, last, before)
 -- total:    total item count from the upstream header (X-Total / X-Total-Count), or nil
--- ctx:      optional GraphQL field context; when present, backward-pagination errors are
---           reported via graphql_error; when nil the error is silently dropped.
+-- _ctx:     reserved for future use; kept for call-site API compatibility
 --
--- Backward pagination (last/before) is not supported in Phase 1: returns an empty connection
--- with an error added to ctx when provided.
-function graphql_make_connection(typename, nodes, args, total, ctx) -- luacheck: globals graphql_make_connection
+-- Backward pagination (last/before):
+--   last: N, before: cursor(P)  → page P-1; hasNextPage = true (cursor page P exists)
+--   last: N  (no before)        → last page when total known; page 1 otherwise (resolver fallback)
+--   before: cursor(1) or malformed before → empty connection (nothing exists before page 1)
+function graphql_make_connection(typename, nodes, args, total, _ctx) -- luacheck: globals graphql_make_connection
   if args.last or args.before then
-    if ctx then
-      graphql_error(ctx, "backward pagination (last/before) is not supported in this version")
+    local per_page = args.last or 30
+    if args.before then
+      -- Backward pagination anchored to a before cursor.
+      local before_page = graphql_cursor_to_page(args.before)
+      if not before_page or before_page <= 1 then
+        -- Nothing exists before the first page (or cursor is malformed).
+        -- hasNextPage: true when cursor decoded to page 1 (that page does exist); false for garbage.
+        return {
+          __typename = typename .. "Connection",
+          totalCount = total or 0,
+          pageInfo = {
+            __typename = "PageInfo",
+            hasNextPage = (before_page ~= nil and before_page >= 1),
+            hasPreviousPage = false,
+            startCursor = nil,
+            endCursor = nil,
+          },
+          nodes = {},
+          edges = {},
+        }
+      end
+      -- before_page >= 2: the target page is one step before the cursor.
+      local page = before_page - 1
+      local count = #nodes
+      local start_cursor = count > 0 and graphql_page_to_cursor(page) or nil
+      local edges = {}
+      for i, node in ipairs(nodes) do
+        edges[i] =
+          { __typename = typename .. "Edge", cursor = graphql_page_to_cursor(page), node = node }
+      end
+      return {
+        __typename = typename .. "Connection",
+        totalCount = total or count,
+        pageInfo = {
+          __typename = "PageInfo",
+          hasNextPage = true, -- items exist at before_page and beyond (cursor proves it)
+          hasPreviousPage = page > 1,
+          startCursor = start_cursor,
+          endCursor = start_cursor,
+        },
+        nodes = nodes,
+        edges = edges,
+      }
+    else
+      -- Backward pagination from the end: last N items overall.
+      local page
+      if total and total > 0 then
+        page = math.max(1, math.ceil(total / per_page))
+      else
+        page = 1 -- fallback: no total; resolver should use two-pass strategy for accuracy
+      end
+      local count = #nodes
+      local has_next
+      if total ~= nil then
+        has_next = (page * per_page) < total -- always false for the computed last page
+      else
+        has_next = count == per_page -- heuristic when total is unknown
+      end
+      local start_cursor = count > 0 and graphql_page_to_cursor(page) or nil
+      local edges = {}
+      for i, node in ipairs(nodes) do
+        edges[i] =
+          { __typename = typename .. "Edge", cursor = graphql_page_to_cursor(page), node = node }
+      end
+      return {
+        __typename = typename .. "Connection",
+        totalCount = total or count,
+        pageInfo = {
+          __typename = "PageInfo",
+          hasNextPage = has_next,
+          hasPreviousPage = page > 1,
+          startCursor = start_cursor,
+          endCursor = start_cursor,
+        },
+        nodes = nodes,
+        edges = edges,
+      }
     end
-    return {
-      __typename = typename .. "Connection",
-      totalCount = 0,
-      pageInfo = {
-        __typename = "PageInfo",
-        hasNextPage = false,
-        hasPreviousPage = false,
-        startCursor = nil,
-        endCursor = nil,
-      },
-      nodes = {},
-      edges = {},
-    }
   end
+  -- Forward pagination.
   local per_page = args.first or 30
   local page = 1
   if args.after then

--- a/internal/graphql_translators.lua
+++ b/internal/graphql_translators.lua
@@ -13,6 +13,7 @@
 --   graphql_page_to_cursor(page)
 --   graphql_cursor_to_page(cursor)
 --   graphql_cursor_url(url_base, args, param_names[, total])
+--   graphql_prefetch_total_from_headers(fetch_json, url_base, param_names, header_names)
 --   graphql_inline_connection(typename, nodes)
 --   graphql_make_connection(typename, nodes, args, total[, ctx])
 --   graphql_issues_connection(nodes, args, total[, ctx])
@@ -252,6 +253,33 @@ function graphql_cursor_url(url_base, args, param_names, total) -- luacheck: glo
     return url_base
   end
   return url_base .. sep .. table.concat(parts, "&")
+end
+
+-- graphql_prefetch_total_from_headers is global: lightweight prefetch for backward pagination.
+-- When a resolver needs to seek the last page (last: N without before cursor), it must know
+-- the total item count before building the URL.  This function fetches the collection endpoint
+-- with a page size of 1 to get the total from response headers without loading a full page.
+--
+-- Returns the total as a number, or nil when the headers are absent or the total is not found.
+-- Only call when args.last is set and args.before is absent.
+--
+-- fetch_json:   backend's local fetch function
+-- url_base:     collection URL base (without pagination params)
+-- param_names:  pagination param table, e.g. { per_page = "limit", page = "page" }
+-- header_names: ordered list of header names to try, e.g. { "X-Total", "X-Total-Count" }
+function graphql_prefetch_total_from_headers(fetch_json, url_base, param_names, header_names) -- luacheck: globals graphql_prefetch_total_from_headers
+  local count_url = graphql_cursor_url(url_base, { first = 1 }, param_names)
+  local _, headers, _ = graphql_fetch_with_headers(fetch_json, count_url)
+  if not headers then
+    return nil
+  end
+  for _, name in ipairs(header_names) do
+    local v = headers[name] and tonumber(headers[name])
+    if v then
+      return v
+    end
+  end
+  return nil
 end
 
 -- ---------------------------------------------------------------------------

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -242,6 +242,51 @@ jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].state" == "AP
 jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].body" == "Looks good!"
 jsonpath "$.data.repository.pullRequests.nodes[0].reviews.nodes[0].author.login" == "octocat"
 
+# ---------------------------------------------------------------------------
+# Backward pagination (last / before)
+# ---------------------------------------------------------------------------
+
+# POST /graphql — issues(last: 1): single-page repo; hasPreviousPage false, hasNextPage false.
+# Mock returns X-Total: 1, so the two-pass resolves last_page = 1.
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues(last: 1) { totalCount pageInfo { hasNextPage hasPreviousPage startCursor endCursor } nodes { number } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.repository.issues.totalCount" == 1
+jsonpath "$.data.repository.issues.pageInfo.hasNextPage" == false
+jsonpath "$.data.repository.issues.pageInfo.hasPreviousPage" == false
+jsonpath "$.data.repository.issues.pageInfo.startCursor" isString
+jsonpath "$.data.repository.issues.nodes[0].number" == 1
+
+# POST /graphql — issues(first: 1): capture endCursor for the before test below.
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues(first: 1) { pageInfo { endCursor } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.repository.issues.pageInfo.endCursor" isString
+[Captures]
+issues_page1_cursor: jsonpath "$.data.repository.issues.pageInfo.endCursor"
+
+# POST /graphql — issues(last: 1, before: cursor(1)): nothing exists before page 1.
+# hasNextPage = true (cursor page 1 exists), hasPreviousPage = false, nodes empty.
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ repository(owner: \"octocat\", name: \"hello-world\") { issues(last: 1, before: \"{{issues_page1_cursor}}\") { totalCount pageInfo { hasNextPage hasPreviousPage } nodes { number } } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.repository.issues.totalCount" == 1
+jsonpath "$.data.repository.issues.pageInfo.hasNextPage" == true
+jsonpath "$.data.repository.issues.pageInfo.hasPreviousPage" == false
+jsonpath "$.data.repository.issues.nodes[0]" not exists
+
 # POST /graphql — Query.search REPOSITORY returns a SearchResultItemConnection
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/graphql-pagination.lua
+++ b/test/graphql-pagination.lua
@@ -196,22 +196,202 @@ is_nil(mc_empty.pageInfo.endCursor, "make_connection empty endCursor nil")
 eq(#mc_empty.nodes, 0, "make_connection empty nodes")
 eq(#mc_empty.edges, 0, "make_connection empty edges")
 
--- Backward pagination: returns empty connection, no ctx error needed.
-local mc_back = graphql_make_connection("Issue", items, { last = 3 }, 10, nil)
-eq(mc_back.__typename, "IssueConnection", "backward pagination returns IssueConnection")
-eq(mc_back.totalCount, 0, "backward pagination totalCount=0")
-eq(#mc_back.nodes, 0, "backward pagination nodes empty")
+-- ---------------------------------------------------------------------------
+-- Backward pagination: graphql_cursor_url
+-- ---------------------------------------------------------------------------
 
--- Backward pagination with ctx: graphql_error is called.
--- We stub graphql_error temporarily to capture the call.
-local error_called = false
-local real_graphql_error = graphql_error -- luacheck: globals graphql_error
-graphql_error = function(_, _) -- luacheck: globals graphql_error
-  error_called = true
+-- last: N with known total → URL for the computed last page.
+local before_total_url = graphql_cursor_url(
+  "https://example.com/api/issues",
+  { last = 10 },
+  { per_page = "limit", page = "page" },
+  25 -- total; last_page = ceil(25/10) = 3
+)
+eq(
+  before_total_url,
+  "https://example.com/api/issues?limit=10&page=3",
+  "cursor_url backward: last+total → last page URL"
+)
+
+-- last: N with total that is an exact multiple → last_page = total/N (no remainder).
+local before_exact_url = graphql_cursor_url(
+  "https://example.com/api/issues",
+  { last = 10 },
+  { per_page = "limit", page = "page" },
+  20 -- total; last_page = ceil(20/10) = 2
+)
+eq(
+  before_exact_url,
+  "https://example.com/api/issues?limit=10&page=2",
+  "cursor_url backward: last+exact total → last page URL"
+)
+
+-- last: N without total → fallback to page 1 (no page param).
+local before_nototal_url = graphql_cursor_url(
+  "https://example.com/api/issues",
+  { last = 10 },
+  { per_page = "limit", page = "page" }
+)
+eq(
+  before_nototal_url,
+  "https://example.com/api/issues?limit=10",
+  "cursor_url backward: last without total → page 1"
+)
+
+-- before: cursor(P) where P > 1 → page P-1.
+local before_c3_url = graphql_cursor_url(
+  "https://example.com/api/issues",
+  { last = 10, before = graphql_page_to_cursor(3) },
+  { per_page = "limit", page = "page" }
+)
+eq(
+  before_c3_url,
+  "https://example.com/api/issues?limit=10&page=2",
+  "cursor_url backward: before cursor(3) → page 2"
+)
+
+-- before: cursor(2) → page 1 (no page param because page == 1).
+local before_c2_url = graphql_cursor_url(
+  "https://example.com/api/issues",
+  { last = 10, before = graphql_page_to_cursor(2) },
+  { per_page = "limit", page = "page" }
+)
+eq(
+  before_c2_url,
+  "https://example.com/api/issues?limit=10",
+  "cursor_url backward: before cursor(2) → page 1"
+)
+
+-- before: cursor(1) → clamps to page 1 (make_connection handles the empty case).
+local before_c1_url = graphql_cursor_url(
+  "https://example.com/api/issues",
+  { last = 5, before = graphql_page_to_cursor(1) },
+  { per_page = "limit", page = "page" }
+)
+eq(
+  before_c1_url,
+  "https://example.com/api/issues?limit=5",
+  "cursor_url backward: before cursor(1) → clamped to page 1"
+)
+
+-- before: malformed cursor → clamps to page 1.
+local before_bad_url = graphql_cursor_url(
+  "https://example.com/api/issues",
+  { before = "notacursor" },
+  { per_page = "limit", page = "page" }
+)
+eq(
+  before_bad_url,
+  "https://example.com/api/issues?limit=30",
+  "cursor_url backward: malformed before → page 1, default per_page"
+)
+
+-- ---------------------------------------------------------------------------
+-- Backward pagination: graphql_make_connection
+-- ---------------------------------------------------------------------------
+
+local items10 = {}
+for i = 1, 10 do
+  items10[i] = { id = i }
 end
-graphql_make_connection("Issue", items, { before = "somecursor" }, 10, {})
-graphql_error = real_graphql_error -- luacheck: globals graphql_error
-ok(error_called, "make_connection calls graphql_error for before arg with ctx")
+
+-- last: N with known total → last page, correct totalCount and flags.
+-- ceil(25/10) = 3; page 3 * 10 = 30 >= 25 → hasNextPage false.
+local mc_last_known = graphql_make_connection("Issue", items10, { last = 10 }, 25, nil)
+eq(mc_last_known.__typename, "IssueConnection", "backward last+total: typename")
+eq(mc_last_known.totalCount, 25, "backward last+total: totalCount from total")
+eq(mc_last_known.pageInfo.hasNextPage, false, "backward last+total: hasNextPage false (last page)")
+eq(
+  mc_last_known.pageInfo.hasPreviousPage,
+  true,
+  "backward last+total: hasPreviousPage true (page 3 > 1)"
+)
+not_nil(mc_last_known.pageInfo.startCursor, "backward last+total: startCursor non-nil")
+not_nil(mc_last_known.pageInfo.endCursor, "backward last+total: endCursor non-nil")
+eq(#mc_last_known.nodes, 10, "backward last+total: nodes length")
+eq(#mc_last_known.edges, 10, "backward last+total: edges length")
+eq(mc_last_known.edges[1].__typename, "IssueEdge", "backward last+total: edge typename")
+
+-- last: N with total = N (single page) → page 1, hasPreviousPage false.
+local mc_last_single = graphql_make_connection("Issue", items10, { last = 10 }, 10, nil)
+eq(mc_last_single.pageInfo.hasNextPage, false, "backward single-page: hasNextPage false")
+eq(
+  mc_last_single.pageInfo.hasPreviousPage,
+  false,
+  "backward single-page: hasPreviousPage false (page 1)"
+)
+
+-- last: N without total → fallback to page 1; count < per_page → hasNextPage false.
+local mc_last_nototal = graphql_make_connection("Issue", items, { last = 5 }, nil, nil)
+-- items has 3 entries, per_page = 5; 3 < 5 → hasNextPage false (heuristic).
+eq(
+  mc_last_nototal.pageInfo.hasNextPage,
+  false,
+  "backward no-total: hasNextPage false (count<per_page)"
+)
+eq(
+  mc_last_nototal.pageInfo.hasPreviousPage,
+  false,
+  "backward no-total: hasPreviousPage false (page 1 fallback)"
+)
+eq(mc_last_nototal.totalCount, 3, "backward no-total: totalCount from count")
+
+-- last: N without total and count == per_page → hasNextPage true (heuristic).
+local mc_last_full = graphql_make_connection("Issue", items, { last = 3 }, nil, nil)
+eq(
+  mc_last_full.pageInfo.hasNextPage,
+  true,
+  "backward no-total count==per_page: hasNextPage true (heuristic)"
+)
+
+-- before: cursor(P) where P > 1 → page P-1.
+-- before: cursor(3) → page 2; hasPreviousPage = true (page 2 > 1).
+local mc_before3 =
+  graphql_make_connection("Issue", items, { last = 3, before = graphql_page_to_cursor(3) }, 10, nil)
+eq(mc_before3.__typename, "IssueConnection", "backward before(3): typename")
+eq(mc_before3.totalCount, 10, "backward before(3): totalCount from total")
+eq(
+  mc_before3.pageInfo.hasNextPage,
+  true,
+  "backward before(3): hasNextPage true (cursor page exists)"
+)
+eq(
+  mc_before3.pageInfo.hasPreviousPage,
+  true,
+  "backward before(3): hasPreviousPage true (page 2 > 1)"
+)
+eq(#mc_before3.nodes, 3, "backward before(3): nodes length")
+not_nil(mc_before3.pageInfo.startCursor, "backward before(3): startCursor non-nil")
+
+-- before: cursor(2) → page 1; hasPreviousPage false.
+local mc_before2 =
+  graphql_make_connection("Issue", items, { last = 3, before = graphql_page_to_cursor(2) }, 10, nil)
+eq(mc_before2.pageInfo.hasNextPage, true, "backward before(2): hasNextPage true")
+eq(mc_before2.pageInfo.hasPreviousPage, false, "backward before(2): hasPreviousPage false (page 1)")
+
+-- before: cursor(1) → empty (nothing exists before page 1).
+local mc_before1 =
+  graphql_make_connection("Issue", items, { last = 3, before = graphql_page_to_cursor(1) }, 10, nil)
+eq(mc_before1.totalCount, 10, "backward before(1): totalCount preserved")
+eq(#mc_before1.nodes, 0, "backward before(1): nodes empty")
+eq(#mc_before1.edges, 0, "backward before(1): edges empty")
+eq(mc_before1.pageInfo.hasNextPage, true, "backward before(1): hasNextPage true (page 1 exists)")
+eq(mc_before1.pageInfo.hasPreviousPage, false, "backward before(1): hasPreviousPage false")
+is_nil(mc_before1.pageInfo.startCursor, "backward before(1): startCursor nil")
+
+-- before: malformed cursor → empty (can't determine position).
+local mc_bad_before = graphql_make_connection("Issue", items, { before = "notacursor" }, 10, nil)
+eq(#mc_bad_before.nodes, 0, "backward malformed before: nodes empty")
+eq(
+  mc_bad_before.pageInfo.hasNextPage,
+  false,
+  "backward malformed before: hasNextPage false (position unknown)"
+)
+eq(
+  mc_bad_before.pageInfo.hasPreviousPage,
+  false,
+  "backward malformed before: hasPreviousPage false"
+)
 
 -- ---------------------------------------------------------------------------
 -- Typed convenience wrappers

--- a/test/integration-graphql-mutations.hurl
+++ b/test/integration-graphql-mutations.hurl
@@ -259,6 +259,82 @@ jsonpath "$.data.updateSubscription.subscribable.name" == "confusio-mutation-tes
 jsonpath "$.data.updateSubscription.clientMutationId" not exists
 
 # -----------------------------------------------------------------------
+# Backward pagination smoke tests
+#
+# Create two additional issues so the repo has 3 total, giving us enough
+# pages to exercise the two-pass total-prefetch path (last: 1 with 3 issues
+# triggers: prefetch → total=3, last_page=3, fetch page 3).
+# -----------------------------------------------------------------------
+
+# POST /graphql — create issue #2 for backward pagination testing
+POST http://{{host}}/graphql
+Authorization: token {{gitea_token}}
+Content-Type: application/json
+{"query": "mutation CreateIssue2($rid: ID!) { createIssue(input: { repositoryId: $rid, title: \"confusio pagination test issue 2\" }) { issue { id number } } }", "variables": {"rid": "{{repo_id}}"}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createIssue.issue.number" isInteger
+
+# POST /graphql — create issue #3 for backward pagination testing
+POST http://{{host}}/graphql
+Authorization: token {{gitea_token}}
+Content-Type: application/json
+{"query": "mutation CreateIssue3($rid: ID!) { createIssue(input: { repositoryId: $rid, title: \"confusio pagination test issue 3\" }) { issue { id number } } }", "variables": {"rid": "{{repo_id}}"}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.createIssue.issue.number" isInteger
+
+# POST /graphql — issues(first: 1): capture endCursor for the before test below.
+POST http://{{host}}/graphql
+Authorization: token {{gitea_token}}
+Content-Type: application/json
+{"query": "query Fwd($id: ID!) { node(id: $id) { ... on Repository { issues(first: 1) { totalCount pageInfo { endCursor } } } } }", "variables": {"id": "{{repo_id}}"}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.node.issues.totalCount" == 3
+jsonpath "$.data.node.issues.pageInfo.endCursor" isString
+[Captures]
+issues_page1_cursor: jsonpath "$.data.node.issues.pageInfo.endCursor"
+
+# POST /graphql — issues(last: 1): two-pass path — prefetch gives total=3,
+# last_page=3; resolver fetches page 3 and returns 1 issue.
+POST http://{{host}}/graphql
+Authorization: token {{gitea_token}}
+Content-Type: application/json
+{"query": "query Last($id: ID!) { node(id: $id) { ... on Repository { issues(last: 1) { totalCount pageInfo { hasNextPage hasPreviousPage startCursor endCursor } nodes { number } } } } }", "variables": {"id": "{{repo_id}}"}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.node.issues.totalCount" == 3
+jsonpath "$.data.node.issues.pageInfo.hasNextPage" == false
+jsonpath "$.data.node.issues.pageInfo.hasPreviousPage" == true
+jsonpath "$.data.node.issues.pageInfo.startCursor" isString
+jsonpath "$.data.node.issues.nodes" isCollection
+jsonpath "$.data.node.issues.nodes[0].number" isInteger
+
+# POST /graphql — issues(last: 1, before: endCursor of page 1): page before first page
+# is empty; hasNextPage true (cursor page 1 exists), hasPreviousPage false.
+POST http://{{host}}/graphql
+Authorization: token {{gitea_token}}
+Content-Type: application/json
+{"query": "query Before($id: ID!, $c: String!) { node(id: $id) { ... on Repository { issues(last: 1, before: $c) { totalCount pageInfo { hasNextPage hasPreviousPage } nodes { number } } } } }", "variables": {"id": "{{repo_id}}", "c": "{{issues_page1_cursor}}"}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.errors" not exists
+jsonpath "$.data.node.issues.totalCount" == 3
+jsonpath "$.data.node.issues.pageInfo.hasNextPage" == true
+jsonpath "$.data.node.issues.pageInfo.hasPreviousPage" == false
+jsonpath "$.data.node.issues.nodes[0]" not exists
+
+# -----------------------------------------------------------------------
 # Cleanup: delete the test repo (cascades to all issues and comments)
 # -----------------------------------------------------------------------
 

--- a/test/mock-gitea.lua
+++ b/test/mock-gitea.lua
@@ -368,7 +368,11 @@ function OnHttpRequest()
     ["GET /api/v1/teams/1/repos/testorg/hello-world"] = { 204, nil },
 
     -- Issues
-    ["/api/v1/repos/octocat/hello-world/issues"] = { 200, "[" .. ISSUE .. "]" },
+    ["/api/v1/repos/octocat/hello-world/issues"] = {
+      200,
+      "[" .. ISSUE .. "]",
+      { ["X-Total"] = "1" },
+    },
     ["POST /api/v1/repos/octocat/hello-world/issues"] = { 201, ISSUE },
     ["/api/v1/repos/octocat/hello-world/issues/1"] = { 200, ISSUE },
     ["PATCH /api/v1/repos/octocat/hello-world/issues/1"] = { 200, ISSUE },


### PR DESCRIPTION
Fixes #162.

Implements backward pagination (`last`/`before`) for the GraphQL layer by extending `graphql_cursor_url` and `graphql_make_connection` with reverse-page math, wiring two-pass total-prefetch through resolver and backend-specific helpers, and adding integration tests. Forward pagination behavior is unchanged.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Wire backward pagination through resolver helpers and backend-specific helpers <!-- type:spec -->
- [x] Add backward pagination integration tests and update design doc <!-- type:spec -->
- [x] Add backward pagination to graphql_cursor_url and graphql_make_connection <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->