### PR TITLE
GraphQL: GQL-26 - Additional node resolvers (Milestone, Team, Commit, Ref) (closes #164)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -106,6 +106,7 @@ globals = {
   "graphql_translate_milestone",
   "graphql_translate_comment",
   "graphql_translate_commit",
+  "graphql_translate_team",
   "graphql_translate_ref",
   "graphql_translate_release",
   "graphql_translate_review",

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -2318,7 +2318,7 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     nodes[#nodes + 1] = {
       __typename = "PullRequestCommit",
       id = encode_node_id("PullRequestCommit", sha),
-      commit = graphql_translate_commit(translated),
+      commit = graphql_translate_commit(translated, owner, repo),
       url = translated.html_url,
     }
   end

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1564,6 +1564,26 @@ graphql_resolvers["node.Commit"] = function(local_id, _ctx)
   return graphql_translate_commit(data, owner, repo)
 end
 
+-- node.Ref: fetch a branch ref by "owner/repo/refs/heads/..." local ID.
+-- GitBucket branch objects are GitHub-compatible (commit.sha already present).
+graphql_resolvers["node.Ref"] = function(local_id, _ctx)
+  local owner, repo, ref_path = local_id:match("^([^/]+)/([^/]+)/(refs/.+)$")
+  if not owner then
+    return nil
+  end
+  local branch = ref_path:match("^refs/heads/(.+)$")
+  if not branch then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/branches/" .. branch)
+  if not data then
+    return nil
+  end
+  local repo_stub = { __typename = "Repository", nameWithOwner = owner .. "/" .. repo }
+  return graphql_translate_ref(data, repo_stub)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1550,6 +1550,20 @@ graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
   return graphql_translate_milestone(data, owner, repo)
 end
 
+-- node.Commit: fetch a commit by "owner/repo/sha" local ID.
+graphql_resolvers["node.Commit"] = function(local_id, _ctx)
+  local owner, repo, sha = local_id:match("^([^/]+)/([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/commits/" .. sha)
+  if not data then
+    return nil
+  end
+  return graphql_translate_commit(data, owner, repo)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1534,6 +1534,22 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
   return graphql_translate_label(data, owner, repo)
 end
 
+-- node.Milestone: fetch a milestone by "owner/repo/number" local ID.
+graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(
+    fetch_json,
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/milestones/" .. number
+  )
+  if not data then
+    return nil
+  end
+  return graphql_translate_milestone(data, owner, repo)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1584,6 +1584,20 @@ graphql_resolvers["node.Ref"] = function(local_id, _ctx)
   return graphql_translate_ref(data, repo_stub)
 end
 
+-- node.Team: fetch a team by "org/slug" local ID.
+-- GitBucket is GitHub-compatible; /orgs/{org}/teams/{slug} returns the team directly.
+graphql_resolvers["node.Team"] = function(local_id, _ctx)
+  local org, slug = local_id:match("^([^/]+)/([^/]+)$")
+  if not org then
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/orgs/" .. org .. "/teams/" .. slug)
+  if not data then
+    return nil
+  end
+  return graphql_translate_team(data, org)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -1710,7 +1710,7 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     nodes[#nodes + 1] = {
       __typename = "PullRequestCommit",
       id = encode_node_id("PullRequestCommit", sha),
-      commit = graphql_translate_commit(c),
+      commit = graphql_translate_commit(c, owner, repo),
       url = c.html_url,
     }
   end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3410,6 +3410,24 @@ graphql_resolvers["node.Ref"] = function(local_id, _ctx)
   return graphql_translate_ref(data, repo_stub)
 end
 
+-- node.Team: fetch a team by "org/slug" local ID.
+-- Gitea teams use numeric IDs; resolve slug → ID via gitea_find_team_id, then fetch /teams/{id}.
+graphql_resolvers["node.Team"] = function(local_id, _ctx)
+  local org, slug = local_id:match("^([^/]+)/([^/]+)$")
+  if not org then
+    return nil
+  end
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/teams/" .. id)
+  if not data then
+    return nil
+  end
+  return graphql_translate_team(translate_gitea_team(data), org)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3373,6 +3373,20 @@ graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
   return graphql_translate_milestone(data, owner, repo)
 end
 
+-- node.Commit: fetch a commit by "owner/repo/sha" local ID.
+graphql_resolvers["node.Commit"] = function(local_id, _ctx)
+  local owner, repo, sha = local_id:match("^([^/]+)/([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/git/commits/" .. sha)
+  if not data then
+    return nil
+  end
+  return graphql_translate_commit(data, owner, repo)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3561,7 +3561,7 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     nodes[#nodes + 1] = {
       __typename = "PullRequestCommit",
       id = encode_node_id("PullRequestCommit", sha),
-      commit = graphql_translate_commit(c),
+      commit = graphql_translate_commit(c, owner, repo),
       url = c.html_url,
     }
   end

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3387,6 +3387,29 @@ graphql_resolvers["node.Commit"] = function(local_id, _ctx)
   return graphql_translate_commit(data, owner, repo)
 end
 
+-- node.Ref: fetch a branch ref by "owner/repo/refs/heads/..." local ID.
+-- Gitea branch objects use commit.id for the SHA; normalise to commit.sha before translating.
+graphql_resolvers["node.Ref"] = function(local_id, _ctx)
+  local owner, repo, ref_path = local_id:match("^([^/]+)/([^/]+)/(refs/.+)$")
+  if not owner then
+    return nil
+  end
+  local branch = ref_path:match("^refs/heads/(.+)$")
+  if not branch then
+    return nil
+  end
+  local data, _ =
+    graphql_fetch(fetch_json, base() .. "/repos/" .. owner .. "/" .. repo .. "/branches/" .. branch)
+  if not data then
+    return nil
+  end
+  if data.commit then
+    data.commit.sha = data.commit.id
+  end
+  local repo_stub = { __typename = "Repository", nameWithOwner = owner .. "/" .. repo }
+  return graphql_translate_ref(data, repo_stub)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -3357,6 +3357,22 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
   return graphql_translate_label(translate_gitea_label(data), owner, repo)
 end
 
+-- node.Milestone: fetch a milestone by "owner/repo/number" local ID.
+graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(
+    fetch_json,
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/milestones/" .. number
+  )
+  if not data then
+    return nil
+  end
+  return graphql_translate_milestone(data, owner, repo)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -4006,6 +4006,36 @@ graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
   return graphql_translate_milestone(translate_gl_milestone(data), owner, repo)
 end
 
+-- node.Commit: fetch a commit by "owner/repo/sha" local ID.
+-- GitLab returns a flat commit object; translate to REST shape before passing to the shared translator.
+graphql_resolvers["node.Commit"] = function(local_id, _ctx)
+  local owner, repo, sha = local_id:match("^([^/]+)/([^/]+)/(.+)$")
+  if not owner then
+    return nil
+  end
+  local c, _ = graphql_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo) .. "/repository/commits/" .. sha
+  )
+  if not c then
+    return nil
+  end
+  local rest_commit = {
+    sha = c.id,
+    html_url = c.web_url or "",
+    commit = {
+      message = c.message,
+      author = { name = c.author_name, email = c.author_email, date = c.authored_date },
+      committer = {
+        name = c.committer_name or c.author_name,
+        email = c.committer_email or c.author_email,
+        date = c.committed_date or c.authored_date,
+      },
+    },
+  }
+  return graphql_translate_commit(rest_commit, owner, repo)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -4036,6 +4036,31 @@ graphql_resolvers["node.Commit"] = function(local_id, _ctx)
   return graphql_translate_commit(rest_commit, owner, repo)
 end
 
+-- node.Ref: fetch a branch ref by "owner/repo/refs/heads/..." local ID.
+-- GitLab branch objects use commit.id for the SHA; normalise to commit.sha before translating.
+graphql_resolvers["node.Ref"] = function(local_id, _ctx)
+  local owner, repo, ref_path = local_id:match("^([^/]+)/([^/]+)/(refs/.+)$")
+  if not owner then
+    return nil
+  end
+  local branch = ref_path:match("^refs/heads/(.+)$")
+  if not branch then
+    return nil
+  end
+  local data, _ = graphql_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo) .. "/repository/branches/" .. branch
+  )
+  if not data then
+    return nil
+  end
+  if data.commit then
+    data.commit.sha = data.commit.id
+  end
+  local repo_stub = { __typename = "Repository", nameWithOwner = owner .. "/" .. repo }
+  return graphql_translate_ref(data, repo_stub)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -4248,7 +4248,7 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     nodes[#nodes + 1] = {
       __typename = "PullRequestCommit",
       id = encode_node_id("PullRequestCommit", c.id or ""),
-      commit = graphql_translate_commit(rest_commit),
+      commit = graphql_translate_commit(rest_commit, owner, repo),
       url = c.web_url or "",
     }
   end

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -3989,6 +3989,23 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
   return graphql_translate_label(translate_gl_label(data), owner, repo)
 end
 
+-- node.Milestone: fetch a milestone by "owner/repo/number" local ID.
+-- GitLab milestone numbers are iid (project-local); stored as number in the node ID.
+graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+  local data, _ = graphql_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo) .. "/milestones/" .. number
+  )
+  if not data then
+    return nil
+  end
+  return graphql_translate_milestone(translate_gl_milestone(data), owner, repo)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -4061,6 +4061,20 @@ graphql_resolvers["node.Ref"] = function(local_id, _ctx)
   return graphql_translate_ref(data, repo_stub)
 end
 
+-- node.Team: fetch a team (subgroup) by "org/slug" local ID.
+-- GitLab teams map to subgroups; fetch by URL-encoded path /groups/{org}%2F{slug}.
+graphql_resolvers["node.Team"] = function(local_id, _ctx)
+  local org, slug = local_id:match("^([^/]+)/([^/]+)$")
+  if not org then
+    return nil
+  end
+  local data, _ = graphql_fetch(fetch_json, base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not data then
+    return nil
+  end
+  return graphql_translate_team(translate_gl_team(data), org)
+end
+
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------

--- a/internal/graphql_translators.lua
+++ b/internal/graphql_translators.lua
@@ -31,7 +31,8 @@
 --   graphql_translate_label(l[, owner, repo])
 --   graphql_translate_milestone(m[, owner, repo])
 --   graphql_translate_comment(c[, owner, repo])
---   graphql_translate_commit(c)
+--   graphql_translate_commit(c[, owner, repo])
+--   graphql_translate_team(t[, org])
 --   graphql_translate_ref(r, repo)
 --   graphql_translate_release(r[, owner, repo])
 --   graphql_translate_review(r[, owner, repo])
@@ -608,11 +609,14 @@ function graphql_translate_comment(c, owner, repo) -- luacheck: globals graphql_
 end
 
 -- graphql_translate_commit is global: converts a GitHub REST commit to GraphQL Commit shape.
--- Node IDs for commits omit owner/repo context (Commit is a Phase 2 node resolver target).
-function graphql_translate_commit(c) -- luacheck: globals graphql_translate_commit
+-- owner and repo are optional; when provided they embed owner/repo in the node ID so the
+-- commit can be re-fetched via node().
+function graphql_translate_commit(c, owner, repo) -- luacheck: globals graphql_translate_commit
   if not c then
     return nil
   end
+  local sha = c.sha or ""
+  local local_id = (owner and repo) and (owner .. "/" .. repo .. "/" .. sha) or sha
   -- REST commits nest author/committer metadata under c.commit; bare objects have them at root.
   local git = c.commit or c
   local msg = git.message or c.message or ""
@@ -620,7 +624,7 @@ function graphql_translate_commit(c) -- luacheck: globals graphql_translate_comm
   local git_committer = git.committer or {}
   return {
     __typename = "Commit",
-    id = encode_node_id("Commit", c.sha or ""),
+    id = encode_node_id("Commit", local_id),
     oid = c.sha,
     message = msg,
     messageHeadline = msg:match("^([^\n]*)") or "",
@@ -641,6 +645,28 @@ function graphql_translate_commit(c) -- luacheck: globals graphql_translate_comm
     authoredDate = git_author.date,
     committedDate = git_committer.date,
     url = c.html_url,
+  }
+end
+
+-- graphql_translate_team is global: converts a GitHub REST team to GraphQL Team shape.
+-- org is optional; when provided it gives the team a resolvable node ID (org/slug).
+local TEAM_PRIVACY = { secret = "SECRET", closed = "VISIBLE" }
+function graphql_translate_team(t, org) -- luacheck: globals graphql_translate_team
+  if not t then
+    return nil
+  end
+  local slug = t.slug or ""
+  local local_id = (org and slug ~= "") and (org .. "/" .. slug) or slug
+  return {
+    __typename = "Team",
+    id = encode_node_id("Team", local_id),
+    databaseId = t.id,
+    name = t.name,
+    slug = slug,
+    combinedSlug = org and (org .. "/" .. slug) or slug,
+    description = (t.description and t.description ~= "") and t.description or nil,
+    privacy = TEAM_PRIVACY[t.privacy] or "VISIBLE",
+    notificationSetting = "NOTIFICATIONS_ENABLED",
   }
 end
 

--- a/test/gitbucket-graphql.hurl
+++ b/test/gitbucket-graphql.hurl
@@ -125,6 +125,17 @@ HTTP 200
 jsonpath "$.data.node.name" == "main"
 jsonpath "$.data.node.prefix" == "refs/heads/"
 
+# POST /graphql — node(Team) fetches a team by encoded node ID
+# Node ID for Team:testorg/core = VGVhbTp0ZXN0b3JnL2NvcmU=
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"VGVhbTp0ZXN0b3JnL2NvcmU=\") { ... on Team { name slug } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "core"
+jsonpath "$.data.node.slug" == "core"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitbucket-graphql.hurl
+++ b/test/gitbucket-graphql.hurl
@@ -92,6 +92,17 @@ HTTP 200
 jsonpath "$.data.node.name" == "bug"
 jsonpath "$.data.node.color" == "d73a4a"
 
+# POST /graphql — node(Milestone) fetches a milestone by encoded node ID
+# Node ID for Milestone:octocat/hello-world/1 = TWlsZXN0b25lOm9jdG9jYXQvaGVsbG8td29ybGQvMQ==
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"TWlsZXN0b25lOm9jdG9jYXQvaGVsbG8td29ybGQvMQ==\") { ... on Milestone { title state } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.title" == "v1.0"
+jsonpath "$.data.node.state" == "OPEN"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitbucket-graphql.hurl
+++ b/test/gitbucket-graphql.hurl
@@ -103,6 +103,17 @@ HTTP 200
 jsonpath "$.data.node.title" == "v1.0"
 jsonpath "$.data.node.state" == "OPEN"
 
+# POST /graphql — node(Commit) fetches a commit by encoded node ID
+# Node ID for Commit:octocat/hello-world/abc123 = Q29tbWl0Om9jdG9jYXQvaGVsbG8td29ybGQvYWJjMTIz
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"Q29tbWl0Om9jdG9jYXQvaGVsbG8td29ybGQvYWJjMTIz\") { ... on Commit { oid message } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.oid" == "abc123def456"
+jsonpath "$.data.node.message" == "Initial commit"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitbucket-graphql.hurl
+++ b/test/gitbucket-graphql.hurl
@@ -114,6 +114,17 @@ HTTP 200
 jsonpath "$.data.node.oid" == "abc123def456"
 jsonpath "$.data.node.message" == "Initial commit"
 
+# POST /graphql — node(Ref) fetches a branch ref by encoded node ID
+# Node ID for Ref:octocat/hello-world/refs/heads/main = UmVmOm9jdG9jYXQvaGVsbG8td29ybGQvcmVmcy9oZWFkcy9tYWlu
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"UmVmOm9jdG9jYXQvaGVsbG8td29ybGQvcmVmcy9oZWFkcy9tYWlu\") { ... on Ref { name prefix } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "main"
+jsonpath "$.data.node.prefix" == "refs/heads/"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -119,6 +119,17 @@ HTTP 200
 jsonpath "$.data.node.oid" == "abc123def456"
 jsonpath "$.data.node.message" == "Initial commit"
 
+# POST /graphql — node(Ref) fetches a branch ref by encoded node ID
+# Node ID for Ref:octocat/hello-world/refs/heads/main = UmVmOm9jdG9jYXQvaGVsbG8td29ybGQvcmVmcy9oZWFkcy9tYWlu
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"UmVmOm9jdG9jYXQvaGVsbG8td29ybGQvcmVmcy9oZWFkcy9tYWlu\") { ... on Ref { name prefix } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "main"
+jsonpath "$.data.node.prefix" == "refs/heads/"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -97,6 +97,17 @@ HTTP 200
 jsonpath "$.data.node.name" == "bug"
 jsonpath "$.data.node.color" == "d73a4a"
 
+# POST /graphql — node(Milestone) fetches a milestone by encoded node ID
+# Node ID for Milestone:octocat/hello-world/1 = TWlsZXN0b25lOm9jdG9jYXQvaGVsbG8td29ybGQvMQ==
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"TWlsZXN0b25lOm9jdG9jYXQvaGVsbG8td29ybGQvMQ==\") { ... on Milestone { title state } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.title" == "v1.0"
+jsonpath "$.data.node.state" == "OPEN"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -108,6 +108,17 @@ HTTP 200
 jsonpath "$.data.node.title" == "v1.0"
 jsonpath "$.data.node.state" == "OPEN"
 
+# POST /graphql — node(Commit) fetches a commit by encoded node ID
+# Node ID for Commit:octocat/hello-world/abc123 = Q29tbWl0Om9jdG9jYXQvaGVsbG8td29ybGQvYWJjMTIz
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"Q29tbWl0Om9jdG9jYXQvaGVsbG8td29ybGQvYWJjMTIz\") { ... on Commit { oid message } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.oid" == "abc123def456"
+jsonpath "$.data.node.message" == "Initial commit"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitea-graphql.hurl
+++ b/test/gitea-graphql.hurl
@@ -130,6 +130,17 @@ HTTP 200
 jsonpath "$.data.node.name" == "main"
 jsonpath "$.data.node.prefix" == "refs/heads/"
 
+# POST /graphql — node(Team) fetches a team by encoded node ID
+# Node ID for Team:testorg/core = VGVhbTp0ZXN0b3JnL2NvcmU=
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"VGVhbTp0ZXN0b3JnL2NvcmU=\") { ... on Team { name slug } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "core"
+jsonpath "$.data.node.slug" == "core"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitlab-graphql.hurl
+++ b/test/gitlab-graphql.hurl
@@ -119,6 +119,17 @@ HTTP 200
 jsonpath "$.data.node.oid" == "abc123def456"
 jsonpath "$.data.node.message" == "Initial commit"
 
+# POST /graphql — node(Ref) fetches a branch ref by encoded node ID
+# Node ID for Ref:octocat/hello-world/refs/heads/main = UmVmOm9jdG9jYXQvaGVsbG8td29ybGQvcmVmcy9oZWFkcy9tYWlu
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"UmVmOm9jdG9jYXQvaGVsbG8td29ybGQvcmVmcy9oZWFkcy9tYWlu\") { ... on Ref { name prefix } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "main"
+jsonpath "$.data.node.prefix" == "refs/heads/"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitlab-graphql.hurl
+++ b/test/gitlab-graphql.hurl
@@ -97,6 +97,17 @@ HTTP 200
 jsonpath "$.data.node.name" == "bug"
 jsonpath "$.data.node.color" == "d73a4a"
 
+# POST /graphql — node(Milestone) fetches a milestone by encoded node ID
+# Node ID for Milestone:octocat/hello-world/1 = TWlsZXN0b25lOm9jdG9jYXQvaGVsbG8td29ybGQvMQ==
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"TWlsZXN0b25lOm9jdG9jYXQvaGVsbG8td29ybGQvMQ==\") { ... on Milestone { title state } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.title" == "v1.0"
+jsonpath "$.data.node.state" == "OPEN"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitlab-graphql.hurl
+++ b/test/gitlab-graphql.hurl
@@ -108,6 +108,17 @@ HTTP 200
 jsonpath "$.data.node.title" == "v1.0"
 jsonpath "$.data.node.state" == "OPEN"
 
+# POST /graphql — node(Commit) fetches a commit by encoded node ID
+# Node ID for Commit:octocat/hello-world/abc123 = Q29tbWl0Om9jdG9jYXQvaGVsbG8td29ybGQvYWJjMTIz
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"Q29tbWl0Om9jdG9jYXQvaGVsbG8td29ybGQvYWJjMTIz\") { ... on Commit { oid message } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.oid" == "abc123def456"
+jsonpath "$.data.node.message" == "Initial commit"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/gitlab-graphql.hurl
+++ b/test/gitlab-graphql.hurl
@@ -130,6 +130,17 @@ HTTP 200
 jsonpath "$.data.node.name" == "main"
 jsonpath "$.data.node.prefix" == "refs/heads/"
 
+# POST /graphql — node(Team) fetches a team by encoded node ID
+# Node ID for Team:testorg/core = VGVhbTp0ZXN0b3JnL2NvcmU=
+POST http://{{host}}/graphql
+Content-Type: application/json
+{"query": "{ node(id: \"VGVhbTp0ZXN0b3JnL2NvcmU=\") { ... on Team { name slug } } }"}
+
+HTTP 200
+[Asserts]
+jsonpath "$.data.node.name" == "core"
+jsonpath "$.data.node.slug" == "core"
+
 # POST /graphql — Repository.owner is inlined by the translator (no sub-resolver)
 POST http://{{host}}/graphql
 Content-Type: application/json

--- a/test/graphql-translators.lua
+++ b/test/graphql-translators.lua
@@ -483,7 +483,7 @@ end
 -- graphql_translate_commit
 -- ============================================================
 
-do -- maps SHA, message, and headline
+do -- maps SHA, message, and headline; node ID is bare SHA without owner/repo context
   local c = graphql_translate_commit({
     sha = "abc123",
     commit = {
@@ -499,8 +499,54 @@ do -- maps SHA, message, and headline
   eq(c.messageHeadline, "Fix the bug", "translate_commit: messageHeadline is first line")
   eq(c.author.name, "Alice", "translate_commit: author.name")
   eq(c.author.email, "alice@example.com", "translate_commit: author.email")
-  eq(c.id, encode_node_id("Commit", "abc123"), "translate_commit: id")
+  eq(c.id, encode_node_id("Commit", "abc123"), "translate_commit: id without owner/repo")
   eq(c.url, "https://github.com/octocat/Hello-World/commit/abc123", "translate_commit: url")
+end
+
+do -- with owner/repo context, node ID embeds owner/repo/sha for re-fetchability
+  local c = graphql_translate_commit({
+    sha = "abc123",
+    commit = { message = "Fix", author = {}, committer = {} },
+  }, "octocat", "Hello-World")
+  eq(
+    c.id,
+    encode_node_id("Commit", "octocat/Hello-World/abc123"),
+    "translate_commit: id with owner/repo"
+  )
+  eq(c.oid, "abc123", "translate_commit: oid unchanged with owner/repo")
+end
+
+-- ============================================================
+-- graphql_translate_team
+-- ============================================================
+
+do -- maps name, slug, combinedSlug, privacy, and node ID
+  local t = graphql_translate_team({
+    id = 42,
+    name = "Core Team",
+    slug = "core-team",
+    description = "The core contributors",
+    privacy = "closed",
+  }, "myorg")
+  eq(t.__typename, "Team", "translate_team: __typename")
+  eq(t.databaseId, 42, "translate_team: databaseId")
+  eq(t.name, "Core Team", "translate_team: name")
+  eq(t.slug, "core-team", "translate_team: slug")
+  eq(t.combinedSlug, "myorg/core-team", "translate_team: combinedSlug")
+  eq(t.description, "The core contributors", "translate_team: description")
+  eq(t.privacy, "VISIBLE", "translate_team: privacy closed -> VISIBLE")
+  eq(t.id, encode_node_id("Team", "myorg/core-team"), "translate_team: id with org")
+end
+
+do -- without org, node ID is bare slug
+  local t = graphql_translate_team({ id = 7, name = "Ops", slug = "ops", privacy = "secret" })
+  eq(t.privacy, "SECRET", "translate_team: privacy secret -> SECRET")
+  eq(t.id, encode_node_id("Team", "ops"), "translate_team: id without org is bare slug")
+  eq(t.combinedSlug, "ops", "translate_team: combinedSlug without org is bare slug")
+end
+
+do -- nil input returns nil
+  eq(graphql_translate_team(nil), nil, "translate_team: nil input returns nil")
 end
 
 -- ============================================================


### PR DESCRIPTION
Fixes #164.

Adds GraphQL node resolvers for Milestone, Commit, Ref, and Team types across all backends. Milestone and Commit resolvers are landed; remaining work adds Ref node resolvers across backends and introduces a new `graphql_translate_team` with Team resolvers.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] Add Ref node resolvers across all backends and tests <!-- type:spec -->
- [x] Add Team GraphQL translator and node resolvers across backends <!-- type:spec -->
- [x] Fix Commit node ID to include owner/repo and add Commit node resolvers <!-- type:spec -->
- [x] Add graphql_translate_team and update graphql_translate_commit for owner/repo context <!-- type:spec -->
- [x] Add Milestone node resolvers across all backends and tests <!-- type:spec -->
- [x] Gitea: add Milestone, Team, Commit, Ref node resolvers with tests <!-- type:spec -->
- [x] Add Milestone, Commit, Ref node resolvers to other backends <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->