### PR TITLE
Support GitHub's GraphQL API (closes #72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 *confusio linguarum* — the confusion of tongues.
 
-A REST API shim that implements a subset of GitHub's API, translating requests to other git hosting providers under the hood.
+A GitHub API shim — REST and GraphQL — that translates requests to other git hosting providers under the hood.
 
 ## What it is
 
 GitHub's API is the lingua franca of git hosting tools. Other providers speak their own dialects. Confusio stands in the middle, translating.
+
+It implements both the GitHub REST API (`GET /repos/{owner}/{repo}`, etc.) and the GitHub GraphQL API (`POST /graphql`), routing each request to the equivalent call on the configured backend. Queries, mutations, Relay pagination, introspection, and batch requests are all supported.
 
 Built with [Redbean](https://redbean.dev) — a single-file web server containing a Lua interpreter, distributed as a self-extracting zip.
 
@@ -104,7 +106,7 @@ Confusio never stores or logs tokens. The raw token value passes through unchang
 
 ## Status
 
-Early design stage.
+Active. REST and GraphQL APIs are implemented and tested across 24 backends. GraphQL support covers queries, mutations, Relay pagination, batch requests, and introspection — all phases of the [GraphQL roadmap](docs/graphql/16-roadmap.md) are complete.
 
 ## Compatibility
 

--- a/docs/graphql/README.md
+++ b/docs/graphql/README.md
@@ -54,5 +54,7 @@ concerns), and finish with **13–16** (validation and delivery plan).
 
 ## Status
 
-All documents are design-phase only.  No production code has been written.  Implementation
-tracks the issue decomposition in [16-roadmap.md](16-roadmap.md).
+Implementation is complete.  All phases of the [rollout roadmap](16-roadmap.md) have shipped:
+Phase 0 (schema), Phase 1 (query engine + Gitea resolvers), Phase 1b (additional backends),
+Phase 2 (mutations), and Phase 2b (batch requests, backward pagination, item-level cursors,
+additional node resolvers).  These documents serve as reference for the design decisions made.


### PR DESCRIPTION
Fixes #72.

All GraphQL API support (phases 0–2b) has already been implemented and merged to main across 26 sub-issues. This PR updates the README to reflect the current project status, including GraphQL support.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Update README with GraphQL support and current project status <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->