### PR TITLE
Rank 2: introduce an explicit app context and composition root for startup and dispatch (closes #203)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -30,17 +30,14 @@ dofile("/zip/internal/graphql_translators.lua")
 dofile("/zip/internal/families.lua")
 dofile("/zip/internal/context.lua")
 
--- Build the initial app context.  backend_impl and backend_allow_anonymous are
--- global shims that backend and families code still write to directly; they are
--- synced into app after the backend loads so that subsequent tasks can migrate
--- each read site from the bare globals to app incrementally.
+-- Build the initial app context.  backend_impl is a global shim that backend
+-- and families code still write to directly; it is synced into app after the
+-- backend loads so that subsequent tasks can migrate each read site from the
+-- bare global to app incrementally.
 app = make_app(config)
 
 -- backend_impl is global: set by backends/<name>.lua at startup.
 backend_impl = {}
--- backend_allow_anonymous is global: backends that require sign-in set this to false
--- at startup (after checking the provider's API settings). Default: allow.
-backend_allow_anonymous = true
 if config.backend ~= "" then
   assert(config.backend:match("^[%a][%w_]*$"), "invalid backend name: " .. config.backend)
   dofile("/zip/backends/" .. config.backend .. ".lua")
@@ -48,7 +45,6 @@ end
 
 -- Sync backend startup state into the app context.
 app.backend_impl = backend_impl
-app.allow_anonymous = backend_allow_anonymous
 
 dofile("/zip/internal/defaults.lua")
 dofile("/zip/internal/router.lua")

--- a/.init.lua
+++ b/.init.lua
@@ -28,6 +28,13 @@ dofile("/zip/internal/graphql_schema.lua")
 dofile("/zip/internal/graphql_executor.lua")
 dofile("/zip/internal/graphql_translators.lua")
 dofile("/zip/internal/families.lua")
+dofile("/zip/internal/context.lua")
+
+-- Build the initial app context.  backend_impl and backend_allow_anonymous are
+-- global shims that backend and families code still write to directly; they are
+-- synced into app after the backend loads so that subsequent tasks can migrate
+-- each read site from the bare globals to app incrementally.
+app = make_app(config)
 
 -- backend_impl is global: set by backends/<name>.lua at startup.
 backend_impl = {}
@@ -38,6 +45,10 @@ if config.backend ~= "" then
   assert(config.backend:match("^[%a][%w_]*$"), "invalid backend name: " .. config.backend)
   dofile("/zip/backends/" .. config.backend .. ".lua")
 end
+
+-- Sync backend startup state into the app context.
+app.backend_impl = backend_impl
+app.allow_anonymous = backend_allow_anonymous
 
 dofile("/zip/internal/defaults.lua")
 dofile("/zip/internal/router.lua")

--- a/.init.lua
+++ b/.init.lua
@@ -30,21 +30,14 @@ dofile("/zip/internal/graphql_translators.lua")
 dofile("/zip/internal/families.lua")
 dofile("/zip/internal/context.lua")
 
--- Build the initial app context.  backend_impl is a global shim that backend
--- and families code still write to directly; it is synced into app after the
--- backend loads so that subsequent tasks can migrate each read site from the
--- bare global to app incrementally.
+-- Build the app context.  Backends write directly to app.backend_impl and
+-- app.allow_anonymous at load time; no post-load sync needed.
 app = make_app(config)
 
--- backend_impl is global: set by backends/<name>.lua at startup.
-backend_impl = {}
 if config.backend ~= "" then
   assert(config.backend:match("^[%a][%w_]*$"), "invalid backend name: " .. config.backend)
   dofile("/zip/backends/" .. config.backend .. ".lua")
 end
-
--- Sync backend startup state into the app context.
-app.backend_impl = backend_impl
 
 dofile("/zip/internal/defaults.lua")
 dofile("/zip/internal/router.lua")

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -48,7 +48,6 @@ globals = {
   "translate_migration",
   -- Set by backends/*.lua, read by .init.lua
   "backend_impl",
-  "backend_allow_anonymous",
   -- App context: constructed in .init.lua, holds config + backend state
   "app",
   "make_app",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -46,8 +46,6 @@ globals = {
   "translate_repo",
   "translate_user",
   "translate_migration",
-  -- Set by backends/*.lua, read by .init.lua
-  "backend_impl",
   -- App context: constructed in .init.lua, holds config + backend state
   "app",
   "make_app",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -49,6 +49,9 @@ globals = {
   -- Set by backends/*.lua, read by .init.lua
   "backend_impl",
   "backend_allow_anonymous",
+  -- App context: constructed in .init.lua, holds config + backend state
+  "app",
+  "make_app",
   -- Default stub handlers: populated by internal/defaults.lua, read by the catalog in .init.lua
   "defaults",
   -- Router: populated by internal/router.lua, used by the catalog and OnHttpRequest in .init.lua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ internal/
   router.lua                 — segment-based radix trie: route_add, route_match, path_known
   catalog.lua                — endpoint_sections table; populates global `endpoints` and registers routes at load time
   dispatch.lua               — OnHttpRequest: auth gate, route_match, handler dispatch
-backends/                    — per-provider implementations; each sets backend_impl = { handler = fn, ... }
+backends/                    — per-provider implementations; each sets app.backend_impl = { handler = fn, ... }
 docs/
   graphql/                   — GraphQL support design docs (README.md + 01–16 numbered documents)
   real-world-testing.md      — plan for weekly live-backend integration tests
@@ -134,7 +134,7 @@ When implementing a new endpoint, check the spec for:
 
 ### Standalone backend (new API family)
 
-1. Create `backends/<name>.lua`. Set `backend_impl = { endpoint = function, ... }` with only
+1. Create `backends/<name>.lua`. Set `app.backend_impl = { endpoint = function, ... }` with only
    the endpoints that differ from the defaults. The file is loaded automatically when
    `config.backend == "<name>"` — no changes to `.init.lua` needed.
 2. Add mock server as `test/mock-<newbackend>.lua` and build it in the `Makefile` (copy pattern from `mock-gitea.com`).
@@ -271,8 +271,8 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 - **`load_family_backend(root)`** is the helper alias backends call instead of raw `dofile`.
   It reads the alias's entry from `provider_families[root].aliases[config.backend]`, sets
   `config.base_url` from `default_url` when none was supplied, dofiles the root backend,
-  then clears any `backend_impl` keys matching the alias's `strip` patterns. All of this
-  replaces the old per-file `dofile` + manual `for k in pairs(backend_impl)` strip loops.
+  then clears any `app.backend_impl` keys matching the alias's `strip` patterns. All of this
+  replaces the old per-file `dofile` + manual `for k in pairs(app.backend_impl)` strip loops.
 - **`strip` patterns are Lua patterns, not exact names.** `"_package"` matches any key
   containing `_package` (e.g. `list_packages`, `get_package`). Keep patterns tight enough
   not to accidentally strip unrelated keys.
@@ -293,10 +293,10 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
   k = path depth. Static edges are preferred over param edges at each node, so `/repos/search`
   beats `/repos/{owner}` when both are registered. Captures from `{param}` segments are passed
   as positional arguments to the handler.
-- **Startup-time handler resolution**: `backend_impl` is populated once by the backend file;
-  `internal/dispatch.lua` reads it on every request via the global directly. The backend is fixed
+- **Startup-time handler resolution**: `app.backend_impl` is populated once by the backend file;
+  `internal/dispatch.lua` reads it on every request via the `app` context. The backend is fixed
   for the program's lifetime — no per-request dispatch needed. Backend files set
-  `backend_impl = { ... }` globally; `dofile` runs in global scope so locals from any module
+  `app.backend_impl = { ... }`; `dofile` runs in global scope so locals from any module
   are not visible to backend files.
 - **`/zip/` prefix for dofile**: Redbean's `dofile` resolves paths on the real filesystem by
   default. Files inside the zip must be accessed as `dofile("/zip/backends/gitea.lua")`.
@@ -360,13 +360,14 @@ The nine `internal/` modules are loaded by `.init.lua` in a fixed order. Each ex
 | `transport.lua` | `append_page_params`, `make_fetch_opts`, `make_proxy_handler`, `make_backend_transport` | backends |
 | `translators.lua` | `owner_repo_id`, `translate_repo`, `translate_user`, `translate_migration` | backends |
 | `families.lua` | `provider_families`, `load_family_backend` | backends + Makefile scripts |
-| *(backend loaded here)* | `backend_impl`; Gitea writes `app.allow_anonymous` | dispatch |
+| *(backend loaded here)* | writes `app.backend_impl`; Gitea writes `app.allow_anonymous` | dispatch |
 | `defaults.lua` | `defaults` (table of handler functions) | catalog |
 | `router.lua` | `route_add`, `route_match`, `path_known` | catalog, dispatch |
 | `catalog.lua` | `endpoints` (flat array); registers routes via `route_add` | dispatch, scripts |
 | `dispatch.lua` | `OnHttpRequest` | Redbean (entry point) |
 
 **Global surface for backend authors** (backends can call any of these):
+- App context (write target): `app.backend_impl`, `app.allow_anonymous`, `app.config`
 - Response: `set_preamble`, `respond_json`
 - Proxy: all of `proxy.lua`'s exports
 - Transport: all of `transport.lua`'s exports
@@ -382,7 +383,7 @@ The nine `internal/` modules are loaded by `.init.lua` in a fixed order. Each ex
 
 ### Compatibility CSV and validate-claims
 
-- **`make validate-claims` cross-checks CSV claims against `backend_impl`** by running
+- **`make validate-claims` cross-checks CSV claims against `app.backend_impl`** by running
   `scripts/dump-claims.lua` (all backends) and piping the JSON output to
   `scripts/validate-claims.lua`. It is wired into `make test` and must pass before any push.
 - **CONFUSIO_NATIVE exemption**: five handlers (`get_meta`, `get_octocat`, `get_teapot`,
@@ -453,11 +454,11 @@ here so they stay visible without reading all 16 docs:
 
 - **`EncodeJson({data=nil})` silently drops the `data` key** — produces `{"errors":[...]}` instead of `{"data":null,"errors":[...]}`. The `respond_graphql` function works around this by using manual string concatenation: `EncodeJson(nil)` → `"null"`, so `'{"data":' .. data_json .. ...}` is assembled by hand when `data` is nil. Never pass `{data=nil}` to `EncodeJson` in the GraphQL response path.
 - **All GraphQL-facing Lua tables use camelCase keys** (GraphQL field names, e.g. `nameWithOwner`, `totalCount`, `hasNextPage`) — not the REST snake_case field names. The executor plucks fields by doing `parent[field_name]` where `field_name` is the GraphQL name from the query, so the keys must match exactly. This is an exception to the REST translator convention.
-- **`graphql_resolvers` is a global table, not part of `backend_impl`**. Backends populate it at load time alongside `backend_impl`. The executor reads it on every request. Backends never set `backend_impl.graphql_request`; that handler is always `graphql_handler` from `graphql_executor.lua`.
+- **`graphql_resolvers` is a global table, not part of `app.backend_impl`**. Backends populate it at load time alongside `app.backend_impl`. The executor reads it on every request. Backends never set `app.backend_impl.graphql_request`; that handler is always `graphql_handler` from `graphql_executor.lua`.
 - **GraphQL coverage is bounded by REST coverage** — a GraphQL resolver calls the same REST endpoint the REST handler already uses. A backend that doesn't implement a REST endpoint will return `null` for the corresponding GraphQL field, with an error entry if the field is non-null. No backend gains new REST coverage by adding GraphQL.
 - **Node IDs use path-segment encoding**: `encode_node_id("Repository", "owner/repo")` = `EncodeBase64("Repository:owner/repo")`. Path segments (not integer IDs) because REST backends universally support `GET /repos/{owner}/{repo}` but rarely `GET /repositories/{integer_id}`. Stable across restarts; the `node()` resolver constructs the same REST URL any other resolver uses.
 - **Item-level cursors** (`EncodeBase64("page:N:M")`) where N is the 1-based page number and M is the 1-based item index within the page. Each edge carries a unique cursor. `graphql_cursor_to_page` accepts both the old `page:N` format (backward compat) and the new `page:N:M` format, extracting only the page number — so all REST URL construction is unaffected. `startCursor` and `endCursor` in `pageInfo` are the first and last edge cursors respectively; they are distinct for multi-item pages.
-- **`graphql_request = true` must be added to `CONFUSIO_NATIVE`** in `scripts/validate-claims.lua` when the GraphQL catalog entry ships. Without this exemption, any `y` CSV claim for `POST /graphql` will fail `make validate-claims` (the handler is `graphql_handler`, not a `backend_impl` key).
+- **`graphql_request = true` must be added to `CONFUSIO_NATIVE`** in `scripts/validate-claims.lua` when the GraphQL catalog entry ships. Without this exemption, any `y` CSV claim for `POST /graphql` will fail `make validate-claims` (the handler is `graphql_handler`, not an `app.backend_impl` key).
 - **`pages.yml` passes args to `gen-matrix.py` in a different order than the Makefile** — the workflow passes `site/compatibility.csv` as the first positional arg (catalog position) while the Makefile pipes catalog via stdin with `-`. This pre-existing discrepancy exists independently of GraphQL; note it before touching either invocation.
 - **`graphql_schema_data.lua` is committed generated output**, not regenerated at build time. The `make generate-schema` target regenerates it from the vendored SDL; `make validate-schema` checks it is up to date. This mirrors how `vendor/github-rest-api-description/` handles the REST OpenAPI spec.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,11 +311,11 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 
 ### Anonymous access
 
-- **`backend_allow_anonymous` is a global boolean** defaulting to `true`. `OnHttpRequest()` checks it on every request: if `false` and no `Authorization` header is present, confusio returns `401 { message = "This instance requires authentication." }` immediately, before routing.
-- **Only Gitea probes its backend at startup.** The Gitea backend calls `GET /api/v1/settings/api` and sets `backend_allow_anonymous = (settings.require_signin_view ~= true)`. If the probe fails (network error or non-200), the default `true` is preserved and anonymous requests are allowed.
-- **All other backends leave the default `true`.** They neither probe nor set `backend_allow_anonymous`, so anonymous access is always permitted regardless of the upstream's actual configuration.
+- **`app.allow_anonymous` is a boolean field on the app context** defaulting to `true`. `OnHttpRequest()` checks it on every request: if `false` and no `Authorization` header is present, confusio returns `401 { message = "This instance requires authentication." }` immediately, before routing.
+- **Only Gitea probes its backend at startup.** The Gitea backend calls `GET /api/v1/settings/api` and sets `app.allow_anonymous = (settings.require_signin_view ~= true)`. If the probe fails (network error or non-200), the default `true` is preserved and anonymous requests are allowed.
+- **All other backends leave the default `true`.** They neither probe nor set `app.allow_anonymous`, so anonymous access is always permitted regardless of the upstream's actual configuration.
 - **Gitea-family backends (forgejo, gogs, codeberg, notabug) inherit Gitea's probe** because `load_family_backend("gitea")` dofiles `backends/gitea.lua`, which includes the probe block.
-- **Test pattern**: `*-anon.hurl` files verify that unauthenticated requests succeed when the mock advertises anonymous access. The mock's `/api/v1/settings/api` route returns `{"require_signin_view": false}` to simulate an open instance. Closed-instance (401) behavior is covered by unit tests that set `backend_allow_anonymous = false` directly.
+- **Test pattern**: `*-anon.hurl` files verify that unauthenticated requests succeed when the mock advertises anonymous access. The mock's `/api/v1/settings/api` route returns `{"require_signin_view": false}` to simulate an open instance. Closed-instance (401) behavior is covered by unit tests that set `app.allow_anonymous = false` directly.
 
 ### Mock server design
 
@@ -360,7 +360,7 @@ The nine `internal/` modules are loaded by `.init.lua` in a fixed order. Each ex
 | `transport.lua` | `append_page_params`, `make_fetch_opts`, `make_proxy_handler`, `make_backend_transport` | backends |
 | `translators.lua` | `owner_repo_id`, `translate_repo`, `translate_user`, `translate_migration` | backends |
 | `families.lua` | `provider_families`, `load_family_backend` | backends + Makefile scripts |
-| *(backend loaded here)* | `backend_impl`, `backend_allow_anonymous` | dispatch |
+| *(backend loaded here)* | `backend_impl`; Gitea writes `app.allow_anonymous` | dispatch |
 | `defaults.lua` | `defaults` (table of handler functions) | catalog |
 | `router.lua` | `route_add`, `route_match`, `path_known` | catalog, dispatch |
 | `catalog.lua` | `endpoints` (flat array); registers routes via `route_add` | dispatch, scripts |

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -350,7 +350,7 @@ local function translate_ado_hook(h)
   }
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, ado_url(config.base_url .. "/_apis/connectionData"), auth()))
   end,
@@ -1472,10 +1472,10 @@ local function translate_ado_analysis(an)
   }
 end
 
--- Patch backend_impl with code scanning handlers.
--- (backend_impl was already assigned above; we extend it here to keep the
+-- Patch app.backend_impl with code scanning handlers.
+-- (app.backend_impl was already assigned above; we extend it here to keep the
 -- check-suite section self-contained and avoid one giant table.)
-local _b = backend_impl
+local _b = app.backend_impl
 
 _b.list_repo_code_scanning_alerts = function(owner, repo_name)
   local alert_type = GetParam("tool_name") or "code"

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -619,7 +619,7 @@ local function snippet_url(gist_id)
   return base() .. "/snippets/" .. ws .. "/" .. eid
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/user", auth()))
   end,

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -372,7 +372,7 @@ local bbs_dc_to_gh = {
   STOPPED = { status = "completed", conclusion = "cancelled" },
 }
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
   end,
@@ -1184,7 +1184,7 @@ local function translate_bbs_report(rpt, idx, sha)
   }
 end
 
-local _b = backend_impl
+local _b = app.backend_impl
 
 _b.list_repo_code_scanning_alerts = function(owner, repo_name)
   local sha = resolve_ref_sha(owner, repo_name)

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -96,7 +96,7 @@ local function check_page()
   return true
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
   end,

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -123,7 +123,7 @@ local function gerrit_repos_from_dict(data)
   return repos
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/config/server/version", auth()))
   end,

--- a/backends/gitblit.lua
+++ b/backends/gitblit.lua
@@ -115,7 +115,7 @@ local function list_repos_by_prefix(prefix)
   return result, 200
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, rpc() .. "?req=LIST_REPOSITORIES", auth()))
   end,

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -28,7 +28,7 @@ local gb_to_gh = {
   warning = { status = "completed", conclusion = "neutral" },
 }
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/rate_limit", auth()))
   end,

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -739,7 +739,7 @@ local function delete_gitea_reaction(url, reaction_id)
   proxy_204({ 200 }, fetch_json(url, "DELETE", '{"content":"' .. content .. '"}'))
 end
 
-backend_impl = {
+app.backend_impl = {
   -- Health check
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/version", auth()))

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -20,12 +20,12 @@ local proxy_handler_created = _t.proxy_handler_created
 local proxy_handler_paged = _t.proxy_handler_paged
 
 -- Check if this Gitea instance allows anonymous access.
--- Sets the global backend_allow_anonymous so OnHttpRequest can gate unauthenticated requests.
+-- Sets app.allow_anonymous so OnHttpRequest can gate unauthenticated requests.
 do
   local ok, status, _, body = pcall(Fetch, base() .. "/settings/api", nil)
   if ok and status == 200 then
     local settings = DecodeJson(body) or {}
-    backend_allow_anonymous = settings.require_signin_view ~= true
+    app.allow_anonymous = settings.require_signin_view ~= true
   end
 end
 

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -554,7 +554,7 @@ local GL_STATUS_TO_CHECK_RUN = {
   canceled = { status = "completed", conclusion = "cancelled" },
 }
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
   end,
@@ -3334,7 +3334,7 @@ local function translate_gl_vuln_list(arr)
   return result
 end
 
-local _b = backend_impl
+local _b = app.backend_impl
 
 _b.list_repo_dependabot_alerts = function(owner, repo_name)
   proxy_json_paged(

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -184,7 +184,7 @@ local function translate_harness_hook_req(body_str)
   })
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base(), auth()))
   end,

--- a/backends/kallithea.lua
+++ b/backends/kallithea.lua
@@ -1,5 +1,5 @@
 -- Kallithea backend handler overrides.
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
   end,

--- a/backends/launchpad.lua
+++ b/backends/launchpad.lua
@@ -90,7 +90,7 @@ local function translate_lp_bug(bug, task)
   }
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/devel/"))
   end,

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -204,7 +204,7 @@ local function translate_onedev_commit(c)
   }
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/server-version", auth()))
   end,

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -190,7 +190,7 @@ local pagure_to_gh = {
   canceled = { status = "completed", conclusion = "cancelled" },
 }
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
   end,

--- a/backends/phabricator.lua
+++ b/backends/phabricator.lua
@@ -204,7 +204,7 @@ local function translate_harbormaster_build(b, ref)
   }
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/api/conduit.ping"))
   end,

--- a/backends/radicle.lua
+++ b/backends/radicle.lua
@@ -91,7 +91,7 @@ local function translate_radicle_repos(repos)
   return translate_list(translate_radicle_repo, repos)
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base(), auth()))
   end,

--- a/backends/rhodecode.lua
+++ b/backends/rhodecode.lua
@@ -1,5 +1,5 @@
 -- RhodeCode backend handler overrides.
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
   end,

--- a/backends/sourceforge.lua
+++ b/backends/sourceforge.lua
@@ -2,7 +2,7 @@
 if config.base_url == "" then
   config.base_url = "https://sourceforge.net"
 end
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/rest/p"))
   end,

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -237,7 +237,7 @@ local function translate_srht_commit(c)
   }
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, config.base_url .. "/api/version", auth()))
   end,

--- a/backends/tuleap.lua
+++ b/backends/tuleap.lua
@@ -135,7 +135,7 @@ local function find_project(shortname)
   return nil
 end
 
-backend_impl = {
+app.backend_impl = {
   get_root = function()
     proxy_health_check(pcall(Fetch, base() .. "/projects?limit=1", auth()))
   end,

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -12,7 +12,7 @@
 -- group_name matches the test file suffix (<backend>-<group>.hurl) and the
 -- compatibility matrix sections in site/compatibility.csv.
 --
--- Backends override handlers by setting backend_impl.<name>. Parametric
+-- Backends override handlers by setting app.backend_impl.<name>. Parametric
 -- captures from {param} segments are passed positionally to the handler.
 -- ---------------------------------------------------------------------------
 
@@ -22,7 +22,7 @@ local endpoint_sections = {
     {
       -- GraphQL API (https://docs.github.com/en/graphql)
       -- graphql_handler is the fixed handler for all backends; backends populate
-      -- graphql_resolvers rather than overriding backend_impl.graphql_request.
+      -- graphql_resolvers rather than overriding app.backend_impl.graphql_request.
       { "POST /graphql", "graphql_request", graphql_handler },
     },
   },

--- a/internal/context.lua
+++ b/internal/context.lua
@@ -1,0 +1,17 @@
+-- Application context constructor.
+--
+-- make_app(cfg) returns the single app context table for the process lifetime.
+-- Fields are populated by .init.lua after the backend loads.
+--
+-- Fields:
+--   config          — backend config table (same object as the global `config`)
+--   backend_impl    — handler registry set by the backend at startup
+--   allow_anonymous — auth-gate flag; true means unauthenticated requests are allowed
+
+function make_app(cfg) -- luacheck: globals make_app
+  return {
+    config = cfg,
+    backend_impl = {},
+    allow_anonymous = true,
+  }
+end

--- a/internal/dispatch.lua
+++ b/internal/dispatch.lua
@@ -2,15 +2,16 @@
 --
 -- Defines OnHttpRequest, the Redbean entry point for every incoming request.
 -- Requires all internal modules to be loaded first (http, proxy, router, catalog).
+-- Reads auth policy and backend handlers from the app context (see internal/context.lua).
 
 function OnHttpRequest()
-  if not backend_allow_anonymous and not GetHeader("Authorization") then
+  if not app.allow_anonymous and not GetHeader("Authorization") then
     respond_json(401, { message = "This instance requires authentication." })
     return
   end
   local ep, caps, default_fn = route_match(GetMethod(), GetPath())
   if ep then
-    local fn = backend_impl[ep] or default_fn
+    local fn = app.backend_impl[ep] or default_fn
     if fn then
       fn(table.unpack(caps))
     else

--- a/internal/families.lua
+++ b/internal/families.lua
@@ -28,7 +28,7 @@ provider_families = {
 -- load_family_backend is global: alias backends call it to inherit a family
 -- implementation.  Looks up config.backend in provider_families[root].aliases,
 -- sets config.base_url from the alias's default_url when the user hasn't
--- supplied one, loads the root backend via dofile, then clears any backend_impl
+-- supplied one, loads the root backend via dofile, then clears any app.backend_impl
 -- keys whose names match the alias's strip patterns (features absent from this
 -- variant).
 function load_family_backend(root)
@@ -41,9 +41,9 @@ function load_family_backend(root)
   end
   dofile("/zip/backends/" .. root .. ".lua")
   for _, pattern in ipairs(alias.strip or {}) do
-    for k in pairs(backend_impl) do
+    for k in pairs(app.backend_impl) do
       if k:find(pattern) then
-        backend_impl[k] = nil
+        app.backend_impl[k] = nil
       end
     end
   end

--- a/internal/families.lua
+++ b/internal/families.lua
@@ -8,7 +8,7 @@
 -- The table key is the root backend name (the canonical family implementation).
 -- Each alias entry declares:
 --   default_url  string — backend default when no base_url is given
---   strip        table  — Lua patterns; backend_impl keys matching any are
+--   strip        table  — Lua patterns; app.backend_impl keys matching any are
 --                         cleared after inheriting from the root implementation,
 --                         because those features are absent from this variant
 provider_families = {

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -5,7 +5,7 @@
 --           graphql_schema_* (internal/graphql_schema.lua).
 --
 -- Globals exported:
---   graphql_resolvers              — table; backends populate at load time alongside backend_impl
+--   graphql_resolvers              — table; backends populate at load time alongside app.backend_impl
 --   graphql_handler()              — HTTP handler for POST /graphql; registered in catalog
 --   respond_graphql(data, errs)    — null-safe GraphQL response writer
 --   graphql_error(ctx, ...)        — error-recording helper called by resolvers
@@ -17,7 +17,7 @@
 -- Resolver registry
 -- ---------------------------------------------------------------------------
 
--- Backends populate graphql_resolvers at load time alongside backend_impl.
+-- Backends populate graphql_resolvers at load time alongside app.backend_impl.
 -- Keys are "TypeName.fieldName" strings (e.g. "Query.repository", "Repository.issues").
 graphql_resolvers = {} -- luacheck: globals graphql_resolvers
 
@@ -929,7 +929,7 @@ local function encode_result(result)
 end
 
 -- graphql_handler is registered in the catalog as the fixed handler for
--- POST /graphql.  Backends do NOT override this via backend_impl; they only
+-- POST /graphql.  Backends do NOT override this via app.backend_impl; they only
 -- populate graphql_resolvers.
 function graphql_handler() -- luacheck: globals graphql_handler
   -- Step 1: decode request body.

--- a/scripts/dump-claims.lua
+++ b/scripts/dump-claims.lua
@@ -60,15 +60,14 @@ end
 
 local backend_parts = {}
 for _, name in ipairs(cli_backends) do
-  backend_impl = {} -- luacheck: globals backend_impl
-  backend_allow_anonymous = true -- luacheck: globals backend_allow_anonymous
   config = { backend = name, base_url = "" } -- luacheck: globals config
+  app.backend_impl = {} -- luacheck: globals app
   Fetch = noop_fetch -- luacheck: globals Fetch
   dofile("/zip/backends/" .. name .. ".lua")
   Fetch = _real_fetch -- luacheck: globals Fetch
 
   local handlers = {}
-  for k in pairs(backend_impl) do -- luacheck: globals backend_impl
+  for k in pairs(app.backend_impl) do -- luacheck: globals app
     handlers[#handlers + 1] = k
   end
   table.sort(handlers)

--- a/scripts/dump-claims.lua
+++ b/scripts/dump-claims.lua
@@ -1,5 +1,5 @@
 -- Export endpoint catalog + per-backend handler sets as JSON.
--- Used by validate-claims.lua to check CSV support claims against backend_impl.
+-- Used by validate-claims.lua to check CSV support claims against app.backend_impl.
 --
 -- Usage: ./redbean.com -i scripts/dump-claims.lua <backend1> [backend2 ...]
 --

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1067,25 +1067,25 @@ reset_request({ method = "GET", path = "/repos/alice/myrepo" })
 OnHttpRequest()
 eq(_last_status, 404, "OnHttpRequest: backend endpoint without default → 404")
 
--- backend_allow_anonymous=false, no Authorization → 401
+-- app.allow_anonymous=false, no Authorization → 401
 reset_response()
 reset_request({ method = "GET", path = "/" })
-backend_allow_anonymous = false
+app.allow_anonymous = false
 OnHttpRequest()
-eq(_last_status, 401, "OnHttpRequest: anon forbidden when backend_allow_anonymous=false → 401")
-backend_allow_anonymous = true
+eq(_last_status, 401, "OnHttpRequest: anon forbidden when app.allow_anonymous=false → 401")
+app.allow_anonymous = true
 
--- backend_allow_anonymous=false, with Authorization → proceeds normally
+-- app.allow_anonymous=false, with Authorization → proceeds normally
 reset_response()
 reset_request({ method = "GET", path = "/", headers = { Authorization = "token mytoken" } })
-backend_allow_anonymous = false
+app.allow_anonymous = false
 OnHttpRequest()
 eq(
   _last_status,
   200,
-  "OnHttpRequest: authorized request allowed when backend_allow_anonymous=false → 200"
+  "OnHttpRequest: authorized request allowed when app.allow_anonymous=false → 200"
 )
-backend_allow_anonymous = true
+app.allow_anonymous = true
 
 -- GET /orgs/{org}/code-scanning/alerts — code_scanning_list_empty default → 200
 reset_response()

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1587,7 +1587,7 @@ eq(_last_status, 501, "OnHttpRequest: GET /feeds → 501 (activity not implement
 do
   local _saved_backend = config.backend
   local _saved_base_url = config.base_url
-  local _saved_impl = backend_impl
+  local _saved_impl = app.backend_impl
 
   -- Stub dofile so load_family_backend's dofile("/zip/backends/gitea.lua") is a no-op.
   -- luacheck: push
@@ -1604,7 +1604,7 @@ do
   -- Happy path: sets base_url from alias default when config.base_url is empty.
   config.backend = "forgejo"
   config.base_url = ""
-  backend_impl = {}
+  app.backend_impl = {}
   load_family_backend("gitea")
   eq(
     config.base_url,
@@ -1615,7 +1615,7 @@ do
   -- Explicit base_url is preserved (not overwritten by alias default).
   config.backend = "forgejo"
   config.base_url = "https://custom.example.com"
-  backend_impl = {}
+  app.backend_impl = {}
   load_family_backend("gitea")
   eq(
     config.base_url,
@@ -1623,26 +1623,32 @@ do
     "load_family_backend: preserves explicit base_url"
   )
 
-  -- Strip patterns remove matching backend_impl keys (gogs strips _package and _actions_).
+  -- Strip patterns remove matching app.backend_impl keys (gogs strips _package and _actions_).
   config.backend = "gogs"
   config.base_url = "https://try.gogs.io"
-  backend_impl = {
+  app.backend_impl = {
     get_package_info = function() end,
     list_actions_runs = function() end,
     get_repo = function() end,
   }
   load_family_backend("gitea")
-  ok(backend_impl["get_package_info"] == nil, "load_family_backend: strips _package keys for gogs")
   ok(
-    backend_impl["list_actions_runs"] == nil,
+    app.backend_impl["get_package_info"] == nil,
+    "load_family_backend: strips _package keys for gogs"
+  )
+  ok(
+    app.backend_impl["list_actions_runs"] == nil,
     "load_family_backend: strips _actions_ keys for gogs"
   )
-  ok(backend_impl["get_repo"] ~= nil, "load_family_backend: preserves non-stripped keys for gogs")
+  ok(
+    app.backend_impl["get_repo"] ~= nil,
+    "load_family_backend: preserves non-stripped keys for gogs"
+  )
 
   dofile = _real_dofile2 -- luacheck: globals dofile
   config.backend = _saved_backend
   config.base_url = _saved_base_url
-  backend_impl = _saved_impl
+  app.backend_impl = _saved_impl
 end
 
 -- ============================================================

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1646,6 +1646,26 @@ do
 end
 
 -- ============================================================
+-- app context
+-- ============================================================
+
+ok(type(app) == "table", "app: is a table")
+ok(app.config == config, "app.config: same object as global config")
+ok(type(app.backend_impl) == "table", "app.backend_impl: is a table")
+ok(type(app.allow_anonymous) == "boolean", "app.allow_anonymous: is a boolean")
+ok(app.allow_anonymous == true, "app.allow_anonymous: default true (no backend loaded)")
+
+-- make_app: constructs independent context from a given config table.
+do
+  local test_cfg = { backend = "test", base_url = "https://test.example.com" }
+  local test_app = make_app(test_cfg)
+  ok(test_app.config == test_cfg, "make_app: config is the supplied table")
+  ok(type(test_app.backend_impl) == "table", "make_app: backend_impl is a table")
+  ok(test_app.allow_anonymous == true, "make_app: allow_anonymous defaults to true")
+  ok(test_app ~= app, "make_app: returns a new independent table each call")
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 


### PR DESCRIPTION
Fixes #203.

Introduces an explicit app context object to replace the global-variable wiring between `.init.lua`, backends, and dispatch. The refactor migrates `config`, `backend_impl`, `graphql_resolvers`, and `backend_allow_anonymous` into a single composition root, making startup and request handling traceable through one object instead of ambient global state.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Migrate all backends to write to app context instead of globals <!-- type:spec -->
- [x] Remove global compatibility shims and finalize composition root <!-- type:spec -->
- [x] Move backend_allow_anonymous into app context <!-- type:spec -->
- [x] Wire dispatch.lua to read from app context instead of globals <!-- type:spec -->
- [x] Add internal/context.lua and construct app context in .init.lua with global shims <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->