### PR TITLE
Rank 3: add a backend builder/registry and stop backend files from mutating global registries directly (closes #204)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -29,9 +29,10 @@ dofile("/zip/internal/graphql_executor.lua")
 dofile("/zip/internal/graphql_translators.lua")
 dofile("/zip/internal/families.lua")
 dofile("/zip/internal/context.lua")
+dofile("/zip/internal/registry.lua")
 
--- Build the app context.  Backends write directly to app.backend_impl and
--- app.allow_anonymous at load time; no post-load sync needed.
+-- Build the app context.  Backends write to app.backend_impl and app.allow_anonymous
+-- either directly (old path) or via make_backend_builder():b:build() (new path).
 app = make_app(config)
 
 if config.backend ~= "" then

--- a/.init.lua
+++ b/.init.lua
@@ -31,8 +31,7 @@ dofile("/zip/internal/families.lua")
 dofile("/zip/internal/context.lua")
 dofile("/zip/internal/registry.lua")
 
--- Build the app context.  Backends write to app.backend_impl and app.allow_anonymous
--- either directly (old path) or via make_backend_builder():b:build() (new path).
+-- Build the app context.  Backends register handlers via make_backend_builder():b:build().
 app = make_app(config)
 
 if config.backend ~= "" then

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -49,6 +49,8 @@ globals = {
   -- App context: constructed in .init.lua, holds config + backend state
   "app",
   "make_app",
+  -- Backend builder: internal/registry.lua; backends use this instead of mutating globals
+  "make_backend_builder",
   -- Default stub handlers: populated by internal/defaults.lua, read by the catalog in .init.lua
   "defaults",
   -- Router: populated by internal/router.lua, used by the catalog and OnHttpRequest in .init.lua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 | Routes and default handler stubs | `endpoint_sections` in `internal/catalog.lua` | route registration, `defaults` table wire-up, compatibility matrix sections, test file discovery, `make dump-endpoints` / `validate-tests` / `validate-csv` / `site` |
 | Provider family membership | `provider_families` in `internal/families.lua` | mock building via `.make-families.mk` (auto-generated), `make validate-providers`, `load_family_backend` behavior |
 | Backend transport scaffold | `make_backend_transport` in `internal/transport.lua` | `fetch_json`, `proxy_json*`, `proxy_204`, `proxy_json_list`, `proxy_health_check`, pagination params — all consumed by backends via the transport object |
-| Application module layout | nine `internal/*.lua` files, dofile'd in fixed order by `.init.lua` | the full global surface for backends; see "Internal module layout" for load order and exported globals |
+| Application module layout | ten `internal/*.lua` files, dofile'd in fixed order by `.init.lua` | the full global surface for backends; see "Internal module layout" for load order and exported globals |
 
 **Adding an endpoint**: touch `internal/catalog.lua` (`endpoint_sections`) and `internal/defaults.lua`, plus per-backend overrides in `backends/<name>.lua` if native support is needed.
 
@@ -349,7 +349,7 @@ Do **not** use `proxy_search_envelope` when:
 
 ### Internal module layout
 
-The nine `internal/` modules are loaded by `.init.lua` in a fixed order. Each exports only globals — no `require`/`return` pattern; `dofile` runs in global scope.
+The ten `internal/` modules are loaded by `.init.lua` in a fixed order. Each exports only globals — no `require`/`return` pattern; `dofile` runs in global scope.
 
 **Load order and exports:**
 
@@ -360,7 +360,8 @@ The nine `internal/` modules are loaded by `.init.lua` in a fixed order. Each ex
 | `transport.lua` | `append_page_params`, `make_fetch_opts`, `make_proxy_handler`, `make_backend_transport` | backends |
 | `translators.lua` | `owner_repo_id`, `translate_repo`, `translate_user`, `translate_migration` | backends |
 | `families.lua` | `provider_families`, `load_family_backend` | backends + Makefile scripts |
-| *(backend loaded here)* | writes `app.backend_impl`; Gitea writes `app.allow_anonymous` | dispatch |
+| `registry.lua` | `make_backend_builder` | backends |
+| *(backend loaded here)* | writes `app.backend_impl` and `graphql_resolvers` (old path) or calls `b:build()` (new path); Gitea sets `app.allow_anonymous` | dispatch |
 | `defaults.lua` | `defaults` (table of handler functions) | catalog |
 | `router.lua` | `route_add`, `route_match`, `path_known` | catalog, dispatch |
 | `catalog.lua` | `endpoints` (flat array); registers routes via `route_add` | dispatch, scripts |
@@ -368,6 +369,7 @@ The nine `internal/` modules are loaded by `.init.lua` in a fixed order. Each ex
 
 **Global surface for backend authors** (backends can call any of these):
 - App context (write target): `app.backend_impl`, `app.allow_anonymous`, `app.config`
+- Builder (preferred new path): `make_backend_builder` — call `b:rest(name, fn)`, `b:graphql(key, fn)`, `b:set_allow_anonymous(v)`, then `b:build()` to commit; see `internal/registry.lua`
 - Response: `set_preamble`, `respond_json`
 - Proxy: all of `proxy.lua`'s exports
 - Transport: all of `transport.lua`'s exports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,8 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 
 **Adding a family-alias backend**: update `provider_families` in `internal/families.lua` (the single declaration), create a one-line `backends/<alias>.lua` calling `load_family_backend`, add to `BACKENDS` — no mock file needed.
 
+**Backend registration**: all backends must use `make_backend_builder()` / `b:rest()` / `b:graphql()` / `b:build()`. Direct assignment to `app.backend_impl` or `graphql_resolvers` is forbidden. `make validate-builders` enforces this and is wired into `make test`.
+
 ### Redbean
 
 - **`-D key=value` is NOT for Lua globals.** It means "directory overlay" — passing `-D backend=gitea` errors with "not a directory: backend=gitea". Use positional SCRIPTARGS instead: `sh ./confusio.com -- gitea`.
@@ -363,15 +365,15 @@ The ten `internal/` modules are loaded by `.init.lua` in a fixed order. Each exp
 | `translators.lua` | `owner_repo_id`, `translate_repo`, `translate_user`, `translate_migration` | backends |
 | `families.lua` | `provider_families`, `load_family_backend` | backends + Makefile scripts |
 | `registry.lua` | `make_backend_builder` | backends |
-| *(backend loaded here)* | writes `app.backend_impl` and `graphql_resolvers` (old path) or calls `b:build()` (new path); Gitea sets `app.allow_anonymous` | dispatch |
+| *(backend loaded here)* | calls `b:build()` to populate `app.backend_impl` and `graphql_resolvers`; Gitea sets `app.allow_anonymous` | dispatch |
 | `defaults.lua` | `defaults` (table of handler functions) | catalog |
 | `router.lua` | `route_add`, `route_match`, `path_known` | catalog, dispatch |
 | `catalog.lua` | `endpoints` (flat array); registers routes via `route_add` | dispatch, scripts |
 | `dispatch.lua` | `OnHttpRequest` | Redbean (entry point) |
 
 **Global surface for backend authors** (backends can call any of these):
-- App context (write target): `app.backend_impl`, `app.allow_anonymous`, `app.config`
-- Builder (preferred new path): `make_backend_builder` — call `b:rest(name, fn)`, `b:graphql(key, fn)`, `b:set_allow_anonymous(v)`, then `b:build()` to commit; see `internal/registry.lua`
+- App context (write target): `app.allow_anonymous`, `app.config` — never assign `app.backend_impl` directly
+- Builder (required): `make_backend_builder` — call `b:rest(name, fn)`, `b:graphql(key, fn)`, `b:set_allow_anonymous(v)`, then `b:build()` to commit; see `internal/registry.lua`
 - Response: `set_preamble`, `respond_json`
 - Proxy: all of `proxy.lua`'s exports
 - Transport: all of `transport.lua`'s exports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,9 +270,11 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
   or Makefile variables — both are derived from this table.
 - **`load_family_backend(root)`** is the helper alias backends call instead of raw `dofile`.
   It reads the alias's entry from `provider_families[root].aliases[config.backend]`, sets
-  `config.base_url` from `default_url` when none was supplied, dofiles the root backend,
-  then clears any `app.backend_impl` keys matching the alias's `strip` patterns. All of this
-  replaces the old per-file `dofile` + manual `for k in pairs(app.backend_impl)` strip loops.
+  `config.base_url` from `default_url` when none was supplied, declares the alias's strip
+  patterns in `app._family_strip`, then dofiles the root backend.  The root backend's
+  builder reads `app._family_strip` in `b:build()` and excludes matching REST keys — no
+  post-hoc `app.backend_impl` mutation needed.  `app._family_strip` is cleared to nil
+  after dofile returns so it doesn't affect other code.
 - **`strip` patterns are Lua patterns, not exact names.** `"_package"` matches any key
   containing `_package` (e.g. `list_packages`, `get_package`). Keep patterns tight enough
   not to accidentally strip unrelated keys.

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ endef
 
 $(foreach b,$(BACKENDS),$(eval $(call BACKEND_RULE,$(b))))
 
-.PHONY: build site dump-endpoints dump-families dump-claims validate-csv validate-tests validate-providers validate-claims generate-schema validate-schema test test-unit test-unit-functions test-unit-graphql test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
+.PHONY: build site dump-endpoints dump-families dump-claims validate-csv validate-tests validate-providers validate-claims validate-builders generate-schema validate-schema test test-unit test-unit-functions test-unit-graphql test-unit-backends test-integration validate-mock test-format test-lint test-coverage clean
 
 build: confusio.com
 
@@ -151,6 +151,17 @@ dump-claims: redbean.com
 validate-claims: redbean.com
 	./redbean.com -i scripts/dump-claims.lua $(BACKENDS) 2>/dev/null | ./redbean.com -i scripts/validate-claims.lua site/compatibility.csv
 
+validate-builders:
+	@if grep -rn 'app\.backend_impl\s*=' backends/ 2>/dev/null | grep -v '^Binary'; then \
+	  echo "ERROR: backend(s) still use direct app.backend_impl assignment; use make_backend_builder():b:build() instead" >&2; \
+	  exit 1; \
+	fi
+	@if grep -rn 'graphql_resolvers\[' backends/ 2>/dev/null | grep -v '^Binary'; then \
+	  echo "ERROR: backend(s) still use direct graphql_resolvers assignment; use b:graphql() instead" >&2; \
+	  exit 1; \
+	fi
+	@echo "validate-builders OK"
+
 generate-schema: redbean.com
 	./redbean.com -i scripts/gen-graphql-schema.lua
 
@@ -164,7 +175,7 @@ site: redbean.com
 	./redbean.com -i scripts/dump-endpoints.lua 2>/dev/null | \
 	  python3 scripts/gen-matrix.py - site/compatibility.csv site/index.html _site/index.html
 
-test: test-unit test-integration test-format test-lint validate-csv validate-tests validate-providers validate-claims validate-schema
+test: test-unit test-integration test-format test-lint validate-csv validate-tests validate-providers validate-claims validate-schema validate-builders
 
 # Pure-Lua unit tests (no HTTP server needed): .init.lua functions + GraphQL subsystem
 test-unit-functions: redbean.com

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -350,816 +350,854 @@ local function translate_ado_hook(h)
   }
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, ado_url(config.base_url .. "/_apis/connectionData"), auth()))
-  end,
-  get_repo = function(owner, repo_name)
-    proxy_json(translate_ado_repo, fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name)))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, ado_url(config.base_url .. "/_apis/connectionData"), auth()))
+end)
+b:rest("get_repo", function(owner, repo_name)
+  proxy_json(translate_ado_repo, fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name)))
+end)
 
-  patch_repo = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local a = {}
-    if req.description ~= nil then
-      a.project = { description = req.description }
+b:rest("patch_repo", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local a = {}
+  if req.description ~= nil then
+    a.project = { description = req.description }
+  end
+  if req.default_branch then
+    a.defaultBranch = "refs/heads/" .. req.default_branch
+  end
+  proxy_json(
+    translate_ado_repo,
+    fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name), "PATCH", EncodeJson(a))
+  )
+end)
+
+b:rest("delete_repo", function(owner, repo_name)
+  -- Must resolve repo ID first
+  local ok, status, _, body = fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name))
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local repo = DecodeJson(body) or {}
+  local repo_id = repo.id or repo_name
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, ado_url(repos_base(owner) .. "/" .. repo_id), dopts))
+end)
+
+b:rest("get_user_repos", function()
+  -- ADO: list repos across all projects
+  local limit = tonumber(GetParam("per_page")) or 30
+  local url = ado_url(config.base_url .. "/_apis/git/repositories")
+  proxy_json(function(data)
+    local repos = {}
+    local all = data.value or {}
+    for i = 1, math.min(limit, #all) do
+      repos[#repos + 1] = translate_ado_repo(all[i])
     end
-    if req.default_branch then
-      a.defaultBranch = "refs/heads/" .. req.default_branch
+    return repos
+  end, fetch_json(url))
+end)
+
+b:rest("post_user_repos", function()
+  -- ADO requires a project; use a "default" project or from request
+  local req = DecodeJson(GetBody() or "{}")
+  local proj = req.organization or "default"
+  local a = { name = req.name or "", project = { name = proj } }
+  proxy_json_created(
+    translate_ado_repo,
+    fetch_json(ado_url(repos_base(proj)), "POST", EncodeJson(a))
+  )
+end)
+
+b:rest("get_org_repos", function(owner)
+  local limit = tonumber(GetParam("per_page")) or 30
+  local url = ado_url(repos_base(owner))
+  proxy_json(function(data)
+    local repos = {}
+    local all = data.value or {}
+    for i = 1, math.min(limit, #all) do
+      repos[#repos + 1] = translate_ado_repo(all[i])
     end
-    proxy_json(
-      translate_ado_repo,
-      fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name), "PATCH", EncodeJson(a))
-    )
-  end,
+    return repos
+  end, fetch_json(url))
+end)
 
-  delete_repo = function(owner, repo_name)
-    -- Must resolve repo ID first
-    local ok, status, _, body = fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name))
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local repo = DecodeJson(body) or {}
-    local repo_id = repo.id or repo_name
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, ado_url(repos_base(owner) .. "/" .. repo_id), dopts))
-  end,
+b:rest("post_org_repos", function(owner)
+  local req = DecodeJson(GetBody() or "{}")
+  local a = { name = req.name or "", project = { name = owner } }
+  proxy_json_created(
+    translate_ado_repo,
+    fetch_json(ado_url(repos_base(owner)), "POST", EncodeJson(a))
+  )
+end)
 
-  get_user_repos = function()
-    -- ADO: list repos across all projects
-    local limit = tonumber(GetParam("per_page")) or 30
-    local url = ado_url(config.base_url .. "/_apis/git/repositories")
-    proxy_json(function(data)
-      local repos = {}
-      local all = data.value or {}
-      for i = 1, math.min(limit, #all) do
-        repos[#repos + 1] = translate_ado_repo(all[i])
-      end
-      return repos
-    end, fetch_json(url))
-  end,
+-- Branches ------------------------------------------------------------------
+-- ADO: GET /{owner}/_apis/git/repositories/{repo}/refs?filter=heads
 
-  post_user_repos = function()
-    -- ADO requires a project; use a "default" project or from request
-    local req = DecodeJson(GetBody() or "{}")
-    local proj = req.organization or "default"
-    local a = { name = req.name or "", project = { name = proj } }
-    proxy_json_created(
-      translate_ado_repo,
-      fetch_json(ado_url(repos_base(proj)), "POST", EncodeJson(a))
-    )
-  end,
+b:rest("get_repo_branches", function(owner, repo_name)
+  local limit = GetParam("per_page") or "30"
+  local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=heads&$top=" .. limit)
+  proxy_json(function(data)
+    return translate_list(translate_ado_branch, data.value)
+  end, fetch_json(url))
+end)
 
-  get_org_repos = function(owner)
-    local limit = tonumber(GetParam("per_page")) or 30
-    local url = ado_url(repos_base(owner))
-    proxy_json(function(data)
-      local repos = {}
-      local all = data.value or {}
-      for i = 1, math.min(limit, #all) do
-        repos[#repos + 1] = translate_ado_repo(all[i])
-      end
-      return repos
-    end, fetch_json(url))
-  end,
+b:rest("get_repo_branch", function(owner, repo_name, branch)
+  local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=heads/" .. branch)
+  proxy_json(function(data)
+    local br = (data.value or {})[1]
+    return br and translate_ado_branch(br) or {}
+  end, fetch_json(url))
+end)
 
-  post_org_repos = function(owner)
-    local req = DecodeJson(GetBody() or "{}")
-    local a = { name = req.name or "", project = { name = owner } }
-    proxy_json_created(
-      translate_ado_repo,
-      fetch_json(ado_url(repos_base(owner)), "POST", EncodeJson(a))
-    )
-  end,
+-- Tags ----------------------------------------------------------------------
+-- ADO: GET /{owner}/_apis/git/repositories/{repo}/refs?filter=tags
 
-  -- Branches ------------------------------------------------------------------
-  -- ADO: GET /{owner}/_apis/git/repositories/{repo}/refs?filter=heads
+b:rest("get_repo_tags", function(owner, repo_name)
+  local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=tags")
+  proxy_json(function(data)
+    return translate_list(translate_ado_tag, data.value)
+  end, fetch_json(url))
+end)
 
-  get_repo_branches = function(owner, repo_name)
-    local limit = GetParam("per_page") or "30"
-    local url =
-      ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=heads&$top=" .. limit)
-    proxy_json(function(data)
-      return translate_list(translate_ado_branch, data.value)
-    end, fetch_json(url))
-  end,
+-- Commits -------------------------------------------------------------------
+-- ADO: GET /{owner}/_apis/git/repositories/{repo}/commits
 
-  get_repo_branch = function(owner, repo_name, branch)
-    local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=heads/" .. branch)
-    proxy_json(function(data)
-      local b = (data.value or {})[1]
-      return b and translate_ado_branch(b) or {}
-    end, fetch_json(url))
-  end,
+b:rest("get_repo_commits", function(owner, repo_name)
+  local limit = GetParam("per_page") or "30"
+  local page = tonumber(GetParam("page")) or 1
+  local skip = (page - 1) * (tonumber(limit) or 30)
+  local ref = GetParam("sha") or ""
+  local url =
+    ado_url(repos_base(owner) .. "/" .. repo_name .. "/commits?$top=" .. limit .. "&$skip=" .. skip)
+  if ref ~= "" then
+    url = url .. "&searchCriteria.itemVersion.version=" .. ref
+  end
+  proxy_json(function(data)
+    return translate_list(translate_ado_commit, data.value)
+  end, fetch_json(url))
+end)
 
-  -- Tags ----------------------------------------------------------------------
-  -- ADO: GET /{owner}/_apis/git/repositories/{repo}/refs?filter=tags
+b:rest("get_repo_commit", function(owner, repo_name, ref)
+  proxy_json(
+    translate_ado_commit,
+    fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name .. "/commits/" .. ref))
+  )
+end)
 
-  get_repo_tags = function(owner, repo_name)
-    local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/refs?filter=tags")
-    proxy_json(function(data)
-      return translate_list(translate_ado_tag, data.value)
-    end, fetch_json(url))
-  end,
+-- Contents ------------------------------------------------------------------
+-- ADO: GET /{owner}/_apis/git/repositories/{repo}/items?path={path}&version={ref}
 
-  -- Commits -------------------------------------------------------------------
-  -- ADO: GET /{owner}/_apis/git/repositories/{repo}/commits
-
-  get_repo_commits = function(owner, repo_name)
-    local limit = GetParam("per_page") or "30"
-    local page = tonumber(GetParam("page")) or 1
-    local skip = (page - 1) * (tonumber(limit) or 30)
-    local ref = GetParam("sha") or ""
-    local url = ado_url(
-      repos_base(owner) .. "/" .. repo_name .. "/commits?$top=" .. limit .. "&$skip=" .. skip
-    )
-    if ref ~= "" then
-      url = url .. "&searchCriteria.itemVersion.version=" .. ref
-    end
-    proxy_json(function(data)
-      return translate_list(translate_ado_commit, data.value)
-    end, fetch_json(url))
-  end,
-
-  get_repo_commit = function(owner, repo_name, ref)
-    proxy_json(
-      translate_ado_commit,
-      fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name .. "/commits/" .. ref))
-    )
-  end,
-
-  -- Contents ------------------------------------------------------------------
-  -- ADO: GET /{owner}/_apis/git/repositories/{repo}/items?path={path}&version={ref}
-
-  get_repo_readme = function(owner, repo_name)
-    local ref = GetParam("ref") or ""
-    local candidates = { "README.md", "README", "readme.md", "README.rst" }
-    for _, fname in ipairs(candidates) do
-      local url = ado_url(
-        repos_base(owner)
-          .. "/"
-          .. repo_name
-          .. "/items?path=/"
-          .. fname
-          .. (ref ~= "" and ("&version=" .. ref) or "")
-      )
-      local ok, status, _, body = fetch_json(url)
-      if ok and status == 200 then
-        respond_json(200, {
-          type = "file",
-          name = fname,
-          path = fname,
-          sha = "",
-          size = #body,
-          encoding = "base64",
-          content = EncodeBase64(body),
-        })
-        return
-      end
-    end
-    respond_json(404, { message = "Not Found" })
-  end,
-
-  -- GET /repos/{owner}/{repo}/license
-  -- ADO has no license template API; fetch the LICENSE file via the items endpoint.
-  get_repo_license = function(owner, repo_name)
-    local candidates = { "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }
-    for _, fname in ipairs(candidates) do
-      local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/items?path=/" .. fname)
-      local ok, status, _, body = fetch_json(url)
-      if ok and status == 200 then
-        respond_json(200, {
-          type = "file",
-          name = fname,
-          path = fname,
-          sha = "",
-          size = #body,
-          encoding = "base64",
-          content = EncodeBase64(body),
-          license = nil,
-        })
-        return
-      end
-    end
-    respond_json(404, { message = "License file not found" })
-  end,
-
-  get_repo_content = function(owner, repo_name, path)
-    local ref = GetParam("ref") or ""
+b:rest("get_repo_readme", function(owner, repo_name)
+  local ref = GetParam("ref") or ""
+  local candidates = { "README.md", "README", "readme.md", "README.rst" }
+  for _, fname in ipairs(candidates) do
     local url = ado_url(
       repos_base(owner)
         .. "/"
         .. repo_name
         .. "/items?path=/"
-        .. path
+        .. fname
         .. (ref ~= "" and ("&version=" .. ref) or "")
     )
     local ok, status, _, body = fetch_json(url)
     if ok and status == 200 then
       respond_json(200, {
         type = "file",
-        name = path:match("[^/]+$") or path,
-        path = path,
+        name = fname,
+        path = fname,
         sha = "",
         size = #body,
         encoding = "base64",
         content = EncodeBase64(body),
       })
-    elseif ok then
-      respond_json(status, { message = "Error" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- Archive -------------------------------------------------------------------
-
-  get_repo_tarball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
-      ado_url(
-        repos_base(owner)
-          .. "/"
-          .. repo_name
-          .. "/items?path=/&$format=zip&versionDescriptor.version="
-          .. ref
-      )
-    )
-    Write("")
-  end,
-
-  get_repo_zipball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
-      ado_url(
-        repos_base(owner)
-          .. "/"
-          .. repo_name
-          .. "/items?path=/&$format=zip&versionDescriptor.version="
-          .. ref
-      )
-    )
-    Write("")
-  end,
-
-  -- Forks ---------------------------------------------------------------------
-  -- ADO: GET /{owner}/_apis/git/repositories/{repo}/forks/{project}
-
-  get_repo_forks = function(owner, repo_name)
-    proxy_json(function(data)
-      return translate_list(translate_ado_repo, data.value)
-    end, fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name .. "/forks/" .. owner)))
-  end,
-
-  post_repo_forks = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local target = req.organization or owner
-    proxy_json_created(
-      translate_ado_repo,
-      fetch_json(
-        ado_url(repos_base(owner) .. "/" .. repo_name .. "/forks"),
-        "POST",
-        EncodeJson({ targetProjectId = target })
-      )
-    )
-  end,
-
-  -- Webhooks ------------------------------------------------------------------
-  -- ADO: GET /_apis/hooks/subscriptions?publisherInputs.repository={repo_id}
-
-  get_repo_hooks = function(owner, repo_name)
-    -- First resolve repo ID
-    local ok, status, _, body = fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name))
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
       return
     end
-    local repo_id = (DecodeJson(body) or {}).id or repo_name
-    proxy_json(
-      function(data)
-        return translate_list(translate_ado_hook, data.value)
-      end,
-      fetch_json(
-        ado_url(
-          config.base_url .. "/_apis/hooks/subscriptions?publisherInputs.repository=" .. repo_id
-        )
+  end
+  respond_json(404, { message = "Not Found" })
+end)
+
+-- GET /repos/{owner}/{repo}/license
+-- ADO has no license template API; fetch the LICENSE file via the items endpoint.
+b:rest("get_repo_license", function(owner, repo_name)
+  local candidates = { "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }
+  for _, fname in ipairs(candidates) do
+    local url = ado_url(repos_base(owner) .. "/" .. repo_name .. "/items?path=/" .. fname)
+    local ok, status, _, body = fetch_json(url)
+    if ok and status == 200 then
+      respond_json(200, {
+        type = "file",
+        name = fname,
+        path = fname,
+        sha = "",
+        size = #body,
+        encoding = "base64",
+        content = EncodeBase64(body),
+        license = nil,
+      })
+      return
+    end
+  end
+  respond_json(404, { message = "License file not found" })
+end)
+
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local ref = GetParam("ref") or ""
+  local url = ado_url(
+    repos_base(owner)
+      .. "/"
+      .. repo_name
+      .. "/items?path=/"
+      .. path
+      .. (ref ~= "" and ("&version=" .. ref) or "")
+  )
+  local ok, status, _, body = fetch_json(url)
+  if ok and status == 200 then
+    respond_json(200, {
+      type = "file",
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = #body,
+      encoding = "base64",
+      content = EncodeBase64(body),
+    })
+  elseif ok then
+    respond_json(status, { message = "Error" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- Archive -------------------------------------------------------------------
+
+b:rest("get_repo_tarball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    ado_url(
+      repos_base(owner)
+        .. "/"
+        .. repo_name
+        .. "/items?path=/&$format=zip&versionDescriptor.version="
+        .. ref
+    )
+  )
+  Write("")
+end)
+
+b:rest("get_repo_zipball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    ado_url(
+      repos_base(owner)
+        .. "/"
+        .. repo_name
+        .. "/items?path=/&$format=zip&versionDescriptor.version="
+        .. ref
+    )
+  )
+  Write("")
+end)
+
+-- Forks ---------------------------------------------------------------------
+-- ADO: GET /{owner}/_apis/git/repositories/{repo}/forks/{project}
+
+b:rest("get_repo_forks", function(owner, repo_name)
+  proxy_json(function(data)
+    return translate_list(translate_ado_repo, data.value)
+  end, fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name .. "/forks/" .. owner)))
+end)
+
+b:rest("post_repo_forks", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local target = req.organization or owner
+  proxy_json_created(
+    translate_ado_repo,
+    fetch_json(
+      ado_url(repos_base(owner) .. "/" .. repo_name .. "/forks"),
+      "POST",
+      EncodeJson({ targetProjectId = target })
+    )
+  )
+end)
+
+-- Webhooks ------------------------------------------------------------------
+-- ADO: GET /_apis/hooks/subscriptions?publisherInputs.repository={repo_id}
+
+b:rest("get_repo_hooks", function(owner, repo_name)
+  -- First resolve repo ID
+  local ok, status, _, body = fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name))
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local repo_id = (DecodeJson(body) or {}).id or repo_name
+  proxy_json(
+    function(data)
+      return translate_list(translate_ado_hook, data.value)
+    end,
+    fetch_json(
+      ado_url(
+        config.base_url .. "/_apis/hooks/subscriptions?publisherInputs.repository=" .. repo_id
       )
     )
-  end,
+  )
+end)
 
-  -- Users' repos --------------------------------------------------------------
+-- Users' repos --------------------------------------------------------------
 
-  get_users_repos = function(username)
-    -- Treat username as a project name in ADO
-    local limit = tonumber(GetParam("per_page")) or 30
-    proxy_json(function(data)
-      local repos = {}
-      local all = data.value or {}
-      for i = 1, math.min(limit, #all) do
-        repos[#repos + 1] = translate_ado_repo(all[i])
+b:rest("get_users_repos", function(username)
+  -- Treat username as a project name in ADO
+  local limit = tonumber(GetParam("per_page")) or 30
+  proxy_json(function(data)
+    local repos = {}
+    local all = data.value or {}
+    for i = 1, math.min(limit, #all) do
+      repos[#repos + 1] = translate_ado_repo(all[i])
+    end
+    return repos
+  end, fetch_json(ado_url(repos_base(username))))
+end)
+
+-- Teams ---------------------------------------------------------------------
+
+b:rest("get_org_teams", function(org)
+  proxy_json(function(data)
+    return translate_list(translate_ado_team, data.value)
+  end, fetch_json(ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams")))
+end)
+
+b:rest("post_org_teams", function(org)
+  local req = DecodeJson(GetBody() or "{}")
+  local a = { name = req.name or "", description = req.description or "" }
+  proxy_json_created(
+    translate_ado_team,
+    fetch_json(
+      ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams"),
+      "POST",
+      EncodeJson(a)
+    )
+  )
+end)
+
+b:rest("get_org_team", function(org, slug)
+  local t = ado_find_team(org, slug)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_ado_team(t))
+end)
+
+b:rest("patch_org_team", function(org, slug)
+  local t = ado_find_team(org, slug)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local a = {}
+  if req.name then
+    a.name = req.name
+  end
+  if req.description then
+    a.description = req.description
+  end
+  proxy_json(
+    translate_ado_team,
+    fetch_json(
+      ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id),
+      "PATCH",
+      EncodeJson(a)
+    )
+  )
+end)
+
+b:rest("delete_org_team", function(org, slug)
+  local t = ado_find_team(org, slug)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204(
+    { 200 },
+    pcall(Fetch, ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id), dopts)
+  )
+end)
+
+b:rest("get_org_team_members", function(org, slug)
+  local t = ado_find_team(org, slug)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(
+    function(data)
+      local result = {}
+      for _, m in ipairs(data.value or {}) do
+        local ident = m.identity or {}
+        result[#result + 1] = {
+          login = ident.uniqueName or ident.displayName or "",
+          id = 0,
+          node_id = ident.id or "",
+          avatar_url = ident.imageUrl or "",
+          type = "User",
+        }
       end
-      return repos
-    end, fetch_json(ado_url(repos_base(username))))
-  end,
-
-  -- Teams ---------------------------------------------------------------------
-
-  get_org_teams = function(org)
-    proxy_json(function(data)
-      return translate_list(translate_ado_team, data.value)
-    end, fetch_json(ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams")))
-  end,
-
-  post_org_teams = function(org)
-    local req = DecodeJson(GetBody() or "{}")
-    local a = { name = req.name or "", description = req.description or "" }
-    proxy_json_created(
-      translate_ado_team,
-      fetch_json(
-        ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams"),
-        "POST",
-        EncodeJson(a)
-      )
-    )
-  end,
-
-  get_org_team = function(org, slug)
-    local t = ado_find_team(org, slug)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_ado_team(t))
-  end,
-
-  patch_org_team = function(org, slug)
-    local t = ado_find_team(org, slug)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local a = {}
-    if req.name then
-      a.name = req.name
-    end
-    if req.description then
-      a.description = req.description
-    end
-    proxy_json(
-      translate_ado_team,
-      fetch_json(
-        ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id),
-        "PATCH",
-        EncodeJson(a)
-      )
-    )
-  end,
-
-  delete_org_team = function(org, slug)
-    local t = ado_find_team(org, slug)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204(
-      { 200 },
-      pcall(
-        Fetch,
-        ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id),
-        dopts
-      )
-    )
-  end,
-
-  get_org_team_members = function(org, slug)
-    local t = ado_find_team(org, slug)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(
-      function(data)
-        local result = {}
-        for _, m in ipairs(data.value or {}) do
-          local ident = m.identity or {}
-          result[#result + 1] = {
-            login = ident.uniqueName or ident.displayName or "",
-            id = 0,
-            node_id = ident.id or "",
-            avatar_url = ident.imageUrl or "",
-            type = "User",
-          }
-        end
-        return result
-      end,
-      fetch_json(
-        ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id .. "/members")
-      )
-    )
-  end,
-
-  get_org_team_membership = function(org, slug, username)
-    local t = ado_find_team(org, slug)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status, _, body = fetch_json(
+      return result
+    end,
+    fetch_json(
       ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id .. "/members")
     )
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    for _, m in ipairs((DecodeJson(body) or {}).value or {}) do
-      local ident = m.identity or {}
-      local name = ident.uniqueName or ident.displayName or ""
-      local short = name:match("^([^@]+)") or name
-      if name == username or short == username then
-        respond_json(200, {
-          url = "",
-          role = m.isTeamAdmin and "maintainer" or "member",
-          state = "active",
-        })
-        return
-      end
-    end
+  )
+end)
+
+b:rest("get_org_team_membership", function(org, slug, username)
+  local t = ado_find_team(org, slug)
+  if not t then
     respond_json(404, { message = "Not Found" })
-  end,
-
-  -- ADO team membership is managed through security groups (no simple add/remove
-  -- in the Teams REST API). Forward as best-effort and pass through the response.
-  put_org_team_membership = function(org, slug, username)
-    local t = ado_find_team(org, slug)
-    if not t then
-      respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status, _, body = fetch_json(
+    ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id .. "/members")
+  )
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  for _, m in ipairs((DecodeJson(body) or {}).value or {}) do
+    local ident = m.identity or {}
+    local name = ident.uniqueName or ident.displayName or ""
+    local short = name:match("^([^@]+)") or name
+    if name == username or short == username then
+      respond_json(200, {
+        url = "",
+        role = m.isTeamAdmin and "maintainer" or "member",
+        state = "active",
+      })
       return
     end
-    local req = DecodeJson(GetBody() or "{}")
-    local role = req.role or "member"
-    local ok, status = fetch_json(
-      ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id .. "/members"),
-      "POST",
-      EncodeJson({ id = username })
+  end
+  respond_json(404, { message = "Not Found" })
+end)
+
+-- ADO team membership is managed through security groups (no simple add/remove
+-- in the Teams REST API). Forward as best-effort and pass through the response.
+b:rest("put_org_team_membership", function(org, slug, username)
+  local t = ado_find_team(org, slug)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local role = req.role or "member"
+  local ok, status = fetch_json(
+    ado_url(config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id .. "/members"),
+    "POST",
+    EncodeJson({ id = username })
+  )
+  -- ADO may return 400/404 here if the username isn't an AAD object ID; surface gracefully.
+  if ok and status == 200 then
+    respond_json(200, { url = "", role = role, state = "active" })
+  elseif ok and (status == 204 or status == 201) then
+    respond_json(200, { url = "", role = role, state = "active" })
+  else
+    respond_json(200, { url = "", role = role, state = "pending" })
+  end
+end)
+
+b:rest("delete_org_team_membership", function(org, slug, username)
+  local t = ado_find_team(org, slug)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  pcall(
+    Fetch,
+    ado_url(
+      config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id .. "/members/" .. username
+    ),
+    dopts
+  )
+  SetStatus(204, "No Content")
+end)
+
+-- ADO does not model team-repo associations at this level; returns empty list via default.
+-- PUT/DELETE team repo not supported in ADO model.
+b:rest("put_org_team_repo", function()
+  respond_json(
+    422,
+    "Unprocessable Entity",
+    { message = "Team repository associations are not supported by Azure DevOps" }
+  )
+end)
+b:rest("delete_org_team_repo", function()
+  SetStatus(204, "No Content")
+end)
+
+-- Legacy team-by-id API (/teams/{team_id}) ----------------------------------
+-- team_id is the ADO team GUID (e.g. "team-abc123").
+
+b:rest("get_user_teams", function()
+  proxy_json(function(data)
+    local result = {}
+    for _, t in ipairs(data.value or {}) do
+      result[#result + 1] = translate_ado_team(t)
+    end
+    return result
+  end, fetch_json(ado_url(config.base_url .. "/_apis/teams")))
+end)
+
+b:rest("get_team", function(team_id)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_ado_team(t))
+end)
+
+b:rest("patch_team", function(team_id)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local a = {}
+  if req.name then
+    a.name = req.name
+  end
+  if req.description then
+    a.description = req.description
+  end
+  proxy_json(
+    translate_ado_team,
+    fetch_json(
+      ado_url(
+        config.base_url .. "/_apis/projects/" .. (t.projectName or "") .. "/teams/" .. team_id
+      ),
+      "PATCH",
+      EncodeJson(a)
     )
-    -- ADO may return 400/404 here if the username isn't an AAD object ID; surface gracefully.
-    if ok and status == 200 then
-      respond_json(200, { url = "", role = role, state = "active" })
-    elseif ok and (status == 204 or status == 201) then
-      respond_json(200, { url = "", role = role, state = "active" })
-    else
-      respond_json(200, { url = "", role = role, state = "pending" })
-    end
-  end,
+  )
+end)
 
-  delete_org_team_membership = function(org, slug, username)
-    local t = ado_find_team(org, slug)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
+b:rest("delete_team", function(team_id)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204(
+    { 200 },
     pcall(
       Fetch,
       ado_url(
-        config.base_url .. "/_apis/projects/" .. org .. "/teams/" .. t.id .. "/members/" .. username
+        config.base_url .. "/_apis/projects/" .. (t.projectName or "") .. "/teams/" .. team_id
       ),
       dopts
     )
-    SetStatus(204, "No Content")
-  end,
+  )
+end)
 
-  -- ADO does not model team-repo associations at this level; returns empty list via default.
-  -- PUT/DELETE team repo not supported in ADO model.
-  put_org_team_repo = function()
-    respond_json(
-      422,
-      "Unprocessable Entity",
-      { message = "Team repository associations are not supported by Azure DevOps" }
-    )
-  end,
-  delete_org_team_repo = function()
-    SetStatus(204, "No Content")
-  end,
+b:rest("get_team_members", function(team_id)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local data = ado_fetch_team_members(t.projectName or "", team_id)
+  if not data then
+    respond_json(503, {})
+    return
+  end
+  local result = {}
+  for _, m in ipairs(data.value or {}) do
+    local ident = m.identity or {}
+    result[#result + 1] = {
+      login = ident.uniqueName or ident.displayName or "",
+      id = 0,
+      node_id = ident.id or "",
+      avatar_url = ident.imageUrl or "",
+      type = "User",
+    }
+  end
+  respond_json(200, result)
+end)
 
-  -- Legacy team-by-id API (/teams/{team_id}) ----------------------------------
-  -- team_id is the ADO team GUID (e.g. "team-abc123").
+b:rest("get_team_member", function(team_id, username)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local data = ado_fetch_team_members(t.projectName or "", team_id)
+  if not data then
+    respond_json(503, {})
+    return
+  end
+  for _, m in ipairs(data.value or {}) do
+    local ident = m.identity or {}
+    local name = ident.uniqueName or ident.displayName or ""
+    local short = name:match("^([^@]+)") or name
+    if name == username or short == username then
+      SetStatus(204, "No Content")
+      return
+    end
+  end
+  respond_json(404, { message = "Not Found" })
+end)
 
-  get_user_teams = function()
-    proxy_json(function(data)
+b:rest("put_team_member", function(team_id, username)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  fetch_json(
+    ado_url(
+      config.base_url
+        .. "/_apis/projects/"
+        .. (t.projectName or "")
+        .. "/teams/"
+        .. team_id
+        .. "/members"
+    ),
+    "POST",
+    EncodeJson({ id = username })
+  )
+  SetStatus(204, "No Content")
+end)
+
+b:rest("delete_team_member", function(team_id, username)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  pcall(
+    Fetch,
+    ado_url(
+      config.base_url
+        .. "/_apis/projects/"
+        .. (t.projectName or "")
+        .. "/teams/"
+        .. team_id
+        .. "/members/"
+        .. username
+    ),
+    dopts
+  )
+  SetStatus(204, "No Content")
+end)
+
+b:rest("get_team_membership", function(team_id, username)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local data = ado_fetch_team_members(t.projectName or "", team_id)
+  if not data then
+    respond_json(503, {})
+    return
+  end
+  for _, m in ipairs(data.value or {}) do
+    local ident = m.identity or {}
+    local name = ident.uniqueName or ident.displayName or ""
+    local short = name:match("^([^@]+)") or name
+    if name == username or short == username then
+      respond_json(200, {
+        url = "",
+        role = m.isTeamAdmin and "maintainer" or "member",
+        state = "active",
+      })
+      return
+    end
+  end
+  respond_json(404, { message = "Not Found" })
+end)
+
+b:rest("put_team_membership", function(team_id, username)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local role = req.role or "member"
+  local ok, status = fetch_json(
+    ado_url(
+      config.base_url
+        .. "/_apis/projects/"
+        .. (t.projectName or "")
+        .. "/teams/"
+        .. team_id
+        .. "/members"
+    ),
+    "POST",
+    EncodeJson({ id = username })
+  )
+  if ok and (status == 200 or status == 201 or status == 204) then
+    respond_json(200, { url = "", role = role, state = "active" })
+  else
+    respond_json(200, { url = "", role = role, state = "pending" })
+  end
+end)
+
+b:rest("delete_team_membership", function(team_id, username)
+  local t = ado_get_team_by_id(team_id)
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  pcall(
+    Fetch,
+    ado_url(
+      config.base_url
+        .. "/_apis/projects/"
+        .. (t.projectName or "")
+        .. "/teams/"
+        .. team_id
+        .. "/members/"
+        .. username
+    ),
+    dopts
+  )
+  SetStatus(204, "No Content")
+end)
+
+b:rest("put_team_repo", function()
+  respond_json(
+    422,
+    "Unprocessable Entity",
+    { message = "Team repository associations are not supported by Azure DevOps" }
+  )
+end)
+b:rest("delete_team_repo", function()
+  SetStatus(204, "No Content")
+end)
+
+-- Issues (Azure Boards work items) -----------------------------------------
+
+b:rest("get_repo_issues", function(owner, _repo_name)
+  local state = GetParam("state") or "open"
+  local limit = tonumber(GetParam("per_page")) or 30
+  local where = "[System.TeamProject] = '" .. owner .. "'"
+  if state == "closed" then
+    where = where .. " AND [System.State] IN ('Closed','Resolved','Done')"
+  elseif state ~= "all" then
+    where = where .. " AND [System.State] NOT IN ('Closed','Resolved','Done')"
+  end
+  local wiql_body = EncodeJson({
+    query = "SELECT [System.Id] FROM WorkItems WHERE "
+      .. where
+      .. " ORDER BY [System.ChangedDate] DESC",
+  })
+  local ok, status, _, body = fetch_json(
+    ado_url(config.base_url .. "/" .. owner .. "/_apis/wit/wiql?$top=" .. limit),
+    "POST",
+    wiql_body
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local refs = (DecodeJson(body) or {}).workItems or {}
+  if #refs == 0 then
+    Write("[]")
+    return
+  end
+  local ids = {}
+  for i = 1, math.min(limit, #refs) do
+    ids[#ids + 1] = tostring(refs[i].id or "")
+  end
+  proxy_json(
+    function(data)
       local result = {}
-      for _, t in ipairs(data.value or {}) do
-        result[#result + 1] = translate_ado_team(t)
+      for _, w in ipairs(data.value or {}) do
+        result[#result + 1] = translate_ado_workitem(w)
       end
       return result
-    end, fetch_json(ado_url(config.base_url .. "/_apis/teams")))
-  end,
-
-  get_team = function(team_id)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_ado_team(t))
-  end,
-
-  patch_team = function(team_id)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local a = {}
-    if req.name then
-      a.name = req.name
-    end
-    if req.description then
-      a.description = req.description
-    end
-    proxy_json(
-      translate_ado_team,
-      fetch_json(
-        ado_url(
-          config.base_url .. "/_apis/projects/" .. (t.projectName or "") .. "/teams/" .. team_id
-        ),
-        "PATCH",
-        EncodeJson(a)
-      )
-    )
-  end,
-
-  delete_team = function(team_id)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204(
-      { 200 },
-      pcall(
-        Fetch,
-        ado_url(
-          config.base_url .. "/_apis/projects/" .. (t.projectName or "") .. "/teams/" .. team_id
-        ),
-        dopts
-      )
-    )
-  end,
-
-  get_team_members = function(team_id)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local data = ado_fetch_team_members(t.projectName or "", team_id)
-    if not data then
-      respond_json(503, {})
-      return
-    end
-    local result = {}
-    for _, m in ipairs(data.value or {}) do
-      local ident = m.identity or {}
-      result[#result + 1] = {
-        login = ident.uniqueName or ident.displayName or "",
-        id = 0,
-        node_id = ident.id or "",
-        avatar_url = ident.imageUrl or "",
-        type = "User",
-      }
-    end
-    respond_json(200, result)
-  end,
-
-  get_team_member = function(team_id, username)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local data = ado_fetch_team_members(t.projectName or "", team_id)
-    if not data then
-      respond_json(503, {})
-      return
-    end
-    for _, m in ipairs(data.value or {}) do
-      local ident = m.identity or {}
-      local name = ident.uniqueName or ident.displayName or ""
-      local short = name:match("^([^@]+)") or name
-      if name == username or short == username then
-        SetStatus(204, "No Content")
-        return
-      end
-    end
-    respond_json(404, { message = "Not Found" })
-  end,
-
-  put_team_member = function(team_id, username)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
+    end,
     fetch_json(
       ado_url(
         config.base_url
-          .. "/_apis/projects/"
-          .. (t.projectName or "")
-          .. "/teams/"
-          .. team_id
-          .. "/members"
-      ),
-      "POST",
-      EncodeJson({ id = username })
-    )
-    SetStatus(204, "No Content")
-  end,
-
-  delete_team_member = function(team_id, username)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    pcall(
-      Fetch,
-      ado_url(
-        config.base_url
-          .. "/_apis/projects/"
-          .. (t.projectName or "")
-          .. "/teams/"
-          .. team_id
-          .. "/members/"
-          .. username
-      ),
-      dopts
-    )
-    SetStatus(204, "No Content")
-  end,
-
-  get_team_membership = function(team_id, username)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local data = ado_fetch_team_members(t.projectName or "", team_id)
-    if not data then
-      respond_json(503, {})
-      return
-    end
-    for _, m in ipairs(data.value or {}) do
-      local ident = m.identity or {}
-      local name = ident.uniqueName or ident.displayName or ""
-      local short = name:match("^([^@]+)") or name
-      if name == username or short == username then
-        respond_json(200, {
-          url = "",
-          role = m.isTeamAdmin and "maintainer" or "member",
-          state = "active",
-        })
-        return
-      end
-    end
-    respond_json(404, { message = "Not Found" })
-  end,
-
-  put_team_membership = function(team_id, username)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local role = req.role or "member"
-    local ok, status = fetch_json(
-      ado_url(
-        config.base_url
-          .. "/_apis/projects/"
-          .. (t.projectName or "")
-          .. "/teams/"
-          .. team_id
-          .. "/members"
-      ),
-      "POST",
-      EncodeJson({ id = username })
-    )
-    if ok and (status == 200 or status == 201 or status == 204) then
-      respond_json(200, { url = "", role = role, state = "active" })
-    else
-      respond_json(200, { url = "", role = role, state = "pending" })
-    end
-  end,
-
-  delete_team_membership = function(team_id, username)
-    local t = ado_get_team_by_id(team_id)
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    pcall(
-      Fetch,
-      ado_url(
-        config.base_url
-          .. "/_apis/projects/"
-          .. (t.projectName or "")
-          .. "/teams/"
-          .. team_id
-          .. "/members/"
-          .. username
-      ),
-      dopts
-    )
-    SetStatus(204, "No Content")
-  end,
-
-  put_team_repo = function()
-    respond_json(
-      422,
-      "Unprocessable Entity",
-      { message = "Team repository associations are not supported by Azure DevOps" }
-    )
-  end,
-  delete_team_repo = function()
-    SetStatus(204, "No Content")
-  end,
-
-  -- Issues (Azure Boards work items) -----------------------------------------
-
-  get_repo_issues = function(owner, _repo_name)
-    local state = GetParam("state") or "open"
-    local limit = tonumber(GetParam("per_page")) or 30
-    local where = "[System.TeamProject] = '" .. owner .. "'"
-    if state == "closed" then
-      where = where .. " AND [System.State] IN ('Closed','Resolved','Done')"
-    elseif state ~= "all" then
-      where = where .. " AND [System.State] NOT IN ('Closed','Resolved','Done')"
-    end
-    local wiql_body = EncodeJson({
-      query = "SELECT [System.Id] FROM WorkItems WHERE "
-        .. where
-        .. " ORDER BY [System.ChangedDate] DESC",
-    })
-    local ok, status, _, body = fetch_json(
-      ado_url(config.base_url .. "/" .. owner .. "/_apis/wit/wiql?$top=" .. limit),
-      "POST",
-      wiql_body
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local refs = (DecodeJson(body) or {}).workItems or {}
-    if #refs == 0 then
-      Write("[]")
-      return
-    end
-    local ids = {}
-    for i = 1, math.min(limit, #refs) do
-      ids[#ids + 1] = tostring(refs[i].id or "")
-    end
-    proxy_json(
-      function(data)
-        local result = {}
-        for _, w in ipairs(data.value or {}) do
-          result[#result + 1] = translate_ado_workitem(w)
-        end
-        return result
-      end,
-      fetch_json(
-        ado_url(
-          config.base_url
-            .. "/"
-            .. owner
-            .. "/_apis/wit/workitems?ids="
-            .. table.concat(ids, ",")
-            .. "&$expand=all"
-        )
+          .. "/"
+          .. owner
+          .. "/_apis/wit/workitems?ids="
+          .. table.concat(ids, ",")
+          .. "&$expand=all"
       )
     )
-  end,
+  )
+end)
 
-  get_repo_issue = function(owner, _repo_name, issue_number)
+b:rest("get_repo_issue", function(owner, _repo_name, issue_number)
+  proxy_json(
+    translate_ado_workitem,
+    fetch_json(
+      ado_url(
+        config.base_url .. "/" .. owner .. "/_apis/wit/workitems/" .. issue_number .. "?$expand=all"
+      )
+    )
+  )
+end)
+
+b:rest("post_repo_issues", function(owner, _repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local patch = {
+    { op = "add", path = "/fields/System.Title", value = req.title or "" },
+  }
+  if req.body then
+    patch[#patch + 1] = { op = "add", path = "/fields/System.Description", value = req.body }
+  end
+  local opts = auth() or {}
+  opts.method = "POST"
+  opts.body = EncodeJson(patch)
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "application/json-patch+json"
+  proxy_json_created(
+    translate_ado_workitem,
+    pcall(Fetch, ado_url(config.base_url .. "/" .. owner .. "/_apis/wit/workitems/$Issue"), opts)
+  )
+end)
+
+b:rest("patch_repo_issue", function(owner, _repo_name, issue_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local patch = {}
+  if req.title ~= nil then
+    patch[#patch + 1] = { op = "replace", path = "/fields/System.Title", value = req.title }
+  end
+  if req.body ~= nil then
+    patch[#patch + 1] = { op = "replace", path = "/fields/System.Description", value = req.body }
+  end
+  if req.state == "closed" then
+    patch[#patch + 1] = { op = "replace", path = "/fields/System.State", value = "Closed" }
+  elseif req.state == "open" then
+    patch[#patch + 1] = { op = "replace", path = "/fields/System.State", value = "Active" }
+  end
+  if #patch == 0 then
     proxy_json(
       translate_ado_workitem,
       fetch_json(
@@ -1173,196 +1211,145 @@ app.backend_impl = {
         )
       )
     )
-  end,
+    return
+  end
+  local opts = auth() or {}
+  opts.method = "PATCH"
+  opts.body = EncodeJson(patch)
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "application/json-patch+json"
+  local pok, pstatus, _, pbody = pcall(
+    Fetch,
+    ado_url(config.base_url .. "/" .. owner .. "/_apis/wit/workitems/" .. issue_number),
+    opts
+  )
+  if pok and pstatus == 200 then
+    respond_json(200, translate_ado_workitem(DecodeJson(pbody) or {}))
+  elseif pok then
+    respond_json(pstatus, {})
+  else
+    respond_json(503, {})
+  end
+end)
 
-  post_repo_issues = function(owner, _repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local patch = {
-      { op = "add", path = "/fields/System.Title", value = req.title or "" },
-    }
-    if req.body then
-      patch[#patch + 1] = { op = "add", path = "/fields/System.Description", value = req.body }
-    end
-    local opts = auth() or {}
-    opts.method = "POST"
-    opts.body = EncodeJson(patch)
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "application/json-patch+json"
-    proxy_json_created(
-      translate_ado_workitem,
-      pcall(Fetch, ado_url(config.base_url .. "/" .. owner .. "/_apis/wit/workitems/$Issue"), opts)
-    )
-  end,
-
-  patch_repo_issue = function(owner, _repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local patch = {}
-    if req.title ~= nil then
-      patch[#patch + 1] = { op = "replace", path = "/fields/System.Title", value = req.title }
-    end
-    if req.body ~= nil then
-      patch[#patch + 1] = { op = "replace", path = "/fields/System.Description", value = req.body }
-    end
-    if req.state == "closed" then
-      patch[#patch + 1] = { op = "replace", path = "/fields/System.State", value = "Closed" }
-    elseif req.state == "open" then
-      patch[#patch + 1] = { op = "replace", path = "/fields/System.State", value = "Active" }
-    end
-    if #patch == 0 then
-      proxy_json(
-        translate_ado_workitem,
-        fetch_json(
-          ado_url(
-            config.base_url
-              .. "/"
-              .. owner
-              .. "/_apis/wit/workitems/"
-              .. issue_number
-              .. "?$expand=all"
-          )
-        )
-      )
-      return
-    end
-    local opts = auth() or {}
-    opts.method = "PATCH"
-    opts.body = EncodeJson(patch)
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "application/json-patch+json"
-    local pok, pstatus, _, pbody = pcall(
-      Fetch,
-      ado_url(config.base_url .. "/" .. owner .. "/_apis/wit/workitems/" .. issue_number),
-      opts
-    )
-    if pok and pstatus == 200 then
-      respond_json(200, translate_ado_workitem(DecodeJson(pbody) or {}))
-    elseif pok then
-      respond_json(pstatus, {})
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  get_issue_comments = function(owner, _repo_name, issue_number)
-    proxy_json(
-      function(data)
-        local result = {}
-        for _, c in ipairs(data.value or {}) do
-          result[#result + 1] = translate_ado_workitem_comment(c)
-        end
-        return result
-      end,
-      fetch_json(
-        ado_url(
-          config.base_url .. "/" .. owner .. "/_apis/wit/workitems/" .. issue_number .. "/comments"
-        )
+b:rest("get_issue_comments", function(owner, _repo_name, issue_number)
+  proxy_json(
+    function(data)
+      local result = {}
+      for _, c in ipairs(data.value or {}) do
+        result[#result + 1] = translate_ado_workitem_comment(c)
+      end
+      return result
+    end,
+    fetch_json(
+      ado_url(
+        config.base_url .. "/" .. owner .. "/_apis/wit/workitems/" .. issue_number .. "/comments"
       )
     )
-  end,
+  )
+end)
 
-  post_issue_comment = function(owner, _repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}")
-    proxy_json_created(
-      translate_ado_workitem_comment,
-      fetch_json(
-        ado_url(
-          config.base_url .. "/" .. owner .. "/_apis/wit/workitems/" .. issue_number .. "/comments"
-        ),
-        "POST",
-        EncodeJson({ text = req.body or "" })
-      )
+b:rest("post_issue_comment", function(owner, _repo_name, issue_number)
+  local req = DecodeJson(GetBody() or "{}")
+  proxy_json_created(
+    translate_ado_workitem_comment,
+    fetch_json(
+      ado_url(
+        config.base_url .. "/" .. owner .. "/_apis/wit/workitems/" .. issue_number .. "/comments"
+      ),
+      "POST",
+      EncodeJson({ text = req.body or "" })
     )
-  end,
+  )
+end)
 
-  -- Checks (via ADO git commit statuses) -------------------------------------
+-- Checks (via ADO git commit statuses) -------------------------------------
 
-  -- POST /repos/{owner}/{repo}/check-runs
-  post_check_runs = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local sha = req.head_sha or ""
-    proxy_json_created(
-      translate_ado_status_to_check_run,
-      fetch_json(
-        ado_url(repos_base(owner) .. "/" .. repo_name .. "/commits/" .. sha .. "/statuses"),
-        "POST",
-        gh_check_run_to_ado_status(req)
-      )
+-- POST /repos/{owner}/{repo}/check-runs
+b:rest("post_check_runs", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local sha = req.head_sha or ""
+  proxy_json_created(
+    translate_ado_status_to_check_run,
+    fetch_json(
+      ado_url(repos_base(owner) .. "/" .. repo_name .. "/commits/" .. sha .. "/statuses"),
+      "POST",
+      gh_check_run_to_ado_status(req)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local ok, status, _, body = fetch_json(
-      ado_url(repos_base(owner) .. "/" .. repo_name .. "/commits/" .. ref .. "/statuses")
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local list = data.value or {}
-    local runs = {}
-    for _, s in ipairs(list) do
-      runs[#runs + 1] = translate_ado_status_to_check_run(s)
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local ok, status, _, body =
+    fetch_json(ado_url(repos_base(owner) .. "/" .. repo_name .. "/commits/" .. ref .. "/statuses"))
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local list = data.value or {}
+  local runs = {}
+  for _, s in ipairs(list) do
+    runs[#runs + 1] = translate_ado_status_to_check_run(s)
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
 
-  -- POST /repos/{owner}/{repo}/check-suites
-  post_check_suites = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    respond_json(201, {
-      id = 0,
-      node_id = "",
-      head_sha = req.head_sha or "",
-      status = "queued",
-      conclusion = nil,
-      url = "",
-      repository = { id = 0, name = repo_name, full_name = owner .. "/" .. repo_name },
-    })
-  end,
+-- POST /repos/{owner}/{repo}/check-suites
+b:rest("post_check_suites", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  respond_json(201, {
+    id = 0,
+    node_id = "",
+    head_sha = req.head_sha or "",
+    status = "queued",
+    conclusion = nil,
+    url = "",
+    repository = { id = 0, name = repo_name, full_name = owner .. "/" .. repo_name },
+  })
+end)
 
-  -- GET /repos/{owner}/{repo}/check-suites/{check_suite_id}
-  get_check_suite = function(owner, repo_name, check_suite_id)
-    respond_json(200, {
-      id = tonumber(check_suite_id) or 0,
-      node_id = "",
-      head_sha = "",
-      status = "completed",
-      conclusion = "success",
-      url = "",
-      repository = { id = 0, name = repo_name, full_name = owner .. "/" .. repo_name },
-    })
-  end,
+-- GET /repos/{owner}/{repo}/check-suites/{check_suite_id}
+b:rest("get_check_suite", function(owner, repo_name, check_suite_id)
+  respond_json(200, {
+    id = tonumber(check_suite_id) or 0,
+    node_id = "",
+    head_sha = "",
+    status = "completed",
+    conclusion = "success",
+    url = "",
+    repository = { id = 0, name = repo_name, full_name = owner .. "/" .. repo_name },
+  })
+end)
 
-  -- Code Scanning (via ADO Advanced Security / GHAzDO) ------------------------
-  --
-  -- Azure DevOps Advanced Security provides code scanning alerts at the
-  -- repository level via:
-  --   GET  /{owner}/_apis/advancedsecurity/alerts/{repo}?alertType=code
-  --   GET  /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
-  --   PATCH /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
-  --   GET  /{owner}/_apis/advancedsecurity/analyses/{repo}
-  --   POST /{owner}/_apis/advancedsecurity/sarifs/{repo}
-  --
-  -- Org-level alert listing is not natively supported; returns empty list.
-  -- CodeQL databases, variant analyses, default-setup, and per-analysis
-  -- detail/delete have no direct ADO equivalent and fall back to 501.
-  --
-  -- ADO alert state mapping:
-  --   active    → open
-  --   dismissed → dismissed
-  --   fixed     → fixed
-  --
-  -- ADO dismissal reason mapping:
-  --   falsePositive  → false positive
-  --   wontFix        → won't fix
-  --   (other)        → used in tests
-}
+-- Code Scanning (via ADO Advanced Security / GHAzDO) ------------------------
+--
+-- Azure DevOps Advanced Security provides code scanning alerts at the
+-- repository level via:
+--   GET  /{owner}/_apis/advancedsecurity/alerts/{repo}?alertType=code
+--   GET  /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
+--   PATCH /{owner}/_apis/advancedsecurity/alerts/{repo}/{alertId}
+--   GET  /{owner}/_apis/advancedsecurity/analyses/{repo}
+--   POST /{owner}/_apis/advancedsecurity/sarifs/{repo}
+--
+-- Org-level alert listing is not natively supported; returns empty list.
+-- CodeQL databases, variant analyses, default-setup, and per-analysis
+-- detail/delete have no direct ADO equivalent and fall back to 501.
+--
+-- ADO alert state mapping:
+--   active    → open
+--   dismissed → dismissed
+--   fixed     → fixed
+--
+-- ADO dismissal reason mapping:
+--   falsePositive  → false positive
+--   wontFix        → won't fix
+--   (other)        → used in tests
 
 local ADVSEC_API_VER = "api-version=7.2-preview.1"
 
@@ -1472,12 +1459,9 @@ local function translate_ado_analysis(an)
   }
 end
 
--- Patch app.backend_impl with code scanning handlers.
--- (app.backend_impl was already assigned above; we extend it here to keep the
--- check-suite section self-contained and avoid one giant table.)
-local _b = app.backend_impl
+-- Code scanning handlers (kept below for readability; same builder b).
 
-_b.list_repo_code_scanning_alerts = function(owner, repo_name)
+b:rest("list_repo_code_scanning_alerts", function(owner, repo_name)
   local alert_type = GetParam("tool_name") or "code"
   local url =
     advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "?alertType=" .. alert_type)
@@ -1492,9 +1476,9 @@ _b.list_repo_code_scanning_alerts = function(owner, repo_name)
   end
   local data = DecodeJson(body) or {}
   respond_json(200, translate_list(translate_ado_alert, data.value))
-end
+end)
 
-_b.get_code_scanning_alert = function(owner, repo_name, alert_number)
+b:rest("get_code_scanning_alert", function(owner, repo_name, alert_number)
   local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "/" .. alert_number)
   local ok, status, _, body = fetch_json(url)
   if not ok then
@@ -1506,9 +1490,9 @@ _b.get_code_scanning_alert = function(owner, repo_name, alert_number)
     return
   end
   respond_json(200, translate_ado_alert(DecodeJson(body) or {}))
-end
+end)
 
-_b.update_code_scanning_alert = function(owner, repo_name, alert_number)
+b:rest("update_code_scanning_alert", function(owner, repo_name, alert_number)
   local req = DecodeJson(GetBody() or "{}")
   local ado_state = GH_STATE_TO_ADO[req.state or ""] or "active"
   local patch = { state = ado_state }
@@ -1529,9 +1513,9 @@ _b.update_code_scanning_alert = function(owner, repo_name, alert_number)
     return
   end
   respond_json(200, translate_ado_alert(DecodeJson(body) or {}))
-end
+end)
 
-_b.list_code_scanning_analyses = function(owner, repo_name)
+b:rest("list_code_scanning_analyses", function(owner, repo_name)
   local url = advsec_url(advsec_base(owner) .. "/analyses/" .. repo_name)
   local ok, status, _, body = fetch_json(url)
   if not ok then
@@ -1544,9 +1528,9 @@ _b.list_code_scanning_analyses = function(owner, repo_name)
   end
   local data = DecodeJson(body) or {}
   respond_json(200, translate_list(translate_ado_analysis, data.value))
-end
+end)
 
-_b.upload_code_scanning_sarif = function(owner, repo_name)
+b:rest("upload_code_scanning_sarif", function(owner, repo_name)
   local body = GetBody() or "{}"
   local url = advsec_url(advsec_base(owner) .. "/sarifs/" .. repo_name)
   local ok, status, _, rbody = fetch_json(url, "POST", body)
@@ -1563,7 +1547,7 @@ _b.upload_code_scanning_sarif = function(owner, repo_name)
   else
     respond_json(status, {})
   end
-end
+end)
 
 -- Dependabot alerts via ADO Advanced Security dependency scanning -----------------
 --
@@ -1645,7 +1629,7 @@ local function translate_ado_dependency_alert(a)
   }
 end
 
-_b.list_repo_dependabot_alerts = function(owner, repo_name)
+b:rest("list_repo_dependabot_alerts", function(owner, repo_name)
   local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "?alertType=dependency")
   local ok, status, _, body = fetch_json(url)
   if not ok then
@@ -1658,9 +1642,9 @@ _b.list_repo_dependabot_alerts = function(owner, repo_name)
   end
   local data = DecodeJson(body) or {}
   respond_json(200, translate_list(translate_ado_dependency_alert, data.value))
-end
+end)
 
-_b.get_repo_dependabot_alert = function(owner, repo_name, alert_number)
+b:rest("get_repo_dependabot_alert", function(owner, repo_name, alert_number)
   local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "/" .. alert_number)
   local ok, status, _, body = fetch_json(url)
   if not ok then
@@ -1672,9 +1656,9 @@ _b.get_repo_dependabot_alert = function(owner, repo_name, alert_number)
     return
   end
   respond_json(200, translate_ado_dependency_alert(DecodeJson(body) or {}))
-end
+end)
 
-_b.update_repo_dependabot_alert = function(owner, repo_name, alert_number)
+b:rest("update_repo_dependabot_alert", function(owner, repo_name, alert_number)
   local req = DecodeJson(GetBody() or "{}")
   local ado_state = GH_STATE_TO_ADO[req.state or ""] or "active"
   local patch = { state = ado_state }
@@ -1695,7 +1679,7 @@ _b.update_repo_dependabot_alert = function(owner, repo_name, alert_number)
     return
   end
   respond_json(200, translate_ado_dependency_alert(DecodeJson(body) or {}))
-end
+end)
 
 -- Secret Scanning via ADO Advanced Security -----------------------------------------
 --
@@ -1778,7 +1762,7 @@ local function translate_ado_secret_alert(a)
   }
 end
 
-_b.list_repo_secret_scanning_alerts = function(owner, repo_name)
+b:rest("list_repo_secret_scanning_alerts", function(owner, repo_name)
   local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "?alertType=secret")
   local ok, status, _, body = fetch_json(url)
   if not ok then
@@ -1791,9 +1775,9 @@ _b.list_repo_secret_scanning_alerts = function(owner, repo_name)
   end
   local data = DecodeJson(body) or {}
   respond_json(200, translate_list(translate_ado_secret_alert, data.value))
-end
+end)
 
-_b.get_secret_scanning_alert = function(owner, repo_name, alert_number)
+b:rest("get_secret_scanning_alert", function(owner, repo_name, alert_number)
   local url = advsec_url(advsec_base(owner) .. "/alerts/" .. repo_name .. "/" .. alert_number)
   local ok, status, _, body = fetch_json(url)
   if not ok then
@@ -1805,9 +1789,9 @@ _b.get_secret_scanning_alert = function(owner, repo_name, alert_number)
     return
   end
   respond_json(200, translate_ado_secret_alert(DecodeJson(body) or {}))
-end
+end)
 
-_b.update_secret_scanning_alert = function(owner, repo_name, alert_number)
+b:rest("update_secret_scanning_alert", function(owner, repo_name, alert_number)
   local req = DecodeJson(GetBody() or "{}")
   local ado_state = GH_STATE_TO_ADO[req.state or ""] or "active"
   local patch = { state = ado_state }
@@ -1828,13 +1812,13 @@ _b.update_secret_scanning_alert = function(owner, repo_name, alert_number)
     return
   end
   respond_json(200, translate_ado_secret_alert(DecodeJson(body) or {}))
-end
+end)
 
 -- Git database (refs only; blobs/commits/tag-objects/trees have no ADO equivalent) ----
 
 local ZERO_SHA = "0000000000000000000000000000000000000000"
 
-_b.list_git_matching_refs = function(owner, repo_name, ref)
+b:rest("list_git_matching_refs", function(owner, repo_name, ref)
   local filter
   if ref:sub(1, 6) == "heads/" or ref:sub(1, 5) == "tags/" then
     filter = ref
@@ -1849,9 +1833,9 @@ _b.list_git_matching_refs = function(owner, repo_name, ref)
     end
     return refs
   end, fetch_json(url))
-end
+end)
 
-_b.get_git_ref = function(owner, repo_name, ref)
+b:rest("get_git_ref", function(owner, repo_name, ref)
   local filter
   if ref:sub(1, 6) == "heads/" or ref:sub(1, 5) == "tags/" then
     filter = ref
@@ -1864,9 +1848,9 @@ _b.get_git_ref = function(owner, repo_name, ref)
     local first = (data.value or {})[1]
     return first and translate_ado_ref(first) or {}
   end, fetch_json(url))
-end
+end)
 
-_b.create_git_ref = function(owner, repo_name)
+b:rest("create_git_ref", function(owner, repo_name)
   local req = DecodeJson(GetBody() or "{}")
   local full_ref = req.ref or ""
   local sha = req.sha or ""
@@ -1886,9 +1870,9 @@ _b.create_git_ref = function(owner, repo_name)
   local data = DecodeJson(body) or {}
   local first = (data.value or {})[1]
   respond_json(201, first and translate_ado_ref(first) or {})
-end
+end)
 
-_b.delete_git_ref = function(owner, repo_name, ref)
+b:rest("delete_git_ref", function(owner, repo_name, ref)
   local full_ref
   if ref:sub(1, 6) == "heads/" or ref:sub(1, 5) == "tags/" then
     full_ref = "refs/" .. ref
@@ -1915,14 +1899,14 @@ _b.delete_git_ref = function(owner, repo_name, ref)
     { name = full_ref, newObjectId = ZERO_SHA, oldObjectId = old_sha },
   })
   proxy_204({ 200 }, fetch_json(url, "POST", del_body))
-end
+end)
 
 -- GraphQL resolvers -----------------------------------------------------------
 -- Minimum foothold: Query.repository and node.Repository only.
 -- ADO has no GET /user, so Query.viewer returns null (handled by default).
 -- Work Items ≠ GitHub Issues, so issue resolvers are omitted.
 
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -1932,9 +1916,9 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(translate_ado_repo(data))
-end
+end)
 
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local owner, name = local_id:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1944,4 +1928,6 @@ graphql_resolvers["node.Repository"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_repo(translate_ado_repo(data))
-end
+end)
+
+b:build()

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -619,614 +619,636 @@ local function snippet_url(gist_id)
   return base() .. "/snippets/" .. ws .. "/" .. eid
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/user", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/user", auth()))
+end)
 
-  get_repo = proxy_handler(translate_bb_repo, function(o, r)
+b:rest(
+  "get_repo",
+  proxy_handler(translate_bb_repo, function(o, r)
     return base() .. "/repositories/" .. o .. "/" .. r
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    proxy_json(
-      translate_bb_repo,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name,
-        "PUT",
-        translate_bb_req(GetBody())
-      )
+b:rest("patch_repo", function(owner, repo_name)
+  proxy_json(
+    translate_bb_repo,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name,
+      "PUT",
+      translate_bb_req(GetBody())
     )
-  end,
+  )
+end)
 
-  delete_repo = function(owner, repo_name)
-    local url = base() .. "/repositories/" .. owner .. "/" .. repo_name
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, url, dopts))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  local url = base() .. "/repositories/" .. owner .. "/" .. repo_name
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, url, dopts))
+end)
 
-  get_user_repos = function()
-    -- Bitbucket: list repos for authenticated user via /repositories?role=member
-    proxy_json(function(data)
-      local repos = data.values or {}
-      for i, r in ipairs(repos) do
-        repos[i] = translate_bb_repo(r)
-      end
-      return repos
-    end, fetch_json(append_page_params(base() .. "/repositories?role=member", PAGES)))
-  end,
-
-  post_user_repos = function()
-    -- Bitbucket requires workspace; no equivalent single endpoint.
-    respond_json(
-      501,
-      "Not Implemented",
-      { message = "POST /user/repos requires workspace context; use POST /orgs/{workspace}/repos" }
-    )
-  end,
-
-  get_org_repos = function(workspace)
-    proxy_json(function(data)
-      local repos = data.values or {}
-      for i, r in ipairs(repos) do
-        repos[i] = translate_bb_repo(r)
-      end
-      return repos
-    end, fetch_json(append_page_params(base() .. "/repositories/" .. workspace, PAGES)))
-  end,
-
-  post_org_repos = function(workspace)
-    local raw = GetBody() or "{}"
-    local req = DecodeJson(raw)
-    local slug = req.name
-    if not slug then
-      respond_json(422, { message = "name required" })
-      return
+b:rest("get_user_repos", function()
+  -- Bitbucket: list repos for authenticated user via /repositories?role=member
+  proxy_json(function(data)
+    local repos = data.values or {}
+    for i, r in ipairs(repos) do
+      repos[i] = translate_bb_repo(r)
     end
-    proxy_json_created(
-      translate_bb_repo,
-      fetch_json(
-        base() .. "/repositories/" .. workspace .. "/" .. slug,
-        "POST",
-        translate_bb_req(raw)
-      )
-    )
-  end,
+    return repos
+  end, fetch_json(append_page_params(base() .. "/repositories?role=member", PAGES)))
+end)
 
-  -- GET /users/{username}/repos
-  get_users_repos = function(username)
-    proxy_json(function(data)
-      local repos = data.values or {}
-      for i, r in ipairs(repos) do
-        repos[i] = translate_bb_repo(r)
+b:rest("post_user_repos", function()
+  -- Bitbucket requires workspace; no equivalent single endpoint.
+  respond_json(
+    501,
+    "Not Implemented",
+    { message = "POST /user/repos requires workspace context; use POST /orgs/{workspace}/repos" }
+  )
+end)
+
+b:rest("get_org_repos", function(workspace)
+  proxy_json(function(data)
+    local repos = data.values or {}
+    for i, r in ipairs(repos) do
+      repos[i] = translate_bb_repo(r)
+    end
+    return repos
+  end, fetch_json(append_page_params(base() .. "/repositories/" .. workspace, PAGES)))
+end)
+
+b:rest("post_org_repos", function(workspace)
+  local raw = GetBody() or "{}"
+  local req = DecodeJson(raw)
+  local slug = req.name
+  if not slug then
+    respond_json(422, { message = "name required" })
+    return
+  end
+  proxy_json_created(
+    translate_bb_repo,
+    fetch_json(
+      base() .. "/repositories/" .. workspace .. "/" .. slug,
+      "POST",
+      translate_bb_req(raw)
+    )
+  )
+end)
+
+-- GET /users/{username}/repos
+b:rest("get_users_repos", function(username)
+  proxy_json(function(data)
+    local repos = data.values or {}
+    for i, r in ipairs(repos) do
+      repos[i] = translate_bb_repo(r)
+    end
+    return repos
+  end, fetch_json(append_page_params(base() .. "/repositories/" .. username, PAGES)))
+end)
+
+-- GET /repositories (public)
+b:rest("get_repositories", function()
+  proxy_json(function(data)
+    local repos = data.values or {}
+    for i, r in ipairs(repos) do
+      repos[i] = translate_bb_repo(r)
+    end
+    return repos
+  end, fetch_json(append_page_params(base() .. "/repositories", PAGES)))
+end)
+
+b:rest("get_repo_languages", function(owner, repo_name)
+  -- Bitbucket exposes primary language only via repo object; no language breakdown.
+  proxy_json(function(r)
+    local lang = r.language
+    return lang and lang ~= "" and { [lang] = 0 } or {}
+  end, fetch_json(base() .. "/repositories/" .. owner .. "/" .. repo_name))
+end)
+
+b:rest("get_repo_tags", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local tags = data.values or {}
+      for i, t in ipairs(tags) do
+        local tgt = t.target or {}
+        tags[i] = { name = t.name, commit = { sha = tgt.hash or "", url = "" } }
       end
-      return repos
-    end, fetch_json(append_page_params(base() .. "/repositories/" .. username, PAGES)))
-  end,
-
-  -- GET /repositories (public)
-  get_repositories = function()
-    proxy_json(function(data)
-      local repos = data.values or {}
-      for i, r in ipairs(repos) do
-        repos[i] = translate_bb_repo(r)
-      end
-      return repos
-    end, fetch_json(append_page_params(base() .. "/repositories", PAGES)))
-  end,
-
-  get_repo_languages = function(owner, repo_name)
-    -- Bitbucket exposes primary language only via repo object; no language breakdown.
-    proxy_json(function(r)
-      local lang = r.language
-      return lang and lang ~= "" and { [lang] = 0 } or {}
-    end, fetch_json(base() .. "/repositories/" .. owner .. "/" .. repo_name))
-  end,
-
-  get_repo_tags = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local tags = data.values or {}
-        for i, t in ipairs(tags) do
-          local tgt = t.target or {}
-          tags[i] = { name = t.name, commit = { sha = tgt.hash or "", url = "" } }
-        end
-        return tags
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/tags",
-          PAGES
-        )
+      return tags
+    end,
+    fetch_json(
+      append_page_params(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/tags",
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  -- Branches ------------------------------------------------------------------
+-- Branches ------------------------------------------------------------------
 
-  get_repo_branches = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local branches = data.values or {}
-        for i, b in ipairs(branches) do
-          branches[i] = {
-            name = b.name,
-            commit = { sha = (b.target and b.target.hash) or "", url = "" },
-            protected = false,
-          }
-        end
-        return branches
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/branches",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  get_repo_branch = function(owner, repo_name, branch)
-    proxy_json(
-      function(b)
-        return {
-          name = b.name,
-          commit = { sha = (b.target and b.target.hash) or "", url = "" },
+b:rest("get_repo_branches", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local branches = data.values or {}
+      for i, br in ipairs(branches) do
+        branches[i] = {
+          name = br.name,
+          commit = { sha = (br.target and br.target.hash) or "", url = "" },
           protected = false,
         }
-      end,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/branches/" .. branch
+      end
+      return branches
+    end,
+    fetch_json(
+      append_page_params(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/branches",
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  -- Commits -------------------------------------------------------------------
+b:rest("get_repo_branch", function(owner, repo_name, branch)
+  proxy_json(
+    function(br)
+      return {
+        name = br.name,
+        commit = { sha = (br.target and br.target.hash) or "", url = "" },
+        protected = false,
+      }
+    end,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/branches/" .. branch
+    )
+  )
+end)
 
-  get_repo_commits = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local commits = data.values or {}
-        for i, c in ipairs(commits) do
-          commits[i] = translate_bb_commit(c)
-        end
-        return commits
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commits",
-          PAGES
-        )
+-- Commits -------------------------------------------------------------------
+
+b:rest("get_repo_commits", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local commits = data.values or {}
+      for i, c in ipairs(commits) do
+        commits[i] = translate_bb_commit(c)
+      end
+      return commits
+    end,
+    fetch_json(
+      append_page_params(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commits",
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  get_repo_commit = proxy_handler(translate_bb_commit, function(o, r, sha)
+b:rest(
+  "get_repo_commit",
+  proxy_handler(translate_bb_commit, function(o, r, sha)
     return base() .. "/repositories/" .. o .. "/" .. r .. "/commit/" .. sha
-  end),
+  end)
+)
 
-  -- Commit statuses -----------------------------------------------------------
+-- Commit statuses -----------------------------------------------------------
 
-  get_commit_statuses = function(owner, repo_name, sha)
-    proxy_json(
-      function(data)
-        local statuses = data.values or {}
-        for i, s in ipairs(statuses) do
-          statuses[i] = translate_bb_status(s)
-        end
-        return statuses
-      end,
-      fetch_json(
-        append_page_params(
-          base()
-            .. "/repositories/"
-            .. owner
-            .. "/"
-            .. repo_name
-            .. "/commit/"
-            .. sha
-            .. "/statuses",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  get_commit_combined_status = function(owner, repo_name, sha)
-    proxy_json(
-      function(data)
-        local statuses = data.values or {}
-        local combined = "success"
-        for _, s in ipairs(statuses) do
-          local g = bb_state_to_github(s.state)
-          if g == "failure" or g == "error" then
-            combined = g
-            break
-          elseif g == "pending" then
-            combined = "pending"
-          end
-        end
-        local out = {}
-        for i, s in ipairs(statuses) do
-          out[i] = translate_bb_status(s)
-        end
-        return { state = combined, statuses = out, total_count = #out }
-      end,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commit/" .. sha .. "/statuses"
-      )
-    )
-  end,
-
-  post_commit_status = function(owner, repo_name, sha)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = {
-      state = github_state_to_bb(req.state or ""),
-      key = req.context or "default",
-      url = req.target_url or "",
-      name = req.context or "default",
-      description = req.description or "",
-    }
-    proxy_json(
-      translate_bb_status,
-      fetch_json(
-        base()
-          .. "/repositories/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/commit/"
-          .. sha
-          .. "/statuses/build",
-        "POST",
-        EncodeJson(bb)
-      )
-    )
-  end,
-
-  -- Contents ------------------------------------------------------------------
-
-  get_repo_readme = function(owner, repo_name)
-    local repo_url = base() .. "/repositories/" .. owner .. "/" .. repo_name
-    local ok, status, _, body = fetch_json(repo_url)
-    if not ok or status ~= 200 then
-      respond_json(404, {})
-      return
-    end
-    local repo = DecodeJson(body or "{}")
-    local ref = (repo.mainbranch and repo.mainbranch.name) or "HEAD"
-    for _, name in ipairs({ "README.md", "README", "readme.md", "Readme.md" }) do
-      local ok2, status2, _, body2 = fetch_json(repo_url .. "/src/" .. ref .. "/" .. name)
-      if ok2 and status2 == 200 then
-        respond_json(200, {
-          type = "file",
-          encoding = "base64",
-          content = EncodeBase64(body2 or ""),
-          name = name,
-          path = name,
-          sha = "",
-          size = #(body2 or ""),
-        })
-        return
+b:rest("get_commit_statuses", function(owner, repo_name, sha)
+  proxy_json(
+    function(data)
+      local statuses = data.values or {}
+      for i, s in ipairs(statuses) do
+        statuses[i] = translate_bb_status(s)
       end
-    end
-    respond_json(404, { message = "README not found" })
-  end,
-
-  get_repo_content = function(owner, repo_name, path)
-    local ref = GetParam("ref") or "HEAD"
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/src/" .. ref .. "/" .. path
+      return statuses
+    end,
+    fetch_json(
+      append_page_params(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commit/" .. sha .. "/statuses",
+        PAGES
+      )
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    -- Detect directory listing (JSON with "values") vs raw file content
-    local parsed = (body and body:sub(1, 1) == "{") and DecodeJson(body) or nil
-    if parsed and parsed.values then
+  )
+end)
+
+b:rest("get_commit_combined_status", function(owner, repo_name, sha)
+  proxy_json(
+    function(data)
+      local statuses = data.values or {}
+      local combined = "success"
+      for _, s in ipairs(statuses) do
+        local g = bb_state_to_github(s.state)
+        if g == "failure" or g == "error" then
+          combined = g
+          break
+        elseif g == "pending" then
+          combined = "pending"
+        end
+      end
       local out = {}
-      for _, e in ipairs(parsed.values or {}) do
-        out[#out + 1] = {
-          type = e.type == "commit_directory" and "dir" or "file",
-          name = e.path and e.path:match("[^/]+$") or "",
-          path = e.path or "",
-          sha = "",
-          size = e.size or 0,
-        }
+      for i, s in ipairs(statuses) do
+        out[i] = translate_bb_status(s)
       end
-      respond_json(200, out)
-    else
+      return { state = combined, statuses = out, total_count = #out }
+    end,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commit/" .. sha .. "/statuses"
+    )
+  )
+end)
+
+b:rest("post_commit_status", function(owner, repo_name, sha)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = {
+    state = github_state_to_bb(req.state or ""),
+    key = req.context or "default",
+    url = req.target_url or "",
+    name = req.context or "default",
+    description = req.description or "",
+  }
+  proxy_json(
+    translate_bb_status,
+    fetch_json(
+      base()
+        .. "/repositories/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/commit/"
+        .. sha
+        .. "/statuses/build",
+      "POST",
+      EncodeJson(bb)
+    )
+  )
+end)
+
+-- Contents ------------------------------------------------------------------
+
+b:rest("get_repo_readme", function(owner, repo_name)
+  local repo_url = base() .. "/repositories/" .. owner .. "/" .. repo_name
+  local ok, status, _, body = fetch_json(repo_url)
+  if not ok or status ~= 200 then
+    respond_json(404, {})
+    return
+  end
+  local repo = DecodeJson(body or "{}")
+  local ref = (repo.mainbranch and repo.mainbranch.name) or "HEAD"
+  for _, name in ipairs({ "README.md", "README", "readme.md", "Readme.md" }) do
+    local ok2, status2, _, body2 = fetch_json(repo_url .. "/src/" .. ref .. "/" .. name)
+    if ok2 and status2 == 200 then
       respond_json(200, {
         type = "file",
         encoding = "base64",
-        content = EncodeBase64(body or ""),
-        name = path:match("[^/]+$") or path,
-        path = path,
+        content = EncodeBase64(body2 or ""),
+        name = name,
+        path = name,
         sha = "",
-        size = #(body or ""),
+        size = #(body2 or ""),
       })
-    end
-  end,
-
-  -- GET /repos/{owner}/{repo}/license
-  -- Bitbucket has no license template API; fetch the LICENSE file via src endpoint.
-  get_repo_license = function(owner, repo_name)
-    local repo_url = base() .. "/repositories/" .. owner .. "/" .. repo_name
-    local ok, status, _, body = fetch_json(repo_url)
-    if not ok or status ~= 200 then
-      respond_json(404, {})
       return
     end
-    local repo = DecodeJson(body or "{}")
-    local ref = (repo.mainbranch and repo.mainbranch.name) or "HEAD"
-    for _, name in ipairs({ "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }) do
-      local ok2, status2, _, body2 = fetch_json(repo_url .. "/src/" .. ref .. "/" .. name)
-      if ok2 and status2 == 200 then
-        respond_json(200, {
-          type = "file",
-          encoding = "base64",
-          content = EncodeBase64(body2 or ""),
-          name = name,
-          path = name,
-          sha = "",
-          size = #(body2 or ""),
-          license = nil,
-        })
-        return
+  end
+  respond_json(404, { message = "README not found" })
+end)
+
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local ref = GetParam("ref") or "HEAD"
+  local ok, status, _, body = fetch_json(
+    base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/src/" .. ref .. "/" .. path
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  -- Detect directory listing (JSON with "values") vs raw file content
+  local parsed = (body and body:sub(1, 1) == "{") and DecodeJson(body) or nil
+  if parsed and parsed.values then
+    local out = {}
+    for _, e in ipairs(parsed.values or {}) do
+      out[#out + 1] = {
+        type = e.type == "commit_directory" and "dir" or "file",
+        name = e.path and e.path:match("[^/]+$") or "",
+        path = e.path or "",
+        sha = "",
+        size = e.size or 0,
+      }
+    end
+    respond_json(200, out)
+  else
+    respond_json(200, {
+      type = "file",
+      encoding = "base64",
+      content = EncodeBase64(body or ""),
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = #(body or ""),
+    })
+  end
+end)
+
+-- GET /repos/{owner}/{repo}/license
+-- Bitbucket has no license template API; fetch the LICENSE file via src endpoint.
+b:rest("get_repo_license", function(owner, repo_name)
+  local repo_url = base() .. "/repositories/" .. owner .. "/" .. repo_name
+  local ok, status, _, body = fetch_json(repo_url)
+  if not ok or status ~= 200 then
+    respond_json(404, {})
+    return
+  end
+  local repo = DecodeJson(body or "{}")
+  local ref = (repo.mainbranch and repo.mainbranch.name) or "HEAD"
+  for _, name in ipairs({ "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }) do
+    local ok2, status2, _, body2 = fetch_json(repo_url .. "/src/" .. ref .. "/" .. name)
+    if ok2 and status2 == 200 then
+      respond_json(200, {
+        type = "file",
+        encoding = "base64",
+        content = EncodeBase64(body2 or ""),
+        name = name,
+        path = name,
+        sha = "",
+        size = #(body2 or ""),
+        license = nil,
+      })
+      return
+    end
+  end
+  respond_json(404, { message = "License file not found" })
+end)
+
+-- Forks ---------------------------------------------------------------------
+
+b:rest("get_repo_forks", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local forks = data.values or {}
+      for i, r in ipairs(forks) do
+        forks[i] = translate_bb_repo(r)
       end
-    end
-    respond_json(404, { message = "License file not found" })
-  end,
-
-  -- Forks ---------------------------------------------------------------------
-
-  get_repo_forks = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local forks = data.values or {}
-        for i, r in ipairs(forks) do
-          forks[i] = translate_bb_repo(r)
-        end
-        return forks
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/forks",
-          PAGES
-        )
-      )
+      return forks
+    end,
+    fetch_json(
+      append_page_params(base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/forks", PAGES)
     )
-  end,
+  )
+end)
 
-  post_repo_forks = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = {}
-    if req.organization then
-      bb.workspace = req.organization
-    end
-    if req.name then
-      bb.name = req.name
-    end
-    proxy_json_created(
-      translate_bb_repo,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/forks",
-        "POST",
-        EncodeJson(bb)
-      )
+b:rest("post_repo_forks", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = {}
+  if req.organization then
+    bb.workspace = req.organization
+  end
+  if req.name then
+    bb.name = req.name
+  end
+  proxy_json_created(
+    translate_bb_repo,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/forks",
+      "POST",
+      EncodeJson(bb)
     )
-  end,
+  )
+end)
 
-  -- Deploy keys ---------------------------------------------------------------
+-- Deploy keys ---------------------------------------------------------------
 
-  get_repo_keys = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local keys = data.values or {}
-        for i, k in ipairs(keys) do
-          keys[i] = translate_bb_key(k)
-        end
-        return keys
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/deploy-keys",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  post_repo_keys = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = { key = req.key or "", label = req.title or "" }
-    proxy_json_created(
-      translate_bb_key,
-      fetch_json(
+b:rest("get_repo_keys", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local keys = data.values or {}
+      for i, k in ipairs(keys) do
+        keys[i] = translate_bb_key(k)
+      end
+      return keys
+    end,
+    fetch_json(
+      append_page_params(
         base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/deploy-keys",
-        "POST",
-        EncodeJson(bb)
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  get_repo_key = proxy_handler(translate_bb_key, function(o, r, key_id)
+b:rest("post_repo_keys", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = { key = req.key or "", label = req.title or "" }
+  proxy_json_created(
+    translate_bb_key,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/deploy-keys",
+      "POST",
+      EncodeJson(bb)
+    )
+  )
+end)
+
+b:rest(
+  "get_repo_key",
+  proxy_handler(translate_bb_key, function(o, r, key_id)
     return base() .. "/repositories/" .. o .. "/" .. r .. "/deploy-keys/" .. key_id
-  end),
+  end)
+)
 
-  delete_repo_key = function(owner, repo_name, key_id)
-    local url = base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/deploy-keys/" .. key_id
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, url, dopts))
-  end,
+b:rest("delete_repo_key", function(owner, repo_name, key_id)
+  local url = base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/deploy-keys/" .. key_id
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, url, dopts))
+end)
 
-  -- Webhooks ------------------------------------------------------------------
+-- Webhooks ------------------------------------------------------------------
 
-  get_repo_hooks = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local hooks = data.values or {}
-        for i, h in ipairs(hooks) do
-          hooks[i] = translate_bb_hook(h)
-        end
-        return hooks
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks",
-          PAGES
-        )
-      )
+b:rest("get_repo_hooks", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local hooks = data.values or {}
+      for i, h in ipairs(hooks) do
+        hooks[i] = translate_bb_hook(h)
+      end
+      return hooks
+    end,
+    fetch_json(
+      append_page_params(base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks", PAGES)
     )
-  end,
+  )
+end)
 
-  post_repo_hooks = function(owner, repo_name)
-    proxy_json_created(
-      translate_bb_hook,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks",
-        "POST",
-        translate_bb_hook_req(GetBody())
-      )
+b:rest("post_repo_hooks", function(owner, repo_name)
+  proxy_json_created(
+    translate_bb_hook,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks",
+      "POST",
+      translate_bb_hook_req(GetBody())
     )
-  end,
+  )
+end)
 
-  get_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      translate_bb_hook,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks/{" .. hook_id .. "}"
-      )
+b:rest("get_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    translate_bb_hook,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks/{" .. hook_id .. "}"
     )
-  end,
+  )
+end)
 
-  patch_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      translate_bb_hook,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks/{" .. hook_id .. "}",
-        "PUT",
-        translate_bb_hook_req(GetBody())
-      )
+b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    translate_bb_hook,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/hooks/{" .. hook_id .. "}",
+      "PUT",
+      translate_bb_hook_req(GetBody())
     )
-  end,
+  )
+end)
 
-  delete_repo_hook = function(owner, repo_name, hook_id)
-    local url = base()
-      .. "/repositories/"
-      .. owner
-      .. "/"
-      .. repo_name
-      .. "/hooks/{"
-      .. hook_id
-      .. "}"
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, url, dopts))
-  end,
+b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+  local url = base()
+    .. "/repositories/"
+    .. owner
+    .. "/"
+    .. repo_name
+    .. "/hooks/{"
+    .. hook_id
+    .. "}"
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, url, dopts))
+end)
 
-  -- Users ---------------------------------------------------------------------
+-- Users ---------------------------------------------------------------------
 
-  -- GET /user
-  get_user = proxy_handler(translate_bb_user, function()
+-- GET /user
+b:rest(
+  "get_user",
+  proxy_handler(translate_bb_user, function()
     return base() .. "/user"
-  end),
+  end)
+)
 
-  -- GET /users/{username}
-  get_users_username = proxy_handler(translate_bb_user, function(username)
+-- GET /users/{username}
+b:rest(
+  "get_users_username",
+  proxy_handler(translate_bb_user, function(username)
     return base() .. "/users/" .. username
-  end),
+  end)
+)
 
-  -- Issues --------------------------------------------------------------------
+-- Issues --------------------------------------------------------------------
 
-  get_repo_issues = proxy_handler(translate_bb_issues, function(o, r)
+b:rest(
+  "get_repo_issues",
+  proxy_handler(translate_bb_issues, function(o, r)
     return append_page_params(base() .. "/repositories/" .. o .. "/" .. r .. "/issues", PAGES)
-  end),
+  end)
+)
 
-  get_repo_issue = proxy_handler(translate_bb_issue, function(o, r, n)
+b:rest(
+  "get_repo_issue",
+  proxy_handler(translate_bb_issue, function(o, r, n)
     return base() .. "/repositories/" .. o .. "/" .. r .. "/issues/" .. n
-  end),
+  end)
+)
 
-  get_issue_comments = proxy_handler(translate_bb_issue_comments_list, function(o, r, n)
+b:rest(
+  "get_issue_comments",
+  proxy_handler(translate_bb_issue_comments_list, function(o, r, n)
     return append_page_params(
       base() .. "/repositories/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments",
       PAGES
     )
-  end),
+  end)
+)
 
-  get_repo_milestones = proxy_handler(translate_bb_milestones, function(o, r)
+b:rest(
+  "get_repo_milestones",
+  proxy_handler(translate_bb_milestones, function(o, r)
     return base() .. "/repositories/" .. o .. "/" .. r .. "/milestones"
-  end),
+  end)
+)
 
-  -- Pull Requests ---------------------------------------------------------------
+-- Pull Requests ---------------------------------------------------------------
 
-  -- GET /repos/{owner}/{repo}/pulls
-  get_repo_pulls = proxy_handler(translate_bb_pulls, function(o, r)
+-- GET /repos/{owner}/{repo}/pulls
+b:rest(
+  "get_repo_pulls",
+  proxy_handler(translate_bb_pulls, function(o, r)
     return append_page_params(base() .. "/repositories/" .. o .. "/" .. r .. "/pullrequests", PAGES)
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/pulls
-  post_repo_pulls = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = {}
-    if req.title then
-      bb.title = req.title
-    end
-    if req.body then
-      bb.description = req.body
-    end
-    if req.head then
-      bb.source = { branch = { name = req.head } }
-    end
-    if req.base then
-      bb.destination = { branch = { name = req.base } }
-    end
-    proxy_json_created(
-      translate_bb_pull,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests",
-        "POST",
-        EncodeJson(bb)
-      )
+-- POST /repos/{owner}/{repo}/pulls
+b:rest("post_repo_pulls", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = {}
+  if req.title then
+    bb.title = req.title
+  end
+  if req.body then
+    bb.description = req.body
+  end
+  if req.head then
+    bb.source = { branch = { name = req.head } }
+  end
+  if req.base then
+    bb.destination = { branch = { name = req.base } }
+  end
+  proxy_json_created(
+    translate_bb_pull,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests",
+      "POST",
+      EncodeJson(bb)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}
-  get_repo_pull = proxy_handler(translate_bb_pull, function(o, r, n)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}
+b:rest(
+  "get_repo_pull",
+  proxy_handler(translate_bb_pull, function(o, r, n)
     return base() .. "/repositories/" .. o .. "/" .. r .. "/pullrequests/" .. n
-  end),
+  end)
+)
 
-  -- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
-  -- Bitbucket uses PUT for updates.
-  patch_repo_pull = function(owner, repo_name, pull_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = {}
-    if req.title then
-      bb.title = req.title
-    end
-    if req.body then
-      bb.description = req.body
-    end
-    -- Bitbucket can close a PR via status but there's no simple state field in PUT.
-    proxy_json(
-      translate_bb_pull,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number,
-        "PUT",
-        EncodeJson(bb)
-      )
+-- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
+-- Bitbucket uses PUT for updates.
+b:rest("patch_repo_pull", function(owner, repo_name, pull_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = {}
+  if req.title then
+    bb.title = req.title
+  end
+  if req.body then
+    bb.description = req.body
+  end
+  -- Bitbucket can close a PR via status but there's no simple state field in PUT.
+  proxy_json(
+    translate_bb_pull,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number,
+      "PUT",
+      EncodeJson(bb)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
-  get_pull_commits = proxy_handler(function(data)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
+b:rest(
+  "get_pull_commits",
+  proxy_handler(function(data)
     local commits = data.values or {}
     for i, c in ipairs(commits) do
       commits[i] = translate_bb_commit(c)
@@ -1237,11 +1259,14 @@ app.backend_impl = {
       base() .. "/repositories/" .. o .. "/" .. r .. "/pullrequests/" .. n .. "/commits",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
-  -- Bitbucket uses /diffstat for file-level change stats.
-  get_pull_files = proxy_handler(function(data)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
+-- Bitbucket uses /diffstat for file-level change stats.
+b:rest(
+  "get_pull_files",
+  proxy_handler(function(data)
     local files = data.values or {}
     for i, f in ipairs(files) do
       files[i] = translate_bb_diffstat_file(f)
@@ -1252,42 +1277,127 @@ app.backend_impl = {
       base() .. "/repositories/" .. o .. "/" .. r .. "/pullrequests/" .. n .. "/diffstat",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- Returns 204 if PR state is MERGED, 404 otherwise.
-  get_pull_merge = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    if pr.state == "MERGED" then
-      SetStatus(204, "No Content")
-    else
-      respond_json(404, { message = "Pull Request is not merged" })
-    end
-  end,
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
+-- Returns 204 if PR state is MERGED, 404 otherwise.
+b:rest("get_pull_merge", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  if pr.state == "MERGED" then
+    SetStatus(204, "No Content")
+  else
+    respond_json(404, { message = "Pull Request is not merged" })
+  end
+end)
 
-  -- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- Bitbucket uses POST for merging.
-  put_pull_merge = function(owner, repo_name, pull_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = {}
-    if req.merge_method then
-      bb.merge_strategy = req.merge_method
+-- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
+-- Bitbucket uses POST for merging.
+b:rest("put_pull_merge", function(owner, repo_name, pull_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = {}
+  if req.merge_method then
+    bb.merge_strategy = req.merge_method
+  end
+  if req.commit_message then
+    bb.message = req.commit_message
+  end
+  local ok, status = fetch_json(
+    base()
+      .. "/repositories/"
+      .. owner
+      .. "/"
+      .. repo_name
+      .. "/pullrequests/"
+      .. pull_number
+      .. "/merge",
+    "POST",
+    EncodeJson(bb)
+  )
+  proxy_204({ 200 }, ok, status)
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+-- Bitbucket: participants with role=REVIEWER and not yet approved.
+b:rest("get_pull_requested_reviewers", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  local users = {}
+  for _, p in ipairs(pr.participants or {}) do
+    if p.role == "REVIEWER" and not p.approved then
+      users[#users + 1] = translate_bb_user(p.user)
     end
-    if req.commit_message then
-      bb.message = req.commit_message
-    end
-    local ok, status = fetch_json(
+  end
+  respond_json(200, { users = users, teams = {} })
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+-- Bitbucket: participants with role=REVIEWER and approved=true → APPROVED reviews.
+b:rest("get_pull_reviews", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  respond_json(200, translate_bb_participants_to_reviews(pr.participants))
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
+b:rest("get_pull_review", function(owner, repo_name, pull_number, review_id)
+  local ok, status, _, body = fetch_json(
+    base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  local reviews = translate_bb_participants_to_reviews(pr.participants)
+  local rid = tonumber(review_id)
+  if rid and reviews[rid] then
+    respond_json(200, reviews[rid])
+  else
+    respond_json(404, { message = "Not Found" })
+  end
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
+-- Bitbucket has no per-review inline comments; return all inline PR comments.
+b:rest("get_pull_review_comments", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    append_page_params(
       base()
         .. "/repositories/"
         .. owner
@@ -1295,657 +1405,572 @@ app.backend_impl = {
         .. repo_name
         .. "/pullrequests/"
         .. pull_number
-        .. "/merge",
-      "POST",
-      EncodeJson(bb)
+        .. "/comments",
+      PAGES
     )
-    proxy_204({ 200 }, ok, status)
-  end,
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local result = {}
+  for _, c in ipairs(data.values or {}) do
+    if c.inline then
+      result[#result + 1] = translate_bb_pr_comment(c)
+    end
+  end
+  respond_json(200, result)
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
-  -- Bitbucket: participants with role=REVIEWER and not yet approved.
-  get_pull_requested_reviewers = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    local users = {}
-    for _, p in ipairs(pr.participants or {}) do
-      if p.role == "REVIEWER" and not p.approved then
-        users[#users + 1] = translate_bb_user(p.user)
-      end
-    end
-    respond_json(200, { users = users, teams = {} })
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
-  -- Bitbucket: participants with role=REVIEWER and approved=true → APPROVED reviews.
-  get_pull_reviews = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    respond_json(200, translate_bb_participants_to_reviews(pr.participants))
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
-  get_pull_review = function(owner, repo_name, pull_number, review_id)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/pullrequests/" .. pull_number
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    local reviews = translate_bb_participants_to_reviews(pr.participants)
-    local rid = tonumber(review_id)
-    if rid and reviews[rid] then
-      respond_json(200, reviews[rid])
-    else
-      respond_json(404, { message = "Not Found" })
-    end
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
-  -- Bitbucket has no per-review inline comments; return all inline PR comments.
-  get_pull_review_comments = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      append_page_params(
-        base()
-          .. "/repositories/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pullrequests/"
-          .. pull_number
-          .. "/comments",
-        PAGES
-      )
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local result = {}
-    for _, c in ipairs(data.values or {}) do
-      if c.inline then
-        result[#result + 1] = translate_bb_pr_comment(c)
-      end
-    end
-    respond_json(200, result)
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
-  -- Bitbucket inline PR comments (those with an "inline" field).
-  get_pull_comments = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      append_page_params(
-        base()
-          .. "/repositories/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pullrequests/"
-          .. pull_number
-          .. "/comments",
-        PAGES
-      )
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local result = {}
-    for _, c in ipairs(data.values or {}) do
-      if c.inline then
-        result[#result + 1] = translate_bb_pr_comment(c)
-      end
-    end
-    respond_json(200, result)
-  end,
-
-  -- Search -----------------------------------------------------------------------
-
-  -- GET /search/repositories — maps to Bitbucket GET /repositories?q=name~"<q>"
-  search_repositories = function()
-    local q = GetParam("q") or ""
-    proxy_search_bb(
-      translate_bb_repo,
-      append_page_params(base() .. '/repositories?q=name~"' .. q .. '"', PAGES)
-    )
-  end,
-
-  -- GET /search/users — maps to Bitbucket GET /workspaces?q=slug~"<q>"
-  search_users = function()
-    local q = GetParam("q") or ""
-    proxy_search_bb(
-      translate_bb_workspace,
-      append_page_params(base() .. '/workspaces?q=slug~"' .. q .. '"', PAGES)
-    )
-  end,
-
-  -- Checks (via Bitbucket commit statuses) ----------------------------------------
-  --
-  -- GitHub Check Runs map onto Bitbucket commit build statuses.  Bitbucket has
-  -- no concept of a check run independent of a commit SHA, so:
-  --   • POST check-runs → POST /repositories/{w}/{r}/commit/{sha}/statuses/build
-  --   • GET check-runs/{id} → minimal stub (no reverse lookup by ID)
-  --   • PATCH check-runs/{id} → minimal stub
-  --   • GET commits/{ref}/check-runs → commit statuses list
-  --   • Check Suites have no Bitbucket equivalent; all suite endpoints are stubs.
-  --   • Annotations are always empty.
-  --
-  -- Status mapping (GitHub → Bitbucket):
-  --   queued/in_progress     → INPROGRESS
-  --   completed/success      → SUCCESSFUL
-  --   completed/failure      → FAILED
-  --   completed/neutral      → SUCCESSFUL
-  --   completed/skipped      → SUCCESSFUL
-  --   completed/(other)      → FAILED
-  --
-  -- Status mapping (Bitbucket → GitHub):
-  --   INPROGRESS  → status=in_progress, conclusion=null
-  --   SUCCESSFUL  → status=completed,   conclusion=success
-  --   FAILED      → status=completed,   conclusion=failure
-  --   STOPPED     → status=completed,   conclusion=cancelled
-  --   other       → status=completed,   conclusion=failure
-
-  post_check_runs = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local sha = req.head_sha or ""
-    local status = req.status or "queued"
-    local conclusion = req.conclusion
-    local gh_conclusion_to_bb = {
-      success = "SUCCESSFUL",
-      neutral = "SUCCESSFUL",
-      skipped = "SUCCESSFUL",
-      cancelled = "STOPPED",
-    }
-    local bb_state = status == "completed" and (gh_conclusion_to_bb[conclusion] or "FAILED")
-      or "INPROGRESS"
-    local bb_to_gh = {
-      INPROGRESS = { status = "in_progress", conclusion = nil },
-      SUCCESSFUL = { status = "completed", conclusion = "success" },
-      FAILED = { status = "completed", conclusion = "failure" },
-      STOPPED = { status = "completed", conclusion = "cancelled" },
-    }
-    local bb_body = EncodeJson({
-      state = bb_state,
-      key = req.name or "",
-      url = req.details_url or "",
-      name = req.name or "",
-      description = (req.output and req.output.summary) or req.name or "",
-    })
-    local function translate(s)
-      if not s then
-        return {}
-      end
-      local mapped = bb_to_gh[s.state] or { status = "completed", conclusion = "failure" }
-      return {
-        id = 0,
-        node_id = "",
-        head_sha = sha,
-        name = s.key or s.name or "",
-        status = mapped.status,
-        conclusion = mapped.conclusion,
-        started_at = s.created_on,
-        completed_at = mapped.status == "completed" and s.updated_on or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.url or "",
-        details_url = s.url or "",
-      }
-    end
-    proxy_json_created(
-      translate,
-      fetch_json(
-        base()
-          .. "/repositories/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/commit/"
-          .. sha
-          .. "/statuses/build",
-        "POST",
-        bb_body
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- Uses Bitbucket commit statuses.
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commit/" .. ref .. "/statuses"
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local bb_to_gh = {
-      INPROGRESS = { status = "in_progress", conclusion = nil },
-      SUCCESSFUL = { status = "completed", conclusion = "success" },
-      FAILED = { status = "completed", conclusion = "failure" },
-      STOPPED = { status = "completed", conclusion = "cancelled" },
-    }
-    local runs = {}
-    for i, s in ipairs(data.values or {}) do
-      local mapped = bb_to_gh[s.state] or { status = "completed", conclusion = "failure" }
-      runs[i] = {
-        id = i,
-        node_id = "",
-        head_sha = ref,
-        name = s.key or s.name or "",
-        status = mapped.status,
-        conclusion = mapped.conclusion,
-        started_at = s.created_on,
-        completed_at = mapped.status == "completed" and s.updated_on or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.url or "",
-        details_url = s.url or "",
-      }
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
-
-  -- Check suites have no Bitbucket equivalent; all suite endpoints fall back
-  -- to the route_defaults stubs defined in .init.lua.
-
-  -- Git database (refs only; blobs/commits/tags/trees have no Bitbucket equivalent) ----
-
-  list_git_matching_refs = function(owner, repo_name, ref)
-    local kind, prefix
-    if ref:sub(1, 6) == "heads/" then
-      kind = "branches"
-      prefix = ref:sub(7)
-    elseif ref:sub(1, 5) == "tags/" then
-      kind = "tags"
-      prefix = ref:sub(6)
-    else
-      kind = nil
-      prefix = ref
-    end
-    local endpoint = kind and ("/refs/" .. kind) or "/refs"
-    local url = append_page_params(
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
+-- Bitbucket inline PR comments (those with an "inline" field).
+b:rest("get_pull_comments", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    append_page_params(
       base()
         .. "/repositories/"
         .. owner
         .. "/"
         .. repo_name
-        .. endpoint
-        .. '?q=name~"'
-        .. prefix
-        .. '"',
+        .. "/pullrequests/"
+        .. pull_number
+        .. "/comments",
       PAGES
     )
-    proxy_json(function(data)
-      local refs = data.values or {}
-      for i, r in ipairs(refs) do
-        refs[i] = translate_bb_ref(r)
-      end
-      return refs
-    end, fetch_json(url))
-  end,
-
-  get_git_ref = function(owner, repo_name, ref)
-    local kind, name
-    if ref:sub(1, 6) == "heads/" then
-      kind = "branches"
-      name = ref:sub(7)
-    elseif ref:sub(1, 5) == "tags/" then
-      kind = "tags"
-      name = ref:sub(6)
-    else
-      respond_json(422, { message = "Invalid ref format" })
-      return
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local result = {}
+  for _, c in ipairs(data.values or {}) do
+    if c.inline then
+      result[#result + 1] = translate_bb_pr_comment(c)
     end
-    proxy_json(
-      translate_bb_ref,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/" .. kind .. "/" .. name
-      )
+  end
+  respond_json(200, result)
+end)
+
+-- Search -----------------------------------------------------------------------
+
+-- GET /search/repositories — maps to Bitbucket GET /repositories?q=name~"<q>"
+b:rest("search_repositories", function()
+  local q = GetParam("q") or ""
+  proxy_search_bb(
+    translate_bb_repo,
+    append_page_params(base() .. '/repositories?q=name~"' .. q .. '"', PAGES)
+  )
+end)
+
+-- GET /search/users — maps to Bitbucket GET /workspaces?q=slug~"<q>"
+b:rest("search_users", function()
+  local q = GetParam("q") or ""
+  proxy_search_bb(
+    translate_bb_workspace,
+    append_page_params(base() .. '/workspaces?q=slug~"' .. q .. '"', PAGES)
+  )
+end)
+
+-- Checks (via Bitbucket commit statuses) ----------------------------------------
+--
+-- GitHub Check Runs map onto Bitbucket commit build statuses.  Bitbucket has
+-- no concept of a check run independent of a commit SHA, so:
+--   • POST check-runs → POST /repositories/{w}/{r}/commit/{sha}/statuses/build
+--   • GET check-runs/{id} → minimal stub (no reverse lookup by ID)
+--   • PATCH check-runs/{id} → minimal stub
+--   • GET commits/{ref}/check-runs → commit statuses list
+--   • Check Suites have no Bitbucket equivalent; all suite endpoints are stubs.
+--   • Annotations are always empty.
+--
+-- Status mapping (GitHub → Bitbucket):
+--   queued/in_progress     → INPROGRESS
+--   completed/success      → SUCCESSFUL
+--   completed/failure      → FAILED
+--   completed/neutral      → SUCCESSFUL
+--   completed/skipped      → SUCCESSFUL
+--   completed/(other)      → FAILED
+--
+-- Status mapping (Bitbucket → GitHub):
+--   INPROGRESS  → status=in_progress, conclusion=null
+--   SUCCESSFUL  → status=completed,   conclusion=success
+--   FAILED      → status=completed,   conclusion=failure
+--   STOPPED     → status=completed,   conclusion=cancelled
+--   other       → status=completed,   conclusion=failure
+
+b:rest("post_check_runs", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local sha = req.head_sha or ""
+  local status = req.status or "queued"
+  local conclusion = req.conclusion
+  local gh_conclusion_to_bb = {
+    success = "SUCCESSFUL",
+    neutral = "SUCCESSFUL",
+    skipped = "SUCCESSFUL",
+    cancelled = "STOPPED",
+  }
+  local bb_state = status == "completed" and (gh_conclusion_to_bb[conclusion] or "FAILED")
+    or "INPROGRESS"
+  local bb_to_gh = {
+    INPROGRESS = { status = "in_progress", conclusion = nil },
+    SUCCESSFUL = { status = "completed", conclusion = "success" },
+    FAILED = { status = "completed", conclusion = "failure" },
+    STOPPED = { status = "completed", conclusion = "cancelled" },
+  }
+  local bb_body = EncodeJson({
+    state = bb_state,
+    key = req.name or "",
+    url = req.details_url or "",
+    name = req.name or "",
+    description = (req.output and req.output.summary) or req.name or "",
+  })
+  local function translate(s)
+    if not s then
+      return {}
+    end
+    local mapped = bb_to_gh[s.state] or { status = "completed", conclusion = "failure" }
+    return {
+      id = 0,
+      node_id = "",
+      head_sha = sha,
+      name = s.key or s.name or "",
+      status = mapped.status,
+      conclusion = mapped.conclusion,
+      started_at = s.created_on,
+      completed_at = mapped.status == "completed" and s.updated_on or nil,
+      output = {
+        title = s.description or "",
+        summary = s.description or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = s.url or "",
+      details_url = s.url or "",
+    }
+  end
+  proxy_json_created(
+    translate,
+    fetch_json(
+      base()
+        .. "/repositories/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/commit/"
+        .. sha
+        .. "/statuses/build",
+      "POST",
+      bb_body
     )
-  end,
+  )
+end)
 
-  create_git_ref = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local full_ref = req.ref or ""
-    local sha = req.sha or ""
-    local kind, name
-    if full_ref:sub(1, 11) == "refs/heads/" then
-      kind = "branches"
-      name = full_ref:sub(12)
-    elseif full_ref:sub(1, 10) == "refs/tags/" then
-      kind = "tags"
-      name = full_ref:sub(11)
-    else
-      respond_json(422, { message = "Invalid ref format" })
-      return
-    end
-    proxy_json_created(
-      translate_bb_ref,
-      fetch_json(
-        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/" .. kind,
-        "POST",
-        EncodeJson({ name = name, target = { hash = sha } })
-      )
-    )
-  end,
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- Uses Bitbucket commit statuses.
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local ok, status, _, body = fetch_json(
+    base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/commit/" .. ref .. "/statuses"
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local bb_to_gh = {
+    INPROGRESS = { status = "in_progress", conclusion = nil },
+    SUCCESSFUL = { status = "completed", conclusion = "success" },
+    FAILED = { status = "completed", conclusion = "failure" },
+    STOPPED = { status = "completed", conclusion = "cancelled" },
+  }
+  local runs = {}
+  for i, s in ipairs(data.values or {}) do
+    local mapped = bb_to_gh[s.state] or { status = "completed", conclusion = "failure" }
+    runs[i] = {
+      id = i,
+      node_id = "",
+      head_sha = ref,
+      name = s.key or s.name or "",
+      status = mapped.status,
+      conclusion = mapped.conclusion,
+      started_at = s.created_on,
+      completed_at = mapped.status == "completed" and s.updated_on or nil,
+      output = {
+        title = s.description or "",
+        summary = s.description or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = s.url or "",
+      details_url = s.url or "",
+    }
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
 
-  delete_git_ref = function(owner, repo_name, ref)
-    local kind, name
-    if ref:sub(1, 6) == "heads/" then
-      kind = "branches"
-      name = ref:sub(7)
-    elseif ref:sub(1, 5) == "tags/" then
-      kind = "tags"
-      name = ref:sub(6)
-    else
-      respond_json(422, { message = "Invalid ref format" })
-      return
-    end
-    local url = base()
+-- Check suites have no Bitbucket equivalent; all suite endpoints fall back
+-- to the route_defaults stubs defined in .init.lua.
+
+-- Git database (refs only; blobs/commits/tags/trees have no Bitbucket equivalent) ----
+
+b:rest("list_git_matching_refs", function(owner, repo_name, ref)
+  local kind, prefix
+  if ref:sub(1, 6) == "heads/" then
+    kind = "branches"
+    prefix = ref:sub(7)
+  elseif ref:sub(1, 5) == "tags/" then
+    kind = "tags"
+    prefix = ref:sub(6)
+  else
+    kind = nil
+    prefix = ref
+  end
+  local endpoint = kind and ("/refs/" .. kind) or "/refs"
+  local url = append_page_params(
+    base()
       .. "/repositories/"
       .. owner
       .. "/"
       .. repo_name
-      .. "/refs/"
-      .. kind
-      .. "/"
-      .. name
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, url, dopts))
-  end,
+      .. endpoint
+      .. '?q=name~"'
+      .. prefix
+      .. '"',
+    PAGES
+  )
+  proxy_json(function(data)
+    local refs = data.values or {}
+    for i, r in ipairs(refs) do
+      refs[i] = translate_bb_ref(r)
+    end
+    return refs
+  end, fetch_json(url))
+end)
 
-  -- Activity (Bitbucket Watchers) ---------------------------------------------
-  --
-  -- Bitbucket has no events feed, notifications, or star concept for repos.
-  -- Watchers (GET /2.0/repositories/{owner}/{repo}/watchers) map to both
-  -- stargazers and subscribers (Bitbucket does not distinguish the two).
+b:rest("get_git_ref", function(owner, repo_name, ref)
+  local kind, name
+  if ref:sub(1, 6) == "heads/" then
+    kind = "branches"
+    name = ref:sub(7)
+  elseif ref:sub(1, 5) == "tags/" then
+    kind = "tags"
+    name = ref:sub(6)
+  else
+    respond_json(422, { message = "Invalid ref format" })
+    return
+  end
+  proxy_json(
+    translate_bb_ref,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/" .. kind .. "/" .. name
+    )
+  )
+end)
 
-  get_repo_stargazers = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local users = data.values or {}
-        for i, u in ipairs(users) do
-          users[i] = translate_bb_user(u)
-        end
-        return users
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/watchers",
-          PAGES
-        )
+b:rest("create_git_ref", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local full_ref = req.ref or ""
+  local sha = req.sha or ""
+  local kind, name
+  if full_ref:sub(1, 11) == "refs/heads/" then
+    kind = "branches"
+    name = full_ref:sub(12)
+  elseif full_ref:sub(1, 10) == "refs/tags/" then
+    kind = "tags"
+    name = full_ref:sub(11)
+  else
+    respond_json(422, { message = "Invalid ref format" })
+    return
+  end
+  proxy_json_created(
+    translate_bb_ref,
+    fetch_json(
+      base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/refs/" .. kind,
+      "POST",
+      EncodeJson({ name = name, target = { hash = sha } })
+    )
+  )
+end)
+
+b:rest("delete_git_ref", function(owner, repo_name, ref)
+  local kind, name
+  if ref:sub(1, 6) == "heads/" then
+    kind = "branches"
+    name = ref:sub(7)
+  elseif ref:sub(1, 5) == "tags/" then
+    kind = "tags"
+    name = ref:sub(6)
+  else
+    respond_json(422, { message = "Invalid ref format" })
+    return
+  end
+  local url = base()
+    .. "/repositories/"
+    .. owner
+    .. "/"
+    .. repo_name
+    .. "/refs/"
+    .. kind
+    .. "/"
+    .. name
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, url, dopts))
+end)
+
+-- Activity (Bitbucket Watchers) ---------------------------------------------
+--
+-- Bitbucket has no events feed, notifications, or star concept for repos.
+-- Watchers (GET /2.0/repositories/{owner}/{repo}/watchers) map to both
+-- stargazers and subscribers (Bitbucket does not distinguish the two).
+
+b:rest("get_repo_stargazers", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local users = data.values or {}
+      for i, u in ipairs(users) do
+        users[i] = translate_bb_user(u)
+      end
+      return users
+    end,
+    fetch_json(
+      append_page_params(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/watchers",
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  get_repo_subscribers = function(owner, repo_name)
-    proxy_json(
-      function(data)
-        local users = data.values or {}
-        for i, u in ipairs(users) do
-          users[i] = translate_bb_user(u)
-        end
-        return users
-      end,
-      fetch_json(
-        append_page_params(
-          base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/watchers",
-          PAGES
-        )
+b:rest("get_repo_subscribers", function(owner, repo_name)
+  proxy_json(
+    function(data)
+      local users = data.values or {}
+      for i, u in ipairs(users) do
+        users[i] = translate_bb_user(u)
+      end
+      return users
+    end,
+    fetch_json(
+      append_page_params(
+        base() .. "/repositories/" .. owner .. "/" .. repo_name .. "/watchers",
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  -- Gists (Bitbucket Snippets) -----------------------------------------------
-  --
-  -- GitHub gist IDs are encoded as "workspace~encoded_id" so that per-gist
-  -- operations can reconstruct the Bitbucket URL without extra lookups.
-  -- e.g. gist_id = "octocat~pHANT4" → /2.0/snippets/octocat/pHANT4
+-- Gists (Bitbucket Snippets) -----------------------------------------------
+--
+-- GitHub gist IDs are encoded as "workspace~encoded_id" so that per-gist
+-- operations can reconstruct the Bitbucket URL without extra lookups.
+-- e.g. gist_id = "octocat~pHANT4" → /2.0/snippets/octocat/pHANT4
 
-  get_gists = function()
-    proxy_json_list(
-      translate_bb_snippets,
-      fetch_json(append_page_params(base() .. "/snippets?role=owner", PAGES))
-    )
-  end,
+b:rest("get_gists", function()
+  proxy_json_list(
+    translate_bb_snippets,
+    fetch_json(append_page_params(base() .. "/snippets?role=owner", PAGES))
+  )
+end)
 
-  get_gists_public = function()
-    proxy_json_list(
-      translate_bb_snippets,
-      fetch_json(append_page_params(base() .. "/snippets", PAGES))
-    )
-  end,
+b:rest("get_gists_public", function()
+  proxy_json_list(
+    translate_bb_snippets,
+    fetch_json(append_page_params(base() .. "/snippets", PAGES))
+  )
+end)
 
-  post_gists = function()
-    local req = DecodeJson(GetBody() or "{}") or {}
+b:rest("post_gists", function()
+  local req = DecodeJson(GetBody() or "{}") or {}
+  local files = {}
+  for name, f in pairs(req.files or {}) do
+    if f then
+      files[name] = { content = f.content or "" }
+    end
+  end
+  local bb_body = EncodeJson({
+    title = req.description or "",
+    is_private = not (req.public == true or req.public == "true"),
+    files = files,
+  })
+  proxy_json_created(translate_bb_snippet, fetch_json(base() .. "/snippets", "POST", bb_body))
+end)
+
+b:rest("get_gist", function(gist_id)
+  local url = snippet_url(gist_id)
+  if url then
+    proxy_json(translate_bb_snippet, fetch_json(url))
+  end
+end)
+
+b:rest("patch_gist", function(gist_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}") or {}
+  local bb_body = {}
+  if req.description ~= nil then
+    bb_body.title = req.description
+  end
+  if req.files ~= nil then
     local files = {}
-    for name, f in pairs(req.files or {}) do
-      if f then
-        files[name] = { content = f.content or "" }
-      end
+    for name, f in pairs(req.files) do
+      files[name] = f and { content = f.content or "" } or {}
     end
-    local bb_body = EncodeJson({
-      title = req.description or "",
-      is_private = not (req.public == true or req.public == "true"),
-      files = files,
-    })
-    proxy_json_created(translate_bb_snippet, fetch_json(base() .. "/snippets", "POST", bb_body))
-  end,
+    bb_body.files = files
+  end
+  proxy_json(translate_bb_snippet, fetch_json(url, "PUT", EncodeJson(bb_body)))
+end)
 
-  get_gist = function(gist_id)
-    local url = snippet_url(gist_id)
-    if url then
-      proxy_json(translate_bb_snippet, fetch_json(url))
-    end
-  end,
+b:rest("delete_gist", function(gist_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, url, dopts))
+end)
 
-  patch_gist = function(gist_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}") or {}
-    local bb_body = {}
-    if req.description ~= nil then
-      bb_body.title = req.description
-    end
-    if req.files ~= nil then
-      local files = {}
-      for name, f in pairs(req.files) do
-        files[name] = f and { content = f.content or "" } or {}
-      end
-      bb_body.files = files
-    end
-    proxy_json(translate_bb_snippet, fetch_json(url, "PUT", EncodeJson(bb_body)))
-  end,
-
-  delete_gist = function(gist_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, url, dopts))
-  end,
-
-  get_gist_comments = function(gist_id)
-    local url = snippet_url(gist_id)
-    if url then
-      proxy_json_list(
-        translate_bb_snippet_comments,
-        fetch_json(append_page_params(url .. "/comments", PAGES))
-      )
-    end
-  end,
-
-  post_gist_comment = function(gist_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}") or {}
-    proxy_json_created(
-      translate_bb_snippet_comment,
-      fetch_json(url .. "/comments", "POST", EncodeJson({ content = { raw = req.body or "" } }))
-    )
-  end,
-
-  get_gist_comment = function(gist_id, comment_id)
-    local url = snippet_url(gist_id)
-    if url then
-      proxy_json(translate_bb_snippet_comment, fetch_json(url .. "/comments/" .. comment_id))
-    end
-  end,
-
-  patch_gist_comment = function(gist_id, comment_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}") or {}
-    proxy_json(
-      translate_bb_snippet_comment,
-      fetch_json(
-        url .. "/comments/" .. comment_id,
-        "PUT",
-        EncodeJson({ content = { raw = req.body or "" } })
-      )
-    )
-  end,
-
-  delete_gist_comment = function(gist_id, comment_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, url .. "/comments/" .. comment_id, dopts))
-  end,
-
-  get_gist_commits = function(gist_id)
-    local url = snippet_url(gist_id)
-    if url then
-      proxy_json_list(
-        translate_bb_snippet_commits,
-        fetch_json(append_page_params(url .. "/commits", PAGES))
-      )
-    end
-  end,
-
-  get_gist_forks = function(gist_id)
-    local url = snippet_url(gist_id)
-    if url then
-      proxy_json_list(translate_bb_snippets, fetch_json(append_page_params(url .. "/forks", PAGES)))
-    end
-  end,
-
-  get_gist_star = function(gist_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local ok, status = fetch_json(url .. "/watch")
-    if ok and (status == 200 or status == 204) then
-      set_preamble(204)
-    elseif ok and status == 404 then
-      respond_json(404, {})
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  put_gist_star = function(gist_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local wopts = auth() or {}
-    wopts.method = "PUT"
-    proxy_204({ 200 }, pcall(Fetch, url .. "/watch", wopts))
-  end,
-
-  delete_gist_star = function(gist_id)
-    local url = snippet_url(gist_id)
-    if not url then
-      return
-    end
-    local wopts = auth() or {}
-    wopts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, url .. "/watch", wopts))
-  end,
-
-  get_gist_revision = function(gist_id, sha)
-    local url = snippet_url(gist_id)
-    if url then
-      proxy_json(translate_bb_snippet, fetch_json(url .. "/" .. sha))
-    end
-  end,
-
-  get_user_gists = function(username)
+b:rest("get_gist_comments", function(gist_id)
+  local url = snippet_url(gist_id)
+  if url then
     proxy_json_list(
-      translate_bb_snippets,
-      fetch_json(append_page_params(base() .. "/snippets/" .. username, PAGES))
+      translate_bb_snippet_comments,
+      fetch_json(append_page_params(url .. "/comments", PAGES))
     )
-  end,
-}
+  end
+end)
+
+b:rest("post_gist_comment", function(gist_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}") or {}
+  proxy_json_created(
+    translate_bb_snippet_comment,
+    fetch_json(url .. "/comments", "POST", EncodeJson({ content = { raw = req.body or "" } }))
+  )
+end)
+
+b:rest("get_gist_comment", function(gist_id, comment_id)
+  local url = snippet_url(gist_id)
+  if url then
+    proxy_json(translate_bb_snippet_comment, fetch_json(url .. "/comments/" .. comment_id))
+  end
+end)
+
+b:rest("patch_gist_comment", function(gist_id, comment_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}") or {}
+  proxy_json(
+    translate_bb_snippet_comment,
+    fetch_json(
+      url .. "/comments/" .. comment_id,
+      "PUT",
+      EncodeJson({ content = { raw = req.body or "" } })
+    )
+  )
+end)
+
+b:rest("delete_gist_comment", function(gist_id, comment_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, url .. "/comments/" .. comment_id, dopts))
+end)
+
+b:rest("get_gist_commits", function(gist_id)
+  local url = snippet_url(gist_id)
+  if url then
+    proxy_json_list(
+      translate_bb_snippet_commits,
+      fetch_json(append_page_params(url .. "/commits", PAGES))
+    )
+  end
+end)
+
+b:rest("get_gist_forks", function(gist_id)
+  local url = snippet_url(gist_id)
+  if url then
+    proxy_json_list(translate_bb_snippets, fetch_json(append_page_params(url .. "/forks", PAGES)))
+  end
+end)
+
+b:rest("get_gist_star", function(gist_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local ok, status = fetch_json(url .. "/watch")
+  if ok and (status == 200 or status == 204) then
+    set_preamble(204)
+  elseif ok and status == 404 then
+    respond_json(404, {})
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
+
+b:rest("put_gist_star", function(gist_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local wopts = auth() or {}
+  wopts.method = "PUT"
+  proxy_204({ 200 }, pcall(Fetch, url .. "/watch", wopts))
+end)
+
+b:rest("delete_gist_star", function(gist_id)
+  local url = snippet_url(gist_id)
+  if not url then
+    return
+  end
+  local wopts = auth() or {}
+  wopts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, url .. "/watch", wopts))
+end)
+
+b:rest("get_gist_revision", function(gist_id, sha)
+  local url = snippet_url(gist_id)
+  if url then
+    proxy_json(translate_bb_snippet, fetch_json(url .. "/" .. sha))
+  end
+end)
+
+b:rest("get_user_gists", function(username)
+  proxy_json_list(
+    translate_bb_snippets,
+    fetch_json(append_page_params(base() .. "/snippets/" .. username, PAGES))
+  )
+end)
 
 -- ---------------------------------------------------------------------------
 -- GraphQL resolvers
@@ -1990,7 +2015,7 @@ end
 
 -- Query.repositoryOwner: look up a User or Organization (workspace) by login.
 -- Tries /users/{login} first; falls back to /workspaces/{login}.
-graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
+b:graphql("Query.repositoryOwner", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "repositoryOwner requires a login argument")
     return nil
@@ -2004,10 +2029,10 @@ graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
     return graphql_translate_org(translate_bb_workspace(wdata))
   end
   return nil
-end
+end)
 
 -- Query.viewer: resolve the authenticated user via GET /user.
-graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+b:graphql("Query.viewer", function(_parent, _args, ctx)
   local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
   if not data then
     return nil
@@ -2015,10 +2040,10 @@ graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
   local u = graphql_translate_user(translate_bb_user(data))
   u.isViewer = true
   return u
-end
+end)
 
 -- Query.user: look up a User by login.
-graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+b:graphql("Query.user", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "user requires a login argument")
     return nil
@@ -2028,10 +2053,10 @@ graphql_resolvers["Query.user"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_user(translate_bb_user(data))
-end
+end)
 
 -- Query.organization: look up a Bitbucket workspace as an Organization.
-graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
+b:graphql("Query.organization", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "organization requires a login argument")
     return nil
@@ -2041,10 +2066,10 @@ graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_org(translate_bb_workspace(data))
-end
+end)
 
 -- Query.repository: look up a Repository by owner and name.
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -2055,37 +2080,37 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(translate_bb_repo(data))
-end
+end)
 
 -- node.Repository: fetch a repository by "owner/repo" local ID.
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/repositories/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_repo(translate_bb_repo(data))
-end
+end)
 
 -- node.User: fetch a user by login.
-graphql_resolvers["node.User"] = function(local_id, _ctx)
+b:graphql("node.User", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_user(translate_bb_user(data))
-end
+end)
 
 -- node.Organization: fetch a workspace by slug.
-graphql_resolvers["node.Organization"] = function(local_id, _ctx)
+b:graphql("node.Organization", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/workspaces/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_org(translate_bb_workspace(data))
-end
+end)
 
 -- node.Issue: fetch an issue by "owner/repo/number" local ID.
-graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+b:graphql("node.Issue", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -2098,10 +2123,10 @@ graphql_resolvers["node.Issue"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_issue(translate_bb_issue(data), owner, repo)
-end
+end)
 
 -- node.PullRequest: fetch a pull request by "owner/repo/number" local ID.
-graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
+b:graphql("node.PullRequest", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -2114,14 +2139,14 @@ graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_pr(translate_bb_pull(data), owner, repo)
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
 -- ---------------------------------------------------------------------------
 
 -- Repository.issues: paginated list of issues.
-graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+b:graphql("Repository.issues", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -2129,10 +2154,10 @@ graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
   return bb_repo_connection(owner, name, "/issues", args, ctx, function(i)
     return graphql_translate_issue(translate_bb_issue(i), owner, name)
   end, graphql_issues_connection)
-end
+end)
 
 -- Repository.pullRequests: paginated list of pull requests.
-graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+b:graphql("Repository.pullRequests", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -2140,10 +2165,10 @@ graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
   return bb_repo_connection(owner, name, "/pullrequests", args, ctx, function(p)
     return graphql_translate_pr(translate_bb_pull(p), owner, name)
   end, graphql_prs_connection)
-end
+end)
 
 -- Repository.milestones: paginated list of milestones.
-graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
+b:graphql("Repository.milestones", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -2153,29 +2178,29 @@ graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("Milestone", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.refs: paginated list of branches as Ref objects.
 -- Bitbucket branch objects use target.hash for the SHA; we normalise to commit.sha
 -- before passing to graphql_translate_ref.
-graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+b:graphql("Repository.refs", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
   end
-  return bb_repo_connection(owner, name, "/refs/branches", args, ctx, function(b)
+  return bb_repo_connection(owner, name, "/refs/branches", args, ctx, function(br)
     -- Normalise Bitbucket branch shape to the {name, commit={sha}} expected by
     -- graphql_translate_ref.
-    if b.target and not b.commit then
-      b.commit = { sha = b.target.hash }
+    if br.target and not br.commit then
+      br.commit = { sha = br.target.hash }
     end
-    return graphql_translate_ref(b, parent)
+    return graphql_translate_ref(br, parent)
   end, graphql_refs_connection)
-end
+end)
 
 -- Repository.defaultBranchRef: enrich the inline stub with full branch data.
 -- The parent already carries {__typename="Ref",name="main"} from graphql_translate_repo.
-graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
+b:graphql("Repository.defaultBranchRef", function(parent, _args, _ctx)
   local branch = parent.defaultBranchRef and parent.defaultBranchRef.name
   if not branch then
     return nil
@@ -2195,12 +2220,12 @@ graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
     data.commit = { sha = data.target.hash }
   end
   return graphql_translate_ref(data, parent)
-end
+end)
 
 -- Repository.languages: fetch primary language as a LanguageConnection.
 -- Bitbucket exposes only the primary language via the repo object; no byte-count breakdown.
 -- Returns a single-entry connection when the repo has a language, empty otherwise.
-graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
+b:graphql("Repository.languages", function(parent, _args, _ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -2236,10 +2261,10 @@ graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
     nodes = nodes,
     edges = edges,
   }
-end
+end)
 
 -- Issue.comments: paginated list of comments for a single issue.
-graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+b:graphql("Issue.comments", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -2276,10 +2301,10 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_comment(translate_bb_issue_comment(c), owner, repo)
   end
   return graphql_make_connection("IssueComment", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.commits: paginated commit list for a pull request.
-graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
+b:graphql("PullRequest.commits", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -2323,12 +2348,12 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     }
   end
   return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.reviews: paginated review list for a pull request.
 -- Bitbucket has no dedicated reviews endpoint; reviews are synthesized from
 -- PR participants with role=REVIEWER and approved=true.
-graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
+b:graphql("PullRequest.reviews", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -2351,7 +2376,7 @@ graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_review(r, owner, repo)
   end
   return graphql_make_connection("PullRequestReview", nodes, args, #nodes, ctx)
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Query.search
@@ -2360,7 +2385,7 @@ end
 -- Query.search: map GitHub GraphQL search to Bitbucket search endpoints.
 -- Supports REPOSITORY (via /repositories?q=name~"...") and USER
 -- (via /workspaces?q=slug~"..."). ISSUE search is not supported.
-graphql_resolvers["Query.search"] = function(_parent, args, _ctx)
+b:graphql("Query.search", function(_parent, args, _ctx)
   local query = args.query or ""
   local search_type = args.type or "REPOSITORY"
   local per_page = args.first or 30
@@ -2416,4 +2441,6 @@ graphql_resolvers["Query.search"] = function(_parent, args, _ctx)
     discussionCount = 0,
     wikiCount = 0,
   }
-end
+end)
+
+b:build()

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -372,166 +372,147 @@ local bbs_dc_to_gh = {
   STOPPED = { status = "completed", conclusion = "cancelled" },
 }
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
+end)
 
-  get_repo = proxy_handler(translate_bbs_repo, function(owner, repo_name)
+b:rest(
+  "get_repo",
+  proxy_handler(translate_bbs_repo, function(owner, repo_name)
     return repo_path(owner, repo_name)
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    proxy_json(function(r)
-      return translate_bbs_repo(r, owner)
-    end, fetch_json(repo_path(owner, repo_name), "PUT", translate_bbs_req(GetBody())))
-  end,
+b:rest("patch_repo", function(owner, repo_name)
+  proxy_json(function(r)
+    return translate_bbs_repo(r, owner)
+  end, fetch_json(repo_path(owner, repo_name), "PUT", translate_bbs_req(GetBody())))
+end)
 
-  delete_repo = function(owner, repo_name)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 202 }, pcall(Fetch, repo_path(owner, repo_name), dopts))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 202 }, pcall(Fetch, repo_path(owner, repo_name), dopts))
+end)
 
-  -- GET /user/repos — DC: GET /repos (all repos visible to the auth'd user)
-  get_user_repos = proxy_handler(translate_bbs_repos, function()
+-- GET /user/repos — DC: GET /repos (all repos visible to the auth'd user)
+b:rest(
+  "get_user_repos",
+  proxy_handler(translate_bbs_repos, function()
     return bbs_page_url(base() .. "/repos")
-  end),
+  end)
+)
 
-  post_user_repos = function()
-    -- DC requires a project key; no generic "my repos" create endpoint.
-    respond_json(
-      501,
-      "Not Implemented",
-      { message = "POST /user/repos requires a project key; use POST /orgs/{project}/repos" }
-    )
-  end,
+b:rest("post_user_repos", function()
+  -- DC requires a project key; no generic "my repos" create endpoint.
+  respond_json(
+    501,
+    "Not Implemented",
+    { message = "POST /user/repos requires a project key; use POST /orgs/{project}/repos" }
+  )
+end)
 
-  get_org_repos = proxy_handler(translate_bbs_repos, function(project_key)
+b:rest(
+  "get_org_repos",
+  proxy_handler(translate_bbs_repos, function(project_key)
     return bbs_page_url(base() .. "/projects/" .. project_key .. "/repos")
-  end),
+  end)
+)
 
-  post_org_repos = function(project_key)
-    proxy_json_created(
-      function(r)
-        return translate_bbs_repo(r, project_key)
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_key .. "/repos",
-        "POST",
-        translate_bbs_req(GetBody())
-      )
+b:rest("post_org_repos", function(project_key)
+  proxy_json_created(
+    function(r)
+      return translate_bbs_repo(r, project_key)
+    end,
+    fetch_json(
+      base() .. "/projects/" .. project_key .. "/repos",
+      "POST",
+      translate_bbs_req(GetBody())
     )
-  end,
+  )
+end)
 
-  -- GET /users/{username}/repos — via personal project ~username
-  get_users_repos = proxy_handler(function(data, username)
+-- GET /users/{username}/repos — via personal project ~username
+b:rest(
+  "get_users_repos",
+  proxy_handler(function(data, username)
     return translate_bbs_repos(data, "~" .. username)
   end, function(username)
     return bbs_page_url(base() .. "/projects/~" .. username .. "/repos")
-  end),
+  end)
+)
 
-  -- GET /repositories — all repos visible to the authenticated user
-  get_repositories = proxy_handler(translate_bbs_repos, function()
+-- GET /repositories — all repos visible to the authenticated user
+b:rest(
+  "get_repositories",
+  proxy_handler(translate_bbs_repos, function()
     return bbs_page_url(base() .. "/repos")
-  end),
+  end)
+)
 
-  -- Tags -----------------------------------------------------------------------
-  -- DC: GET /projects/{proj}/repos/{slug}/tags → { values: [{id, displayId, latestCommit}] }
+-- Tags -----------------------------------------------------------------------
+-- DC: GET /projects/{proj}/repos/{slug}/tags → { values: [{id, displayId, latestCommit}] }
 
-  get_repo_tags = proxy_handler(function(data)
+b:rest(
+  "get_repo_tags",
+  proxy_handler(function(data)
     return translate_list(translate_bbs_tag, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/tags")
-  end),
+  end)
+)
 
-  -- Branches -------------------------------------------------------------------
+-- Branches -------------------------------------------------------------------
 
-  get_repo_branches = proxy_handler(function(data)
+b:rest(
+  "get_repo_branches",
+  proxy_handler(function(data)
     return translate_list(translate_bbs_branch, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/branches")
-  end),
+  end)
+)
 
-  get_repo_branch = proxy_handler(function(data)
-    local b = (data.values or {})[1]
-    return b and translate_bbs_branch(b) or {}
+b:rest(
+  "get_repo_branch",
+  proxy_handler(function(data)
+    local br = (data.values or {})[1]
+    return br and translate_bbs_branch(br) or {}
   end, function(owner, repo_name, branch)
     return repo_path(owner, repo_name) .. "/branches?filterText=" .. branch .. "&limit=1"
-  end),
+  end)
+)
 
-  -- Commits --------------------------------------------------------------------
+-- Commits --------------------------------------------------------------------
 
-  get_repo_commits = function(owner, repo_name)
-    local ref = GetParam("sha") or ""
-    local url = bbs_page_url(repo_path(owner, repo_name) .. "/commits")
-    if ref ~= "" then
-      local sep = url:find("?") and "&" or "?"
-      url = url .. sep .. "until=" .. ref
-    end
-    proxy_json(function(data)
-      return translate_list(translate_bbs_commit, data.values)
-    end, fetch_json(url))
-  end,
+b:rest("get_repo_commits", function(owner, repo_name)
+  local ref = GetParam("sha") or ""
+  local url = bbs_page_url(repo_path(owner, repo_name) .. "/commits")
+  if ref ~= "" then
+    local sep = url:find("?") and "&" or "?"
+    url = url .. sep .. "until=" .. ref
+  end
+  proxy_json(function(data)
+    return translate_list(translate_bbs_commit, data.values)
+  end, fetch_json(url))
+end)
 
-  get_repo_commit = proxy_handler(translate_bbs_commit, function(owner, repo_name, sha)
+b:rest(
+  "get_repo_commit",
+  proxy_handler(translate_bbs_commit, function(owner, repo_name, sha)
     return repo_path(owner, repo_name) .. "/commits/" .. sha
-  end),
+  end)
+)
 
-  -- Contents -------------------------------------------------------------------
-  -- DC: GET /projects/{proj}/repos/{slug}/raw/{path}?at={ref}
+-- Contents -------------------------------------------------------------------
+-- DC: GET /projects/{proj}/repos/{slug}/raw/{path}?at={ref}
 
-  get_repo_readme = function(owner, repo_name)
-    local ref = GetParam("ref") or ""
-    local candidates = { "README.md", "README", "readme.md", "README.rst" }
-    for _, fname in ipairs(candidates) do
-      local url = repo_path(owner, repo_name) .. "/raw/" .. fname
-      if ref ~= "" then
-        url = url .. "?at=" .. ref
-      end
-      local ok, status, _, body = fetch_json(url)
-      if ok and status == 200 then
-        respond_json(200, {
-          type = "file",
-          name = fname,
-          path = fname,
-          sha = "",
-          size = #body,
-          encoding = "base64",
-          content = EncodeBase64(body),
-        })
-        return
-      end
-    end
-    respond_json(404, { message = "Not Found" })
-  end,
-
-  -- GET /repos/{owner}/{repo}/license
-  -- BBS has no license template API; fetch the LICENSE file via raw endpoint.
-  get_repo_license = function(owner, repo_name)
-    local candidates = { "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }
-    for _, fname in ipairs(candidates) do
-      local ok, status, _, body = fetch_json(repo_path(owner, repo_name) .. "/raw/" .. fname)
-      if ok and status == 200 then
-        respond_json(200, {
-          type = "file",
-          name = fname,
-          path = fname,
-          sha = "",
-          size = #body,
-          encoding = "base64",
-          content = EncodeBase64(body),
-          license = nil,
-        })
-        return
-      end
-    end
-    respond_json(404, { message = "License file not found" })
-  end,
-
-  get_repo_content = function(owner, repo_name, path)
-    local ref = GetParam("ref") or ""
-    local url = repo_path(owner, repo_name) .. "/raw/" .. path
+b:rest("get_repo_readme", function(owner, repo_name)
+  local ref = GetParam("ref") or ""
+  local candidates = { "README.md", "README", "readme.md", "README.rst" }
+  for _, fname in ipairs(candidates) do
+    local url = repo_path(owner, repo_name) .. "/raw/" .. fname
     if ref ~= "" then
       url = url .. "?at=" .. ref
     end
@@ -539,518 +520,596 @@ app.backend_impl = {
     if ok and status == 200 then
       respond_json(200, {
         type = "file",
-        name = path:match("[^/]+$") or path,
-        path = path,
+        name = fname,
+        path = fname,
         sha = "",
         size = #body,
         encoding = "base64",
         content = EncodeBase64(body),
       })
-    elseif ok then
-      respond_json(status, { message = "Error" })
-    else
-      respond_json(503, {})
+      return
     end
-  end,
+  end
+  respond_json(404, { message = "Not Found" })
+end)
 
-  -- Forks ----------------------------------------------------------------------
+-- GET /repos/{owner}/{repo}/license
+-- BBS has no license template API; fetch the LICENSE file via raw endpoint.
+b:rest("get_repo_license", function(owner, repo_name)
+  local candidates = { "LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING" }
+  for _, fname in ipairs(candidates) do
+    local ok, status, _, body = fetch_json(repo_path(owner, repo_name) .. "/raw/" .. fname)
+    if ok and status == 200 then
+      respond_json(200, {
+        type = "file",
+        name = fname,
+        path = fname,
+        sha = "",
+        size = #body,
+        encoding = "base64",
+        content = EncodeBase64(body),
+        license = nil,
+      })
+      return
+    end
+  end
+  respond_json(404, { message = "License file not found" })
+end)
 
-  get_repo_forks = proxy_handler(translate_bbs_repos, function(owner, repo_name)
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local ref = GetParam("ref") or ""
+  local url = repo_path(owner, repo_name) .. "/raw/" .. path
+  if ref ~= "" then
+    url = url .. "?at=" .. ref
+  end
+  local ok, status, _, body = fetch_json(url)
+  if ok and status == 200 then
+    respond_json(200, {
+      type = "file",
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = #body,
+      encoding = "base64",
+      content = EncodeBase64(body),
+    })
+  elseif ok then
+    respond_json(status, { message = "Error" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- Forks ----------------------------------------------------------------------
+
+b:rest(
+  "get_repo_forks",
+  proxy_handler(translate_bbs_repos, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/forks")
-  end),
+  end)
+)
 
-  post_repo_forks = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = {}
-    if req.organization then
-      bb.project = { key = req.organization }
-    end
-    proxy_json_created(function(r)
-      return translate_bbs_repo(r, owner)
-    end, fetch_json(repo_path(owner, repo_name) .. "/forks", "POST", EncodeJson(bb)))
-  end,
+b:rest("post_repo_forks", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = {}
+  if req.organization then
+    bb.project = { key = req.organization }
+  end
+  proxy_json_created(function(r)
+    return translate_bbs_repo(r, owner)
+  end, fetch_json(repo_path(owner, repo_name) .. "/forks", "POST", EncodeJson(bb)))
+end)
 
-  -- Deploy keys ----------------------------------------------------------------
-  -- DC: /ssh endpoint (not /deploy-keys)
+-- Deploy keys ----------------------------------------------------------------
+-- DC: /ssh endpoint (not /deploy-keys)
 
-  get_repo_keys = proxy_handler(function(data)
+b:rest(
+  "get_repo_keys",
+  proxy_handler(function(data)
     return translate_list(translate_bbs_key, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/ssh")
-  end),
+  end)
+)
 
-  post_repo_keys = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local bb = {
-      key = { text = req.key or "", label = req.title or "" },
-      permission = "REPO_READ",
-    }
-    proxy_json_created(
-      translate_bbs_key,
-      fetch_json(repo_path(owner, repo_name) .. "/ssh", "POST", EncodeJson(bb))
-    )
-  end,
+b:rest("post_repo_keys", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local bb = {
+    key = { text = req.key or "", label = req.title or "" },
+    permission = "REPO_READ",
+  }
+  proxy_json_created(
+    translate_bbs_key,
+    fetch_json(repo_path(owner, repo_name) .. "/ssh", "POST", EncodeJson(bb))
+  )
+end)
 
-  get_repo_key = proxy_handler(translate_bbs_key, function(owner, repo_name, key_id)
+b:rest(
+  "get_repo_key",
+  proxy_handler(translate_bbs_key, function(owner, repo_name, key_id)
     return repo_path(owner, repo_name) .. "/ssh/" .. key_id
-  end),
+  end)
+)
 
-  delete_repo_key = function(owner, repo_name, key_id)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, repo_path(owner, repo_name) .. "/ssh/" .. key_id, dopts))
-  end,
+b:rest("delete_repo_key", function(owner, repo_name, key_id)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, repo_path(owner, repo_name) .. "/ssh/" .. key_id, dopts))
+end)
 
-  -- Webhooks -------------------------------------------------------------------
+-- Webhooks -------------------------------------------------------------------
 
-  get_repo_hooks = proxy_handler(function(data)
+b:rest(
+  "get_repo_hooks",
+  proxy_handler(function(data)
     return translate_list(translate_bbs_hook, data.values)
   end, function(owner, repo_name)
     return bbs_page_url(repo_path(owner, repo_name) .. "/webhooks")
-  end),
+  end)
+)
 
-  post_repo_hooks = function(owner, repo_name)
-    proxy_json_created(
-      translate_bbs_hook,
-      fetch_json(
-        repo_path(owner, repo_name) .. "/webhooks",
-        "POST",
-        translate_bbs_hook_req(GetBody())
-      )
+b:rest("post_repo_hooks", function(owner, repo_name)
+  proxy_json_created(
+    translate_bbs_hook,
+    fetch_json(
+      repo_path(owner, repo_name) .. "/webhooks",
+      "POST",
+      translate_bbs_hook_req(GetBody())
     )
-  end,
+  )
+end)
 
-  get_repo_hook = proxy_handler(translate_bbs_hook, function(owner, repo_name, hook_id)
+b:rest(
+  "get_repo_hook",
+  proxy_handler(translate_bbs_hook, function(owner, repo_name, hook_id)
     return repo_path(owner, repo_name) .. "/webhooks/" .. hook_id
-  end),
+  end)
+)
 
-  patch_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      translate_bbs_hook,
-      fetch_json(
-        repo_path(owner, repo_name) .. "/webhooks/" .. hook_id,
-        "PUT",
-        translate_bbs_hook_req(GetBody())
-      )
+b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    translate_bbs_hook,
+    fetch_json(
+      repo_path(owner, repo_name) .. "/webhooks/" .. hook_id,
+      "PUT",
+      translate_bbs_hook_req(GetBody())
     )
-  end,
+  )
+end)
 
-  delete_repo_hook = function(owner, repo_name, hook_id)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, repo_path(owner, repo_name) .. "/webhooks/" .. hook_id, dopts))
-  end,
+b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, repo_path(owner, repo_name) .. "/webhooks/" .. hook_id, dopts))
+end)
 
-  get_repo_hook_config = proxy_handler(function(h)
+b:rest(
+  "get_repo_hook_config",
+  proxy_handler(function(h)
     return (translate_bbs_hook(h)).config or {}
   end, function(owner, repo_name, hook_id)
     return repo_path(owner, repo_name) .. "/webhooks/" .. hook_id
-  end),
+  end)
+)
 
-  -- Users ---------------------------------------------------------------------
+-- Users ---------------------------------------------------------------------
 
-  -- GET /users/{username}
-  get_users_username = proxy_handler(translate_bbs_user, function(username)
+-- GET /users/{username}
+b:rest(
+  "get_users_username",
+  proxy_handler(translate_bbs_user, function(username)
     return base() .. "/users/" .. username
-  end),
+  end)
+)
 
-  -- GET /users
-  get_users = proxy_handler(function(data)
+-- GET /users
+b:rest(
+  "get_users",
+  proxy_handler(function(data)
     return translate_list(translate_bbs_user, (data and data.values))
   end, function()
     return bbs_page_url(base() .. "/users")
-  end),
+  end)
+)
 
-  -- Pull Requests ---------------------------------------------------------------
+-- Pull Requests ---------------------------------------------------------------
 
-  -- GET /repos/{owner}/{repo}/pulls
-  get_repo_pulls = function(owner, repo_name)
-    local state = GetParam("state") or "open"
-    local dc_state = state == "closed" and "MERGED,DECLINED" or state == "all" and "ALL" or "OPEN"
-    local url = bbs_page_url(repo_path(owner, repo_name) .. "/pull-requests?state=" .. dc_state)
-    proxy_json(translate_bbs_pulls, fetch_json(url))
-  end,
+-- GET /repos/{owner}/{repo}/pulls
+b:rest("get_repo_pulls", function(owner, repo_name)
+  local state = GetParam("state") or "open"
+  local dc_state = state == "closed" and "MERGED,DECLINED" or state == "all" and "ALL" or "OPEN"
+  local url = bbs_page_url(repo_path(owner, repo_name) .. "/pull-requests?state=" .. dc_state)
+  proxy_json(translate_bbs_pulls, fetch_json(url))
+end)
 
-  -- POST /repos/{owner}/{repo}/pulls
-  post_repo_pulls = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local dc = {}
-    if req.title then
-      dc.title = req.title
-    end
-    if req.body then
-      dc.description = req.body
-    end
-    if req.head then
-      dc.fromRef = { id = "refs/heads/" .. req.head }
-    end
-    if req.base then
-      dc.toRef = { id = "refs/heads/" .. req.base }
-    end
-    proxy_json_created(
-      translate_bbs_pull,
-      fetch_json(repo_path(owner, repo_name) .. "/pull-requests", "POST", EncodeJson(dc))
-    )
-  end,
+-- POST /repos/{owner}/{repo}/pulls
+b:rest("post_repo_pulls", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local dc = {}
+  if req.title then
+    dc.title = req.title
+  end
+  if req.body then
+    dc.description = req.body
+  end
+  if req.head then
+    dc.fromRef = { id = "refs/heads/" .. req.head }
+  end
+  if req.base then
+    dc.toRef = { id = "refs/heads/" .. req.base }
+  end
+  proxy_json_created(
+    translate_bbs_pull,
+    fetch_json(repo_path(owner, repo_name) .. "/pull-requests", "POST", EncodeJson(dc))
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}
-  get_repo_pull = proxy_handler(translate_bbs_pull, function(owner, repo_name, pull_number)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}
+b:rest(
+  "get_repo_pull",
+  proxy_handler(translate_bbs_pull, function(owner, repo_name, pull_number)
     return repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number
-  end),
+  end)
+)
 
-  -- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
-  -- DC uses PUT for updates and requires a version field.
-  patch_repo_pull = function(owner, repo_name, pull_number)
-    local pr_url = repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number
-    local ok, status, _, body = fetch_json(pr_url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local current = DecodeJson(body) or {}
-    local req = DecodeJson(GetBody() or "{}")
-    local dc = { version = current.version or 0 }
-    if req.title then
-      dc.title = req.title
-    end
-    if req.body then
-      dc.description = req.body
-    end
-    proxy_json(translate_bbs_pull, fetch_json(pr_url, "PUT", EncodeJson(dc)))
-  end,
+-- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
+-- DC uses PUT for updates and requires a version field.
+b:rest("patch_repo_pull", function(owner, repo_name, pull_number)
+  local pr_url = repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number
+  local ok, status, _, body = fetch_json(pr_url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local current = DecodeJson(body) or {}
+  local req = DecodeJson(GetBody() or "{}")
+  local dc = { version = current.version or 0 }
+  if req.title then
+    dc.title = req.title
+  end
+  if req.body then
+    dc.description = req.body
+  end
+  proxy_json(translate_bbs_pull, fetch_json(pr_url, "PUT", EncodeJson(dc)))
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
-  get_pull_commits = proxy_handler(function(data)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
+b:rest(
+  "get_pull_commits",
+  proxy_handler(function(data)
     return translate_list(translate_bbs_commit, (data and data.values))
   end, function(owner, repo_name, pull_number)
     return bbs_page_url(
       repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/commits"
     )
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
-  -- DC uses /changes for per-file info (no line stats).
-  get_pull_files = proxy_handler(function(data)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
+-- DC uses /changes for per-file info (no line stats).
+b:rest(
+  "get_pull_files",
+  proxy_handler(function(data)
     return translate_list(translate_bbs_pr_change, (data and data.values))
   end, function(owner, repo_name, pull_number)
     return bbs_page_url(
       repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/changes"
     )
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- Cannot use proxy_json: DC always returns 200 with a PR object; the response
-  -- status (204 merged / 404 not merged) is synthesised from the body's state field.
-  get_pull_merge = function(owner, repo_name, pull_number)
-    local ok, status, _, body =
-      fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    if pr.state == "MERGED" then
-      SetStatus(204, "No Content")
-    else
-      respond_json(404, { message = "Pull Request is not merged" })
-    end
-  end,
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
+-- Cannot use proxy_json: DC always returns 200 with a PR object; the response
+-- status (204 merged / 404 not merged) is synthesised from the body's state field.
+b:rest("get_pull_merge", function(owner, repo_name, pull_number)
+  local ok, status, _, body =
+    fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  if pr.state == "MERGED" then
+    SetStatus(204, "No Content")
+  else
+    respond_json(404, { message = "Pull Request is not merged" })
+  end
+end)
 
-  -- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- DC: POST /pull-requests/{id}/merge; requires version from current PR.
-  put_pull_merge = function(owner, repo_name, pull_number)
-    local pr_url = repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number
-    local ok, status, _, body = fetch_json(pr_url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local current = DecodeJson(body) or {}
-    local req = DecodeJson(GetBody() or "{}")
-    local dc = { version = current.version or 0 }
-    if req.commit_message then
-      dc.message = req.commit_message
-    end
-    proxy_204({ 200 }, fetch_json(pr_url .. "/merge", "POST", EncodeJson(dc)))
-  end,
+-- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
+-- DC: POST /pull-requests/{id}/merge; requires version from current PR.
+b:rest("put_pull_merge", function(owner, repo_name, pull_number)
+  local pr_url = repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number
+  local ok, status, _, body = fetch_json(pr_url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local current = DecodeJson(body) or {}
+  local req = DecodeJson(GetBody() or "{}")
+  local dc = { version = current.version or 0 }
+  if req.commit_message then
+    dc.message = req.commit_message
+  end
+  proxy_204({ 200 }, fetch_json(pr_url .. "/merge", "POST", EncodeJson(dc)))
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
-  -- DC: reviewers in PR object who have not yet approved.
-  get_pull_requested_reviewers = function(owner, repo_name, pull_number)
-    local ok, status, _, body =
-      fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
-    if not ok then
-      respond_json(503, {})
-      return
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+-- DC: reviewers in PR object who have not yet approved.
+b:rest("get_pull_requested_reviewers", function(owner, repo_name, pull_number)
+  local ok, status, _, body =
+    fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  local users = {}
+  for _, r in ipairs(pr.reviewers or {}) do
+    if not r.approved then
+      users[#users + 1] = translate_bbs_user(r.user)
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    local users = {}
-    for _, r in ipairs(pr.reviewers or {}) do
-      if not r.approved then
-        users[#users + 1] = translate_bbs_user(r.user)
-      end
-    end
-    respond_json(200, { users = users, teams = {} })
-  end,
+  end
+  respond_json(200, { users = users, teams = {} })
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
-  -- DC: reviewers with approved=true in PR object.
-  get_pull_reviews = function(owner, repo_name, pull_number)
-    local ok, status, _, body =
-      fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    respond_json(200, translate_bbs_reviewers_to_reviews(pr.reviewers))
-  end,
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+-- DC: reviewers with approved=true in PR object.
+b:rest("get_pull_reviews", function(owner, repo_name, pull_number)
+  local ok, status, _, body =
+    fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  respond_json(200, translate_bbs_reviewers_to_reviews(pr.reviewers))
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
-  get_pull_review = function(owner, repo_name, pull_number, review_id)
-    local ok, status, _, body =
-      fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local pr = DecodeJson(body) or {}
-    local reviews = translate_bbs_reviewers_to_reviews(pr.reviewers)
-    local rid = tonumber(review_id)
-    if rid and reviews[rid] then
-      respond_json(200, reviews[rid])
-    else
-      respond_json(404, { message = "Not Found" })
-    end
-  end,
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
+b:rest("get_pull_review", function(owner, repo_name, pull_number, review_id)
+  local ok, status, _, body =
+    fetch_json(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local pr = DecodeJson(body) or {}
+  local reviews = translate_bbs_reviewers_to_reviews(pr.reviewers)
+  local rid = tonumber(review_id)
+  if rid and reviews[rid] then
+    respond_json(200, reviews[rid])
+  else
+    respond_json(404, { message = "Not Found" })
+  end
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
-  -- DC has no per-review comments; return all PR inline comments.
-  get_pull_review_comments = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      bbs_page_url(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/comments")
-    )
-    if not ok then
-      respond_json(503, {})
-      return
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
+-- DC has no per-review comments; return all PR inline comments.
+b:rest("get_pull_review_comments", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    bbs_page_url(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/comments")
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local result = {}
+  for _, c in ipairs(data.values or {}) do
+    if c.anchor then
+      result[#result + 1] = translate_bbs_pr_comment(c)
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local result = {}
-    for _, c in ipairs(data.values or {}) do
-      if c.anchor then
-        result[#result + 1] = translate_bbs_pr_comment(c)
-      end
-    end
-    respond_json(200, result)
-  end,
+  end
+  respond_json(200, result)
+end)
 
-  -- Issues -----------------------------------------------------------------------
-  -- Bitbucket Datacenter has no native issue tracker; it relies on Jira.
-  -- All issues, labels, milestones, and assignees endpoints fall back to the
-  -- default empty-list handlers defined in .init.lua.
+-- Issues -----------------------------------------------------------------------
+-- Bitbucket Datacenter has no native issue tracker; it relies on Jira.
+-- All issues, labels, milestones, and assignees endpoints fall back to the
+-- default empty-list handlers defined in .init.lua.
 
-  -- Search -----------------------------------------------------------------------
+-- Search -----------------------------------------------------------------------
 
-  -- GET /search/repositories — DC: GET /repos?name=<q>
-  search_repositories = function()
-    local q = GetParam("q") or ""
-    proxy_search_envelope(
-      translate_bbs_repo,
-      "values",
-      fetch_json(bbs_page_url(base() .. "/repos?name=" .. q))
-    )
-  end,
+-- GET /search/repositories — DC: GET /repos?name=<q>
+b:rest("search_repositories", function()
+  local q = GetParam("q") or ""
+  proxy_search_envelope(
+    translate_bbs_repo,
+    "values",
+    fetch_json(bbs_page_url(base() .. "/repos?name=" .. q))
+  )
+end)
 
-  -- GET /search/users — DC: GET /users?filter=<q>
-  search_users = function()
-    local q = GetParam("q") or ""
-    proxy_search_envelope(
-      translate_bbs_user,
-      "values",
-      fetch_json(bbs_page_url(base() .. "/users?filter=" .. q))
-    )
-  end,
+-- GET /search/users — DC: GET /users?filter=<q>
+b:rest("search_users", function()
+  local q = GetParam("q") or ""
+  proxy_search_envelope(
+    translate_bbs_user,
+    "values",
+    fetch_json(bbs_page_url(base() .. "/users?filter=" .. q))
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
-  -- DC inline PR comments (those with an anchor field).
-  get_pull_comments = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      bbs_page_url(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/comments")
-    )
-    if not ok then
-      respond_json(503, {})
-      return
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
+-- DC inline PR comments (those with an anchor field).
+b:rest("get_pull_comments", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    bbs_page_url(repo_path(owner, repo_name) .. "/pull-requests/" .. pull_number .. "/comments")
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local result = {}
+  for _, c in ipairs(data.values or {}) do
+    if c.anchor then
+      result[#result + 1] = translate_bbs_pr_comment(c)
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local result = {}
-    for _, c in ipairs(data.values or {}) do
-      if c.anchor then
-        result[#result + 1] = translate_bbs_pr_comment(c)
-      end
-    end
-    respond_json(200, result)
-  end,
+  end
+  respond_json(200, result)
+end)
 
-  -- Checks (via Bitbucket DC build status API) ------------------------------------
-  --
-  -- Bitbucket DC has a dedicated build status REST API at:
-  --   POST /rest/build-status/1.0/commits/{sha}  — create/update a build status
-  --   GET  /rest/build-status/1.0/commits/{sha}  — list build statuses for a commit
-  --
-  -- GitHub Check Runs map onto DC build statuses:
-  --   • POST check-runs → POST /rest/build-status/1.0/commits/{sha}
-  --   • GET check-runs/{id} → minimal stub (no reverse lookup by ID)
-  --   • PATCH check-runs/{id} → minimal stub
-  --   • GET commits/{ref}/check-runs → build statuses list
-  --   • Check Suites have no DC equivalent; all suite endpoints are stubs.
-  --   • Annotations are always empty.
-  --
-  -- Status mapping (GitHub → DC):
-  --   queued/in_progress     → INPROGRESS
-  --   completed/success      → SUCCESSFUL
-  --   completed/failure      → FAILED
-  --   completed/neutral      → SUCCESSFUL
-  --   completed/skipped      → SUCCESSFUL
-  --   completed/cancelled    → STOPPED
-  --   completed/(other)      → FAILED
-  --
-  -- Status mapping (DC → GitHub):
-  --   INPROGRESS  → status=in_progress, conclusion=null
-  --   SUCCESSFUL  → status=completed,   conclusion=success
-  --   FAILED      → status=completed,   conclusion=failure
-  --   STOPPED     → status=completed,   conclusion=cancelled
-  --   other       → status=completed,   conclusion=failure
+-- Checks (via Bitbucket DC build status API) ------------------------------------
+--
+-- Bitbucket DC has a dedicated build status REST API at:
+--   POST /rest/build-status/1.0/commits/{sha}  — create/update a build status
+--   GET  /rest/build-status/1.0/commits/{sha}  — list build statuses for a commit
+--
+-- GitHub Check Runs map onto DC build statuses:
+--   • POST check-runs → POST /rest/build-status/1.0/commits/{sha}
+--   • GET check-runs/{id} → minimal stub (no reverse lookup by ID)
+--   • PATCH check-runs/{id} → minimal stub
+--   • GET commits/{ref}/check-runs → build statuses list
+--   • Check Suites have no DC equivalent; all suite endpoints are stubs.
+--   • Annotations are always empty.
+--
+-- Status mapping (GitHub → DC):
+--   queued/in_progress     → INPROGRESS
+--   completed/success      → SUCCESSFUL
+--   completed/failure      → FAILED
+--   completed/neutral      → SUCCESSFUL
+--   completed/skipped      → SUCCESSFUL
+--   completed/cancelled    → STOPPED
+--   completed/(other)      → FAILED
+--
+-- Status mapping (DC → GitHub):
+--   INPROGRESS  → status=in_progress, conclusion=null
+--   SUCCESSFUL  → status=completed,   conclusion=success
+--   FAILED      → status=completed,   conclusion=failure
+--   STOPPED     → status=completed,   conclusion=cancelled
+--   other       → status=completed,   conclusion=failure
 
-  post_check_runs = function(owner, repo_name) -- luacheck: ignore 212
-    local req = DecodeJson(GetBody() or "{}")
-    local sha = req.head_sha or ""
-    local gh_status = req.status or "queued"
-    local conclusion = req.conclusion
-    local gh_conclusion_to_dc = {
-      success = "SUCCESSFUL",
-      neutral = "SUCCESSFUL",
-      skipped = "SUCCESSFUL",
-      cancelled = "STOPPED",
-    }
-    local dc_state = gh_status == "completed" and (gh_conclusion_to_dc[conclusion] or "FAILED")
-      or "INPROGRESS"
-    local dc_body = EncodeJson({
-      state = dc_state,
-      key = req.name or "",
-      url = req.details_url or "",
-      name = req.name or "",
-      description = (req.output and req.output.summary) or req.name or "",
-    })
-    -- DC POST returns 204 No Content on success (no body); synthesise a GitHub response.
-    local ok, up_status =
-      fetch_json(config.base_url .. "/rest/build-status/1.0/commits/" .. sha, "POST", dc_body)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if up_status ~= 204 and up_status ~= 200 and up_status ~= 201 then
-      respond_json(up_status, {})
-      return
-    end
-    local mapped = bbs_dc_to_gh[dc_state] or { status = "completed", conclusion = "failure" }
-    respond_json(201, {
-      id = 0,
+b:rest("post_check_runs", function(owner, repo_name) -- luacheck: ignore 212
+  local req = DecodeJson(GetBody() or "{}")
+  local sha = req.head_sha or ""
+  local gh_status = req.status or "queued"
+  local conclusion = req.conclusion
+  local gh_conclusion_to_dc = {
+    success = "SUCCESSFUL",
+    neutral = "SUCCESSFUL",
+    skipped = "SUCCESSFUL",
+    cancelled = "STOPPED",
+  }
+  local dc_state = gh_status == "completed" and (gh_conclusion_to_dc[conclusion] or "FAILED")
+    or "INPROGRESS"
+  local dc_body = EncodeJson({
+    state = dc_state,
+    key = req.name or "",
+    url = req.details_url or "",
+    name = req.name or "",
+    description = (req.output and req.output.summary) or req.name or "",
+  })
+  -- DC POST returns 204 No Content on success (no body); synthesise a GitHub response.
+  local ok, up_status =
+    fetch_json(config.base_url .. "/rest/build-status/1.0/commits/" .. sha, "POST", dc_body)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if up_status ~= 204 and up_status ~= 200 and up_status ~= 201 then
+    respond_json(up_status, {})
+    return
+  end
+  local mapped = bbs_dc_to_gh[dc_state] or { status = "completed", conclusion = "failure" }
+  respond_json(201, {
+    id = 0,
+    node_id = "",
+    head_sha = sha,
+    name = req.name or "",
+    status = mapped.status,
+    conclusion = mapped.conclusion,
+    started_at = nil,
+    completed_at = mapped.status == "completed" and "" or nil,
+    output = {
+      title = (req.output and req.output.title) or req.name or "",
+      summary = (req.output and req.output.summary) or req.name or "",
+      text = "",
+      annotations_count = 0,
+      annotations_url = "",
+    },
+    url = "",
+    html_url = req.details_url or "",
+    details_url = req.details_url or "",
+  })
+end)
+
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- Uses DC build status API.
+b:rest("get_commit_check_runs", function(_owner, _repo_name, ref)
+  local ok, status, _, body =
+    fetch_json(config.base_url .. "/rest/build-status/1.0/commits/" .. ref)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local runs = {}
+  for i, s in ipairs(data.values or {}) do
+    local mapped = bbs_dc_to_gh[s.state] or { status = "completed", conclusion = "failure" }
+    runs[i] = {
+      id = i,
       node_id = "",
-      head_sha = sha,
-      name = req.name or "",
+      head_sha = ref,
+      name = s.key or s.name or "",
       status = mapped.status,
       conclusion = mapped.conclusion,
       started_at = nil,
       completed_at = mapped.status == "completed" and "" or nil,
       output = {
-        title = (req.output and req.output.title) or req.name or "",
-        summary = (req.output and req.output.summary) or req.name or "",
+        title = s.description or "",
+        summary = s.description or "",
         text = "",
         annotations_count = 0,
         annotations_url = "",
       },
       url = "",
-      html_url = req.details_url or "",
-      details_url = req.details_url or "",
-    })
-  end,
+      html_url = s.url or "",
+      details_url = s.url or "",
+    }
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
 
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- Uses DC build status API.
-  get_commit_check_runs = function(_owner, _repo_name, ref)
-    local ok, status, _, body =
-      fetch_json(config.base_url .. "/rest/build-status/1.0/commits/" .. ref)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local runs = {}
-    for i, s in ipairs(data.values or {}) do
-      local mapped = bbs_dc_to_gh[s.state] or { status = "completed", conclusion = "failure" }
-      runs[i] = {
-        id = i,
-        node_id = "",
-        head_sha = ref,
-        name = s.key or s.name or "",
-        status = mapped.status,
-        conclusion = mapped.conclusion,
-        started_at = nil,
-        completed_at = mapped.status == "completed" and "" or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.url or "",
-        details_url = s.url or "",
-      }
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
-
-  -- Check suites have no DC equivalent; all suite endpoints fall back to
-  -- the route_defaults stubs defined in .init.lua.
-}
+-- Check suites have no DC equivalent; all suite endpoints fall back to
+-- the route_defaults stubs defined in .init.lua.
 
 -- Code Scanning via Bitbucket DC Code Insights API.
 -- BBS Code Insights (/rest/insights/1.0) stores per-commit analysis reports
@@ -1097,9 +1156,9 @@ local function resolve_ref_sha(owner, repo_name)
     return nil
   end
   local data = DecodeJson(body) or {}
-  for _, b in ipairs(data.values or {}) do
-    if b.isDefault then
-      return b.latestCommit or b.latestChangeset
+  for _, br in ipairs(data.values or {}) do
+    if br.isDefault then
+      return br.latestCommit or br.latestChangeset
     end
   end
   -- Fall back to first branch if no default found.
@@ -1184,9 +1243,7 @@ local function translate_bbs_report(rpt, idx, sha)
   }
 end
 
-local _b = app.backend_impl
-
-_b.list_repo_code_scanning_alerts = function(owner, repo_name)
+b:rest("list_repo_code_scanning_alerts", function(owner, repo_name)
   local sha = resolve_ref_sha(owner, repo_name)
   if not sha then
     respond_json(200, {})
@@ -1208,9 +1265,9 @@ _b.list_repo_code_scanning_alerts = function(owner, repo_name)
     result[i] = translate_bbs_annotation(ann, i)
   end
   respond_json(200, result)
-end
+end)
 
-_b.list_code_scanning_analyses = function(owner, repo_name)
+b:rest("list_code_scanning_analyses", function(owner, repo_name)
   local sha = resolve_ref_sha(owner, repo_name)
   if not sha then
     respond_json(200, {})
@@ -1232,7 +1289,7 @@ _b.list_code_scanning_analyses = function(owner, repo_name)
     result[i] = translate_bbs_report(rpt, i, sha)
   end
   respond_json(200, result)
-end
+end)
 
 -- Git database (refs only; blobs/commits/tag-objects/trees have no DC equivalent) -----
 
@@ -1247,7 +1304,7 @@ local function translate_bbs_ref(r)
   }
 end
 
-_b.list_git_matching_refs = function(owner, repo_name, ref)
+b:rest("list_git_matching_refs", function(owner, repo_name, ref)
   local endpoint, prefix
   if ref:sub(1, 6) == "heads/" then
     endpoint = "/branches"
@@ -1263,9 +1320,9 @@ _b.list_git_matching_refs = function(owner, repo_name, ref)
   proxy_json(function(data)
     return translate_list(translate_bbs_ref, data.values)
   end, fetch_json(url))
-end
+end)
 
-_b.get_git_ref = function(owner, repo_name, ref)
+b:rest("get_git_ref", function(owner, repo_name, ref)
   local endpoint, prefix
   if ref:sub(1, 6) == "heads/" then
     endpoint = "/branches"
@@ -1282,9 +1339,9 @@ _b.get_git_ref = function(owner, repo_name, ref)
     local first = (data.values or {})[1]
     return first and translate_bbs_ref(first) or {}
   end, fetch_json(url))
-end
+end)
 
-_b.create_git_ref = function(owner, repo_name)
+b:rest("create_git_ref", function(owner, repo_name)
   local req = DecodeJson(GetBody() or "{}")
   local full_ref = req.ref or ""
   local sha = req.sha or ""
@@ -1303,9 +1360,9 @@ _b.create_git_ref = function(owner, repo_name)
     translate_bbs_ref,
     fetch_json(repo_path(owner, repo_name) .. endpoint, "POST", bb_body)
   )
-end
+end)
 
-_b.delete_git_ref = function(owner, repo_name, ref)
+b:rest("delete_git_ref", function(owner, repo_name, ref)
   local endpoint, body_or_nil
   if ref:sub(1, 6) == "heads/" then
     endpoint = "/branches"
@@ -1326,7 +1383,7 @@ _b.delete_git_ref = function(owner, repo_name, ref)
     dopts.headers["Content-Type"] = "application/json"
   end
   proxy_204({ 200, 202 }, pcall(Fetch, url, dopts))
-end
+end)
 
 -- GraphQL resolvers -----------------------------------------------------------
 -- BBS scope: Query.repository, Query.user, Repository.pullRequests.
@@ -1374,7 +1431,7 @@ local function bbs_repo_connection(owner, repo_name, suffix, args, ctx, translat
   return make_conn(nodes, args, nil, ctx)
 end
 
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -1384,9 +1441,9 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(translate_bbs_repo(data))
-end
+end)
 
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local owner, name = local_id:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1396,9 +1453,9 @@ graphql_resolvers["node.Repository"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_repo(translate_bbs_repo(data))
-end
+end)
 
-graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+b:graphql("Query.user", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "user requires a login argument")
     return nil
@@ -1408,17 +1465,17 @@ graphql_resolvers["Query.user"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_user(translate_bbs_user(data))
-end
+end)
 
-graphql_resolvers["node.User"] = function(local_id, _ctx)
+b:graphql("node.User", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_user(translate_bbs_user(data))
-end
+end)
 
-graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+b:graphql("Repository.pullRequests", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1426,9 +1483,9 @@ graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
   return bbs_repo_connection(owner, name, "/pull-requests", args, ctx, function(pr)
     return graphql_translate_pr(translate_bbs_pull(pr), owner, name)
   end, graphql_prs_connection)
-end
+end)
 
-graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
+b:graphql("node.PullRequest", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -1438,4 +1495,6 @@ graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_pr(translate_bbs_pull(data), owner, repo)
-end
+end)
+
+b:build()

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -96,102 +96,103 @@ local function check_page()
   return true
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/repos", auth()))
+end)
 
-  -- GET /repos/{owner}/{repo}: owner must be "codecommit".
-  -- CodeCommit returns 400 (RepositoryDoesNotExistException) for unknown repos;
-  -- map that to 404 for GitHub compatibility.
-  get_repo = function(owner, repo_name)
-    if owner ~= "codecommit" then
+-- GET /repos/{owner}/{repo}: owner must be "codecommit".
+-- CodeCommit returns 400 (RepositoryDoesNotExistException) for unknown repos;
+-- map that to 404 for GitHub compatibility.
+b:rest("get_repo", function(owner, repo_name)
+  if owner ~= "codecommit" then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status, _, body = fetch_json(base() .. "/repos/" .. repo_name)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status == 400 then
+    local err = DecodeJson(body) or {}
+    if (err["__type"] or ""):find("DoesNotExist") then
       respond_json(404, { message = "Not Found" })
       return
     end
-    local ok, status, _, body = fetch_json(base() .. "/repos/" .. repo_name)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status == 400 then
-      local err = DecodeJson(body) or {}
-      if (err["__type"] or ""):find("DoesNotExist") then
-        respond_json(404, { message = "Not Found" })
-        return
-      end
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local r = data.repositoryMetadata
-    if not r then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_repo(r))
-  end,
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local r = data.repositoryMetadata
+  if not r then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_repo(r))
+end)
 
-  get_repositories = function()
-    if not check_page() then
-      return
-    end
-    local per_page = tonumber(GetParam("per_page") or "") or nil
-    local repos, _, status = list_repos_page(per_page)
-    if not repos then
-      respond_json(status, {})
-      return
-    end
-    respond_json(200, translate_list(translate_repo, repos))
-  end,
+b:rest("get_repositories", function()
+  if not check_page() then
+    return
+  end
+  local per_page = tonumber(GetParam("per_page") or "") or nil
+  local repos, _, status = list_repos_page(per_page)
+  if not repos then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, translate_list(translate_repo, repos))
+end)
 
-  -- GET /repos/{owner}/{repo}/branches: owner must be "codecommit".
-  get_repo_branches = function(owner, repo_name)
-    if owner ~= "codecommit" then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status, _, body = fetch_json(base() .. "/repos/" .. repo_name .. "/branches")
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local result = {}
-    for _, branch_name in ipairs(data.branches or {}) do
-      result[#result + 1] = {
-        name = branch_name,
-        commit = { sha = "", url = "" },
-        protected = false,
-      }
-    end
-    respond_json(200, result)
-  end,
+-- GET /repos/{owner}/{repo}/branches: owner must be "codecommit".
+b:rest("get_repo_branches", function(owner, repo_name)
+  if owner ~= "codecommit" then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status, _, body = fetch_json(base() .. "/repos/" .. repo_name .. "/branches")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local result = {}
+  for _, branch_name in ipairs(data.branches or {}) do
+    result[#result + 1] = {
+      name = branch_name,
+      commit = { sha = "", url = "" },
+      protected = false,
+    }
+  end
+  respond_json(200, result)
+end)
 
-  search_repositories = function()
-    if not check_page() then
-      return
+b:rest("search_repositories", function()
+  if not check_page() then
+    return
+  end
+  local q = (GetParam("q") or ""):lower()
+  local per_page = tonumber(GetParam("per_page") or "") or nil
+  local repos, incomplete, status = list_repos_page(per_page)
+  if not repos then
+    respond_json(status, {})
+    return
+  end
+  local items = {}
+  for _, r in ipairs(repos) do
+    local name = (r.repositoryName or ""):lower()
+    if q == "" or name:find(q, 1, true) then
+      items[#items + 1] = translate_repo(r)
     end
-    local q = (GetParam("q") or ""):lower()
-    local per_page = tonumber(GetParam("per_page") or "") or nil
-    local repos, incomplete, status = list_repos_page(per_page)
-    if not repos then
-      respond_json(status, {})
-      return
-    end
-    local items = {}
-    for _, r in ipairs(repos) do
-      local name = (r.repositoryName or ""):lower()
-      if q == "" or name:find(q, 1, true) then
-        items[#items + 1] = translate_repo(r)
-      end
-    end
-    respond_json(200, { total_count = #items, incomplete_results = incomplete, items = items })
-  end,
-}
+  end
+  respond_json(200, { total_count = #items, incomplete_results = incomplete, items = items })
+end)
+
+b:build()

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -123,95 +123,109 @@ local function gerrit_repos_from_dict(data)
   return repos
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, config.base_url .. "/config/server/version", auth()))
-  end,
-  get_repo = proxy_handler(translate_gerrit_repo, function(owner, repo_name)
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, config.base_url .. "/config/server/version", auth()))
+end)
+b:rest(
+  "get_repo",
+  proxy_handler(translate_gerrit_repo, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name)
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local g = {}
-    if req.description then
-      g.description = req.description
-    end
-    proxy_json(
-      function(r)
-        return translate_gerrit_repo(r, owner, repo_name)
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/config",
-        "PUT",
-        EncodeJson(g)
-      )
+b:rest("patch_repo", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local g = {}
+  if req.description then
+    g.description = req.description
+  end
+  proxy_json(
+    function(r)
+      return translate_gerrit_repo(r, owner, repo_name)
+    end,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/config",
+      "PUT",
+      EncodeJson(g)
     )
-  end,
+  )
+end)
 
-  -- Gerrit: GET /a/projects/ → dict of project_name → project_info
-  get_user_repos = function()
-    local limit = GetParam("per_page") or "30"
-    local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
-    local url = base() .. "/projects/?n=" .. limit .. (skip > 0 and ("&S=" .. skip) or "")
-    proxy_json(gerrit_repos_from_dict, fetch_json(url))
-  end,
+-- Gerrit: GET /a/projects/ → dict of project_name → project_info
+b:rest("get_user_repos", function()
+  local limit = GetParam("per_page") or "30"
+  local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
+  local url = base() .. "/projects/?n=" .. limit .. (skip > 0 and ("&S=" .. skip) or "")
+  proxy_json(gerrit_repos_from_dict, fetch_json(url))
+end)
 
-  get_users_repos = function(username)
-    local limit = GetParam("per_page") or "30"
-    local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
-    local url = base()
-      .. "/projects/?p="
-      .. username
-      .. "%2F&n="
-      .. limit
-      .. (skip > 0 and ("&S=" .. skip) or "")
-    proxy_json(gerrit_repos_from_dict, fetch_json(url))
-  end,
+b:rest("get_users_repos", function(username)
+  local limit = GetParam("per_page") or "30"
+  local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
+  local url = base()
+    .. "/projects/?p="
+    .. username
+    .. "%2F&n="
+    .. limit
+    .. (skip > 0 and ("&S=" .. skip) or "")
+  proxy_json(gerrit_repos_from_dict, fetch_json(url))
+end)
 
-  get_repositories = function()
-    local limit = GetParam("per_page") or "30"
-    local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
-    local url = base() .. "/projects/?n=" .. limit .. (skip > 0 and ("&S=" .. skip) or "")
-    proxy_json(gerrit_repos_from_dict, fetch_json(url))
-  end,
+b:rest("get_repositories", function()
+  local limit = GetParam("per_page") or "30"
+  local skip = ((tonumber(GetParam("page")) or 1) - 1) * (tonumber(limit) or 30)
+  local url = base() .. "/projects/?n=" .. limit .. (skip > 0 and ("&S=" .. skip) or "")
+  proxy_json(gerrit_repos_from_dict, fetch_json(url))
+end)
 
-  -- Branches ------------------------------------------------------------------
-  -- GET /a/projects/{id}/branches/ → [{ ref, revision }]
+-- Branches ------------------------------------------------------------------
+-- GET /a/projects/{id}/branches/ → [{ ref, revision }]
 
-  get_repo_branches = proxy_handler(function(branches)
+b:rest(
+  "get_repo_branches",
+  proxy_handler(function(branches)
     local result = {}
-    for _, b in ipairs(branches or {}) do
-      if b.ref and b.ref:match("^refs/heads/") then
-        result[#result + 1] = translate_gerrit_branch(b)
+    for _, br in ipairs(branches or {}) do
+      if br.ref and br.ref:match("^refs/heads/") then
+        result[#result + 1] = translate_gerrit_branch(br)
       end
     end
     return result
   end, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/branches/"
-  end),
+  end)
+)
 
-  get_repo_branch = proxy_handler(translate_gerrit_branch, function(owner, repo_name, branch)
+b:rest(
+  "get_repo_branch",
+  proxy_handler(translate_gerrit_branch, function(owner, repo_name, branch)
     return base()
       .. "/projects/"
       .. project_id(owner, repo_name)
       .. "/branches/refs%2Fheads%2F"
       .. branch
-  end),
+  end)
+)
 
-  -- Tags ----------------------------------------------------------------------
-  -- GET /a/projects/{id}/tags/ → [{ ref, revision, object }]
+-- Tags ----------------------------------------------------------------------
+-- GET /a/projects/{id}/tags/ → [{ ref, revision, object }]
 
-  get_repo_tags = proxy_handler(function(tags)
+b:rest(
+  "get_repo_tags",
+  proxy_handler(function(tags)
     return translate_list(translate_gerrit_tag, tags)
   end, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/tags/"
-  end),
+  end)
+)
 
-  -- Commits -------------------------------------------------------------------
-  -- Gerrit: GET /a/projects/{id}/commits/{sha}
+-- Commits -------------------------------------------------------------------
+-- Gerrit: GET /a/projects/{id}/commits/{sha}
 
-  get_repo_commit = proxy_handler(function(c)
+b:rest(
+  "get_repo_commit",
+  proxy_handler(function(c)
     if not c then
       return {}
     end
@@ -231,91 +245,93 @@ app.backend_impl = {
     }
   end, function(owner, repo_name, ref)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/commits/" .. ref
-  end),
+  end)
+)
 
-  -- Users ---------------------------------------------------------------------
-  -- These handlers cannot use proxy_json: Gerrit prefixes every JSON response
-  -- with ")]}'\n" to prevent XSS cross-domain reads.  gerrit_decode strips that
-  -- prefix before passing the body to DecodeJson.
+-- Users ---------------------------------------------------------------------
+-- These handlers cannot use proxy_json: Gerrit prefixes every JSON response
+-- with ")]}'\n" to prevent XSS cross-domain reads.  gerrit_decode strips that
+-- prefix before passing the body to DecodeJson.
 
-  -- GET /user — authenticated user
-  get_user = function()
-    local ok, status, _, body = fetch_json(base() .. "/accounts/self?o=DETAILS")
-    if ok and status == 200 then
-      respond_json(200, translate_gerrit_user(gerrit_decode(body)))
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
+-- GET /user — authenticated user
+b:rest("get_user", function()
+  local ok, status, _, body = fetch_json(base() .. "/accounts/self?o=DETAILS")
+  if ok and status == 200 then
+    respond_json(200, translate_gerrit_user(gerrit_decode(body)))
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
 
-  -- GET /users/{username}
-  get_users_username = function(username)
-    local ok, status, _, body = fetch_json(base() .. "/accounts/" .. username .. "?o=DETAILS")
-    if ok and status == 200 then
-      respond_json(200, translate_gerrit_user(gerrit_decode(body)))
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
+-- GET /users/{username}
+b:rest("get_users_username", function(username)
+  local ok, status, _, body = fetch_json(base() .. "/accounts/" .. username .. "?o=DETAILS")
+  if ok and status == 200 then
+    respond_json(200, translate_gerrit_user(gerrit_decode(body)))
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
 
-  -- GET /users — search active accounts
-  get_users = function()
-    local limit = GetParam("per_page") or "30"
-    local page = tonumber(GetParam("page")) or 1
-    local skip = (page - 1) * (tonumber(limit) or 30)
-    local url = base()
-      .. "/accounts/?q=is:active&o=DETAILS&n="
-      .. limit
-      .. (skip > 0 and ("&S=" .. skip) or "")
-    local ok, status, _, body = fetch_json(url)
-    if ok and status == 200 then
-      respond_json(200, translate_list(translate_gerrit_user, gerrit_decode(body)))
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
+-- GET /users — search active accounts
+b:rest("get_users", function()
+  local limit = GetParam("per_page") or "30"
+  local page = tonumber(GetParam("page")) or 1
+  local skip = (page - 1) * (tonumber(limit) or 30)
+  local url = base()
+    .. "/accounts/?q=is:active&o=DETAILS&n="
+    .. limit
+    .. (skip > 0 and ("&S=" .. skip) or "")
+  local ok, status, _, body = fetch_json(url)
+  if ok and status == 200 then
+    respond_json(200, translate_list(translate_gerrit_user, gerrit_decode(body)))
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
 
-  -- Issues -----------------------------------------------------------------------
-  -- Gerrit has no native issue tracker; it is a code-review system only.
-  -- All issues, labels, milestones, and assignees endpoints fall back to the
-  -- default empty-list / 404 handlers defined in .init.lua.
+-- Issues -----------------------------------------------------------------------
+-- Gerrit has no native issue tracker; it is a code-review system only.
+-- All issues, labels, milestones, and assignees endpoints fall back to the
+-- default empty-list / 404 handlers defined in .init.lua.
 
-  -- Contents ------------------------------------------------------------------
-  -- Cannot use proxy_json: Gerrit returns the raw base64-encoded file bytes
-  -- directly (no JSON envelope), so DecodeJson is not applicable.
+-- Contents ------------------------------------------------------------------
+-- Cannot use proxy_json: Gerrit returns the raw base64-encoded file bytes
+-- directly (no JSON envelope), so DecodeJson is not applicable.
 
-  get_repo_content = function(owner, repo_name, path)
-    local ref = GetParam("ref") or "HEAD"
-    local url = base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/branches/"
-      .. ref
-      .. "/files/"
-      .. path
-      .. "/content"
-    local ok, status, _, body = fetch_json(url)
-    if ok and status == 200 then
-      -- Gerrit returns already-base64-encoded content
-      respond_json(200, {
-        type = "file",
-        name = path:match("[^/]+$") or path,
-        path = path,
-        sha = "",
-        size = 0,
-        encoding = "base64",
-        content = body,
-      })
-    elseif ok then
-      respond_json(status, { message = "Error" })
-    else
-      respond_json(503, {})
-    end
-  end,
-}
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local ref = GetParam("ref") or "HEAD"
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/branches/"
+    .. ref
+    .. "/files/"
+    .. path
+    .. "/content"
+  local ok, status, _, body = fetch_json(url)
+  if ok and status == 200 then
+    -- Gerrit returns already-base64-encoded content
+    respond_json(200, {
+      type = "file",
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = 0,
+      encoding = "base64",
+      content = body,
+    })
+  elseif ok then
+    respond_json(status, { message = "Error" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+b:build()

--- a/backends/gitblit.lua
+++ b/backends/gitblit.lua
@@ -115,132 +115,133 @@ local function list_repos_by_prefix(prefix)
   return result, 200
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, rpc() .. "?req=LIST_REPOSITORIES", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, rpc() .. "?req=LIST_REPOSITORIES", auth()))
+end)
 
-  get_repo = function(owner, repo_name)
-    local gitblit_name = owner .. "/" .. repo_name .. ".git"
-    local ok, status, _, body = fetch_rpc("GET_REPOSITORY", "&name=" .. gitblit_name)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local r = DecodeJson(body) or {}
-    if not r.name then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_repo(r))
-  end,
+b:rest("get_repo", function(owner, repo_name)
+  local gitblit_name = owner .. "/" .. repo_name .. ".git"
+  local ok, status, _, body = fetch_rpc("GET_REPOSITORY", "&name=" .. gitblit_name)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local r = DecodeJson(body) or {}
+  if not r.name then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_repo(r))
+end)
 
-  get_org_repos = function(org)
-    local repos, status = list_repos_by_prefix(org .. "/")
-    if not repos then
-      respond_json(status, {})
-      return
-    end
-    respond_json(200, repos)
-  end,
+b:rest("get_org_repos", function(org)
+  local repos, status = list_repos_by_prefix(org .. "/")
+  if not repos then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, repos)
+end)
 
-  get_users_repos = function(username)
-    local repos, status = list_repos_by_prefix(username .. "/")
-    if not repos then
-      respond_json(status, {})
-      return
-    end
-    respond_json(200, repos)
-  end,
+b:rest("get_users_repos", function(username)
+  local repos, status = list_repos_by_prefix(username .. "/")
+  if not repos then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, repos)
+end)
 
-  get_repositories = function()
-    local repos, status = list_repos_by_prefix("")
-    if not repos then
-      respond_json(status, {})
-      return
-    end
-    respond_json(200, repos)
-  end,
+b:rest("get_repositories", function()
+  local repos, status = list_repos_by_prefix("")
+  if not repos then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, repos)
+end)
 
-  get_users_username = function(username)
-    local ok, status, _, body = fetch_rpc("GET_USER", "&name=" .. username)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local u = DecodeJson(body) or {}
-    if not u.name then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_user(u))
-  end,
+b:rest("get_users_username", function(username)
+  local ok, status, _, body = fetch_rpc("GET_USER", "&name=" .. username)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local u = DecodeJson(body) or {}
+  if not u.name then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_user(u))
+end)
 
-  get_users = function()
-    local ok, status, _, body = fetch_rpc("LIST_USERS")
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local users = DecodeJson(body) or {}
-    local result = {}
-    for _, u in ipairs(users) do
-      result[#result + 1] = translate_user(u)
-    end
-    respond_json(200, result)
-  end,
+b:rest("get_users", function()
+  local ok, status, _, body = fetch_rpc("LIST_USERS")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local users = DecodeJson(body) or {}
+  local result = {}
+  for _, u in ipairs(users) do
+    result[#result + 1] = translate_user(u)
+  end
+  respond_json(200, result)
+end)
 
-  search_repositories = function()
-    local q = (GetParam("q") or ""):lower()
-    local repos, status = list_repos_by_prefix("")
-    if not repos then
-      respond_json(status, {})
-      return
-    end
-    local items = repos
-    if q ~= "" then
-      items = {}
-      for _, r in ipairs(repos) do
-        if
-          (r.name or ""):lower():find(q, 1, true) or (r.full_name or ""):lower():find(q, 1, true)
-        then
-          items[#items + 1] = r
-        end
+b:rest("search_repositories", function()
+  local q = (GetParam("q") or ""):lower()
+  local repos, status = list_repos_by_prefix("")
+  if not repos then
+    respond_json(status, {})
+    return
+  end
+  local items = repos
+  if q ~= "" then
+    items = {}
+    for _, r in ipairs(repos) do
+      if
+        (r.name or ""):lower():find(q, 1, true) or (r.full_name or ""):lower():find(q, 1, true)
+      then
+        items[#items + 1] = r
       end
     end
-    respond_json(200, { total_count = #items, incomplete_results = false, items = items })
-  end,
+  end
+  respond_json(200, { total_count = #items, incomplete_results = false, items = items })
+end)
 
-  search_users = function()
-    local q = (GetParam("q") or ""):lower()
-    local ok, status, _, body = fetch_rpc("LIST_USERS")
-    if not ok then
-      respond_json(503, {})
-      return
+b:rest("search_users", function()
+  local q = (GetParam("q") or ""):lower()
+  local ok, status, _, body = fetch_rpc("LIST_USERS")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local users = DecodeJson(body) or {}
+  local items = {}
+  for _, u in ipairs(users) do
+    if q == "" or (u.name or ""):lower():find(q, 1, true) then
+      items[#items + 1] = translate_user(u)
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local users = DecodeJson(body) or {}
-    local items = {}
-    for _, u in ipairs(users) do
-      if q == "" or (u.name or ""):lower():find(q, 1, true) then
-        items[#items + 1] = translate_user(u)
-      end
-    end
-    respond_json(200, { total_count = #items, incomplete_results = false, items = items })
-  end,
-}
+  end
+  respond_json(200, { total_count = #items, incomplete_results = false, items = items })
+end)
+
+b:build()

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -28,1158 +28,1456 @@ local gb_to_gh = {
   warning = { status = "completed", conclusion = "neutral" },
 }
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/rate_limit", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/rate_limit", auth()))
+end)
 
-  get_rate_limit = proxy_handler(function(data)
+b:rest(
+  "get_rate_limit",
+  proxy_handler(function(data)
     return { rate = data.rate or data }
   end, function()
     return base() .. "/rate_limit"
-  end),
+  end)
+)
 
-  get_repo = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo",
+  proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name, "PATCH", GetBody())
-    )
-  end,
+b:rest("patch_repo", function(owner, repo_name)
+  proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name, "PATCH", GetBody()))
+end)
 
-  delete_repo = function(owner, repo_name)
-    local url = base() .. "/repos/" .. owner .. "/" .. repo_name
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, url, dopts))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  local url = base() .. "/repos/" .. owner .. "/" .. repo_name
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, url, dopts))
+end)
 
-  get_user_repos = proxy_handler(nil, function()
+b:rest(
+  "get_user_repos",
+  proxy_handler(nil, function()
     return append_page_params(base() .. "/user/repos", PAGES)
-  end),
+  end)
+)
 
-  post_user_repos = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/repos", "POST", GetBody()))
-  end,
+b:rest("post_user_repos", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/repos", "POST", GetBody()))
+end)
 
-  get_org_repos = proxy_handler(nil, function(org)
+b:rest(
+  "get_org_repos",
+  proxy_handler(nil, function(org)
     return append_page_params(base() .. "/orgs/" .. org .. "/repos", PAGES)
-  end),
+  end)
+)
 
-  post_org_repos = function(org)
-    proxy_json_created(nil, fetch_json(base() .. "/orgs/" .. org .. "/repos", "POST", GetBody()))
-  end,
+b:rest("post_org_repos", function(org)
+  proxy_json_created(nil, fetch_json(base() .. "/orgs/" .. org .. "/repos", "POST", GetBody()))
+end)
 
-  get_repo_topics = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo_topics",
+  proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/topics"
-  end),
+  end)
+)
 
-  put_repo_topics = function(owner, repo_name)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/topics", "PUT", GetBody())
-    )
-  end,
+b:rest("put_repo_topics", function(owner, repo_name)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/topics", "PUT", GetBody())
+  )
+end)
 
-  get_repo_languages = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo_languages",
+  proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/languages"
-  end),
+  end)
+)
 
-  get_repo_contributors = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo_contributors",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/contributors", PAGES)
-  end),
+  end)
+)
 
-  get_repo_tags = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo_tags",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/tags", PAGES)
-  end),
+  end)
+)
 
-  get_repo_teams = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo_teams",
+  proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/teams"
-  end),
+  end)
+)
 
-  -- Branches ------------------------------------------------------------------
-  get_repo_branches = proxy_handler(nil, function(o, r)
+-- Branches ------------------------------------------------------------------
+b:rest(
+  "get_repo_branches",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/branches", PAGES)
-  end),
+  end)
+)
 
-  get_repo_branch = proxy_handler(nil, function(o, r, branch)
+b:rest(
+  "get_repo_branch",
+  proxy_handler(nil, function(o, r, branch)
     return base() .. "/repos/" .. o .. "/" .. r .. "/branches/" .. branch
-  end),
+  end)
+)
 
-  -- Commits -------------------------------------------------------------------
-  get_repo_commits = proxy_handler(nil, function(o, r)
+-- Commits -------------------------------------------------------------------
+b:rest(
+  "get_repo_commits",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/commits", PAGES)
-  end),
+  end)
+)
 
-  get_repo_commit = proxy_handler(nil, function(o, r, ref)
+b:rest(
+  "get_repo_commit",
+  proxy_handler(nil, function(o, r, ref)
     return base() .. "/repos/" .. o .. "/" .. r .. "/commits/" .. ref
-  end),
+  end)
+)
 
-  -- Statuses ------------------------------------------------------------------
-  get_commit_statuses = proxy_handler(nil, function(o, r, ref)
+-- Statuses ------------------------------------------------------------------
+b:rest(
+  "get_commit_statuses",
+  proxy_handler(nil, function(o, r, ref)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/statuses/" .. ref, PAGES)
-  end),
+  end)
+)
 
-  get_commit_combined_status = proxy_handler(nil, function(o, r, ref)
+b:rest(
+  "get_commit_combined_status",
+  proxy_handler(nil, function(o, r, ref)
     return base() .. "/repos/" .. o .. "/" .. r .. "/commits/" .. ref .. "/status"
-  end),
+  end)
+)
 
-  post_commit_status = function(owner, repo_name, sha)
-    proxy_json_created(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
-        "POST",
-        GetBody()
-      )
+b:rest("post_commit_status", function(owner, repo_name, sha)
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
+      "POST",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- Checks (via GitBucket commit statuses) ------------------------------------
-  --
-  -- GitBucket exposes a GitHub-compatible commit statuses API at /api/v3/,
-  -- so the translation is identical to Gitea: state is "pending", "success",
-  -- "failure", or "error".
-  --
-  -- GitHub → GitBucket state:
-  --   queued/in_progress      → pending
-  --   completed/success|neutral|skipped → success
-  --   completed/failure       → failure
-  --   completed/(other)       → error
-  --
-  -- GitBucket → GitHub:
-  --   pending  → status=in_progress, conclusion=nil
-  --   success  → status=completed,   conclusion=success
-  --   failure  → status=completed,   conclusion=failure
-  --   error    → status=completed,   conclusion=failure
-  --   warning  → status=completed,   conclusion=neutral
+-- Checks (via GitBucket commit statuses) ------------------------------------
+--
+-- GitBucket exposes a GitHub-compatible commit statuses API at /api/v3/,
+-- so the translation is identical to Gitea: state is "pending", "success",
+-- "failure", or "error".
+--
+-- GitHub → GitBucket state:
+--   queued/in_progress      → pending
+--   completed/success|neutral|skipped → success
+--   completed/failure       → failure
+--   completed/(other)       → error
+--
+-- GitBucket → GitHub:
+--   pending  → status=in_progress, conclusion=nil
+--   success  → status=completed,   conclusion=success
+--   failure  → status=completed,   conclusion=failure
+--   error    → status=completed,   conclusion=failure
+--   warning  → status=completed,   conclusion=neutral
 
-  post_check_runs = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}") or {}
-    local sha = req.head_sha or ""
-    local status = req.status or "queued"
-    local conclusion = req.conclusion
-    local gh_conclusion_to_gb = {
-      success = "success",
-      neutral = "success",
-      skipped = "success",
-      failure = "failure",
+b:rest("post_check_runs", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}") or {}
+  local sha = req.head_sha or ""
+  local status = req.status or "queued"
+  local conclusion = req.conclusion
+  local gh_conclusion_to_gb = {
+    success = "success",
+    neutral = "success",
+    skipped = "success",
+    failure = "failure",
+  }
+  local gb_state = status == "completed" and (gh_conclusion_to_gb[conclusion] or "error")
+    or "pending"
+  local function translate(s)
+    if not s then
+      return {}
+    end
+    local state = s.state or "pending"
+    local mapped = gb_to_gh[state] or { status = "completed", conclusion = "failure" }
+    local gh_status, gh_conclusion = mapped.status, mapped.conclusion
+    return {
+      id = s.id or 0,
+      node_id = "",
+      head_sha = sha,
+      name = s.context or req.name or "",
+      status = gh_status,
+      conclusion = gh_conclusion,
+      started_at = s.created_at or s.updated_at,
+      completed_at = gh_status == "completed" and (s.updated_at or s.created_at) or nil,
+      output = {
+        title = s.description or "",
+        summary = s.description or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = s.target_url or "",
+      details_url = s.target_url or "",
     }
-    local gb_state = status == "completed" and (gh_conclusion_to_gb[conclusion] or "error")
-      or "pending"
-    local function translate(s)
-      if not s then
-        return {}
-      end
-      local state = s.state or "pending"
-      local mapped = gb_to_gh[state] or { status = "completed", conclusion = "failure" }
-      local gh_status, gh_conclusion = mapped.status, mapped.conclusion
-      return {
-        id = s.id or 0,
-        node_id = "",
-        head_sha = sha,
-        name = s.context or req.name or "",
-        status = gh_status,
-        conclusion = gh_conclusion,
-        started_at = s.created_at or s.updated_at,
-        completed_at = gh_status == "completed" and (s.updated_at or s.created_at) or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.target_url or "",
-        details_url = s.target_url or "",
-      }
-    end
-    proxy_json_created(
-      translate,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
-        "POST",
-        EncodeJson({
-          state = gb_state,
-          target_url = req.details_url or "",
-          description = (req.output and req.output.summary) or req.name or "",
-          context = req.name or "",
-        })
-      )
+  end
+  proxy_json_created(
+    translate,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
+      "POST",
+      EncodeJson({
+        state = gb_state,
+        target_url = req.details_url or "",
+        description = (req.output and req.output.summary) or req.name or "",
+        context = req.name or "",
+      })
     )
-  end,
+  )
+end)
 
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local ok, status, _, body = fetch_json(
-      append_page_params(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. ref,
-        PAGES
-      )
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local ok, status, _, body = fetch_json(
+    append_page_params(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. ref,
+      PAGES
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local statuses = DecodeJson(body) or {}
-    local runs = {}
-    for i, s in ipairs(statuses) do
-      local state = s.state or "pending"
-      local mapped = gb_to_gh[state] or { status = "completed", conclusion = "failure" }
-      local gh_status, gh_conclusion = mapped.status, mapped.conclusion
-      runs[i] = {
-        id = s.id or i,
-        node_id = "",
-        head_sha = ref,
-        name = s.context or "",
-        status = gh_status,
-        conclusion = gh_conclusion,
-        started_at = s.created_at or s.updated_at,
-        completed_at = gh_status == "completed" and (s.updated_at or s.created_at) or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.target_url or "",
-        details_url = s.target_url or "",
-      }
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local statuses = DecodeJson(body) or {}
+  local runs = {}
+  for i, s in ipairs(statuses) do
+    local state = s.state or "pending"
+    local mapped = gb_to_gh[state] or { status = "completed", conclusion = "failure" }
+    local gh_status, gh_conclusion = mapped.status, mapped.conclusion
+    runs[i] = {
+      id = s.id or i,
+      node_id = "",
+      head_sha = ref,
+      name = s.context or "",
+      status = gh_status,
+      conclusion = gh_conclusion,
+      started_at = s.created_at or s.updated_at,
+      completed_at = gh_status == "completed" and (s.updated_at or s.created_at) or nil,
+      output = {
+        title = s.description or "",
+        summary = s.description or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = s.target_url or "",
+      details_url = s.target_url or "",
+    }
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
 
-  -- Check suites have no GitBucket equivalent; all suite endpoints fall back
-  -- to the route_defaults stubs defined in .init.lua.
+-- Check suites have no GitBucket equivalent; all suite endpoints fall back
+-- to the route_defaults stubs defined in .init.lua.
 
-  -- Licenses ------------------------------------------------------------------
-  get_licenses = proxy_handler(nil, function()
+-- Licenses ------------------------------------------------------------------
+b:rest(
+  "get_licenses",
+  proxy_handler(nil, function()
     return base() .. "/licenses"
-  end),
+  end)
+)
 
-  get_license = proxy_handler(nil, function(license_name)
+b:rest(
+  "get_license",
+  proxy_handler(nil, function(license_name)
     return base() .. "/licenses/" .. license_name
-  end),
+  end)
+)
 
-  get_repo_license = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo_license",
+  proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/license"
-  end),
+  end)
+)
 
-  -- Contents ------------------------------------------------------------------
-  get_repo_readme = proxy_handler(nil, function(o, r)
+-- Contents ------------------------------------------------------------------
+b:rest(
+  "get_repo_readme",
+  proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/readme"
-  end),
+  end)
+)
 
-  get_repo_readme_dir = proxy_handler(nil, function(o, r, dir)
+b:rest(
+  "get_repo_readme_dir",
+  proxy_handler(nil, function(o, r, dir)
     return base() .. "/repos/" .. o .. "/" .. r .. "/readme/" .. dir
-  end),
+  end)
+)
 
-  get_repo_content = proxy_handler(nil, function(o, r, path)
+b:rest(
+  "get_repo_content",
+  proxy_handler(nil, function(o, r, path)
     return base() .. "/repos/" .. o .. "/" .. r .. "/contents/" .. path
-  end),
+  end)
+)
 
-  put_repo_content = function(owner, repo_name, path)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
-        "PUT",
-        GetBody()
-      )
+b:rest("put_repo_content", function(owner, repo_name, path)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
+      "PUT",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  delete_repo_content = function(owner, repo_name, path)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
-        "DELETE",
-        GetBody()
-      )
+b:rest("delete_repo_content", function(owner, repo_name, path)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
+      "DELETE",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  get_repo_tarball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader("Location", base() .. "/repos/" .. owner .. "/" .. repo_name .. "/tarball/" .. ref)
-    Write("")
-  end,
+b:rest("get_repo_tarball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader("Location", base() .. "/repos/" .. owner .. "/" .. repo_name .. "/tarball/" .. ref)
+  Write("")
+end)
 
-  get_repo_zipball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader("Location", base() .. "/repos/" .. owner .. "/" .. repo_name .. "/zipball/" .. ref)
-    Write("")
-  end,
+b:rest("get_repo_zipball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader("Location", base() .. "/repos/" .. owner .. "/" .. repo_name .. "/zipball/" .. ref)
+  Write("")
+end)
 
-  -- Compare -------------------------------------------------------------------
-  get_repo_compare = proxy_handler(nil, function(o, r, basehead)
+-- Compare -------------------------------------------------------------------
+b:rest(
+  "get_repo_compare",
+  proxy_handler(nil, function(o, r, basehead)
     return base() .. "/repos/" .. o .. "/" .. r .. "/compare/" .. basehead
-  end),
+  end)
+)
 
-  -- Collaborators -------------------------------------------------------------
-  get_repo_collaborators = proxy_handler(nil, function(o, r)
+-- Collaborators -------------------------------------------------------------
+b:rest(
+  "get_repo_collaborators",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/collaborators", PAGES)
-  end),
+  end)
+)
 
-  get_repo_collaborator = function(owner, repo_name, username)
-    local ok, status = pcall(
-      Fetch,
+b:rest("get_repo_collaborator", function(owner, repo_name, username)
+  local ok, status = pcall(
+    Fetch,
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+    auth()
+  )
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(status, { message = "Not a collaborator" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+b:rest("put_repo_collaborator", function(owner, repo_name, username)
+  proxy_204(
+    { 201 },
+    fetch_json(
       base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-      auth()
+      "PUT",
+      GetBody()
     )
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, { message = "Not a collaborator" })
-    else
-      respond_json(503, {})
-    end
-  end,
+  )
+end)
 
-  put_repo_collaborator = function(owner, repo_name, username)
-    proxy_204(
-      { 201 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-        "PUT",
-        GetBody()
-      )
+b:rest("delete_repo_collaborator", function(owner, repo_name, username)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  delete_repo_collaborator = function(owner, repo_name, username)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-        "DELETE"
-      )
-    )
-  end,
-
-  get_repo_collaborator_permission = proxy_handler(nil, function(o, r, username)
+b:rest(
+  "get_repo_collaborator_permission",
+  proxy_handler(nil, function(o, r, username)
     return base() .. "/repos/" .. o .. "/" .. r .. "/collaborators/" .. username .. "/permission"
-  end),
+  end)
+)
 
-  -- Forks ---------------------------------------------------------------------
-  get_repo_forks = proxy_handler(nil, function(o, r)
+-- Forks ---------------------------------------------------------------------
+b:rest(
+  "get_repo_forks",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/forks", PAGES)
-  end),
+  end)
+)
 
-  post_repo_forks = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/forks", "POST", GetBody())
-    )
-  end,
+b:rest("post_repo_forks", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/forks", "POST", GetBody())
+  )
+end)
 
-  -- Releases ------------------------------------------------------------------
-  get_repo_releases = proxy_handler(nil, function(o, r)
+-- Releases ------------------------------------------------------------------
+b:rest(
+  "get_repo_releases",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/releases", PAGES)
-  end),
+  end)
+)
 
-  post_repo_releases = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases", "POST", GetBody())
-    )
-  end,
+b:rest("post_repo_releases", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases", "POST", GetBody())
+  )
+end)
 
-  get_repo_release_latest = proxy_handler(nil, function(o, r)
+b:rest(
+  "get_repo_release_latest",
+  proxy_handler(nil, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/releases/latest"
-  end),
+  end)
+)
 
-  get_repo_release_by_tag = proxy_handler(nil, function(o, r, tag)
+b:rest(
+  "get_repo_release_by_tag",
+  proxy_handler(nil, function(o, r, tag)
     return base() .. "/repos/" .. o .. "/" .. r .. "/releases/tags/" .. tag
-  end),
+  end)
+)
 
-  get_repo_release = proxy_handler(nil, function(o, r, id)
+b:rest(
+  "get_repo_release",
+  proxy_handler(nil, function(o, r, id)
     return base() .. "/repos/" .. o .. "/" .. r .. "/releases/" .. id
-  end),
+  end)
+)
 
-  patch_repo_release = function(owner, repo_name, release_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
-        "PATCH",
-        GetBody()
-      )
+b:rest("patch_repo_release", function(owner, repo_name, release_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
+      "PATCH",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  delete_repo_release = function(owner, repo_name, release_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
-        "DELETE"
-      )
+b:rest("delete_repo_release", function(owner, repo_name, release_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  get_repo_release_assets = proxy_handler(nil, function(o, r, id)
+b:rest(
+  "get_repo_release_assets",
+  proxy_handler(nil, function(o, r, id)
     return append_page_params(
       base() .. "/repos/" .. o .. "/" .. r .. "/releases/" .. id .. "/assets",
       PAGES
     )
-  end),
+  end)
+)
 
-  post_repo_release_assets = function(owner, repo_name, release_id)
-    local url = base()
-      .. "/repos/"
-      .. owner
-      .. "/"
-      .. repo_name
-      .. "/releases/"
-      .. release_id
-      .. "/assets"
-    local opts = auth() or {}
-    opts.method = "POST"
-    opts.body = GetBody()
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = GetHeader("Content-Type") or "application/octet-stream"
-    proxy_json_created(nil, pcall(Fetch, url, opts))
-  end,
+b:rest("post_repo_release_assets", function(owner, repo_name, release_id)
+  local url = base()
+    .. "/repos/"
+    .. owner
+    .. "/"
+    .. repo_name
+    .. "/releases/"
+    .. release_id
+    .. "/assets"
+  local opts = auth() or {}
+  opts.method = "POST"
+  opts.body = GetBody()
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = GetHeader("Content-Type") or "application/octet-stream"
+  proxy_json_created(nil, pcall(Fetch, url, opts))
+end)
 
-  get_repo_release_asset = proxy_handler(nil, function(o, r, asset_id)
+b:rest(
+  "get_repo_release_asset",
+  proxy_handler(nil, function(o, r, asset_id)
     return base() .. "/repos/" .. o .. "/" .. r .. "/releases/assets/" .. asset_id
-  end),
+  end)
+)
 
-  patch_repo_release_asset = function(owner, repo_name, asset_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
-        "PATCH",
-        GetBody()
-      )
+b:rest("patch_repo_release_asset", function(owner, repo_name, asset_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
+      "PATCH",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  delete_repo_release_asset = function(owner, repo_name, asset_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
-        "DELETE"
-      )
+b:rest("delete_repo_release_asset", function(owner, repo_name, asset_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  -- Deploy keys ---------------------------------------------------------------
-  get_repo_keys = proxy_handler(nil, function(o, r)
+-- Deploy keys ---------------------------------------------------------------
+b:rest(
+  "get_repo_keys",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/keys", PAGES)
-  end),
+  end)
+)
 
-  post_repo_keys = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys", "POST", GetBody())
-    )
-  end,
+b:rest("post_repo_keys", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys", "POST", GetBody())
+  )
+end)
 
-  get_repo_key = proxy_handler(nil, function(o, r, key_id)
+b:rest(
+  "get_repo_key",
+  proxy_handler(nil, function(o, r, key_id)
     return base() .. "/repos/" .. o .. "/" .. r .. "/keys/" .. key_id
-  end),
+  end)
+)
 
-  delete_repo_key = function(owner, repo_name, key_id)
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id, "DELETE")
-    )
-  end,
+b:rest("delete_repo_key", function(owner, repo_name, key_id)
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id, "DELETE")
+  )
+end)
 
-  -- Webhooks ------------------------------------------------------------------
-  get_repo_hooks = proxy_handler(nil, function(o, r)
+-- Webhooks ------------------------------------------------------------------
+b:rest(
+  "get_repo_hooks",
+  proxy_handler(nil, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/hooks", PAGES)
-  end),
+  end)
+)
 
-  post_repo_hooks = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks", "POST", GetBody())
-    )
-  end,
+b:rest("post_repo_hooks", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks", "POST", GetBody())
+  )
+end)
 
-  get_repo_hook = proxy_handler(nil, function(o, r, hook_id)
+b:rest(
+  "get_repo_hook",
+  proxy_handler(nil, function(o, r, hook_id)
     return base() .. "/repos/" .. o .. "/" .. r .. "/hooks/" .. hook_id
-  end),
+  end)
+)
 
-  patch_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id,
-        "PATCH",
-        GetBody()
-      )
+b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id,
+      "PATCH",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  delete_repo_hook = function(owner, repo_name, hook_id)
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id, "DELETE")
-    )
-  end,
+b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id, "DELETE")
+  )
+end)
 
-  get_repo_hook_config = proxy_handler(function(h)
+b:rest(
+  "get_repo_hook_config",
+  proxy_handler(function(h)
     return h.config or {}
   end, function(o, r, hook_id)
     return base() .. "/repos/" .. o .. "/" .. r .. "/hooks/" .. hook_id
-  end),
-
-  patch_repo_hook_config = function(owner, repo_name, hook_id)
-    local url = base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id
-    local ok, status, _, body = fetch_json(url)
-    if not ok or status ~= 200 then
-      if ok then
-        respond_json(status, {})
-      else
-        respond_json(503, {})
-      end
-      return
-    end
-    local hook = DecodeJson(body) or {}
-    local new_cfg = DecodeJson(GetBody() or "{}")
-    hook.config = hook.config or {}
-    for k, v in pairs(new_cfg) do
-      hook.config[k] = v
-    end
-    proxy_json(function(h)
-      return h.config or {}
-    end, fetch_json(url, "PATCH", EncodeJson(hook)))
-  end,
-
-  post_repo_hook_ping = function(owner, repo_name, hook_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/pings",
-        "POST"
-      )
-    )
-  end,
-
-  post_repo_hook_test = function(owner, repo_name, hook_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
-        "POST"
-      )
-    )
-  end,
-
-  -- Commit comments -----------------------------------------------------------
-  get_repo_comments = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/comments", PAGES)
-  end),
-
-  get_repo_comment = proxy_handler(nil, function(o, r, comment_id)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/comments/" .. comment_id
-  end),
-
-  patch_repo_comment = function(owner, repo_name, comment_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
-        "PATCH",
-        GetBody()
-      )
-    )
-  end,
-
-  delete_repo_comment = function(owner, repo_name, comment_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
-        "DELETE"
-      )
-    )
-  end,
-
-  get_commit_comments = proxy_handler(nil, function(o, r, sha)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/commits/" .. sha .. "/comments",
-      PAGES
-    )
-  end),
-
-  post_commit_comment = function(owner, repo_name, commit_sha)
-    proxy_json_created(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/commits/" .. commit_sha .. "/comments",
-        "POST",
-        GetBody()
-      )
-    )
-  end,
-
-  -- GET /users/{username}/repos + public repos --------------------------------
-  get_users_repos = proxy_handler(nil, function(username)
-    return append_page_params(base() .. "/users/" .. username .. "/repos", PAGES)
-  end),
-
-  get_repositories = proxy_handler(nil, function()
-    return append_page_params(base() .. "/repositories", PAGES)
-  end),
-
-  -- Users (GitHub-compatible passthrough) -------------------------------------
-
-  get_user = proxy_handler(nil, function()
-    return base() .. "/user"
-  end),
-
-  patch_user = function()
-    proxy_json(nil, fetch_json(base() .. "/user", "PATCH", GetBody()))
-  end,
-
-  get_users_username = proxy_handler(nil, function(username)
-    return base() .. "/users/" .. username
-  end),
-
-  get_users = proxy_handler(nil, function()
-    return append_page_params(base() .. "/users", PAGES)
-  end),
-
-  get_user_followers = proxy_handler(nil, function()
-    return append_page_params(base() .. "/user/followers", PAGES)
-  end),
-
-  get_user_following = proxy_handler(nil, function()
-    return append_page_params(base() .. "/user/following", PAGES)
-  end),
-
-  get_user_is_following = function(username)
-    local ok, status = pcall(Fetch, base() .. "/user/following/" .. username, auth())
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(404, { message = "Not Following" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  put_user_following = function(username)
-    set_204_or_error("PUT", base() .. "/user/following/" .. username)
-  end,
-
-  delete_user_following = function(username)
-    set_204_or_error("DELETE", base() .. "/user/following/" .. username)
-  end,
-
-  get_users_followers = proxy_handler(nil, function(username)
-    return append_page_params(base() .. "/users/" .. username .. "/followers", PAGES)
-  end),
-
-  get_users_following = proxy_handler(nil, function(username)
-    return append_page_params(base() .. "/users/" .. username .. "/following", PAGES)
-  end),
-
-  get_users_is_following = function(username, target)
-    local ok, status =
-      pcall(Fetch, base() .. "/users/" .. username .. "/following/" .. target, auth())
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(404, { message = "Not Following" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  get_user_emails = proxy_handler(nil, function()
-    return base() .. "/user/emails"
-  end),
-
-  post_user_emails = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/emails", "POST", GetBody()))
-  end,
-
-  delete_user_emails = function()
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    opts.body = GetBody()
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "application/json"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/user/emails", opts))
-  end,
-
-  get_user_keys = proxy_handler(nil, function()
-    return append_page_params(base() .. "/user/keys", PAGES)
-  end),
-
-  post_user_keys = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/keys", "POST", GetBody()))
-  end,
-
-  get_user_key = proxy_handler(nil, function(key_id)
-    return base() .. "/user/keys/" .. key_id
-  end),
-
-  delete_user_key = function(key_id)
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/user/keys/" .. key_id, opts))
-  end,
-
-  get_users_keys = proxy_handler(nil, function(username)
-    return append_page_params(base() .. "/users/" .. username .. "/keys", PAGES)
-  end),
-
-  -- Teams (GitHub-compatible passthrough) -------------------------------------
-
-  get_org_teams = proxy_handler(nil, function(org)
-    return append_page_params(base() .. "/orgs/" .. org .. "/teams", PAGES)
-  end),
-
-  post_org_teams = function(org)
-    proxy_json_created(nil, fetch_json(base() .. "/orgs/" .. org .. "/teams", "POST", GetBody()))
-  end,
-
-  get_org_team = proxy_handler(nil, function(org, slug)
-    return base() .. "/orgs/" .. org .. "/teams/" .. slug
-  end),
-
-  patch_org_team = function(org, slug)
-    proxy_json(nil, fetch_json(base() .. "/orgs/" .. org .. "/teams/" .. slug, "PATCH", GetBody()))
-  end,
-
-  delete_org_team = function(org, slug)
-    proxy_204({ 200 }, fetch_json(base() .. "/orgs/" .. org .. "/teams/" .. slug, "DELETE"))
-  end,
-
-  get_org_team_invitations = proxy_handler(nil, function(org, slug)
-    return append_page_params(
-      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/invitations",
-      PAGES
-    )
-  end),
-
-  get_org_team_members = proxy_handler(nil, function(org, slug)
-    return append_page_params(base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/members", PAGES)
-  end),
-
-  get_org_team_membership = proxy_handler(nil, function(org, slug, username)
-    return base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username
-  end),
-
-  put_org_team_membership = function(org, slug, username)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username,
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-
-  delete_org_team_membership = function(org, slug, username)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username,
-        "DELETE"
-      )
-    )
-  end,
-
-  get_org_team_repos = proxy_handler(nil, function(org, slug)
-    return append_page_params(base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos", PAGES)
-  end),
-
-  get_org_team_repo = proxy_handler(nil, function(org, slug, owner, repo_name)
-    return base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name
-  end),
-
-  put_org_team_repo = function(org, slug, owner, repo_name)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-
-  delete_org_team_repo = function(org, slug, owner, repo_name)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
-        "DELETE"
-      )
-    )
-  end,
-
-  get_org_team_children = proxy_handler(nil, function(org, slug)
-    return append_page_params(base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/teams", PAGES)
-  end),
-
-  -- Issues (GitHub-compatible passthrough) -------------------------------------
-
-  get_repo_issues = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues", PAGES)
-  end),
-
-  post_repo_issues = proxy_handler_created(nil, function(o, r)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues", "POST", GetBody()
-  end),
-
-  get_repo_issue = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n
-  end),
-
-  patch_repo_issue = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n, "PATCH", GetBody()
-  end),
-
-  get_repo_issue_comments = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments", PAGES)
-  end),
-
-  get_repo_issue_comment = proxy_handler(nil, function(o, r, comment_id)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. comment_id
-  end),
-
-  patch_repo_issue_comment = proxy_handler(nil, function(o, r, id)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id, "PATCH", GetBody()
-  end),
-
-  delete_repo_issue_comment = function(owner, repo_name, comment_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
-        "DELETE"
-      )
-    )
-  end,
-
-  get_repo_issue_events = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/events", PAGES)
-  end),
-
-  get_issue_comments = proxy_handler(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments",
-      PAGES
-    )
-  end),
-
-  post_issue_comment = proxy_handler_created(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments", "POST", GetBody()
-  end),
-
-  get_issue_events = proxy_handler(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/events",
-      PAGES
-    )
-  end),
-
-  get_issue_timeline = proxy_handler(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/timeline",
-      PAGES
-    )
-  end),
-
-  get_issue_labels = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels"
-  end),
-
-  post_issue_labels = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels", "POST", GetBody()
-  end),
-
-  put_issue_labels = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels", "PUT", GetBody()
-  end),
-
-  delete_issue_labels = function(owner, repo_name, issue_number)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
-        "DELETE"
-      )
-    )
-  end,
-
-  delete_issue_label = function(owner, repo_name, issue_number, label_name)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base()
-          .. "/repos/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/issues/"
-          .. issue_number
-          .. "/labels/"
-          .. label_name,
-        "DELETE"
-      )
-    )
-  end,
-
-  post_issue_assignees = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/assignees",
-      "POST",
-      GetBody()
-  end),
-
-  delete_issue_assignees = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/assignees",
-      "DELETE",
-      GetBody()
-  end),
-
-  get_repo_assignees = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/assignees", PAGES)
-  end),
-
-  get_repo_labels = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/labels", PAGES)
-  end),
-
-  post_repo_labels = proxy_handler_created(nil, function(o, r)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/labels", "POST", GetBody()
-  end),
-
-  get_repo_label = proxy_handler(nil, function(o, r, name)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/labels/" .. name
-  end),
-
-  patch_repo_label = proxy_handler(nil, function(o, r, name)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/labels/" .. name, "PATCH", GetBody()
-  end),
-
-  delete_repo_label = function(owner, repo_name, label_name)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. label_name,
-        "DELETE"
-      )
-    )
-  end,
-
-  get_repo_milestones = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/milestones", PAGES)
-  end),
-
-  get_repo_milestone = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n
-  end),
-
-  get_repo_milestone_labels = proxy_handler(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n .. "/labels",
-      PAGES
-    )
-  end),
-
-  -- Legacy team-by-id API (/teams/{team_id}) ------------------------------------
-
-  get_user_teams = proxy_handler(nil, function()
-    return append_page_params(base() .. "/user/teams", PAGES)
-  end),
-
-  get_team = proxy_handler(nil, function(team_id)
-    return base() .. "/teams/" .. team_id
-  end),
-
-  patch_team = function(team_id)
-    proxy_json(nil, fetch_json(base() .. "/teams/" .. team_id, "PATCH", GetBody()))
-  end,
-
-  delete_team = function(team_id)
-    proxy_204({ 200 }, fetch_json(base() .. "/teams/" .. team_id, "DELETE"))
-  end,
-
-  get_team_invitations = proxy_handler(nil, function(team_id)
-    return append_page_params(base() .. "/teams/" .. team_id .. "/invitations", PAGES)
-  end),
-
-  get_team_members = proxy_handler(nil, function(team_id)
-    return append_page_params(base() .. "/teams/" .. team_id .. "/members", PAGES)
-  end),
-
-  get_team_member = function(team_id, username)
-    local ok, status =
-      pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, auth())
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  put_team_member = function(team_id, username)
-    set_204_or_error("PUT", base() .. "/teams/" .. team_id .. "/members/" .. username)
-  end,
-
-  delete_team_member = function(team_id, username)
-    set_204_or_error("DELETE", base() .. "/teams/" .. team_id .. "/members/" .. username)
-  end,
-
-  get_team_membership = proxy_handler(nil, function(team_id, username)
-    return base() .. "/teams/" .. team_id .. "/memberships/" .. username
-  end),
-
-  put_team_membership = function(team_id, username)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/teams/" .. team_id .. "/memberships/" .. username, "PUT", GetBody())
-    )
-  end,
-
-  delete_team_membership = function(team_id, username)
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/teams/" .. team_id .. "/memberships/" .. username, "DELETE")
-    )
-  end,
-
-  get_team_repos = proxy_handler(nil, function(team_id)
-    return append_page_params(base() .. "/teams/" .. team_id .. "/repos", PAGES)
-  end),
-
-  get_team_repo = proxy_handler(nil, function(team_id, owner, repo_name)
-    return base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name
-  end),
-
-  put_team_repo = function(team_id, owner, repo_name)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name,
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-
-  delete_team_repo = function(team_id, owner, repo_name)
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name, "DELETE")
-    )
-  end,
-
-  get_team_children = proxy_handler(nil, function(team_id)
-    return append_page_params(base() .. "/teams/" .. team_id .. "/teams", PAGES)
-  end),
-
-  -- Pull Requests (GitHub-compatible passthrough) --------------------------------
-
-  get_repo_pulls = proxy_handler(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/pulls", PAGES)
-  end),
-
-  post_repo_pulls = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls", "POST", GetBody())
-    )
-  end,
-
-  get_repo_pull = proxy_handler(nil, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n
-  end),
-
-  patch_repo_pull = function(owner, repo_name, pull_number)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number,
-        "PATCH",
-        GetBody()
-      )
-    )
-  end,
-
-  get_pull_commits = proxy_handler(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/commits",
-      PAGES
-    )
-  end),
-
-  get_pull_files = proxy_handler(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/files",
-      PAGES
-    )
-  end),
-
-  get_pull_merge = function(owner, repo_name, pull_number)
-    local ok, status = pcall(
-      Fetch,
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
-      auth()
-    )
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok and status == 404 then
-      respond_json(404, { message = "Pull Request is not merged" })
-    elseif ok then
+  end)
+)
+
+b:rest("patch_repo_hook_config", function(owner, repo_name, hook_id)
+  local url = base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id
+  local ok, status, _, body = fetch_json(url)
+  if not ok or status ~= 200 then
+    if ok then
       respond_json(status, {})
     else
       respond_json(503, {})
     end
-  end,
+    return
+  end
+  local hook = DecodeJson(body) or {}
+  local new_cfg = DecodeJson(GetBody() or "{}")
+  hook.config = hook.config or {}
+  for k, v in pairs(new_cfg) do
+    hook.config[k] = v
+  end
+  proxy_json(function(h)
+    return h.config or {}
+  end, fetch_json(url, "PATCH", EncodeJson(hook)))
+end)
 
-  put_pull_merge = function(owner, repo_name, pull_number)
-    proxy_204(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
-        "PUT",
-        GetBody()
-      )
+b:rest("post_repo_hook_ping", function(owner, repo_name, hook_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/pings",
+      "POST"
     )
-  end,
+  )
+end)
 
-  get_pull_requested_reviewers = proxy_handler(nil, function(o, r, n)
+b:rest("post_repo_hook_test", function(owner, repo_name, hook_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
+      "POST"
+    )
+  )
+end)
+
+-- Commit comments -----------------------------------------------------------
+b:rest(
+  "get_repo_comments",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/comments", PAGES)
+  end)
+)
+
+b:rest(
+  "get_repo_comment",
+  proxy_handler(nil, function(o, r, comment_id)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/comments/" .. comment_id
+  end)
+)
+
+b:rest("patch_repo_comment", function(owner, repo_name, comment_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
+      "PATCH",
+      GetBody()
+    )
+  )
+end)
+
+b:rest("delete_repo_comment", function(owner, repo_name, comment_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
+      "DELETE"
+    )
+  )
+end)
+
+b:rest(
+  "get_commit_comments",
+  proxy_handler(nil, function(o, r, sha)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/commits/" .. sha .. "/comments",
+      PAGES
+    )
+  end)
+)
+
+b:rest("post_commit_comment", function(owner, repo_name, commit_sha)
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/commits/" .. commit_sha .. "/comments",
+      "POST",
+      GetBody()
+    )
+  )
+end)
+
+-- GET /users/{username}/repos + public repos --------------------------------
+b:rest(
+  "get_users_repos",
+  proxy_handler(nil, function(username)
+    return append_page_params(base() .. "/users/" .. username .. "/repos", PAGES)
+  end)
+)
+
+b:rest(
+  "get_repositories",
+  proxy_handler(nil, function()
+    return append_page_params(base() .. "/repositories", PAGES)
+  end)
+)
+
+-- Users (GitHub-compatible passthrough) -------------------------------------
+
+b:rest(
+  "get_user",
+  proxy_handler(nil, function()
+    return base() .. "/user"
+  end)
+)
+
+b:rest("patch_user", function()
+  proxy_json(nil, fetch_json(base() .. "/user", "PATCH", GetBody()))
+end)
+
+b:rest(
+  "get_users_username",
+  proxy_handler(nil, function(username)
+    return base() .. "/users/" .. username
+  end)
+)
+
+b:rest(
+  "get_users",
+  proxy_handler(nil, function()
+    return append_page_params(base() .. "/users", PAGES)
+  end)
+)
+
+b:rest(
+  "get_user_followers",
+  proxy_handler(nil, function()
+    return append_page_params(base() .. "/user/followers", PAGES)
+  end)
+)
+
+b:rest(
+  "get_user_following",
+  proxy_handler(nil, function()
+    return append_page_params(base() .. "/user/following", PAGES)
+  end)
+)
+
+b:rest("get_user_is_following", function(username)
+  local ok, status = pcall(Fetch, base() .. "/user/following/" .. username, auth())
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(404, { message = "Not Following" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+b:rest("put_user_following", function(username)
+  set_204_or_error("PUT", base() .. "/user/following/" .. username)
+end)
+
+b:rest("delete_user_following", function(username)
+  set_204_or_error("DELETE", base() .. "/user/following/" .. username)
+end)
+
+b:rest(
+  "get_users_followers",
+  proxy_handler(nil, function(username)
+    return append_page_params(base() .. "/users/" .. username .. "/followers", PAGES)
+  end)
+)
+
+b:rest(
+  "get_users_following",
+  proxy_handler(nil, function(username)
+    return append_page_params(base() .. "/users/" .. username .. "/following", PAGES)
+  end)
+)
+
+b:rest("get_users_is_following", function(username, target)
+  local ok, status =
+    pcall(Fetch, base() .. "/users/" .. username .. "/following/" .. target, auth())
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(404, { message = "Not Following" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+b:rest(
+  "get_user_emails",
+  proxy_handler(nil, function()
+    return base() .. "/user/emails"
+  end)
+)
+
+b:rest("post_user_emails", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/emails", "POST", GetBody()))
+end)
+
+b:rest("delete_user_emails", function()
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  opts.body = GetBody()
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "application/json"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/user/emails", opts))
+end)
+
+b:rest(
+  "get_user_keys",
+  proxy_handler(nil, function()
+    return append_page_params(base() .. "/user/keys", PAGES)
+  end)
+)
+
+b:rest("post_user_keys", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/keys", "POST", GetBody()))
+end)
+
+b:rest(
+  "get_user_key",
+  proxy_handler(nil, function(key_id)
+    return base() .. "/user/keys/" .. key_id
+  end)
+)
+
+b:rest("delete_user_key", function(key_id)
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/user/keys/" .. key_id, opts))
+end)
+
+b:rest(
+  "get_users_keys",
+  proxy_handler(nil, function(username)
+    return append_page_params(base() .. "/users/" .. username .. "/keys", PAGES)
+  end)
+)
+
+-- Teams (GitHub-compatible passthrough) -------------------------------------
+
+b:rest(
+  "get_org_teams",
+  proxy_handler(nil, function(org)
+    return append_page_params(base() .. "/orgs/" .. org .. "/teams", PAGES)
+  end)
+)
+
+b:rest("post_org_teams", function(org)
+  proxy_json_created(nil, fetch_json(base() .. "/orgs/" .. org .. "/teams", "POST", GetBody()))
+end)
+
+b:rest(
+  "get_org_team",
+  proxy_handler(nil, function(org, slug)
+    return base() .. "/orgs/" .. org .. "/teams/" .. slug
+  end)
+)
+
+b:rest("patch_org_team", function(org, slug)
+  proxy_json(nil, fetch_json(base() .. "/orgs/" .. org .. "/teams/" .. slug, "PATCH", GetBody()))
+end)
+
+b:rest("delete_org_team", function(org, slug)
+  proxy_204({ 200 }, fetch_json(base() .. "/orgs/" .. org .. "/teams/" .. slug, "DELETE"))
+end)
+
+b:rest(
+  "get_org_team_invitations",
+  proxy_handler(nil, function(org, slug)
+    return append_page_params(
+      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/invitations",
+      PAGES
+    )
+  end)
+)
+
+b:rest(
+  "get_org_team_members",
+  proxy_handler(nil, function(org, slug)
+    return append_page_params(base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/members", PAGES)
+  end)
+)
+
+b:rest(
+  "get_org_team_membership",
+  proxy_handler(nil, function(org, slug, username)
+    return base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username
+  end)
+)
+
+b:rest("put_org_team_membership", function(org, slug, username)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username,
+      "PUT",
+      GetBody()
+    )
+  )
+end)
+
+b:rest("delete_org_team_membership", function(org, slug, username)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/memberships/" .. username,
+      "DELETE"
+    )
+  )
+end)
+
+b:rest(
+  "get_org_team_repos",
+  proxy_handler(nil, function(org, slug)
+    return append_page_params(base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos", PAGES)
+  end)
+)
+
+b:rest(
+  "get_org_team_repo",
+  proxy_handler(nil, function(org, slug, owner, repo_name)
+    return base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name
+  end)
+)
+
+b:rest("put_org_team_repo", function(org, slug, owner, repo_name)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
+      "PUT",
+      GetBody()
+    )
+  )
+end)
+
+b:rest("delete_org_team_repo", function(org, slug, owner, repo_name)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/repos/" .. owner .. "/" .. repo_name,
+      "DELETE"
+    )
+  )
+end)
+
+b:rest(
+  "get_org_team_children",
+  proxy_handler(nil, function(org, slug)
+    return append_page_params(base() .. "/orgs/" .. org .. "/teams/" .. slug .. "/teams", PAGES)
+  end)
+)
+
+-- Issues (GitHub-compatible passthrough) -------------------------------------
+
+b:rest(
+  "get_repo_issues",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues", PAGES)
+  end)
+)
+
+b:rest(
+  "post_repo_issues",
+  proxy_handler_created(nil, function(o, r)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues", "POST", GetBody()
+  end)
+)
+
+b:rest(
+  "get_repo_issue",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n
+  end)
+)
+
+b:rest(
+  "patch_repo_issue",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n, "PATCH", GetBody()
+  end)
+)
+
+b:rest(
+  "get_repo_issue_comments",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments", PAGES)
+  end)
+)
+
+b:rest(
+  "get_repo_issue_comment",
+  proxy_handler(nil, function(o, r, comment_id)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. comment_id
+  end)
+)
+
+b:rest(
+  "patch_repo_issue_comment",
+  proxy_handler(nil, function(o, r, id)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id, "PATCH", GetBody()
+  end)
+)
+
+b:rest("delete_repo_issue_comment", function(owner, repo_name, comment_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
+      "DELETE"
+    )
+  )
+end)
+
+b:rest(
+  "get_repo_issue_events",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/events", PAGES)
+  end)
+)
+
+b:rest(
+  "get_issue_comments",
+  proxy_handler(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments",
+      PAGES
+    )
+  end)
+)
+
+b:rest(
+  "post_issue_comment",
+  proxy_handler_created(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments", "POST", GetBody()
+  end)
+)
+
+b:rest(
+  "get_issue_events",
+  proxy_handler(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/events",
+      PAGES
+    )
+  end)
+)
+
+b:rest(
+  "get_issue_timeline",
+  proxy_handler(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/timeline",
+      PAGES
+    )
+  end)
+)
+
+b:rest(
+  "get_issue_labels",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels"
+  end)
+)
+
+b:rest(
+  "post_issue_labels",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels", "POST", GetBody()
+  end)
+)
+
+b:rest(
+  "put_issue_labels",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels", "PUT", GetBody()
+  end)
+)
+
+b:rest("delete_issue_labels", function(owner, repo_name, issue_number)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
+      "DELETE"
+    )
+  )
+end)
+
+b:rest("delete_issue_label", function(owner, repo_name, issue_number, label_name)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base()
+        .. "/repos/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/issues/"
+        .. issue_number
+        .. "/labels/"
+        .. label_name,
+      "DELETE"
+    )
+  )
+end)
+
+b:rest(
+  "post_issue_assignees",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/assignees",
+      "POST",
+      GetBody()
+  end)
+)
+
+b:rest(
+  "delete_issue_assignees",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/assignees",
+      "DELETE",
+      GetBody()
+  end)
+)
+
+b:rest(
+  "get_repo_assignees",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/assignees", PAGES)
+  end)
+)
+
+b:rest(
+  "get_repo_labels",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/labels", PAGES)
+  end)
+)
+
+b:rest(
+  "post_repo_labels",
+  proxy_handler_created(nil, function(o, r)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/labels", "POST", GetBody()
+  end)
+)
+
+b:rest(
+  "get_repo_label",
+  proxy_handler(nil, function(o, r, name)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/labels/" .. name
+  end)
+)
+
+b:rest(
+  "patch_repo_label",
+  proxy_handler(nil, function(o, r, name)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/labels/" .. name, "PATCH", GetBody()
+  end)
+)
+
+b:rest("delete_repo_label", function(owner, repo_name, label_name)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. label_name,
+      "DELETE"
+    )
+  )
+end)
+
+b:rest(
+  "get_repo_milestones",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/milestones", PAGES)
+  end)
+)
+
+b:rest(
+  "get_repo_milestone",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n
+  end)
+)
+
+b:rest(
+  "get_repo_milestone_labels",
+  proxy_handler(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n .. "/labels",
+      PAGES
+    )
+  end)
+)
+
+-- Legacy team-by-id API (/teams/{team_id}) ------------------------------------
+
+b:rest(
+  "get_user_teams",
+  proxy_handler(nil, function()
+    return append_page_params(base() .. "/user/teams", PAGES)
+  end)
+)
+
+b:rest(
+  "get_team",
+  proxy_handler(nil, function(team_id)
+    return base() .. "/teams/" .. team_id
+  end)
+)
+
+b:rest("patch_team", function(team_id)
+  proxy_json(nil, fetch_json(base() .. "/teams/" .. team_id, "PATCH", GetBody()))
+end)
+
+b:rest("delete_team", function(team_id)
+  proxy_204({ 200 }, fetch_json(base() .. "/teams/" .. team_id, "DELETE"))
+end)
+
+b:rest(
+  "get_team_invitations",
+  proxy_handler(nil, function(team_id)
+    return append_page_params(base() .. "/teams/" .. team_id .. "/invitations", PAGES)
+  end)
+)
+
+b:rest(
+  "get_team_members",
+  proxy_handler(nil, function(team_id)
+    return append_page_params(base() .. "/teams/" .. team_id .. "/members", PAGES)
+  end)
+)
+
+b:rest("get_team_member", function(team_id, username)
+  local ok, status = pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, auth())
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+b:rest("put_team_member", function(team_id, username)
+  set_204_or_error("PUT", base() .. "/teams/" .. team_id .. "/members/" .. username)
+end)
+
+b:rest("delete_team_member", function(team_id, username)
+  set_204_or_error("DELETE", base() .. "/teams/" .. team_id .. "/members/" .. username)
+end)
+
+b:rest(
+  "get_team_membership",
+  proxy_handler(nil, function(team_id, username)
+    return base() .. "/teams/" .. team_id .. "/memberships/" .. username
+  end)
+)
+
+b:rest("put_team_membership", function(team_id, username)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/teams/" .. team_id .. "/memberships/" .. username, "PUT", GetBody())
+  )
+end)
+
+b:rest("delete_team_membership", function(team_id, username)
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/teams/" .. team_id .. "/memberships/" .. username, "DELETE")
+  )
+end)
+
+b:rest(
+  "get_team_repos",
+  proxy_handler(nil, function(team_id)
+    return append_page_params(base() .. "/teams/" .. team_id .. "/repos", PAGES)
+  end)
+)
+
+b:rest(
+  "get_team_repo",
+  proxy_handler(nil, function(team_id, owner, repo_name)
+    return base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name
+  end)
+)
+
+b:rest("put_team_repo", function(team_id, owner, repo_name)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name,
+      "PUT",
+      GetBody()
+    )
+  )
+end)
+
+b:rest("delete_team_repo", function(team_id, owner, repo_name)
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name, "DELETE")
+  )
+end)
+
+b:rest(
+  "get_team_children",
+  proxy_handler(nil, function(team_id)
+    return append_page_params(base() .. "/teams/" .. team_id .. "/teams", PAGES)
+  end)
+)
+
+-- Pull Requests (GitHub-compatible passthrough) --------------------------------
+
+b:rest(
+  "get_repo_pulls",
+  proxy_handler(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/pulls", PAGES)
+  end)
+)
+
+b:rest("post_repo_pulls", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls", "POST", GetBody())
+  )
+end)
+
+b:rest(
+  "get_repo_pull",
+  proxy_handler(nil, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n
+  end)
+)
+
+b:rest("patch_repo_pull", function(owner, repo_name, pull_number)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number,
+      "PATCH",
+      GetBody()
+    )
+  )
+end)
+
+b:rest(
+  "get_pull_commits",
+  proxy_handler(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/commits",
+      PAGES
+    )
+  end)
+)
+
+b:rest(
+  "get_pull_files",
+  proxy_handler(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/files",
+      PAGES
+    )
+  end)
+)
+
+b:rest("get_pull_merge", function(owner, repo_name, pull_number)
+  local ok, status = pcall(
+    Fetch,
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
+    auth()
+  )
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok and status == 404 then
+    respond_json(404, { message = "Pull Request is not merged" })
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
+
+b:rest("put_pull_merge", function(owner, repo_name, pull_number)
+  proxy_204(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
+      "PUT",
+      GetBody()
+    )
+  )
+end)
+
+b:rest(
+  "get_pull_requested_reviewers",
+  proxy_handler(nil, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/requested_reviewers"
-  end),
+  end)
+)
 
-  get_pull_reviews = proxy_handler(nil, function(o, r, n)
+b:rest(
+  "get_pull_reviews",
+  proxy_handler(nil, function(o, r, n)
     return append_page_params(
       base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/reviews",
       PAGES
     )
-  end),
+  end)
+)
 
-  get_pull_review = proxy_handler(nil, function(o, r, n, review_id)
+b:rest(
+  "get_pull_review",
+  proxy_handler(nil, function(o, r, n, review_id)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/reviews/" .. review_id
-  end),
+  end)
+)
 
-  get_pull_review_comments = proxy_handler(nil, function(o, r, n, review_id)
+b:rest(
+  "get_pull_review_comments",
+  proxy_handler(nil, function(o, r, n, review_id)
     return append_page_params(
       base()
         .. "/repos/"
@@ -1193,137 +1491,191 @@ app.backend_impl = {
         .. "/comments",
       PAGES
     )
-  end),
+  end)
+)
 
-  get_pull_comments = proxy_handler(nil, function(o, r, n)
+b:rest(
+  "get_pull_comments",
+  proxy_handler(nil, function(o, r, n)
     return append_page_params(
       base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/comments",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- Search -------------------------------------------------------------------
-  -- GitBucket's GitHub-compatible API exposes /api/v3/search/{repositories,users}
-  -- which return the GitHub search envelope format directly — no translation needed.
-  search_repositories = proxy_handler(nil, function()
+-- Search -------------------------------------------------------------------
+-- GitBucket's GitHub-compatible API exposes /api/v3/search/{repositories,users}
+-- which return the GitHub search envelope format directly — no translation needed.
+b:rest(
+  "search_repositories",
+  proxy_handler(nil, function()
     local q = GetParam("q") or ""
     return append_page_params(base() .. "/search/repositories?q=" .. q, PAGES)
-  end),
+  end)
+)
 
-  search_users = proxy_handler(nil, function()
+b:rest(
+  "search_users",
+  proxy_handler(nil, function()
     local q = GetParam("q") or ""
     return append_page_params(base() .. "/search/users?q=" .. q, PAGES)
-  end),
+  end)
+)
 
-  -- Git database --------------------------------------------------------------
+-- Git database --------------------------------------------------------------
 
-  get_git_blob = proxy_handler(nil, function(o, r, sha)
+b:rest(
+  "get_git_blob",
+  proxy_handler(nil, function(o, r, sha)
     return base() .. "/repos/" .. o .. "/" .. r .. "/git/blobs/" .. sha
-  end),
+  end)
+)
 
-  get_git_commit = proxy_handler(nil, function(o, r, sha)
+b:rest(
+  "get_git_commit",
+  proxy_handler(nil, function(o, r, sha)
     return base() .. "/repos/" .. o .. "/" .. r .. "/git/commits/" .. sha
-  end),
+  end)
+)
 
-  list_git_matching_refs = proxy_handler(nil, function(o, r, ref)
+b:rest(
+  "list_git_matching_refs",
+  proxy_handler(nil, function(o, r, ref)
     return base() .. "/repos/" .. o .. "/" .. r .. "/git/matching-refs/" .. ref
-  end),
+  end)
+)
 
-  get_git_ref = proxy_handler(nil, function(o, r, ref)
+b:rest(
+  "get_git_ref",
+  proxy_handler(nil, function(o, r, ref)
     return base() .. "/repos/" .. o .. "/" .. r .. "/git/ref/" .. ref
-  end),
+  end)
+)
 
-  create_git_ref = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs", "POST", GetBody())
-    )
-  end,
+b:rest("create_git_ref", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs", "POST", GetBody())
+  )
+end)
 
-  delete_git_ref = function(owner, repo_name, ref)
-    set_204_or_error(
-      "DELETE",
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref
-    )
-  end,
+b:rest("delete_git_ref", function(owner, repo_name, ref)
+  set_204_or_error(
+    "DELETE",
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref
+  )
+end)
 
-  get_git_tag = proxy_handler(nil, function(o, r, sha)
+b:rest(
+  "get_git_tag",
+  proxy_handler(nil, function(o, r, sha)
     return base() .. "/repos/" .. o .. "/" .. r .. "/git/tags/" .. sha
-  end),
+  end)
+)
 
-  create_git_tag = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/tags", "POST", GetBody())
-    )
-  end,
+b:rest("create_git_tag", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/tags", "POST", GetBody())
+  )
+end)
 
-  get_git_tree = proxy_handler(nil, function(o, r, sha)
+b:rest(
+  "get_git_tree",
+  proxy_handler(nil, function(o, r, sha)
     return base() .. "/repos/" .. o .. "/" .. r .. "/git/trees/" .. sha
-  end),
+  end)
+)
 
-  -- Gists (GitHub-compatible passthrough) ------------------------------------
-  get_gists = proxy_handler(nil, function()
+-- Gists (GitHub-compatible passthrough) ------------------------------------
+b:rest(
+  "get_gists",
+  proxy_handler(nil, function()
     return base() .. "/gists"
-  end),
-  post_gists = function()
-    proxy_json_created(nil, fetch_json(base() .. "/gists", "POST", GetBody()))
-  end,
-  get_gists_public = proxy_handler(nil, function()
+  end)
+)
+b:rest("post_gists", function()
+  proxy_json_created(nil, fetch_json(base() .. "/gists", "POST", GetBody()))
+end)
+b:rest(
+  "get_gists_public",
+  proxy_handler(nil, function()
     return base() .. "/gists/public"
-  end),
-  get_gists_starred = proxy_handler(nil, function()
+  end)
+)
+b:rest(
+  "get_gists_starred",
+  proxy_handler(nil, function()
     return base() .. "/gists/starred"
-  end),
-  get_gist = proxy_handler(nil, function(id)
+  end)
+)
+b:rest(
+  "get_gist",
+  proxy_handler(nil, function(id)
     return base() .. "/gists/" .. id
-  end),
-  patch_gist = function(id)
-    proxy_json(nil, fetch_json(base() .. "/gists/" .. id, "PATCH", GetBody()))
-  end,
-  delete_gist = function(id)
-    set_204_or_error("DELETE", base() .. "/gists/" .. id)
-  end,
-  get_gist_comments = proxy_handler(nil, function(id)
+  end)
+)
+b:rest("patch_gist", function(id)
+  proxy_json(nil, fetch_json(base() .. "/gists/" .. id, "PATCH", GetBody()))
+end)
+b:rest("delete_gist", function(id)
+  set_204_or_error("DELETE", base() .. "/gists/" .. id)
+end)
+b:rest(
+  "get_gist_comments",
+  proxy_handler(nil, function(id)
     return base() .. "/gists/" .. id .. "/comments"
-  end),
-  post_gist_comment = function(id)
-    proxy_json_created(nil, fetch_json(base() .. "/gists/" .. id .. "/comments", "POST", GetBody()))
-  end,
-  get_gist_comment = proxy_handler(nil, function(id, cid)
+  end)
+)
+b:rest("post_gist_comment", function(id)
+  proxy_json_created(nil, fetch_json(base() .. "/gists/" .. id .. "/comments", "POST", GetBody()))
+end)
+b:rest(
+  "get_gist_comment",
+  proxy_handler(nil, function(id, cid)
     return base() .. "/gists/" .. id .. "/comments/" .. cid
-  end),
-  patch_gist_comment = function(id, cid)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/gists/" .. id .. "/comments/" .. cid, "PATCH", GetBody())
-    )
-  end,
-  delete_gist_comment = function(id, cid)
-    set_204_or_error("DELETE", base() .. "/gists/" .. id .. "/comments/" .. cid)
-  end,
-  get_gist_commits = proxy_handler(nil, function(id)
+  end)
+)
+b:rest("patch_gist_comment", function(id, cid)
+  proxy_json(nil, fetch_json(base() .. "/gists/" .. id .. "/comments/" .. cid, "PATCH", GetBody()))
+end)
+b:rest("delete_gist_comment", function(id, cid)
+  set_204_or_error("DELETE", base() .. "/gists/" .. id .. "/comments/" .. cid)
+end)
+b:rest(
+  "get_gist_commits",
+  proxy_handler(nil, function(id)
     return base() .. "/gists/" .. id .. "/commits"
-  end),
-  get_gist_forks = proxy_handler(nil, function(id)
+  end)
+)
+b:rest(
+  "get_gist_forks",
+  proxy_handler(nil, function(id)
     return base() .. "/gists/" .. id .. "/forks"
-  end),
-  get_gist_star = function(id)
-    set_204_or_error("GET", base() .. "/gists/" .. id .. "/star")
-  end,
-  put_gist_star = function(id)
-    set_204_or_error("PUT", base() .. "/gists/" .. id .. "/star")
-  end,
-  delete_gist_star = function(id)
-    set_204_or_error("DELETE", base() .. "/gists/" .. id .. "/star")
-  end,
-  get_gist_revision = proxy_handler(nil, function(id, sha)
+  end)
+)
+b:rest("get_gist_star", function(id)
+  set_204_or_error("GET", base() .. "/gists/" .. id .. "/star")
+end)
+b:rest("put_gist_star", function(id)
+  set_204_or_error("PUT", base() .. "/gists/" .. id .. "/star")
+end)
+b:rest("delete_gist_star", function(id)
+  set_204_or_error("DELETE", base() .. "/gists/" .. id .. "/star")
+end)
+b:rest(
+  "get_gist_revision",
+  proxy_handler(nil, function(id, sha)
     return base() .. "/gists/" .. id .. "/" .. sha
-  end),
-  get_user_gists = proxy_handler(nil, function(user)
+  end)
+)
+b:rest(
+  "get_user_gists",
+  proxy_handler(nil, function(user)
     return base() .. "/users/" .. user .. "/gists"
-  end),
-}
+  end)
+)
 
 -- ---------------------------------------------------------------------------
 -- GraphQL resolvers
@@ -1369,7 +1721,7 @@ end
 
 -- Query.repositoryOwner: look up a User or Organization by login.
 -- Tries /users/{login} first; falls back to /orgs/{login}.
-graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
+b:graphql("Query.repositoryOwner", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "repositoryOwner requires a login argument")
     return nil
@@ -1383,10 +1735,10 @@ graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
     return graphql_translate_org(odata)
   end
   return nil
-end
+end)
 
 -- Query.viewer: resolve the authenticated user via GET /user.
-graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+b:graphql("Query.viewer", function(_parent, _args, ctx)
   local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
   if not data then
     return nil
@@ -1394,10 +1746,10 @@ graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
   local u = graphql_translate_user(data)
   u.isViewer = true
   return u
-end
+end)
 
 -- Query.user: look up a User by login.
-graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+b:graphql("Query.user", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "user requires a login argument")
     return nil
@@ -1407,10 +1759,10 @@ graphql_resolvers["Query.user"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_user(data)
-end
+end)
 
 -- Query.organization: look up an Organization by login.
-graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
+b:graphql("Query.organization", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "organization requires a login argument")
     return nil
@@ -1420,10 +1772,10 @@ graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_org(data)
-end
+end)
 
 -- Query.repository: look up a Repository by owner and name.
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -1433,37 +1785,37 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(data)
-end
+end)
 
 -- node.Repository: fetch a repository by "owner/repo" local ID.
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/repos/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_repo(data)
-end
+end)
 
 -- node.User: fetch a user by login.
-graphql_resolvers["node.User"] = function(local_id, _ctx)
+b:graphql("node.User", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_user(data)
-end
+end)
 
 -- node.Organization: fetch an organization by login.
-graphql_resolvers["node.Organization"] = function(local_id, _ctx)
+b:graphql("node.Organization", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/orgs/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_org(data)
-end
+end)
 
 -- node.Issue: fetch an issue by "owner/repo/number" local ID.
-graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+b:graphql("node.Issue", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -1474,10 +1826,10 @@ graphql_resolvers["node.Issue"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_issue(data, owner, repo)
-end
+end)
 
 -- node.PullRequest: fetch a pull request by "owner/repo/number" local ID.
-graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
+b:graphql("node.PullRequest", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -1488,10 +1840,10 @@ graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_pr(data, owner, repo)
-end
+end)
 
 -- node.IssueComment: fetch an issue comment by "owner/repo/comment_id" local ID.
-graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
+b:graphql("node.IssueComment", function(local_id, _ctx)
   local owner, repo, cid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -1504,10 +1856,10 @@ graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_comment(data, owner, repo)
-end
+end)
 
 -- node.Release: fetch a release by "owner/repo/release_id" local ID.
-graphql_resolvers["node.Release"] = function(local_id, _ctx)
+b:graphql("node.Release", function(local_id, _ctx)
   local owner, repo, rid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -1518,10 +1870,10 @@ graphql_resolvers["node.Release"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_release(data, owner, repo)
-end
+end)
 
 -- node.Label: fetch a label by "owner/repo/label_id" local ID.
-graphql_resolvers["node.Label"] = function(local_id, _ctx)
+b:graphql("node.Label", function(local_id, _ctx)
   local owner, repo, lid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -1532,10 +1884,10 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_label(data, owner, repo)
-end
+end)
 
 -- node.Milestone: fetch a milestone by "owner/repo/number" local ID.
-graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
+b:graphql("node.Milestone", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -1548,10 +1900,10 @@ graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_milestone(data, owner, repo)
-end
+end)
 
 -- node.Commit: fetch a commit by "owner/repo/sha" local ID.
-graphql_resolvers["node.Commit"] = function(local_id, _ctx)
+b:graphql("node.Commit", function(local_id, _ctx)
   local owner, repo, sha = local_id:match("^([^/]+)/([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1562,11 +1914,11 @@ graphql_resolvers["node.Commit"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_commit(data, owner, repo)
-end
+end)
 
 -- node.Ref: fetch a branch ref by "owner/repo/refs/heads/..." local ID.
 -- GitBucket branch objects are GitHub-compatible (commit.sha already present).
-graphql_resolvers["node.Ref"] = function(local_id, _ctx)
+b:graphql("node.Ref", function(local_id, _ctx)
   local owner, repo, ref_path = local_id:match("^([^/]+)/([^/]+)/(refs/.+)$")
   if not owner then
     return nil
@@ -1582,11 +1934,11 @@ graphql_resolvers["node.Ref"] = function(local_id, _ctx)
   end
   local repo_stub = { __typename = "Repository", nameWithOwner = owner .. "/" .. repo }
   return graphql_translate_ref(data, repo_stub)
-end
+end)
 
 -- node.Team: fetch a team by "org/slug" local ID.
 -- GitBucket is GitHub-compatible; /orgs/{org}/teams/{slug} returns the team directly.
-graphql_resolvers["node.Team"] = function(local_id, _ctx)
+b:graphql("node.Team", function(local_id, _ctx)
   local org, slug = local_id:match("^([^/]+)/([^/]+)$")
   if not org then
     return nil
@@ -1596,7 +1948,7 @@ graphql_resolvers["node.Team"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_team(data, org)
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
@@ -1605,7 +1957,7 @@ end
 -- Repository.issues: paginated list of issues.
 -- GitBucket's issue list includes PRs (like GitHub); filter them out by checking
 -- the pull_request field.
-graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+b:graphql("Repository.issues", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1629,10 +1981,10 @@ graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
     end
   end
   return graphql_issues_connection(nodes, args, total, ctx)
-end
+end)
 
 -- Repository.pullRequests: paginated list of pull requests.
-graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+b:graphql("Repository.pullRequests", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1640,10 +1992,10 @@ graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
   return gb_repo_connection(owner, name, "/pulls", args, ctx, function(p)
     return graphql_translate_pr(p, owner, name)
   end, graphql_prs_connection)
-end
+end)
 
 -- Repository.releases: paginated list of releases.
-graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
+b:graphql("Repository.releases", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1653,10 +2005,10 @@ graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("Release", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.labels: paginated list of labels.
-graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
+b:graphql("Repository.labels", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1664,10 +2016,10 @@ graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
   return gb_repo_connection(owner, name, "/labels", args, ctx, function(l)
     return graphql_translate_label(l, owner, name)
   end, graphql_labels_connection)
-end
+end)
 
 -- Repository.milestones: paginated list of milestones.
-graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
+b:graphql("Repository.milestones", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1677,23 +2029,23 @@ graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("Milestone", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.refs: paginated list of branches as Ref objects.
 -- GitBucket branch objects already include commit.sha (GitHub-compatible);
 -- no commit.id → commit.sha normalisation needed.
-graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+b:graphql("Repository.refs", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
   end
-  return gb_repo_connection(owner, name, "/branches", args, ctx, function(b)
-    return graphql_translate_ref(b, parent)
+  return gb_repo_connection(owner, name, "/branches", args, ctx, function(br)
+    return graphql_translate_ref(br, parent)
   end, graphql_refs_connection)
-end
+end)
 
 -- Issue.comments: paginated list of comments for a single issue.
-graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+b:graphql("Issue.comments", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -1726,10 +2078,10 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_comment(c, owner, repo)
   end
   return graphql_make_connection("IssueComment", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.commits: paginated commit list for a pull request.
-graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
+b:graphql("PullRequest.commits", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -1763,10 +2115,10 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     }
   end
   return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.reviews: paginated review list for a pull request.
-graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
+b:graphql("PullRequest.reviews", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -1792,10 +2144,10 @@ graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_review(r, owner, repo)
   end
   return graphql_make_connection("PullRequestReview", nodes, args, total, ctx)
-end
+end)
 
 -- Repository.collaborators: paginated list of collaborators as Users.
-graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
+b:graphql("Repository.collaborators", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1805,11 +2157,11 @@ graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("RepositoryCollaborator", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.defaultBranchRef: enrich the inline stub with full branch data.
 -- The parent already carries {__typename="Ref",name="main"} from graphql_translate_repo.
-graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
+b:graphql("Repository.defaultBranchRef", function(parent, _args, _ctx)
   local branch = parent.defaultBranchRef and parent.defaultBranchRef.name
   if not branch then
     return nil
@@ -1824,11 +2176,11 @@ graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
     return nil
   end
   return graphql_translate_ref(data, parent)
-end
+end)
 
 -- Repository.languages: fetch language byte-count breakdown as a LanguageConnection.
 -- GitBucket returns {"Language": bytes, ...}; we convert to the Relay Connection shape.
-graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
+b:graphql("Repository.languages", function(parent, _args, _ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -1865,7 +2217,7 @@ graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
     nodes = nodes,
     edges = edges,
   }
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Query.search
@@ -1875,7 +2227,7 @@ end
 -- GitBucket exposes GitHub-compatible /search/{repositories,users} returning
 -- the standard {total_count, items} envelope.
 -- ISSUE search is not supported (GitBucket has no /search/issues endpoint).
-graphql_resolvers["Query.search"] = function(_parent, args, _ctx)
+b:graphql("Query.search", function(_parent, args, _ctx)
   local query = args.query or ""
   local search_type = args.type or "REPOSITORY"
   local per_page = args.first or 30
@@ -1933,4 +2285,6 @@ graphql_resolvers["Query.search"] = function(_parent, args, _ctx)
     discussionCount = 0,
     wikiCount = 0,
   }
-end
+end)
+
+b:build()

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -20,12 +20,13 @@ local proxy_handler_created = _t.proxy_handler_created
 local proxy_handler_paged = _t.proxy_handler_paged
 
 -- Check if this Gitea instance allows anonymous access.
--- Sets app.allow_anonymous so OnHttpRequest can gate unauthenticated requests.
+-- Stored in _allow_anon; committed to app context via b:set_allow_anonymous() at the end.
+local _allow_anon = true -- default
 do
   local ok, status, _, body = pcall(Fetch, base() .. "/settings/api", nil)
   if ok and status == 200 then
     local settings = DecodeJson(body) or {}
-    app.allow_anonymous = settings.require_signin_view ~= true
+    _allow_anon = settings.require_signin_view ~= true
   end
 end
 
@@ -739,789 +740,759 @@ local function delete_gitea_reaction(url, reaction_id)
   proxy_204({ 200 }, fetch_json(url, "DELETE", '{"content":"' .. content .. '"}'))
 end
 
-app.backend_impl = {
-  -- Health check
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
-  end,
+local b = make_backend_builder()
 
-  get_rate_limit = proxy_handler(function(data)
+-- Health check
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
+end)
+
+b:rest(
+  "get_rate_limit",
+  proxy_handler(function(data)
     return { rate = data.rate or data }
   end, function()
     return base() .. "/rate_limit"
-  end),
+  end)
+)
 
-  -- GET /gitignore/templates
-  get_gitignore_templates = function()
-    proxy_json(nil, fetch_json(base() .. "/gitignores"))
-  end,
+-- GET /gitignore/templates
+b:rest("get_gitignore_templates", function()
+  proxy_json(nil, fetch_json(base() .. "/gitignores"))
+end)
 
-  -- GET /gitignore/templates/{name}
-  get_gitignore_template = function(name)
-    proxy_json(nil, fetch_json(base() .. "/gitignores/" .. name))
-  end,
+-- GET /gitignore/templates/{name}
+b:rest("get_gitignore_template", function(name)
+  proxy_json(nil, fetch_json(base() .. "/gitignores/" .. name))
+end)
 
-  -- GET /licenses
-  get_licenses = function()
-    proxy_json(nil, fetch_json(base() .. "/licenses"))
-  end,
+-- GET /licenses
+b:rest("get_licenses", function()
+  proxy_json(nil, fetch_json(base() .. "/licenses"))
+end)
 
-  -- GET /licenses/{license}
-  get_license = function(license_name)
-    proxy_json(nil, fetch_json(base() .. "/licenses/" .. license_name))
-  end,
+-- GET /licenses/{license}
+b:rest("get_license", function(license_name)
+  proxy_json(nil, fetch_json(base() .. "/licenses/" .. license_name))
+end)
 
-  -- GET /repos/{owner}/{repo}/license
-  -- Gitea has no dedicated endpoint; combine contents/LICENSE with repo license metadata.
-  get_repo_license = function(owner, repo_name)
-    local ok, status, _, body =
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/LICENSE")
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local content = DecodeJson(body) or {}
-    local rok, rstatus, _, rbody = fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name)
-    if rok and rstatus == 200 then
-      content.license = (DecodeJson(rbody) or {}).license
-    end
-    respond_json(200, content)
-  end,
+-- GET /repos/{owner}/{repo}/license
+-- Gitea has no dedicated endpoint; combine contents/LICENSE with repo license metadata.
+b:rest("get_repo_license", function(owner, repo_name)
+  local ok, status, _, body =
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/LICENSE")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local content = DecodeJson(body) or {}
+  local rok, rstatus, _, rbody = fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name)
+  if rok and rstatus == 200 then
+    content.license = (DecodeJson(rbody) or {}).license
+  end
+  respond_json(200, content)
+end)
 
-  -- GET /repos/{owner}/{repo}
-  get_repo = function(owner, repo_name)
-    proxy_json(translate_repo, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name))
-  end,
+-- GET /repos/{owner}/{repo}
+b:rest("get_repo", function(owner, repo_name)
+  proxy_json(translate_repo, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name))
+end)
 
-  -- PATCH /repos/{owner}/{repo}
-  patch_repo = function(owner, repo_name)
-    proxy_json(
-      translate_repo,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name, "PATCH", GetBody())
-    )
-  end,
+-- PATCH /repos/{owner}/{repo}
+b:rest("patch_repo", function(owner, repo_name)
+  proxy_json(
+    translate_repo,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name, "PATCH", GetBody())
+  )
+end)
 
-  -- DELETE /repos/{owner}/{repo}
-  delete_repo = function(owner, repo_name)
-    local url = base() .. "/repos/" .. owner .. "/" .. repo_name
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, url, dopts))
-  end,
+-- DELETE /repos/{owner}/{repo}
+b:rest("delete_repo", function(owner, repo_name)
+  local url = base() .. "/repos/" .. owner .. "/" .. repo_name
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, url, dopts))
+end)
 
-  -- GET /user/repos
-  get_user_repos = function()
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/user/repos", PAGES))
-    )
-  end,
+-- GET /user/repos
+b:rest("get_user_repos", function()
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/user/repos", PAGES))
+  )
+end)
 
-  -- POST /user/repos
-  post_user_repos = function()
-    proxy_json_created(translate_repo, fetch_json(base() .. "/user/repos", "POST", GetBody()))
-  end,
+-- POST /user/repos
+b:rest("post_user_repos", function()
+  proxy_json_created(translate_repo, fetch_json(base() .. "/user/repos", "POST", GetBody()))
+end)
 
-  -- GET /orgs/{org}/repos
-  get_org_repos = function(org)
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/orgs/" .. org .. "/repos", PAGES))
-    )
-  end,
+-- GET /orgs/{org}/repos
+b:rest("get_org_repos", function(org)
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/orgs/" .. org .. "/repos", PAGES))
+  )
+end)
 
-  -- POST /orgs/{org}/repos
-  post_org_repos = function(org)
-    proxy_json_created(
-      translate_repo,
-      fetch_json(base() .. "/orgs/" .. org .. "/repos", "POST", GetBody())
-    )
-  end,
+-- POST /orgs/{org}/repos
+b:rest("post_org_repos", function(org)
+  proxy_json_created(
+    translate_repo,
+    fetch_json(base() .. "/orgs/" .. org .. "/repos", "POST", GetBody())
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/topics
-  get_repo_topics = function(owner, repo_name)
-    proxy_json(function(t)
+-- GET /repos/{owner}/{repo}/topics
+b:rest("get_repo_topics", function(owner, repo_name)
+  proxy_json(function(t)
+    return { names = t.topics or t.names or {} }
+  end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/topics"))
+end)
+
+-- PUT /repos/{owner}/{repo}/topics
+b:rest("put_repo_topics", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  proxy_json(
+    function(t)
       return { names = t.topics or t.names or {} }
-    end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/topics"))
-  end,
-
-  -- PUT /repos/{owner}/{repo}/topics
-  put_repo_topics = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    proxy_json(
-      function(t)
-        return { names = t.topics or t.names or {} }
-      end,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/topics",
-        "PUT",
-        EncodeJson({ topics = req.names or {} })
-      )
+    end,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/topics",
+      "PUT",
+      EncodeJson({ topics = req.names or {} })
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/languages
-  -- Both Gitea and GitHub return { "Language": bytes } — pass through.
-  get_repo_languages = function(owner, repo_name)
-    proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/languages"))
-  end,
+-- GET /repos/{owner}/{repo}/languages
+-- Both Gitea and GitHub return { "Language": bytes } — pass through.
+b:rest("get_repo_languages", function(owner, repo_name)
+  proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/languages"))
+end)
 
-  -- GET /repos/{owner}/{repo}/contributors
-  -- Gitea uses "contributions"; GitHub uses "contributions" — same key, pass through.
-  get_repo_contributors = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contributors",
-          PAGES
-        )
-      )
+-- GET /repos/{owner}/{repo}/contributors
+-- Gitea uses "contributions"; GitHub uses "contributions" — same key, pass through.
+b:rest("get_repo_contributors", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contributors", PAGES)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/tags
-  -- Both Gitea and GitHub return [{ name, commit: { sha, url }, ... }] — pass through.
-  get_repo_tags = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/tags", PAGES)
-      )
+-- GET /repos/{owner}/{repo}/tags
+-- Both Gitea and GitHub return [{ name, commit: { sha, url }, ... }] — pass through.
+b:rest("get_repo_tags", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/tags", PAGES)
     )
-  end,
+  )
+end)
 
-  -- Branches ------------------------------------------------------------------
+-- Branches ------------------------------------------------------------------
 
-  -- Gitea branch objects use commit.id instead of GitHub's commit.sha.
-  -- GET /repos/{owner}/{repo}/branches
-  get_repo_branches = function(owner, repo_name)
-    local function tr_branches(branches)
-      for _, b in ipairs(branches or {}) do
-        if b.commit then
-          b.commit.sha = b.commit.id
-        end
+-- Gitea branch objects use commit.id instead of GitHub's commit.sha.
+-- GET /repos/{owner}/{repo}/branches
+b:rest("get_repo_branches", function(owner, repo_name)
+  local function tr_branches(branches)
+    for _, br in ipairs(branches or {}) do
+      if br.commit then
+        br.commit.sha = br.commit.id
       end
-      return branches or {}
     end
-    proxy_json_paged(
-      tr_branches,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/branches", PAGES)
+    return branches or {}
+  end
+  proxy_json_paged(
+    tr_branches,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/branches", PAGES)
+    )
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/branches/{branch}
+b:rest("get_repo_branch", function(owner, repo_name, branch)
+  proxy_json(function(br)
+    if br and br.commit then
+      br.commit.sha = br.commit.id
+    end
+    return br or {}
+  end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/branches/" .. branch))
+end)
+
+-- Commits -------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/commits
+b:rest("get_repo_commits", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/commits", PAGES)
+    )
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/commits/{ref}
+b:rest("get_repo_commit", function(owner, repo_name, ref)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/commits/" .. ref)
+  )
+end)
+
+-- Statuses ------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/commits/{ref}/statuses
+b:rest("get_commit_statuses", function(owner, repo_name, ref)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. ref,
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/branches/{branch}
-  get_repo_branch = function(owner, repo_name, branch)
-    proxy_json(function(b)
-      if b and b.commit then
-        b.commit.sha = b.commit.id
-      end
-      return b or {}
-    end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/branches/" .. branch))
-  end,
+-- GET /repos/{owner}/{repo}/commits/{ref}/status  (combined)
+b:rest("get_commit_combined_status", function(owner, repo_name, ref)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/commits/" .. ref .. "/statuses"
+    )
+  )
+end)
 
-  -- Commits -------------------------------------------------------------------
+-- POST /repos/{owner}/{repo}/statuses/{sha}
+b:rest("post_commit_status", function(owner, repo_name, sha)
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
+      "POST",
+      GetBody()
+    )
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/commits
-  get_repo_commits = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/commits", PAGES)
+-- Contents ------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/readme
+b:rest("get_repo_readme", function(owner, repo_name)
+  proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/readme"))
+end)
+
+-- GET /repos/{owner}/{repo}/readme/{dir}
+b:rest("get_repo_readme_dir", function(owner, repo_name, dir)
+  proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/readme/" .. dir))
+end)
+
+-- GET /repos/{owner}/{repo}/contents/{path}
+b:rest("get_repo_content", function(owner, repo_name, path)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path)
+  )
+end)
+
+-- PUT /repos/{owner}/{repo}/contents/{path}
+b:rest("put_repo_content", function(owner, repo_name, path)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
+      "PUT",
+      GetBody()
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/contents/{path}
+b:rest("delete_repo_content", function(owner, repo_name, path)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
+      "DELETE",
+      GetBody()
+    )
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/tarball/{ref} — redirect to Gitea's archive URL
+b:rest("get_repo_tarball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/archive/" .. ref .. ".tar.gz"
+  )
+  Write("")
+end)
+
+-- GET /repos/{owner}/{repo}/zipball/{ref} — redirect to Gitea's archive URL
+b:rest("get_repo_zipball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/archive/" .. ref .. ".zip"
+  )
+  Write("")
+end)
+
+-- Compare -------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/compare/{basehead}
+-- Gitea uses /{owner}/{repo}/compare/{base}...{head} (3 dots) in UI, but
+-- the API endpoint uses {base}...{head} or {base}..{head} in the basehead param.
+b:rest("get_repo_compare", function(owner, repo_name, basehead)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/compare/" .. basehead)
+  )
+end)
+
+-- Collaborators -------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/collaborators
+b:rest("get_repo_collaborators", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators",
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/commits/{ref}
-  get_repo_commit = function(owner, repo_name, ref)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/commits/" .. ref)
-    )
-  end,
+-- GET /repos/{owner}/{repo}/collaborators/{username} — 204 if collaborator, 404 if not
+b:rest("get_repo_collaborator", function(owner, repo_name, username)
+  local ok, status = pcall(
+    Fetch,
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+    auth()
+  )
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(status, { message = "Not a collaborator" })
+  else
+    respond_json(503, {})
+  end
+end)
 
-  -- Statuses ------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/commits/{ref}/statuses
-  get_commit_statuses = function(owner, repo_name, ref)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. ref,
-          PAGES
-        )
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/commits/{ref}/status  (combined)
-  get_commit_combined_status = function(owner, repo_name, ref)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/commits/" .. ref .. "/statuses"
-      )
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/statuses/{sha}
-  post_commit_status = function(owner, repo_name, sha)
-    proxy_json_created(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
-        "POST",
-        GetBody()
-      )
-    )
-  end,
-
-  -- Contents ------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/readme
-  get_repo_readme = function(owner, repo_name)
-    proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/readme"))
-  end,
-
-  -- GET /repos/{owner}/{repo}/readme/{dir}
-  get_repo_readme_dir = function(owner, repo_name, dir)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/readme/" .. dir)
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/contents/{path}
-  get_repo_content = function(owner, repo_name, path)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path)
-    )
-  end,
-
-  -- PUT /repos/{owner}/{repo}/contents/{path}
-  put_repo_content = function(owner, repo_name, path)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/contents/{path}
-  delete_repo_content = function(owner, repo_name, path)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/contents/" .. path,
-        "DELETE",
-        GetBody()
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/tarball/{ref} — redirect to Gitea's archive URL
-  get_repo_tarball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/archive/" .. ref .. ".tar.gz"
-    )
-    Write("")
-  end,
-
-  -- GET /repos/{owner}/{repo}/zipball/{ref} — redirect to Gitea's archive URL
-  get_repo_zipball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/archive/" .. ref .. ".zip"
-    )
-    Write("")
-  end,
-
-  -- Compare -------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/compare/{basehead}
-  -- Gitea uses /{owner}/{repo}/compare/{base}...{head} (3 dots) in UI, but
-  -- the API endpoint uses {base}...{head} or {base}..{head} in the basehead param.
-  get_repo_compare = function(owner, repo_name, basehead)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/compare/" .. basehead)
-    )
-  end,
-
-  -- Collaborators -------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/collaborators
-  get_repo_collaborators = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/collaborators/{username} — 204 if collaborator, 404 if not
-  get_repo_collaborator = function(owner, repo_name, username)
-    local ok, status = pcall(
-      Fetch,
+-- PUT /repos/{owner}/{repo}/collaborators/{username}
+b:rest("put_repo_collaborator", function(owner, repo_name, username)
+  proxy_204(
+    { 201 },
+    fetch_json(
       base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-      auth()
+      "PUT",
+      GetBody()
     )
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(status, { message = "Not a collaborator" })
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/collaborators/{username}
+b:rest("delete_repo_collaborator", function(owner, repo_name, username)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
+      "DELETE"
+    )
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/collaborators/{username}/permission
+b:rest("get_repo_collaborator_permission", function(owner, repo_name, username)
+  proxy_json(
+    nil,
+    fetch_json(
+      base()
+        .. "/repos/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/collaborators/"
+        .. username
+        .. "/permission"
+    )
+  )
+end)
+
+-- Forks ---------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/forks
+b:rest("get_repo_forks", function(owner, repo_name)
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/forks", PAGES)
+    )
+  )
+end)
+
+-- POST /repos/{owner}/{repo}/forks
+b:rest("post_repo_forks", function(owner, repo_name)
+  proxy_json_created(
+    translate_repo,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/forks", "POST", GetBody())
+  )
+end)
+
+-- Releases ------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/releases
+b:rest("get_repo_releases", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases", PAGES)
+    )
+  )
+end)
+
+-- POST /repos/{owner}/{repo}/releases
+b:rest("post_repo_releases", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases", "POST", GetBody())
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/releases/latest
+b:rest("get_repo_release_latest", function(owner, repo_name)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/latest")
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/releases/tags/{tag}
+b:rest("get_repo_release_by_tag", function(owner, repo_name, tag)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/tags/" .. tag)
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/releases/{release_id}
+b:rest("get_repo_release", function(owner, repo_name, release_id)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id)
+  )
+end)
+
+-- PATCH /repos/{owner}/{repo}/releases/{release_id}
+b:rest("patch_repo_release", function(owner, repo_name, release_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
+      "PATCH",
+      GetBody()
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/releases/{release_id}
+b:rest("delete_repo_release", function(owner, repo_name, release_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
+      "DELETE"
+    )
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/releases/{release_id}/assets
+b:rest("get_repo_release_assets", function(owner, repo_name, release_id)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(
+        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id .. "/assets",
+        PAGES
+      )
+    )
+  )
+end)
+
+-- POST /repos/{owner}/{repo}/releases/{release_id}/assets — multipart; pass through
+b:rest("post_repo_release_assets", function(owner, repo_name, release_id)
+  -- Gitea uses the same multipart upload path; proxy the entire request.
+  -- The Content-Type header (multipart/form-data) must be forwarded.
+  local url = base()
+    .. "/repos/"
+    .. owner
+    .. "/"
+    .. repo_name
+    .. "/releases/"
+    .. release_id
+    .. "/assets"
+  local opts = auth() or {}
+  opts.method = "POST"
+  opts.body = GetBody()
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = GetHeader("Content-Type") or "application/octet-stream"
+  proxy_json_created(nil, pcall(Fetch, url, opts))
+end)
+
+-- GET /repos/{owner}/{repo}/releases/assets/{asset_id}
+b:rest("get_repo_release_asset", function(owner, repo_name, asset_id)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id)
+  )
+end)
+
+-- PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}
+b:rest("patch_repo_release_asset", function(owner, repo_name, asset_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
+      "PATCH",
+      GetBody()
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}
+b:rest("delete_repo_release_asset", function(owner, repo_name, asset_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
+      "DELETE"
+    )
+  )
+end)
+
+-- Deploy keys ---------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/keys
+b:rest("get_repo_keys", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys", PAGES)
+    )
+  )
+end)
+
+-- POST /repos/{owner}/{repo}/keys
+b:rest("post_repo_keys", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys", "POST", GetBody())
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/keys/{key_id}
+b:rest("get_repo_key", function(owner, repo_name, key_id)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id)
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/keys/{key_id}
+b:rest("delete_repo_key", function(owner, repo_name, key_id)
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id, "DELETE")
+  )
+end)
+
+-- Webhooks ------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/hooks
+b:rest("get_repo_hooks", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks", PAGES)
+    )
+  )
+end)
+
+-- POST /repos/{owner}/{repo}/hooks
+b:rest("post_repo_hooks", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks", "POST", GetBody())
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/hooks/{hook_id}
+b:rest("get_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id)
+  )
+end)
+
+-- PATCH /repos/{owner}/{repo}/hooks/{hook_id}
+b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id,
+      "PATCH",
+      GetBody()
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/hooks/{hook_id}
+b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id, "DELETE")
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/hooks/{hook_id}/config
+-- Gitea stores config inline in the hook object; extract the config sub-object.
+b:rest("get_repo_hook_config", function(owner, repo_name, hook_id)
+  proxy_json(function(hook)
+    return hook.config or {}
+  end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id))
+end)
+
+-- PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config
+-- Gitea has no separate config endpoint; merge into a full PATCH.
+b:rest("patch_repo_hook_config", function(owner, repo_name, hook_id)
+  local url = base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id
+  -- Fetch current hook, merge new config, write back.
+  local ok, status, _, body = fetch_json(url)
+  if not ok or status ~= 200 then
+    if ok then
+      respond_json(status, {})
     else
       respond_json(503, {})
     end
-  end,
+    return
+  end
+  local hook = DecodeJson(body) or {}
+  local new_config = DecodeJson(GetBody() or "{}")
+  hook.config = hook.config or {}
+  for k, v in pairs(new_config) do
+    hook.config[k] = v
+  end
+  proxy_json(function(h)
+    return h.config or {}
+  end, fetch_json(url, "PATCH", EncodeJson(hook)))
+end)
 
-  -- PUT /repos/{owner}/{repo}/collaborators/{username}
-  put_repo_collaborator = function(owner, repo_name, username)
-    proxy_204(
-      { 201 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-        "PUT",
-        GetBody()
-      )
+-- POST /repos/{owner}/{repo}/hooks/{hook_id}/tests
+b:rest("post_repo_hook_test", function(owner, repo_name, hook_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
+      "POST"
     )
-  end,
+  )
+end)
 
-  -- DELETE /repos/{owner}/{repo}/collaborators/{username}
-  delete_repo_collaborator = function(owner, repo_name, username)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/collaborators/" .. username,
-        "DELETE"
-      )
+-- Users' repos --------------------------------------------------------------
+
+-- GET /users/{username}/repos
+b:rest("get_users_repos", function(username)
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/users/" .. username .. "/repos", PAGES))
+  )
+end)
+
+-- GET /repositories (public repos list) — use Gitea's repo search
+b:rest("get_repositories", function()
+  proxy_json_paged(function(data)
+    return translate_repos(data.data or {})
+  end, PAGES, fetch_json(append_page_params(base() .. "/repos/search", PAGES)))
+end)
+
+-- Commit comments -----------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/comments
+b:rest("get_repo_comments", function(owner, repo_name)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments", PAGES)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/collaborators/{username}/permission
-  get_repo_collaborator_permission = function(owner, repo_name, username)
-    proxy_json(
-      nil,
-      fetch_json(
-        base()
-          .. "/repos/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/collaborators/"
-          .. username
-          .. "/permission"
-      )
+-- GET /repos/{owner}/{repo}/comments/{comment_id}
+b:rest("get_repo_comment", function(owner, repo_name, comment_id)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id)
+  )
+end)
+
+-- PATCH /repos/{owner}/{repo}/comments/{comment_id}
+b:rest("patch_repo_comment", function(owner, repo_name, comment_id)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
+      "PATCH",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- Forks ---------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/forks
-  get_repo_forks = function(owner, repo_name)
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/forks", PAGES)
-      )
+-- DELETE /repos/{owner}/{repo}/comments/{comment_id}
+b:rest("delete_repo_comment", function(owner, repo_name, comment_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  -- POST /repos/{owner}/{repo}/forks
-  post_repo_forks = function(owner, repo_name)
-    proxy_json_created(
-      translate_repo,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/forks", "POST", GetBody())
-    )
-  end,
-
-  -- Releases ------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/releases
-  get_repo_releases = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases", PAGES)
-      )
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/releases
-  post_repo_releases = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases", "POST", GetBody())
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/releases/latest
-  get_repo_release_latest = function(owner, repo_name)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/latest")
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/releases/tags/{tag}
-  get_repo_release_by_tag = function(owner, repo_name, tag)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/tags/" .. tag)
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/releases/{release_id}
-  get_repo_release = function(owner, repo_name, release_id)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id)
-    )
-  end,
-
-  -- PATCH /repos/{owner}/{repo}/releases/{release_id}
-  patch_repo_release = function(owner, repo_name, release_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
-        "PATCH",
-        GetBody()
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/releases/{release_id}
-  delete_repo_release = function(owner, repo_name, release_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/" .. release_id,
-        "DELETE"
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/releases/{release_id}/assets
-  get_repo_release_assets = function(owner, repo_name, release_id)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base()
-            .. "/repos/"
-            .. owner
-            .. "/"
-            .. repo_name
-            .. "/releases/"
-            .. release_id
-            .. "/assets",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/releases/{release_id}/assets — multipart; pass through
-  post_repo_release_assets = function(owner, repo_name, release_id)
-    -- Gitea uses the same multipart upload path; proxy the entire request.
-    -- The Content-Type header (multipart/form-data) must be forwarded.
-    local url = base()
-      .. "/repos/"
-      .. owner
-      .. "/"
-      .. repo_name
-      .. "/releases/"
-      .. release_id
-      .. "/assets"
-    local opts = auth() or {}
-    opts.method = "POST"
-    opts.body = GetBody()
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = GetHeader("Content-Type") or "application/octet-stream"
-    proxy_json_created(nil, pcall(Fetch, url, opts))
-  end,
-
-  -- GET /repos/{owner}/{repo}/releases/assets/{asset_id}
-  get_repo_release_asset = function(owner, repo_name, asset_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id
-      )
-    )
-  end,
-
-  -- PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}
-  patch_repo_release_asset = function(owner, repo_name, asset_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
-        "PATCH",
-        GetBody()
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}
-  delete_repo_release_asset = function(owner, repo_name, asset_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/releases/assets/" .. asset_id,
-        "DELETE"
-      )
-    )
-  end,
-
-  -- Deploy keys ---------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/keys
-  get_repo_keys = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys", PAGES)
-      )
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/keys
-  post_repo_keys = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys", "POST", GetBody())
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/keys/{key_id}
-  get_repo_key = function(owner, repo_name, key_id)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id)
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/keys/{key_id}
-  delete_repo_key = function(owner, repo_name, key_id)
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/keys/" .. key_id, "DELETE")
-    )
-  end,
-
-  -- Webhooks ------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/hooks
-  get_repo_hooks = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks", PAGES)
-      )
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/hooks
-  post_repo_hooks = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks", "POST", GetBody())
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/hooks/{hook_id}
-  get_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id)
-    )
-  end,
-
-  -- PATCH /repos/{owner}/{repo}/hooks/{hook_id}
-  patch_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id,
-        "PATCH",
-        GetBody()
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/hooks/{hook_id}
-  delete_repo_hook = function(owner, repo_name, hook_id)
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id, "DELETE")
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/hooks/{hook_id}/config
-  -- Gitea stores config inline in the hook object; extract the config sub-object.
-  get_repo_hook_config = function(owner, repo_name, hook_id)
-    proxy_json(function(hook)
-      return hook.config or {}
-    end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id))
-  end,
-
-  -- PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config
-  -- Gitea has no separate config endpoint; merge into a full PATCH.
-  patch_repo_hook_config = function(owner, repo_name, hook_id)
-    local url = base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id
-    -- Fetch current hook, merge new config, write back.
-    local ok, status, _, body = fetch_json(url)
-    if not ok or status ~= 200 then
-      if ok then
-        respond_json(status, {})
-      else
-        respond_json(503, {})
-      end
-      return
-    end
-    local hook = DecodeJson(body) or {}
-    local new_config = DecodeJson(GetBody() or "{}")
-    hook.config = hook.config or {}
-    for k, v in pairs(new_config) do
-      hook.config[k] = v
-    end
-    proxy_json(function(h)
-      return h.config or {}
-    end, fetch_json(url, "PATCH", EncodeJson(hook)))
-  end,
-
-  -- POST /repos/{owner}/{repo}/hooks/{hook_id}/tests
-  post_repo_hook_test = function(owner, repo_name, hook_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/hooks/" .. hook_id .. "/tests",
-        "POST"
-      )
-    )
-  end,
-
-  -- Users' repos --------------------------------------------------------------
-
-  -- GET /users/{username}/repos
-  get_users_repos = function(username)
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/users/" .. username .. "/repos", PAGES))
-    )
-  end,
-
-  -- GET /repositories (public repos list) — use Gitea's repo search
-  get_repositories = function()
-    proxy_json_paged(function(data)
-      return translate_repos(data.data or {})
-    end, PAGES, fetch_json(append_page_params(base() .. "/repos/search", PAGES)))
-  end,
-
-  -- Commit comments -----------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/comments
-  get_repo_comments = function(owner, repo_name)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments", PAGES)
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/comments/{comment_id}
-  get_repo_comment = function(owner, repo_name, comment_id)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id)
-    )
-  end,
-
-  -- PATCH /repos/{owner}/{repo}/comments/{comment_id}
-  patch_repo_comment = function(owner, repo_name, comment_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
-        "PATCH",
-        GetBody()
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/comments/{comment_id}
-  delete_repo_comment = function(owner, repo_name, comment_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/comments/" .. comment_id,
-        "DELETE"
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/commits/{commit_sha}/comments
-  get_commit_comments = function(owner, repo_name, commit_sha)
-    proxy_json_paged(
-      nil,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base()
-            .. "/repos/"
-            .. owner
-            .. "/"
-            .. repo_name
-            .. "/git/commits/"
-            .. commit_sha
-            .. "/notes",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/commits/{commit_sha}/comments
-  post_commit_comment = function(owner, repo_name, commit_sha)
-    proxy_json_created(
-      nil,
-      fetch_json(
+-- GET /repos/{owner}/{repo}/commits/{commit_sha}/comments
+b:rest("get_commit_comments", function(owner, repo_name, commit_sha)
+  proxy_json_paged(
+    nil,
+    PAGES,
+    fetch_json(
+      append_page_params(
         base()
           .. "/repos/"
           .. owner
@@ -1530,1044 +1501,1198 @@ app.backend_impl = {
           .. "/git/commits/"
           .. commit_sha
           .. "/notes",
-        "POST",
-        GetBody()
-      )
-    )
-  end,
-
-  -- Users ---------------------------------------------------------------------
-
-  -- GET /user
-  get_user = proxy_handler(translate_user, function()
-    return base() .. "/user"
-  end),
-
-  -- PATCH /user
-  patch_user = function()
-    proxy_json(translate_user, fetch_json(base() .. "/user/settings", "PATCH", GetBody()))
-  end,
-
-  -- GET /users/{username}
-  get_users_username = proxy_handler(translate_user, function(u)
-    return base() .. "/users/" .. u
-  end),
-
-  -- GET /users
-  get_users = proxy_handler_paged(translate_users, function()
-    return append_page_params(base() .. "/admin/users", PAGES)
-  end),
-
-  -- GET /user/followers
-  get_user_followers = proxy_handler_paged(translate_users, function()
-    return append_page_params(base() .. "/user/followers", PAGES)
-  end),
-
-  -- GET /user/following
-  get_user_following = proxy_handler_paged(translate_users, function()
-    return append_page_params(base() .. "/user/following", PAGES)
-  end),
-
-  -- GET /user/following/{username} — 204 if following, 404 if not
-  get_user_is_following = function(username)
-    local ok, status = pcall(Fetch, base() .. "/user/following/" .. username, auth())
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(404, { message = "Not Following" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- PUT /user/following/{username}
-  put_user_following = function(username)
-    set_204_or_error("PUT", base() .. "/user/following/" .. username)
-  end,
-
-  -- DELETE /user/following/{username}
-  delete_user_following = function(username)
-    set_204_or_error("DELETE", base() .. "/user/following/" .. username)
-  end,
-
-  -- GET /users/{username}/followers
-  get_users_followers = function(username)
-    proxy_users_follow_list(username, "followers")
-  end,
-
-  -- GET /users/{username}/following
-  get_users_following = function(username)
-    proxy_users_follow_list(username, "following")
-  end,
-
-  -- SSH Keys ------------------------------------------------------------------
-
-  -- GET /user/keys
-  get_user_keys = proxy_handler_paged(nil, function()
-    return append_page_params(base() .. "/user/keys", PAGES)
-  end),
-
-  -- POST /user/keys
-  post_user_keys = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/keys", "POST", GetBody()))
-  end,
-
-  -- GET /user/keys/{key_id}
-  get_user_key = proxy_handler(nil, function(id)
-    return base() .. "/user/keys/" .. id
-  end),
-
-  -- DELETE /user/keys/{key_id}
-  delete_user_key = function(key_id)
-    proxy_204({ 200 }, fetch_json(base() .. "/user/keys/" .. key_id, "DELETE"))
-  end,
-
-  -- GET /users/{username}/keys
-  get_users_keys = proxy_handler_paged(nil, function(u)
-    return append_page_params(base() .. "/users/" .. u .. "/keys", PAGES)
-  end),
-
-  -- GPG Keys ------------------------------------------------------------------
-
-  -- GET /user/gpg_keys
-  get_user_gpg_keys = proxy_handler_paged(nil, function()
-    return append_page_params(base() .. "/user/gpg_keys", PAGES)
-  end),
-
-  -- POST /user/gpg_keys
-  post_user_gpg_keys = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/gpg_keys", "POST", GetBody()))
-  end,
-
-  -- GET /user/gpg_keys/{gpg_key_id}
-  get_user_gpg_key = proxy_handler(nil, function(id)
-    return base() .. "/user/gpg_keys/" .. id
-  end),
-
-  -- DELETE /user/gpg_keys/{gpg_key_id}
-  delete_user_gpg_key = function(gpg_key_id)
-    proxy_204({ 200 }, fetch_json(base() .. "/user/gpg_keys/" .. gpg_key_id, "DELETE"))
-  end,
-
-  -- GET /users/{username}/gpg_keys
-  get_users_gpg_keys = proxy_handler_paged(nil, function(u)
-    return append_page_params(base() .. "/users/" .. u .. "/gpg_keys", PAGES)
-  end),
-
-  -- Emails --------------------------------------------------------------------
-
-  -- GET /user/emails
-  get_user_emails = proxy_handler(nil, function()
-    return base() .. "/user/emails"
-  end),
-
-  -- POST /user/emails
-  post_user_emails = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/emails", "POST", GetBody()))
-  end,
-
-  -- DELETE /user/emails
-  delete_user_emails = function()
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    opts.body = GetBody()
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "application/json"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/user/emails", opts))
-  end,
-
-  -- GET /user/public_emails — Gitea has no separate endpoint; filter verified from /user/emails
-  get_user_public_emails = proxy_handler(filter_verified_emails, function()
-    return base() .. "/user/emails"
-  end),
-
-  -- Teams ---------------------------------------------------------------------
-  -- Gitea teams use numeric IDs, not slugs.  find_team_id lists all teams for
-  -- the org and matches by lowercased, slugified name.
-
-  -- GET /orgs/{org}/teams
-  get_org_teams = function(org)
-    proxy_json_paged(function(teams)
-      for i, t in ipairs(teams) do
-        teams[i] = translate_gitea_team(t)
-      end
-      return teams
-    end, PAGES, fetch_json(append_page_params(base() .. "/orgs/" .. org .. "/teams", PAGES)))
-  end,
-
-  -- POST /orgs/{org}/teams
-  post_org_teams = function(org)
-    local req = DecodeJson(GetBody() or "{}")
-    local body = {
-      name = req.name,
-      description = req.description,
-      permission = req.permission == "admin" and "owner" or (req.permission or "read"),
-      units = { "repo.code", "repo.issues", "repo.pulls", "repo.releases" },
-      includes_all_repositories = false,
-    }
-    proxy_json_created(
-      translate_gitea_team,
-      fetch_json(base() .. "/orgs/" .. org .. "/teams", "POST", EncodeJson(body))
-    )
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}
-  get_org_team = function(org, slug)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(translate_gitea_team, fetch_json(base() .. "/teams/" .. id))
-  end,
-
-  -- PATCH /orgs/{org}/teams/{team_slug}
-  patch_org_team = function(org, slug)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local body = {}
-    if req.name then
-      body.name = req.name
-    end
-    if req.description then
-      body.description = req.description
-    end
-    if req.permission then
-      body.permission = req.permission == "admin" and "owner" or req.permission
-    end
-    proxy_json(
-      translate_gitea_team,
-      fetch_json(base() .. "/teams/" .. id, "PATCH", EncodeJson(body))
-    )
-  end,
-
-  -- DELETE /orgs/{org}/teams/{team_slug}
-  delete_org_team = function(org, slug)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, base() .. "/teams/" .. id, opts))
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/members
-  get_org_team_members = function(org, slug)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json_paged(
-      translate_users,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/teams/" .. id .. "/members", PAGES))
-    )
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/memberships/{username}
-  get_org_team_membership = function(org, slug, username)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status = pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, auth())
-    if ok and status == 204 then
-      respond_json(200, { url = "", role = "member", state = "active" })
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
-  put_org_team_membership = function(org, slug, username)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local opts = auth() or {}
-    opts.method = "PUT"
-    local ok, status = pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, opts)
-    if ok and (status == 204 or status == 200) then
-      respond_json(200, { url = "", role = "member", state = "active" })
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
-  delete_org_team_membership = function(org, slug, username)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, opts))
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/repos
-  get_org_team_repos = function(org, slug)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json_paged(function(repos)
-      for i, r in ipairs(repos) do
-        repos[i] = translate_repo(r)
-      end
-      return repos
-    end, PAGES, fetch_json(append_page_params(base() .. "/teams/" .. id .. "/repos", PAGES)))
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-  get_org_team_repo = function(org, slug, owner, repo_name)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status, _, body =
-      fetch_json(base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name)
-    if ok and (status == 204 or status == 200) then
-      local r = (status == 200 and DecodeJson(body)) or {}
-      respond_json(200, translate_repo(r))
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-  put_org_team_repo = function(org, slug, owner, repo_name)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local opts = auth() or {}
-    opts.method = "PUT"
-    proxy_204(
-      nil,
-      pcall(Fetch, base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name, opts)
-    )
-  end,
-
-  -- DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-  delete_org_team_repo = function(org, slug, owner, repo_name)
-    local id = gitea_find_team_id(org, slug)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    proxy_204(
-      nil,
-      pcall(Fetch, base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name, opts)
-    )
-  end,
-
-  -- Issues -------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/issues
-  get_repo_issues = proxy_handler_paged(translate_gitea_issues, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues", PAGES)
-  end),
-
-  -- POST /repos/{owner}/{repo}/issues
-  post_repo_issues = proxy_handler_created(translate_gitea_issue, function(o, r)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues", "POST", GetBody()
-  end),
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}
-  get_repo_issue = proxy_handler(translate_gitea_issue, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n
-  end),
-
-  -- PATCH /repos/{owner}/{repo}/issues/{issue_number}
-  patch_repo_issue = proxy_handler(translate_gitea_issue, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n, "PATCH", GetBody()
-  end),
-
-  -- GET /repos/{owner}/{repo}/issues/comments  (all issue comments in repo)
-  get_repo_issue_comments = proxy_handler_paged(translate_gitea_issue_comments, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments", PAGES)
-  end),
-
-  -- GET /repos/{owner}/{repo}/issues/comments/{comment_id}
-  get_repo_issue_comment = proxy_handler(translate_gitea_issue_comment, function(o, r, id)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id
-  end),
-
-  -- PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
-  patch_repo_issue_comment = proxy_handler(translate_gitea_issue_comment, function(o, r, id)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id, "PATCH", GetBody()
-  end),
-
-  -- DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}
-  delete_repo_issue_comment = function(owner, repo_name, comment_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
-        "DELETE"
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
-  get_repo_issue_comment_reactions = proxy_handler_paged(
-    translate_gitea_reactions,
-    function(o, r, id)
-      return append_page_params(
-        base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id .. "/reactions",
         PAGES
       )
-    end
-  ),
+    )
+  )
+end)
 
-  -- POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
-  post_repo_issue_comment_reaction = proxy_handler_created(
-    translate_gitea_reaction,
-    function(o, r, id)
-      return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id .. "/reactions",
-        "POST",
-        GetBody()
-    end
-  ),
+-- POST /repos/{owner}/{repo}/commits/{commit_sha}/comments
+b:rest("post_commit_comment", function(owner, repo_name, commit_sha)
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/commits/" .. commit_sha .. "/notes",
+      "POST",
+      GetBody()
+    )
+  )
+end)
 
-  -- DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}
-  delete_repo_issue_comment_reaction = function(owner, repo_name, comment_id, reaction_id)
-    delete_gitea_reaction(
+-- Users ---------------------------------------------------------------------
+
+-- GET /user
+b:rest(
+  "get_user",
+  proxy_handler(translate_user, function()
+    return base() .. "/user"
+  end)
+)
+
+-- PATCH /user
+b:rest("patch_user", function()
+  proxy_json(translate_user, fetch_json(base() .. "/user/settings", "PATCH", GetBody()))
+end)
+
+-- GET /users/{username}
+b:rest(
+  "get_users_username",
+  proxy_handler(translate_user, function(u)
+    return base() .. "/users/" .. u
+  end)
+)
+
+-- GET /users
+b:rest(
+  "get_users",
+  proxy_handler_paged(translate_users, function()
+    return append_page_params(base() .. "/admin/users", PAGES)
+  end)
+)
+
+-- GET /user/followers
+b:rest(
+  "get_user_followers",
+  proxy_handler_paged(translate_users, function()
+    return append_page_params(base() .. "/user/followers", PAGES)
+  end)
+)
+
+-- GET /user/following
+b:rest(
+  "get_user_following",
+  proxy_handler_paged(translate_users, function()
+    return append_page_params(base() .. "/user/following", PAGES)
+  end)
+)
+
+-- GET /user/following/{username} — 204 if following, 404 if not
+b:rest("get_user_is_following", function(username)
+  local ok, status = pcall(Fetch, base() .. "/user/following/" .. username, auth())
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(404, { message = "Not Following" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /user/following/{username}
+b:rest("put_user_following", function(username)
+  set_204_or_error("PUT", base() .. "/user/following/" .. username)
+end)
+
+-- DELETE /user/following/{username}
+b:rest("delete_user_following", function(username)
+  set_204_or_error("DELETE", base() .. "/user/following/" .. username)
+end)
+
+-- GET /users/{username}/followers
+b:rest("get_users_followers", function(username)
+  proxy_users_follow_list(username, "followers")
+end)
+
+-- GET /users/{username}/following
+b:rest("get_users_following", function(username)
+  proxy_users_follow_list(username, "following")
+end)
+
+-- SSH Keys ------------------------------------------------------------------
+
+-- GET /user/keys
+b:rest(
+  "get_user_keys",
+  proxy_handler_paged(nil, function()
+    return append_page_params(base() .. "/user/keys", PAGES)
+  end)
+)
+
+-- POST /user/keys
+b:rest("post_user_keys", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/keys", "POST", GetBody()))
+end)
+
+-- GET /user/keys/{key_id}
+b:rest(
+  "get_user_key",
+  proxy_handler(nil, function(id)
+    return base() .. "/user/keys/" .. id
+  end)
+)
+
+-- DELETE /user/keys/{key_id}
+b:rest("delete_user_key", function(key_id)
+  proxy_204({ 200 }, fetch_json(base() .. "/user/keys/" .. key_id, "DELETE"))
+end)
+
+-- GET /users/{username}/keys
+b:rest(
+  "get_users_keys",
+  proxy_handler_paged(nil, function(u)
+    return append_page_params(base() .. "/users/" .. u .. "/keys", PAGES)
+  end)
+)
+
+-- GPG Keys ------------------------------------------------------------------
+
+-- GET /user/gpg_keys
+b:rest(
+  "get_user_gpg_keys",
+  proxy_handler_paged(nil, function()
+    return append_page_params(base() .. "/user/gpg_keys", PAGES)
+  end)
+)
+
+-- POST /user/gpg_keys
+b:rest("post_user_gpg_keys", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/gpg_keys", "POST", GetBody()))
+end)
+
+-- GET /user/gpg_keys/{gpg_key_id}
+b:rest(
+  "get_user_gpg_key",
+  proxy_handler(nil, function(id)
+    return base() .. "/user/gpg_keys/" .. id
+  end)
+)
+
+-- DELETE /user/gpg_keys/{gpg_key_id}
+b:rest("delete_user_gpg_key", function(gpg_key_id)
+  proxy_204({ 200 }, fetch_json(base() .. "/user/gpg_keys/" .. gpg_key_id, "DELETE"))
+end)
+
+-- GET /users/{username}/gpg_keys
+b:rest(
+  "get_users_gpg_keys",
+  proxy_handler_paged(nil, function(u)
+    return append_page_params(base() .. "/users/" .. u .. "/gpg_keys", PAGES)
+  end)
+)
+
+-- Emails --------------------------------------------------------------------
+
+-- GET /user/emails
+b:rest(
+  "get_user_emails",
+  proxy_handler(nil, function()
+    return base() .. "/user/emails"
+  end)
+)
+
+-- POST /user/emails
+b:rest("post_user_emails", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/emails", "POST", GetBody()))
+end)
+
+-- DELETE /user/emails
+b:rest("delete_user_emails", function()
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  opts.body = GetBody()
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "application/json"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/user/emails", opts))
+end)
+
+-- GET /user/public_emails — Gitea has no separate endpoint; filter verified from /user/emails
+b:rest(
+  "get_user_public_emails",
+  proxy_handler(filter_verified_emails, function()
+    return base() .. "/user/emails"
+  end)
+)
+
+-- Teams ---------------------------------------------------------------------
+-- Gitea teams use numeric IDs, not slugs.  find_team_id lists all teams for
+-- the org and matches by lowercased, slugified name.
+
+-- GET /orgs/{org}/teams
+b:rest("get_org_teams", function(org)
+  proxy_json_paged(function(teams)
+    for i, t in ipairs(teams) do
+      teams[i] = translate_gitea_team(t)
+    end
+    return teams
+  end, PAGES, fetch_json(append_page_params(base() .. "/orgs/" .. org .. "/teams", PAGES)))
+end)
+
+-- POST /orgs/{org}/teams
+b:rest("post_org_teams", function(org)
+  local req = DecodeJson(GetBody() or "{}")
+  local body = {
+    name = req.name,
+    description = req.description,
+    permission = req.permission == "admin" and "owner" or (req.permission or "read"),
+    units = { "repo.code", "repo.issues", "repo.pulls", "repo.releases" },
+    includes_all_repositories = false,
+  }
+  proxy_json_created(
+    translate_gitea_team,
+    fetch_json(base() .. "/orgs/" .. org .. "/teams", "POST", EncodeJson(body))
+  )
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}
+b:rest("get_org_team", function(org, slug)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(translate_gitea_team, fetch_json(base() .. "/teams/" .. id))
+end)
+
+-- PATCH /orgs/{org}/teams/{team_slug}
+b:rest("patch_org_team", function(org, slug)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local body = {}
+  if req.name then
+    body.name = req.name
+  end
+  if req.description then
+    body.description = req.description
+  end
+  if req.permission then
+    body.permission = req.permission == "admin" and "owner" or req.permission
+  end
+  proxy_json(translate_gitea_team, fetch_json(base() .. "/teams/" .. id, "PATCH", EncodeJson(body)))
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}
+b:rest("delete_org_team", function(org, slug)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, base() .. "/teams/" .. id, opts))
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/members
+b:rest("get_org_team_members", function(org, slug)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json_paged(
+    translate_users,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/teams/" .. id .. "/members", PAGES))
+  )
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("get_org_team_membership", function(org, slug, username)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status = pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, auth())
+  if ok and status == 204 then
+    respond_json(200, { url = "", role = "member", state = "active" })
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("put_org_team_membership", function(org, slug, username)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local opts = auth() or {}
+  opts.method = "PUT"
+  local ok, status = pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, opts)
+  if ok and (status == 204 or status == 200) then
+    respond_json(200, { url = "", role = "member", state = "active" })
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("delete_org_team_membership", function(org, slug, username)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, base() .. "/teams/" .. id .. "/members/" .. username, opts))
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/repos
+b:rest("get_org_team_repos", function(org, slug)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json_paged(function(repos)
+    for i, r in ipairs(repos) do
+      repos[i] = translate_repo(r)
+    end
+    return repos
+  end, PAGES, fetch_json(append_page_params(base() .. "/teams/" .. id .. "/repos", PAGES)))
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("get_org_team_repo", function(org, slug, owner, repo_name)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status, _, body =
+    fetch_json(base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name)
+  if ok and (status == 204 or status == 200) then
+    local r = (status == 200 and DecodeJson(body)) or {}
+    respond_json(200, translate_repo(r))
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("put_org_team_repo", function(org, slug, owner, repo_name)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local opts = auth() or {}
+  opts.method = "PUT"
+  proxy_204(
+    nil,
+    pcall(Fetch, base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name, opts)
+  )
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("delete_org_team_repo", function(org, slug, owner, repo_name)
+  local id = gitea_find_team_id(org, slug)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  proxy_204(
+    nil,
+    pcall(Fetch, base() .. "/teams/" .. id .. "/repos/" .. owner .. "/" .. repo_name, opts)
+  )
+end)
+
+-- Issues -------------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/issues
+b:rest(
+  "get_repo_issues",
+  proxy_handler_paged(translate_gitea_issues, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues", PAGES)
+  end)
+)
+
+-- POST /repos/{owner}/{repo}/issues
+b:rest(
+  "post_repo_issues",
+  proxy_handler_created(translate_gitea_issue, function(o, r)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues", "POST", GetBody()
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}
+b:rest(
+  "get_repo_issue",
+  proxy_handler(translate_gitea_issue, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n
+  end)
+)
+
+-- PATCH /repos/{owner}/{repo}/issues/{issue_number}
+b:rest(
+  "patch_repo_issue",
+  proxy_handler(translate_gitea_issue, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n, "PATCH", GetBody()
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/comments  (all issue comments in repo)
+b:rest(
+  "get_repo_issue_comments",
+  proxy_handler_paged(translate_gitea_issue_comments, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments", PAGES)
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/comments/{comment_id}
+b:rest(
+  "get_repo_issue_comment",
+  proxy_handler(translate_gitea_issue_comment, function(o, r, id)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id
+  end)
+)
+
+-- PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
+b:rest(
+  "patch_repo_issue_comment",
+  proxy_handler(translate_gitea_issue_comment, function(o, r, id)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id, "PATCH", GetBody()
+  end)
+)
+
+-- DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}
+b:rest("delete_repo_issue_comment", function(owner, repo_name, comment_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/comments/" .. comment_id,
+      "DELETE"
+    )
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
+b:rest(
+  "get_repo_issue_comment_reactions",
+  proxy_handler_paged(translate_gitea_reactions, function(o, r, id)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id .. "/reactions",
+      PAGES
+    )
+  end)
+)
+
+-- POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
+b:rest(
+  "post_repo_issue_comment_reaction",
+  proxy_handler_created(translate_gitea_reaction, function(o, r, id)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/comments/" .. id .. "/reactions",
+      "POST",
+      GetBody()
+  end)
+)
+
+-- DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}
+b:rest("delete_repo_issue_comment_reaction", function(owner, repo_name, comment_id, reaction_id)
+  delete_gitea_reaction(
+    base()
+      .. "/repos/"
+      .. owner
+      .. "/"
+      .. repo_name
+      .. "/issues/comments/"
+      .. comment_id
+      .. "/reactions",
+    reaction_id
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/issues/events  (all issue events in repo)
+b:rest(
+  "get_repo_issue_events",
+  proxy_handler_paged(nil, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/events", PAGES)
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/events/{event_id}
+b:rest(
+  "get_repo_issue_event",
+  proxy_handler(nil, function(o, r, id)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/events/" .. id
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
+b:rest(
+  "get_issue_comments",
+  proxy_handler_paged(translate_gitea_issue_comments, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments",
+      PAGES
+    )
+  end)
+)
+
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+b:rest(
+  "post_issue_comment",
+  proxy_handler_created(translate_gitea_issue_comment, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments", "POST", GetBody()
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/events
+b:rest(
+  "get_issue_events",
+  proxy_handler_paged(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/events",
+      PAGES
+    )
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/timeline
+b:rest(
+  "get_issue_timeline",
+  proxy_handler_paged(nil, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/timeline",
+      PAGES
+    )
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/reactions
+b:rest(
+  "get_issue_reactions",
+  proxy_handler_paged(translate_gitea_reactions, function(o, r, n)
+    return append_page_params(
+      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/reactions",
+      PAGES
+    )
+  end)
+)
+
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/reactions
+b:rest(
+  "post_issue_reaction",
+  proxy_handler_created(translate_gitea_reaction, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/reactions",
+      "POST",
+      GetBody()
+  end)
+)
+
+-- DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}
+b:rest("delete_issue_reaction", function(owner, repo_name, issue_number, reaction_id)
+  delete_gitea_reaction(
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/reactions",
+    reaction_id
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/labels
+b:rest(
+  "get_issue_labels",
+  proxy_handler(translate_gitea_labels, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels"
+  end)
+)
+
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/labels
+-- GitHub body: { labels: ["name1", ...] }; Gitea body: { labels: [id1, ...] }
+-- Look up each name to find its ID.
+b:rest("post_issue_labels", function(owner, repo_name, issue_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local ids = {}
+  for _, name in ipairs(req.labels or {}) do
+    local id = gitea_find_label_id(owner, repo_name, name)
+    if id then
+      ids[#ids + 1] = id
+    end
+  end
+  proxy_json(
+    translate_gitea_labels,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
+      "POST",
+      EncodeJson({ labels = ids })
+    )
+  )
+end)
+
+-- PUT /repos/{owner}/{repo}/issues/{issue_number}/labels  (replace all)
+b:rest("put_issue_labels", function(owner, repo_name, issue_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local ids = {}
+  for _, name in ipairs(req.labels or {}) do
+    local id = gitea_find_label_id(owner, repo_name, name)
+    if id then
+      ids[#ids + 1] = id
+    end
+  end
+  proxy_json(
+    translate_gitea_labels,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
+      "PUT",
+      EncodeJson({ labels = ids })
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels  (remove all)
+b:rest("delete_issue_labels", function(owner, repo_name, issue_number)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
+      "DELETE"
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
+-- GitHub uses the label name; Gitea uses the numeric label ID.
+b:rest("delete_issue_label", function(owner, repo_name, issue_number, label_name)
+  local id = gitea_find_label_id(owner, repo_name, label_name)
+  if not id then
+    respond_json(404, { message = "Label not found" })
+    return
+  end
+  proxy_204(
+    { 200 },
+    fetch_json(
       base()
         .. "/repos/"
         .. owner
         .. "/"
         .. repo_name
-        .. "/issues/comments/"
-        .. comment_id
-        .. "/reactions",
-      reaction_id
+        .. "/issues/"
+        .. issue_number
+        .. "/labels/"
+        .. id,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/issues/events  (all issue events in repo)
-  get_repo_issue_events = proxy_handler_paged(nil, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/issues/events", PAGES)
-  end),
-
-  -- GET /repos/{owner}/{repo}/issues/events/{event_id}
-  get_repo_issue_event = proxy_handler(nil, function(o, r, id)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/events/" .. id
-  end),
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-  get_issue_comments = proxy_handler_paged(translate_gitea_issue_comments, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments",
-      PAGES
+-- PUT /repos/{owner}/{repo}/issues/{issue_number}/lock
+b:rest("put_issue_lock", function(owner, repo_name, issue_number)
+  local opts = auth() or {}
+  opts.method = "PUT"
+  opts.body = GetBody()
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "application/json"
+  proxy_204(
+    nil,
+    pcall(
+      Fetch,
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/lock",
+      opts
     )
-  end),
+  )
+end)
 
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
-  post_issue_comment = proxy_handler_created(translate_gitea_issue_comment, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/comments", "POST", GetBody()
-  end),
+-- DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock
+b:rest("delete_issue_lock", function(owner, repo_name, issue_number)
+  set_204_or_error(
+    "DELETE",
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/lock"
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/events
-  get_issue_events = proxy_handler_paged(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/events",
-      PAGES
-    )
-  end),
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/timeline
-  get_issue_timeline = proxy_handler_paged(nil, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/timeline",
-      PAGES
-    )
-  end),
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/reactions
-  get_issue_reactions = proxy_handler_paged(translate_gitea_reactions, function(o, r, n)
-    return append_page_params(
-      base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/reactions",
-      PAGES
-    )
-  end),
-
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/reactions
-  post_issue_reaction = proxy_handler_created(translate_gitea_reaction, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/reactions",
-      "POST",
-      GetBody()
-  end),
-
-  -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}
-  delete_issue_reaction = function(owner, repo_name, issue_number, reaction_id)
-    delete_gitea_reaction(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/reactions",
-      reaction_id
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/labels
-  get_issue_labels = proxy_handler(translate_gitea_labels, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/labels"
-  end),
-
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/labels
-  -- GitHub body: { labels: ["name1", ...] }; Gitea body: { labels: [id1, ...] }
-  -- Look up each name to find its ID.
-  post_issue_labels = function(owner, repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local ids = {}
-    for _, name in ipairs(req.labels or {}) do
-      local id = gitea_find_label_id(owner, repo_name, name)
-      if id then
-        ids[#ids + 1] = id
-      end
-    end
-    proxy_json(
-      translate_gitea_labels,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
-        "POST",
-        EncodeJson({ labels = ids })
-      )
-    )
-  end,
-
-  -- PUT /repos/{owner}/{repo}/issues/{issue_number}/labels  (replace all)
-  put_issue_labels = function(owner, repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local ids = {}
-    for _, name in ipairs(req.labels or {}) do
-      local id = gitea_find_label_id(owner, repo_name, name)
-      if id then
-        ids[#ids + 1] = id
-      end
-    end
-    proxy_json(
-      translate_gitea_labels,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
-        "PUT",
-        EncodeJson({ labels = ids })
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels  (remove all)
-  delete_issue_labels = function(owner, repo_name, issue_number)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/labels",
-        "DELETE"
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
-  -- GitHub uses the label name; Gitea uses the numeric label ID.
-  delete_issue_label = function(owner, repo_name, issue_number, label_name)
-    local id = gitea_find_label_id(owner, repo_name, label_name)
-    if not id then
-      respond_json(404, { message = "Label not found" })
-      return
-    end
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base()
-          .. "/repos/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/issues/"
-          .. issue_number
-          .. "/labels/"
-          .. id,
-        "DELETE"
-      )
-    )
-  end,
-
-  -- PUT /repos/{owner}/{repo}/issues/{issue_number}/lock
-  put_issue_lock = function(owner, repo_name, issue_number)
-    local opts = auth() or {}
-    opts.method = "PUT"
-    opts.body = GetBody()
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "application/json"
-    proxy_204(
-      nil,
-      pcall(
-        Fetch,
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/lock",
-        opts
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock
-  delete_issue_lock = function(owner, repo_name, issue_number)
-    set_204_or_error(
-      "DELETE",
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number .. "/lock"
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/assignees
-  post_issue_assignees = proxy_handler(translate_gitea_issue, function(o, r, n)
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/assignees
+b:rest(
+  "post_issue_assignees",
+  proxy_handler(translate_gitea_issue, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/assignees",
       "POST",
       GetBody()
-  end),
+  end)
+)
 
-  -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees
-  delete_issue_assignees = proxy_handler(translate_gitea_issue, function(o, r, n)
+-- DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees
+b:rest(
+  "delete_issue_assignees",
+  proxy_handler(translate_gitea_issue, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/issues/" .. n .. "/assignees",
       "DELETE",
       GetBody()
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}
-  -- Gitea has no direct endpoint; check the issue's assignees list.
-  get_issue_assignee = function(owner, repo_name, issue_number, assignee)
-    local ok, status, _, body =
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local issue = DecodeJson(body) or {}
-    for _, u in ipairs(issue.assignees or {}) do
-      if u.login == assignee then
-        SetStatus(204, "No Content")
-        return
-      end
-    end
-    respond_json(404, { message = "Not an assignee" })
-  end,
-
-  -- Assignees -----------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/assignees  (users eligible for assignment)
-  get_repo_assignees = proxy_handler_paged(translate_users, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/assignees", PAGES)
-  end),
-
-  -- Labels (repo-level) -------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/labels
-  get_repo_labels = proxy_handler_paged(translate_gitea_labels, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/labels", PAGES)
-  end),
-
-  -- POST /repos/{owner}/{repo}/labels
-  post_repo_labels = proxy_handler_created(translate_gitea_label, function(o, r)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/labels", "POST", GetBody()
-  end),
-
-  -- GET /repos/{owner}/{repo}/labels/{name}
-  -- GitHub uses label name in the URL; Gitea uses numeric ID.
-  get_repo_label = function(owner, repo_name, label_name)
-    local id = gitea_find_label_id(owner, repo_name, label_name)
-    if not id then
-      respond_json(404, { message = "Label not found" })
-      return
-    end
-    proxy_json(
-      translate_gitea_label,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. id)
-    )
-  end,
-
-  -- PATCH /repos/{owner}/{repo}/labels/{name}
-  patch_repo_label = function(owner, repo_name, label_name)
-    local id = gitea_find_label_id(owner, repo_name, label_name)
-    if not id then
-      respond_json(404, { message = "Label not found" })
-      return
-    end
-    proxy_json(
-      translate_gitea_label,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. id,
-        "PATCH",
-        GetBody()
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/labels/{name}
-  delete_repo_label = function(owner, repo_name, label_name)
-    local id = gitea_find_label_id(owner, repo_name, label_name)
-    if not id then
-      respond_json(404, { message = "Label not found" })
-      return
-    end
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. id, "DELETE")
-    )
-  end,
-
-  -- Milestones ----------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/milestones
-  get_repo_milestones = proxy_handler_paged(translate_gitea_milestones, function(o, r)
-    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/milestones", PAGES)
-  end),
-
-  -- POST /repos/{owner}/{repo}/milestones
-  post_repo_milestones = proxy_handler_created(translate_gitea_milestone, function(o, r)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones", "POST", GetBody()
-  end),
-
-  -- GET /repos/{owner}/{repo}/milestones/{milestone_number}
-  get_repo_milestone = proxy_handler(translate_gitea_milestone, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n
-  end),
-
-  -- PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
-  patch_repo_milestone = proxy_handler(translate_gitea_milestone, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n, "PATCH", GetBody()
-  end),
-
-  -- DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
-  delete_repo_milestone = function(owner, repo_name, milestone_number)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/milestones/" .. milestone_number,
-        "DELETE"
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels
-  get_repo_milestone_labels = proxy_handler(translate_gitea_labels, function(o, r, n)
-    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n .. "/labels"
-  end),
-
-  -- Legacy team-by-id endpoints (GitHub /teams/{team_id} → Gitea /teams/{id}).
-  -- No slug lookup needed — the caller already provides the numeric ID.
-
-  -- GET /user/teams
-  get_user_teams = function()
-    proxy_json_paged(function(teams)
-      for i, t in ipairs(teams) do
-        teams[i] = translate_gitea_team(t)
-      end
-      return teams
-    end, PAGES, fetch_json(append_page_params(base() .. "/user/teams", PAGES)))
-  end,
-
-  -- GET /teams/{team_id}
-  get_team = function(team_id)
-    proxy_json(translate_gitea_team, fetch_json(base() .. "/teams/" .. team_id))
-  end,
-
-  -- PATCH /teams/{team_id}
-  patch_team = function(team_id)
-    local req = DecodeJson(GetBody() or "{}")
-    local body = {}
-    if req.name then
-      body.name = req.name
-    end
-    if req.description then
-      body.description = req.description
-    end
-    if req.permission then
-      body.permission = req.permission == "admin" and "owner" or req.permission
-    end
-    proxy_json(
-      translate_gitea_team,
-      fetch_json(base() .. "/teams/" .. team_id, "PATCH", EncodeJson(body))
-    )
-  end,
-
-  -- DELETE /teams/{team_id}
-  delete_team = function(team_id)
-    set_204_or_error("DELETE", base() .. "/teams/" .. team_id)
-  end,
-
-  -- GET /teams/{team_id}/members
-  get_team_members = function(team_id)
-    proxy_json_paged(
-      translate_users,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/teams/" .. team_id .. "/members", PAGES))
-    )
-  end,
-
-  -- GET /teams/{team_id}/members/{username} — deprecated legacy endpoint
-  get_team_member = function(team_id, username)
-    local ok, status =
-      pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, auth())
-    if ok and status == 204 then
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}
+-- Gitea has no direct endpoint; check the issue's assignees list.
+b:rest("get_issue_assignee", function(owner, repo_name, issue_number, assignee)
+  local ok, status, _, body =
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/issues/" .. issue_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local issue = DecodeJson(body) or {}
+  for _, u in ipairs(issue.assignees or {}) do
+    if u.login == assignee then
       SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
+      return
     end
-  end,
+  end
+  respond_json(404, { message = "Not an assignee" })
+end)
 
-  -- PUT /teams/{team_id}/members/{username} — deprecated legacy endpoint
-  put_team_member = function(team_id, username)
-    local opts = auth() or {}
-    opts.method = "PUT"
-    proxy_204(
-      { 200 },
-      pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, opts)
+-- Assignees -----------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/assignees  (users eligible for assignment)
+b:rest(
+  "get_repo_assignees",
+  proxy_handler_paged(translate_users, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/assignees", PAGES)
+  end)
+)
+
+-- Labels (repo-level) -------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/labels
+b:rest(
+  "get_repo_labels",
+  proxy_handler_paged(translate_gitea_labels, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/labels", PAGES)
+  end)
+)
+
+-- POST /repos/{owner}/{repo}/labels
+b:rest(
+  "post_repo_labels",
+  proxy_handler_created(translate_gitea_label, function(o, r)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/labels", "POST", GetBody()
+  end)
+)
+
+-- GET /repos/{owner}/{repo}/labels/{name}
+-- GitHub uses label name in the URL; Gitea uses numeric ID.
+b:rest("get_repo_label", function(owner, repo_name, label_name)
+  local id = gitea_find_label_id(owner, repo_name, label_name)
+  if not id then
+    respond_json(404, { message = "Label not found" })
+    return
+  end
+  proxy_json(
+    translate_gitea_label,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. id)
+  )
+end)
+
+-- PATCH /repos/{owner}/{repo}/labels/{name}
+b:rest("patch_repo_label", function(owner, repo_name, label_name)
+  local id = gitea_find_label_id(owner, repo_name, label_name)
+  if not id then
+    respond_json(404, { message = "Label not found" })
+    return
+  end
+  proxy_json(
+    translate_gitea_label,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. id,
+      "PATCH",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- DELETE /teams/{team_id}/members/{username} — deprecated legacy endpoint
-  delete_team_member = function(team_id, username)
-    set_204_or_error("DELETE", base() .. "/teams/" .. team_id .. "/members/" .. username)
-  end,
+-- DELETE /repos/{owner}/{repo}/labels/{name}
+b:rest("delete_repo_label", function(owner, repo_name, label_name)
+  local id = gitea_find_label_id(owner, repo_name, label_name)
+  if not id then
+    respond_json(404, { message = "Label not found" })
+    return
+  end
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/labels/" .. id, "DELETE")
+  )
+end)
 
-  -- GET /teams/{team_id}/memberships/{username}
-  get_team_membership = function(team_id, username)
-    local ok, status =
-      pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, auth())
-    if ok and status == 204 then
-      respond_json(200, { url = "", role = "member", state = "active" })
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
+-- Milestones ----------------------------------------------------------------
 
-  -- PUT /teams/{team_id}/memberships/{username}
-  put_team_membership = function(team_id, username)
-    local opts = auth() or {}
-    opts.method = "PUT"
-    local ok, status = pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, opts)
-    if ok and (status == 204 or status == 200) then
-      respond_json(200, { url = "", role = "member", state = "active" })
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
+-- GET /repos/{owner}/{repo}/milestones
+b:rest(
+  "get_repo_milestones",
+  proxy_handler_paged(translate_gitea_milestones, function(o, r)
+    return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/milestones", PAGES)
+  end)
+)
 
-  -- DELETE /teams/{team_id}/memberships/{username}
-  delete_team_membership = function(team_id, username)
-    set_204_or_error("DELETE", base() .. "/teams/" .. team_id .. "/members/" .. username)
-  end,
+-- POST /repos/{owner}/{repo}/milestones
+b:rest(
+  "post_repo_milestones",
+  proxy_handler_created(translate_gitea_milestone, function(o, r)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones", "POST", GetBody()
+  end)
+)
 
-  -- GET /teams/{team_id}/repos
-  get_team_repos = function(team_id)
-    proxy_json_paged(function(repos)
-      for i, r in ipairs(repos) do
-        repos[i] = translate_repo(r)
-      end
-      return repos
-    end, PAGES, fetch_json(
-      append_page_params(base() .. "/teams/" .. team_id .. "/repos", PAGES)
-    ))
-  end,
+-- GET /repos/{owner}/{repo}/milestones/{milestone_number}
+b:rest(
+  "get_repo_milestone",
+  proxy_handler(translate_gitea_milestone, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n
+  end)
+)
 
-  -- GET /teams/{team_id}/repos/{owner}/{repo}
-  get_team_repo = function(team_id, owner, repo_name)
-    local ok, status, _, body =
-      fetch_json(base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name)
-    if ok and (status == 204 or status == 200) then
-      local r = (status == 200 and DecodeJson(body)) or {}
-      respond_json(200, translate_repo(r))
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
+-- PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
+b:rest(
+  "patch_repo_milestone",
+  proxy_handler(translate_gitea_milestone, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n, "PATCH", GetBody()
+  end)
+)
 
-  -- PUT /teams/{team_id}/repos/{owner}/{repo}
-  put_team_repo = function(team_id, owner, repo_name)
-    local opts = auth() or {}
-    opts.method = "PUT"
-    proxy_204(
-      nil,
-      pcall(Fetch, base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name, opts)
+-- DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
+b:rest("delete_repo_milestone", function(owner, repo_name, milestone_number)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/milestones/" .. milestone_number,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  -- DELETE /teams/{team_id}/repos/{owner}/{repo}
-  delete_team_repo = function(team_id, owner, repo_name)
-    set_204_or_error(
-      "DELETE",
-      base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name
-    )
-  end,
+-- GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels
+b:rest(
+  "get_repo_milestone_labels",
+  proxy_handler(translate_gitea_labels, function(o, r, n)
+    return base() .. "/repos/" .. o .. "/" .. r .. "/milestones/" .. n .. "/labels"
+  end)
+)
 
-  -- Pull Requests ---------------------------------------------------------------
+-- Legacy team-by-id endpoints (GitHub /teams/{team_id} → Gitea /teams/{id}).
+-- No slug lookup needed — the caller already provides the numeric ID.
 
-  -- GET /repos/{owner}/{repo}/pulls
-  get_repo_pulls = proxy_handler_paged(translate_gitea_pulls, function(o, r)
+-- GET /user/teams
+b:rest("get_user_teams", function()
+  proxy_json_paged(function(teams)
+    for i, t in ipairs(teams) do
+      teams[i] = translate_gitea_team(t)
+    end
+    return teams
+  end, PAGES, fetch_json(append_page_params(base() .. "/user/teams", PAGES)))
+end)
+
+-- GET /teams/{team_id}
+b:rest("get_team", function(team_id)
+  proxy_json(translate_gitea_team, fetch_json(base() .. "/teams/" .. team_id))
+end)
+
+-- PATCH /teams/{team_id}
+b:rest("patch_team", function(team_id)
+  local req = DecodeJson(GetBody() or "{}")
+  local body = {}
+  if req.name then
+    body.name = req.name
+  end
+  if req.description then
+    body.description = req.description
+  end
+  if req.permission then
+    body.permission = req.permission == "admin" and "owner" or req.permission
+  end
+  proxy_json(
+    translate_gitea_team,
+    fetch_json(base() .. "/teams/" .. team_id, "PATCH", EncodeJson(body))
+  )
+end)
+
+-- DELETE /teams/{team_id}
+b:rest("delete_team", function(team_id)
+  set_204_or_error("DELETE", base() .. "/teams/" .. team_id)
+end)
+
+-- GET /teams/{team_id}/members
+b:rest("get_team_members", function(team_id)
+  proxy_json_paged(
+    translate_users,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/teams/" .. team_id .. "/members", PAGES))
+  )
+end)
+
+-- GET /teams/{team_id}/members/{username} — deprecated legacy endpoint
+b:rest("get_team_member", function(team_id, username)
+  local ok, status = pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, auth())
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /teams/{team_id}/members/{username} — deprecated legacy endpoint
+b:rest("put_team_member", function(team_id, username)
+  local opts = auth() or {}
+  opts.method = "PUT"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, opts))
+end)
+
+-- DELETE /teams/{team_id}/members/{username} — deprecated legacy endpoint
+b:rest("delete_team_member", function(team_id, username)
+  set_204_or_error("DELETE", base() .. "/teams/" .. team_id .. "/members/" .. username)
+end)
+
+-- GET /teams/{team_id}/memberships/{username}
+b:rest("get_team_membership", function(team_id, username)
+  local ok, status = pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, auth())
+  if ok and status == 204 then
+    respond_json(200, { url = "", role = "member", state = "active" })
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /teams/{team_id}/memberships/{username}
+b:rest("put_team_membership", function(team_id, username)
+  local opts = auth() or {}
+  opts.method = "PUT"
+  local ok, status = pcall(Fetch, base() .. "/teams/" .. team_id .. "/members/" .. username, opts)
+  if ok and (status == 204 or status == 200) then
+    respond_json(200, { url = "", role = "member", state = "active" })
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- DELETE /teams/{team_id}/memberships/{username}
+b:rest("delete_team_membership", function(team_id, username)
+  set_204_or_error("DELETE", base() .. "/teams/" .. team_id .. "/members/" .. username)
+end)
+
+-- GET /teams/{team_id}/repos
+b:rest("get_team_repos", function(team_id)
+  proxy_json_paged(function(repos)
+    for i, r in ipairs(repos) do
+      repos[i] = translate_repo(r)
+    end
+    return repos
+  end, PAGES, fetch_json(append_page_params(base() .. "/teams/" .. team_id .. "/repos", PAGES)))
+end)
+
+-- GET /teams/{team_id}/repos/{owner}/{repo}
+b:rest("get_team_repo", function(team_id, owner, repo_name)
+  local ok, status, _, body =
+    fetch_json(base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name)
+  if ok and (status == 204 or status == 200) then
+    local r = (status == 200 and DecodeJson(body)) or {}
+    respond_json(200, translate_repo(r))
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /teams/{team_id}/repos/{owner}/{repo}
+b:rest("put_team_repo", function(team_id, owner, repo_name)
+  local opts = auth() or {}
+  opts.method = "PUT"
+  proxy_204(
+    nil,
+    pcall(Fetch, base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name, opts)
+  )
+end)
+
+-- DELETE /teams/{team_id}/repos/{owner}/{repo}
+b:rest("delete_team_repo", function(team_id, owner, repo_name)
+  set_204_or_error(
+    "DELETE",
+    base() .. "/teams/" .. team_id .. "/repos/" .. owner .. "/" .. repo_name
+  )
+end)
+
+-- Pull Requests ---------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/pulls
+b:rest(
+  "get_repo_pulls",
+  proxy_handler_paged(translate_gitea_pulls, function(o, r)
     return append_page_params(base() .. "/repos/" .. o .. "/" .. r .. "/pulls", PAGES)
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/pulls
-  post_repo_pulls = proxy_handler_created(translate_gitea_pull, function(o, r)
+-- POST /repos/{owner}/{repo}/pulls
+b:rest(
+  "post_repo_pulls",
+  proxy_handler_created(translate_gitea_pull, function(o, r)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls", "POST", GetBody()
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}
-  get_repo_pull = proxy_handler(translate_gitea_pull, function(o, r, n)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}
+b:rest(
+  "get_repo_pull",
+  proxy_handler(translate_gitea_pull, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n
-  end),
+  end)
+)
 
-  -- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
-  patch_repo_pull = proxy_handler(translate_gitea_pull, function(o, r, n)
+-- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
+b:rest(
+  "patch_repo_pull",
+  proxy_handler(translate_gitea_pull, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n, "PATCH", GetBody()
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
-  get_pull_commits = proxy_handler_paged(nil, function(o, r, n)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
+b:rest(
+  "get_pull_commits",
+  proxy_handler_paged(nil, function(o, r, n)
     return append_page_params(
       base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/commits",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
-  get_pull_files = proxy_handler_paged(nil, function(o, r, n)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
+b:rest(
+  "get_pull_files",
+  proxy_handler_paged(nil, function(o, r, n)
     return append_page_params(
       base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/files",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- Gitea returns 204 if merged, 404 if not — same semantics as GitHub.
-  get_pull_merge = function(owner, repo_name, pull_number)
-    local ok, status = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge"
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
+-- Gitea returns 204 if merged, 404 if not — same semantics as GitHub.
+b:rest("get_pull_merge", function(owner, repo_name, pull_number)
+  local ok, status = fetch_json(
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge"
+  )
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok and status == 404 then
+    respond_json(404, { message = "Pull Request is not merged" })
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
+-- GitHub uses PUT; Gitea uses POST.
+b:rest("put_pull_merge", function(owner, repo_name, pull_number)
+  proxy_204(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
+      "POST",
+      GetBody()
     )
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok and status == 404 then
-      respond_json(404, { message = "Pull Request is not merged" })
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
+  )
+end)
 
-  -- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- GitHub uses PUT; Gitea uses POST.
-  put_pull_merge = function(owner, repo_name, pull_number)
-    proxy_204(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/merge",
-        "POST",
-        GetBody()
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
-  get_pull_requested_reviewers = proxy_handler(nil, function(o, r, n)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+b:rest(
+  "get_pull_requested_reviewers",
+  proxy_handler(nil, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/requested_reviewers"
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
-  post_pull_requested_reviewers = proxy_handler(nil, function(o, r, n)
+-- POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+b:rest(
+  "post_pull_requested_reviewers",
+  proxy_handler(nil, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/requested_reviewers",
       "POST",
       GetBody()
-  end),
+  end)
+)
 
-  -- DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
-  delete_pull_requested_reviewers = function(owner, repo_name, pull_number)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base()
-          .. "/repos/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pulls/"
-          .. pull_number
-          .. "/requested_reviewers",
-        "DELETE",
-        GetBody()
-      )
+-- DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+b:rest("delete_pull_requested_reviewers", function(owner, repo_name, pull_number)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base()
+        .. "/repos/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/pulls/"
+        .. pull_number
+        .. "/requested_reviewers",
+      "DELETE",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
-  get_pull_reviews = proxy_handler_paged(translate_gitea_reviews, function(o, r, n)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+b:rest(
+  "get_pull_reviews",
+  proxy_handler_paged(translate_gitea_reviews, function(o, r, n)
     return append_page_params(
       base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/reviews",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews
-  post_pull_review = proxy_handler_created(translate_gitea_review, function(o, r, n)
+-- POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+b:rest(
+  "post_pull_review",
+  proxy_handler_created(translate_gitea_review, function(o, r, n)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/reviews", "POST", GetBody()
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
-  get_pull_review = proxy_handler(translate_gitea_review, function(o, r, n, id)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
+b:rest(
+  "get_pull_review",
+  proxy_handler(translate_gitea_review, function(o, r, n, id)
     return base() .. "/repos/" .. o .. "/" .. r .. "/pulls/" .. n .. "/reviews/" .. id
-  end),
+  end)
+)
 
-  -- DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
-  delete_pull_review = function(owner, repo_name, pull_number, review_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base()
-          .. "/repos/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pulls/"
-          .. pull_number
-          .. "/reviews/"
-          .. review_id,
-        "DELETE"
-      )
+-- DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
+b:rest("delete_pull_review", function(owner, repo_name, pull_number, review_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base()
+        .. "/repos/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/pulls/"
+        .. pull_number
+        .. "/reviews/"
+        .. review_id,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
-  get_pull_review_comments = proxy_handler(translate_gitea_review_comments, function(o, r, n, id)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
+b:rest(
+  "get_pull_review_comments",
+  proxy_handler(translate_gitea_review_comments, function(o, r, n, id)
     return base()
       .. "/repos/"
       .. o
@@ -2578,607 +2703,632 @@ app.backend_impl = {
       .. "/reviews/"
       .. id
       .. "/comments"
-  end),
+  end)
+)
 
-  -- PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals
-  -- GitHub uses PUT; Gitea uses POST.
-  put_pull_review_dismissal = function(owner, repo_name, pull_number, review_id)
-    proxy_json(
-      translate_gitea_review,
-      fetch_json(
-        base()
-          .. "/repos/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pulls/"
-          .. pull_number
-          .. "/reviews/"
-          .. review_id
-          .. "/dismissals",
-        "POST",
-        GetBody()
-      )
+-- PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals
+-- GitHub uses PUT; Gitea uses POST.
+b:rest("put_pull_review_dismissal", function(owner, repo_name, pull_number, review_id)
+  proxy_json(
+    translate_gitea_review,
+    fetch_json(
+      base()
+        .. "/repos/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/pulls/"
+        .. pull_number
+        .. "/reviews/"
+        .. review_id
+        .. "/dismissals",
+      "POST",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
-  -- Aggregates inline review comments across all reviews for the PR.
-  get_pull_comments = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/reviews"
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
+-- Aggregates inline review comments across all reviews for the PR.
+b:rest("get_pull_comments", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/pulls/" .. pull_number .. "/reviews"
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local reviews = DecodeJson(body) or {}
+  local all_comments = {}
+  for _, rev in ipairs(reviews) do
+    local cok, cstatus, _, cbody = fetch_json(
+      base()
+        .. "/repos/"
+        .. owner
+        .. "/"
+        .. repo_name
+        .. "/pulls/"
+        .. pull_number
+        .. "/reviews/"
+        .. rev.id
+        .. "/comments"
     )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local reviews = DecodeJson(body) or {}
-    local all_comments = {}
-    for _, rev in ipairs(reviews) do
-      local cok, cstatus, _, cbody = fetch_json(
-        base()
-          .. "/repos/"
-          .. owner
-          .. "/"
-          .. repo_name
-          .. "/pulls/"
-          .. pull_number
-          .. "/reviews/"
-          .. rev.id
-          .. "/comments"
-      )
-      if cok and cstatus == 200 then
-        for _, c in ipairs(DecodeJson(cbody) or {}) do
-          all_comments[#all_comments + 1] = translate_gitea_review_comment(c)
-        end
+    if cok and cstatus == 200 then
+      for _, c in ipairs(DecodeJson(cbody) or {}) do
+        all_comments[#all_comments + 1] = translate_gitea_review_comment(c)
       end
     end
-    respond_json(200, all_comments)
-  end,
+  end
+  respond_json(200, all_comments)
+end)
 
-  -- Checks (via Gitea commit statuses) ------------------------------------------
+-- Checks (via Gitea commit statuses) ------------------------------------------
 
-  -- POST /repos/{owner}/{repo}/check-runs
-  -- Maps to Gitea POST /api/v1/repos/{owner}/{repo}/statuses/{sha}.
-  post_check_runs = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}") or {}
-    local sha = req.head_sha or ""
-    local gitea_body = gh_check_run_to_gitea_status(req)
-    proxy_json_created(
-      translate_gitea_status_to_check_run,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
-        "POST",
-        gitea_body
-      )
+-- POST /repos/{owner}/{repo}/check-runs
+-- Maps to Gitea POST /api/v1/repos/{owner}/{repo}/statuses/{sha}.
+b:rest("post_check_runs", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}") or {}
+  local sha = req.head_sha or ""
+  local gitea_body = gh_check_run_to_gitea_status(req)
+  proxy_json_created(
+    translate_gitea_status_to_check_run,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. sha,
+      "POST",
+      gitea_body
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- Maps to Gitea GET /api/v1/repos/{owner}/{repo}/statuses/{ref}.
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local ok, status, _, body = fetch_json(
-      append_page_params(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. ref,
-        PAGES
-      )
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- Maps to Gitea GET /api/v1/repos/{owner}/{repo}/statuses/{ref}.
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local ok, status, _, body = fetch_json(
+    append_page_params(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/statuses/" .. ref,
+      PAGES
     )
-    if ok and status == 200 then
-      local statuses = DecodeJson(body) or {}
-      local runs = translate_gitea_statuses_to_check_runs(statuses)
-      respond_json(200, {
-        total_count = #runs,
-        check_runs = runs,
-      })
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- Check Suites — no Gitea equivalent; all are stubs --------------------
-
-  -- POST /repos/{owner}/{repo}/check-suites
-  post_check_suites = function(owner, repo_name)
-    respond_json(201, {
-      id = 1,
-      node_id = "",
-      head_sha = "",
-      status = "completed",
-      conclusion = "success",
-      app = { id = 0, slug = "", name = "" },
-      repository = { full_name = owner .. "/" .. repo_name },
-    })
-  end,
-
-  -- Search -----------------------------------------------------------------------
-
-  -- GET /search/repositories — maps to Gitea GET /repos/search
-  search_repositories = function()
-    local q = GetParam("q") or ""
-    proxy_search(translate_repo, append_page_params(base() .. "/repos/search?q=" .. q, PAGES))
-  end,
-
-  -- GET /search/users — maps to Gitea GET /users/search
-  search_users = function()
-    local q = GetParam("q") or ""
-    proxy_search(translate_user, append_page_params(base() .. "/users/search?q=" .. q, PAGES))
-  end,
-
-  -- Packages (org) ---------------------------------------------------------------
-
-  get_org_packages = function(org)
-    pkg_list(org)
-  end,
-  get_org_package = function(org, pkg_type, pkg_name)
-    pkg_get(org, pkg_type, pkg_name)
-  end,
-  delete_org_package = function(org, pkg_type, pkg_name)
-    pkg_delete(org, pkg_type, pkg_name)
-  end,
-  get_org_package_versions = function(org, pkg_type, pkg_name)
-    pkg_versions(org, pkg_type, pkg_name)
-  end,
-  get_org_package_version = function(org, pkg_type, pkg_name, version_id)
-    pkg_get_version(org, pkg_type, pkg_name, version_id)
-  end,
-  delete_org_package_version = function(org, pkg_type, pkg_name, version_id)
-    pkg_delete_version(org, pkg_type, pkg_name, version_id)
-  end,
-
-  -- Packages (authenticated user) ------------------------------------------------
-
-  get_user_packages = function()
-    local login = resolve_user_login()
-    if not login then
-      respond_json(401, { message = "Requires authentication" })
-      return
-    end
-    pkg_list(login)
-  end,
-  get_user_package = function(pkg_type, pkg_name)
-    local login = resolve_user_login()
-    if not login then
-      respond_json(401, { message = "Requires authentication" })
-      return
-    end
-    pkg_get(login, pkg_type, pkg_name)
-  end,
-  delete_user_package = function(pkg_type, pkg_name)
-    local login = resolve_user_login()
-    if not login then
-      respond_json(401, { message = "Requires authentication" })
-      return
-    end
-    pkg_delete(login, pkg_type, pkg_name)
-  end,
-  get_user_package_versions = function(pkg_type, pkg_name)
-    local login = resolve_user_login()
-    if not login then
-      respond_json(401, { message = "Requires authentication" })
-      return
-    end
-    pkg_versions(login, pkg_type, pkg_name)
-  end,
-  get_user_package_version = function(pkg_type, pkg_name, version_id)
-    local login = resolve_user_login()
-    if not login then
-      respond_json(401, { message = "Requires authentication" })
-      return
-    end
-    pkg_get_version(login, pkg_type, pkg_name, version_id)
-  end,
-  delete_user_package_version = function(pkg_type, pkg_name, version_id)
-    local login = resolve_user_login()
-    if not login then
-      respond_json(401, { message = "Requires authentication" })
-      return
-    end
-    pkg_delete_version(login, pkg_type, pkg_name, version_id)
-  end,
-
-  -- Pages (https://docs.github.com/en/rest/pages) ---------------------------------
-  -- Gitea has no native GitHub Pages API.  We synthesize a minimal GET response
-  -- by checking whether the repo has a "gh-pages" branch.  Write, build, and
-  -- deployment endpoints have no Gitea equivalent and fall back to the default
-  -- pages_not_implemented (501) handler.
-
-  get_repo_pages = function(owner, repo_name)
-    local ok, status, _, _ =
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/branches/gh-pages")
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
+  )
+  if ok and status == 200 then
+    local statuses = DecodeJson(body) or {}
+    local runs = translate_gitea_statuses_to_check_runs(statuses)
     respond_json(200, {
-      url = "",
-      status = "built",
-      cname = nil,
-      custom_404 = false,
-      html_url = config.base_url .. "/" .. owner .. "/" .. repo_name,
-      source = { branch = "gh-pages", path = "/" },
-      public = true,
-      https_enforced = false,
-      build_type = "legacy",
+      total_count = #runs,
+      check_runs = runs,
     })
-  end,
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
 
-  -- Packages (public user) -------------------------------------------------------
+-- Check Suites — no Gitea equivalent; all are stubs --------------------
 
-  get_users_packages = function(username)
-    pkg_list(username)
-  end,
-  get_users_package = function(username, pkg_type, pkg_name)
-    pkg_get(username, pkg_type, pkg_name)
-  end,
-  delete_users_package = function(username, pkg_type, pkg_name)
-    pkg_delete(username, pkg_type, pkg_name)
-  end,
-  get_users_package_versions = function(username, pkg_type, pkg_name)
-    pkg_versions(username, pkg_type, pkg_name)
-  end,
-  get_users_package_version = function(username, pkg_type, pkg_name, version_id)
-    pkg_get_version(username, pkg_type, pkg_name, version_id)
-  end,
-  delete_users_package_version = function(username, pkg_type, pkg_name, version_id)
-    pkg_delete_version(username, pkg_type, pkg_name, version_id)
-  end,
+-- POST /repos/{owner}/{repo}/check-suites
+b:rest("post_check_suites", function(owner, repo_name)
+  respond_json(201, {
+    id = 1,
+    node_id = "",
+    head_sha = "",
+    status = "completed",
+    conclusion = "success",
+    app = { id = 0, slug = "", name = "" },
+    repository = { full_name = owner .. "/" .. repo_name },
+  })
+end)
 
-  -- Markdown -------------------------------------------------------------------
+-- Search -----------------------------------------------------------------------
 
-  -- POST /markdown → POST /api/v1/markdown
-  -- Gitea accepts the same JSON body as GitHub and returns rendered HTML.
-  render_markdown = function()
-    local opts = auth() or {}
-    opts.method = "POST"
-    opts.body = GetBody()
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = GetHeader("Content-Type") or "application/json"
-    local ok, status, headers, body = pcall(Fetch, base() .. "/markdown", opts)
-    if not ok then
-      respond_json(503, {})
-      return
+-- GET /search/repositories — maps to Gitea GET /repos/search
+b:rest("search_repositories", function()
+  local q = GetParam("q") or ""
+  proxy_search(translate_repo, append_page_params(base() .. "/repos/search?q=" .. q, PAGES))
+end)
+
+-- GET /search/users — maps to Gitea GET /users/search
+b:rest("search_users", function()
+  local q = GetParam("q") or ""
+  proxy_search(translate_user, append_page_params(base() .. "/users/search?q=" .. q, PAGES))
+end)
+
+-- Packages (org) ---------------------------------------------------------------
+
+b:rest("get_org_packages", function(org)
+  pkg_list(org)
+end)
+
+b:rest("get_org_package", function(org, pkg_type, pkg_name)
+  pkg_get(org, pkg_type, pkg_name)
+end)
+
+b:rest("delete_org_package", function(org, pkg_type, pkg_name)
+  pkg_delete(org, pkg_type, pkg_name)
+end)
+
+b:rest("get_org_package_versions", function(org, pkg_type, pkg_name)
+  pkg_versions(org, pkg_type, pkg_name)
+end)
+
+b:rest("get_org_package_version", function(org, pkg_type, pkg_name, version_id)
+  pkg_get_version(org, pkg_type, pkg_name, version_id)
+end)
+
+b:rest("delete_org_package_version", function(org, pkg_type, pkg_name, version_id)
+  pkg_delete_version(org, pkg_type, pkg_name, version_id)
+end)
+
+-- Packages (authenticated user) ------------------------------------------------
+
+b:rest("get_user_packages", function()
+  local login = resolve_user_login()
+  if not login then
+    respond_json(401, { message = "Requires authentication" })
+    return
+  end
+  pkg_list(login)
+end)
+
+b:rest("get_user_package", function(pkg_type, pkg_name)
+  local login = resolve_user_login()
+  if not login then
+    respond_json(401, { message = "Requires authentication" })
+    return
+  end
+  pkg_get(login, pkg_type, pkg_name)
+end)
+
+b:rest("delete_user_package", function(pkg_type, pkg_name)
+  local login = resolve_user_login()
+  if not login then
+    respond_json(401, { message = "Requires authentication" })
+    return
+  end
+  pkg_delete(login, pkg_type, pkg_name)
+end)
+
+b:rest("get_user_package_versions", function(pkg_type, pkg_name)
+  local login = resolve_user_login()
+  if not login then
+    respond_json(401, { message = "Requires authentication" })
+    return
+  end
+  pkg_versions(login, pkg_type, pkg_name)
+end)
+
+b:rest("get_user_package_version", function(pkg_type, pkg_name, version_id)
+  local login = resolve_user_login()
+  if not login then
+    respond_json(401, { message = "Requires authentication" })
+    return
+  end
+  pkg_get_version(login, pkg_type, pkg_name, version_id)
+end)
+
+b:rest("delete_user_package_version", function(pkg_type, pkg_name, version_id)
+  local login = resolve_user_login()
+  if not login then
+    respond_json(401, { message = "Requires authentication" })
+    return
+  end
+  pkg_delete_version(login, pkg_type, pkg_name, version_id)
+end)
+
+-- Pages (https://docs.github.com/en/rest/pages) ---------------------------------
+-- Gitea has no native GitHub Pages API.  We synthesize a minimal GET response
+-- by checking whether the repo has a "gh-pages" branch.  Write, build, and
+-- deployment endpoints have no Gitea equivalent and fall back to the default
+-- pages_not_implemented (501) handler.
+
+b:rest("get_repo_pages", function(owner, repo_name)
+  local ok, status, _, _ =
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/branches/gh-pages")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  respond_json(200, {
+    url = "",
+    status = "built",
+    cname = nil,
+    custom_404 = false,
+    html_url = config.base_url .. "/" .. owner .. "/" .. repo_name,
+    source = { branch = "gh-pages", path = "/" },
+    public = true,
+    https_enforced = false,
+    build_type = "legacy",
+  })
+end)
+
+-- Packages (public user) -------------------------------------------------------
+
+b:rest("get_users_packages", function(username)
+  pkg_list(username)
+end)
+
+b:rest("get_users_package", function(username, pkg_type, pkg_name)
+  pkg_get(username, pkg_type, pkg_name)
+end)
+
+b:rest("delete_users_package", function(username, pkg_type, pkg_name)
+  pkg_delete(username, pkg_type, pkg_name)
+end)
+
+b:rest("get_users_package_versions", function(username, pkg_type, pkg_name)
+  pkg_versions(username, pkg_type, pkg_name)
+end)
+
+b:rest("get_users_package_version", function(username, pkg_type, pkg_name, version_id)
+  pkg_get_version(username, pkg_type, pkg_name, version_id)
+end)
+
+b:rest("delete_users_package_version", function(username, pkg_type, pkg_name, version_id)
+  pkg_delete_version(username, pkg_type, pkg_name, version_id)
+end)
+
+-- Markdown -------------------------------------------------------------------
+
+-- POST /markdown → POST /api/v1/markdown
+-- Gitea accepts the same JSON body as GitHub and returns rendered HTML.
+b:rest("render_markdown", function()
+  local opts = auth() or {}
+  opts.method = "POST"
+  opts.body = GetBody()
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = GetHeader("Content-Type") or "application/json"
+  local ok, status, headers, body = pcall(Fetch, base() .. "/markdown", opts)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  local ct = (headers and (headers["Content-Type"] or headers["content-type"])) or "text/html"
+  set_preamble(status, ct)
+  Write(body or "")
+end)
+
+-- POST /markdown/raw → POST /api/v1/markdown/raw
+-- Gitea accepts raw markdown text and returns rendered HTML.
+b:rest("render_markdown_raw", function()
+  local opts = auth() or {}
+  opts.method = "POST"
+  opts.body = GetBody()
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "text/plain"
+  local ok, status, headers, body = pcall(Fetch, base() .. "/markdown/raw", opts)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  local ct = (headers and (headers["Content-Type"] or headers["content-type"])) or "text/html"
+  set_preamble(status, ct)
+  Write(body or "")
+end)
+
+-- Actions ------------------------------------------------------------------
+-- Gitea natively supports secrets, variables, and runners (repo + org level).
+-- Workflow runs, artifacts, caches, jobs, OIDC, and permissions use defaults.
+--
+-- Secrets: list/get/delete only. GitHub encrypts secrets with NaCl before
+-- sending; Gitea stores plaintext. The wire formats are incompatible, so
+-- create/update (PUT) falls back to the default 501 handler.
+
+b:rest("get_repo_actions_secrets", function(owner, repo)
+  proxy_actions_list(
+    "secrets",
+    translate_gitea_actions_secret,
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/secrets"
+  )
+end)
+
+b:rest("get_repo_actions_secret", function(owner, repo, secret_name)
+  proxy_json(
+    translate_gitea_actions_secret,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/secrets/" .. secret_name)
+  )
+end)
+
+b:rest("delete_repo_actions_secret", function(owner, repo, secret_name)
+  set_204_or_error(
+    "DELETE",
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/secrets/" .. secret_name
+  )
+end)
+
+b:rest("get_org_actions_secrets", function(org)
+  proxy_actions_list(
+    "secrets",
+    translate_gitea_actions_secret,
+    base() .. "/orgs/" .. org .. "/actions/secrets"
+  )
+end)
+
+b:rest("get_org_actions_secret", function(org, secret_name)
+  proxy_json(
+    translate_gitea_actions_secret,
+    fetch_json(base() .. "/orgs/" .. org .. "/actions/secrets/" .. secret_name)
+  )
+end)
+
+b:rest("delete_org_actions_secret", function(org, secret_name)
+  set_204_or_error("DELETE", base() .. "/orgs/" .. org .. "/actions/secrets/" .. secret_name)
+end)
+
+-- Variables: full CRUD. Gitea uses PUT for updates; GitHub uses PATCH.
+b:rest("get_repo_actions_variables", function(owner, repo)
+  proxy_actions_list(
+    "variables",
+    translate_gitea_actions_variable,
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables"
+  )
+end)
+
+b:rest("get_repo_actions_variable", function(owner, repo, name)
+  proxy_json(
+    translate_gitea_actions_variable,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name)
+  )
+end)
+
+b:rest("post_repo_actions_variable", function(owner, repo)
+  proxy_json_created(
+    translate_gitea_actions_variable,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables",
+      "POST",
+      GetBody()
+    )
+  )
+end)
+
+b:rest("patch_repo_actions_variable", function(owner, repo, name)
+  proxy_204(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name,
+      "PUT",
+      GetBody()
+    )
+  )
+end)
+
+b:rest("delete_repo_actions_variable", function(owner, repo, name)
+  set_204_or_error(
+    "DELETE",
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name
+  )
+end)
+
+b:rest("get_org_actions_variables", function(org)
+  proxy_actions_list(
+    "variables",
+    translate_gitea_actions_variable,
+    base() .. "/orgs/" .. org .. "/actions/variables"
+  )
+end)
+
+b:rest("get_org_actions_variable", function(org, name)
+  proxy_json(
+    translate_gitea_actions_variable,
+    fetch_json(base() .. "/orgs/" .. org .. "/actions/variables/" .. name)
+  )
+end)
+
+b:rest("post_org_actions_variable", function(org)
+  proxy_json_created(
+    translate_gitea_actions_variable,
+    fetch_json(base() .. "/orgs/" .. org .. "/actions/variables", "POST", GetBody())
+  )
+end)
+
+b:rest("patch_org_actions_variable", function(org, name)
+  proxy_204(
+    nil,
+    fetch_json(base() .. "/orgs/" .. org .. "/actions/variables/" .. name, "PUT", GetBody())
+  )
+end)
+
+b:rest("delete_org_actions_variable", function(org, name)
+  set_204_or_error("DELETE", base() .. "/orgs/" .. org .. "/actions/variables/" .. name)
+end)
+
+-- Runners: list only (individual runner operations not proxied).
+b:rest("get_repo_actions_runners", function(owner, repo)
+  proxy_actions_list(
+    "runners",
+    translate_gitea_actions_runner,
+    base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/runners"
+  )
+end)
+
+b:rest("get_org_actions_runners", function(org)
+  proxy_actions_list(
+    "runners",
+    translate_gitea_actions_runner,
+    base() .. "/orgs/" .. org .. "/actions/runners"
+  )
+end)
+
+-- Git database (https://docs.github.com/en/rest/git) -----------------------
+
+-- GET /repos/{owner}/{repo}/git/blobs/{file_sha}
+b:rest("get_git_blob", function(owner, repo_name, file_sha)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/blobs/" .. file_sha)
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/git/commits/{commit_sha}
+b:rest("get_git_commit", function(owner, repo_name, commit_sha)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/commits/" .. commit_sha)
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/git/matching-refs/{ref}
+-- Gitea: GET /repos/{owner}/{repo}/git/refs/{ref} returns an array.
+b:rest("list_git_matching_refs", function(owner, repo_name, ref)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref)
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/git/ref/{ref}
+-- GitHub returns a single ref object; Gitea returns an array — take the first element.
+b:rest("get_git_ref", function(owner, repo_name, ref)
+  proxy_json(function(arr)
+    if type(arr) == "table" and arr[1] then
+      return arr[1]
     end
-    local ct = (headers and (headers["Content-Type"] or headers["content-type"])) or "text/html"
-    set_preamble(status, ct)
-    Write(body or "")
-  end,
+    return arr
+  end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref))
+end)
 
-  -- POST /markdown/raw → POST /api/v1/markdown/raw
-  -- Gitea accepts raw markdown text and returns rendered HTML.
-  render_markdown_raw = function()
-    local opts = auth() or {}
-    opts.method = "POST"
-    opts.body = GetBody()
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "text/plain"
-    local ok, status, headers, body = pcall(Fetch, base() .. "/markdown/raw", opts)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    local ct = (headers and (headers["Content-Type"] or headers["content-type"])) or "text/html"
-    set_preamble(status, ct)
-    Write(body or "")
-  end,
+-- POST /repos/{owner}/{repo}/git/refs
+b:rest("create_git_ref", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs", "POST", GetBody())
+  )
+end)
 
-  -- Actions ------------------------------------------------------------------
-  -- Gitea natively supports secrets, variables, and runners (repo + org level).
-  -- Workflow runs, artifacts, caches, jobs, OIDC, and permissions use defaults.
-  --
-  -- Secrets: list/get/delete only. GitHub encrypts secrets with NaCl before
-  -- sending; Gitea stores plaintext. The wire formats are incompatible, so
-  -- create/update (PUT) falls back to the default 501 handler.
+-- DELETE /repos/{owner}/{repo}/git/refs/{ref}
+b:rest("delete_git_ref", function(owner, repo_name, ref)
+  set_204_or_error(
+    "DELETE",
+    base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref
+  )
+end)
 
-  get_repo_actions_secrets = function(owner, repo)
-    proxy_actions_list(
-      "secrets",
-      translate_gitea_actions_secret,
-      base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/secrets"
-    )
-  end,
-  get_repo_actions_secret = function(owner, repo, secret_name)
-    proxy_json(
-      translate_gitea_actions_secret,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/secrets/" .. secret_name)
-    )
-  end,
-  delete_repo_actions_secret = function(owner, repo, secret_name)
-    set_204_or_error(
-      "DELETE",
-      base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/secrets/" .. secret_name
-    )
-  end,
+-- GET /repos/{owner}/{repo}/git/tags/{tag_sha}
+b:rest("get_git_tag", function(owner, repo_name, tag_sha)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/tags/" .. tag_sha)
+  )
+end)
 
-  get_org_actions_secrets = function(org)
-    proxy_actions_list(
-      "secrets",
-      translate_gitea_actions_secret,
-      base() .. "/orgs/" .. org .. "/actions/secrets"
-    )
-  end,
-  get_org_actions_secret = function(org, secret_name)
-    proxy_json(
-      translate_gitea_actions_secret,
-      fetch_json(base() .. "/orgs/" .. org .. "/actions/secrets/" .. secret_name)
-    )
-  end,
-  delete_org_actions_secret = function(org, secret_name)
-    set_204_or_error("DELETE", base() .. "/orgs/" .. org .. "/actions/secrets/" .. secret_name)
-  end,
+-- POST /repos/{owner}/{repo}/git/tags
+b:rest("create_git_tag", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/tags", "POST", GetBody())
+  )
+end)
 
-  -- Variables: full CRUD. Gitea uses PUT for updates; GitHub uses PATCH.
-  get_repo_actions_variables = function(owner, repo)
-    proxy_actions_list(
-      "variables",
-      translate_gitea_actions_variable,
-      base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables"
-    )
-  end,
-  get_repo_actions_variable = function(owner, repo, name)
-    proxy_json(
-      translate_gitea_actions_variable,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name)
-    )
-  end,
-  post_repo_actions_variable = function(owner, repo)
-    proxy_json_created(
-      translate_gitea_actions_variable,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables",
-        "POST",
-        GetBody()
-      )
-    )
-  end,
-  patch_repo_actions_variable = function(owner, repo, name)
-    proxy_204(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name,
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-  delete_repo_actions_variable = function(owner, repo, name)
-    set_204_or_error(
-      "DELETE",
-      base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/variables/" .. name
-    )
-  end,
+-- GET /repos/{owner}/{repo}/git/trees/{tree_sha}
+b:rest("get_git_tree", function(owner, repo_name, tree_sha)
+  proxy_json(
+    nil,
+    fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/trees/" .. tree_sha)
+  )
+end)
 
-  get_org_actions_variables = function(org)
-    proxy_actions_list(
-      "variables",
-      translate_gitea_actions_variable,
-      base() .. "/orgs/" .. org .. "/actions/variables"
+-- Activity (https://docs.github.com/en/rest/activity)
+-- Gitea supports starring, watching, and subscription endpoints.
+-- Events feeds and notifications have no Gitea equivalent.
+
+b:rest("get_repo_stargazers", function(owner, repo_name)
+  proxy_json_paged(
+    translate_users,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/stargazers", PAGES)
     )
-  end,
-  get_org_actions_variable = function(org, name)
-    proxy_json(
-      translate_gitea_actions_variable,
-      fetch_json(base() .. "/orgs/" .. org .. "/actions/variables/" .. name)
+  )
+end)
+
+b:rest("get_repo_subscribers", function(owner, repo_name)
+  proxy_json_paged(
+    translate_users,
+    PAGES,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscribers", PAGES)
     )
-  end,
-  post_org_actions_variable = function(org)
-    proxy_json_created(
-      translate_gitea_actions_variable,
-      fetch_json(base() .. "/orgs/" .. org .. "/actions/variables", "POST", GetBody())
+  )
+end)
+
+b:rest("get_repo_subscription", function(owner, repo_name)
+  proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscription"))
+end)
+
+b:rest("put_repo_subscription", function(owner, repo_name)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscription",
+      "PUT",
+      GetBody()
     )
-  end,
-  patch_org_actions_variable = function(org, name)
-    proxy_204(
-      nil,
-      fetch_json(base() .. "/orgs/" .. org .. "/actions/variables/" .. name, "PUT", GetBody())
-    )
-  end,
-  delete_org_actions_variable = function(org, name)
-    set_204_or_error("DELETE", base() .. "/orgs/" .. org .. "/actions/variables/" .. name)
-  end,
+  )
+end)
 
-  -- Runners: list only (individual runner operations not proxied).
-  get_repo_actions_runners = function(owner, repo)
-    proxy_actions_list(
-      "runners",
-      translate_gitea_actions_runner,
-      base() .. "/repos/" .. owner .. "/" .. repo .. "/actions/runners"
-    )
-  end,
-  get_org_actions_runners = function(org)
-    proxy_actions_list(
-      "runners",
-      translate_gitea_actions_runner,
-      base() .. "/orgs/" .. org .. "/actions/runners"
-    )
-  end,
+b:rest("delete_repo_subscription", function(owner, repo_name)
+  set_204_or_error("DELETE", base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscription")
+end)
 
-  -- Git database (https://docs.github.com/en/rest/git) -----------------------
+b:rest("get_user_starred", function()
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/user/starred", PAGES))
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/git/blobs/{file_sha}
-  get_git_blob = function(owner, repo_name, file_sha)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/blobs/" .. file_sha)
-    )
-  end,
+b:rest("get_user_starred_repo", function(owner, repo_name)
+  local ok, status = fetch_json(base() .. "/user/starred/" .. owner .. "/" .. repo_name)
+  if ok and status == 204 then
+    SetStatus(204, "No Content")
+  elseif ok and status == 404 then
+    respond_json(404, { message = "Not Found" })
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
 
-  -- GET /repos/{owner}/{repo}/git/commits/{commit_sha}
-  get_git_commit = function(owner, repo_name, commit_sha)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/commits/" .. commit_sha)
-    )
-  end,
+b:rest("put_user_starred_repo", function(owner, repo_name)
+  set_204_or_error("PUT", base() .. "/user/starred/" .. owner .. "/" .. repo_name)
+end)
 
-  -- GET /repos/{owner}/{repo}/git/matching-refs/{ref}
-  -- Gitea: GET /repos/{owner}/{repo}/git/refs/{ref} returns an array.
-  list_git_matching_refs = function(owner, repo_name, ref)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref)
-    )
-  end,
+b:rest("delete_user_starred_repo", function(owner, repo_name)
+  set_204_or_error("DELETE", base() .. "/user/starred/" .. owner .. "/" .. repo_name)
+end)
 
-  -- GET /repos/{owner}/{repo}/git/ref/{ref}
-  -- GitHub returns a single ref object; Gitea returns an array — take the first element.
-  get_git_ref = function(owner, repo_name, ref)
-    proxy_json(function(arr)
-      if type(arr) == "table" and arr[1] then
-        return arr[1]
-      end
-      return arr
-    end, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref))
-  end,
+b:rest("get_user_subscriptions", function()
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/user/subscriptions", PAGES))
+  )
+end)
 
-  -- POST /repos/{owner}/{repo}/git/refs
-  create_git_ref = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs", "POST", GetBody())
-    )
-  end,
+b:rest("get_users_starred", function(username)
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/users/" .. username .. "/starred", PAGES))
+  )
+end)
 
-  -- DELETE /repos/{owner}/{repo}/git/refs/{ref}
-  delete_git_ref = function(owner, repo_name, ref)
-    set_204_or_error(
-      "DELETE",
-      base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/refs/" .. ref
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/git/tags/{tag_sha}
-  get_git_tag = function(owner, repo_name, tag_sha)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/tags/" .. tag_sha)
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/git/tags
-  create_git_tag = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/tags", "POST", GetBody())
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/git/trees/{tree_sha}
-  get_git_tree = function(owner, repo_name, tree_sha)
-    proxy_json(
-      nil,
-      fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/git/trees/" .. tree_sha)
-    )
-  end,
-
-  -- Activity (https://docs.github.com/en/rest/activity)
-  -- Gitea supports starring, watching, and subscription endpoints.
-  -- Events feeds and notifications have no Gitea equivalent.
-
-  get_repo_stargazers = function(owner, repo_name)
-    proxy_json_paged(
-      translate_users,
-      PAGES,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/stargazers", PAGES)
-      )
-    )
-  end,
-
-  get_repo_subscribers = function(owner, repo_name)
-    proxy_json_paged(
-      translate_users,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscribers",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  get_repo_subscription = function(owner, repo_name)
-    proxy_json(nil, fetch_json(base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscription"))
-  end,
-
-  put_repo_subscription = function(owner, repo_name)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscription",
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-
-  delete_repo_subscription = function(owner, repo_name)
-    set_204_or_error("DELETE", base() .. "/repos/" .. owner .. "/" .. repo_name .. "/subscription")
-  end,
-
-  get_user_starred = function()
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/user/starred", PAGES))
-    )
-  end,
-
-  get_user_starred_repo = function(owner, repo_name)
-    local ok, status = fetch_json(base() .. "/user/starred/" .. owner .. "/" .. repo_name)
-    if ok and status == 204 then
-      SetStatus(204, "No Content")
-    elseif ok and status == 404 then
-      respond_json(404, { message = "Not Found" })
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  put_user_starred_repo = function(owner, repo_name)
-    set_204_or_error("PUT", base() .. "/user/starred/" .. owner .. "/" .. repo_name)
-  end,
-
-  delete_user_starred_repo = function(owner, repo_name)
-    set_204_or_error("DELETE", base() .. "/user/starred/" .. owner .. "/" .. repo_name)
-  end,
-
-  get_user_subscriptions = function()
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/user/subscriptions", PAGES))
-    )
-  end,
-
-  get_users_starred = function(username)
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/users/" .. username .. "/starred", PAGES))
-    )
-  end,
-
-  get_users_subscriptions = function(username)
-    proxy_json_paged(
-      translate_repos,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/users/" .. username .. "/subscriptions", PAGES))
-    )
-  end,
-}
+b:rest("get_users_subscriptions", function(username)
+  proxy_json_paged(
+    translate_repos,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/users/" .. username .. "/subscriptions", PAGES))
+  )
+end)
 
 -- ---------------------------------------------------------------------------
 -- GraphQL resolvers
@@ -3187,7 +3337,7 @@ app.backend_impl = {
 -- Query.repositoryOwner: look up a User or Organization by login.
 -- Tries /users/{login} first; falls back to /orgs/{login}.
 -- Returns a RepositoryOwner (User or Organization) or nil when not found.
-graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
+b:graphql("Query.repositoryOwner", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "repositoryOwner requires a login argument")
     return nil
@@ -3201,12 +3351,12 @@ graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
     return graphql_translate_org(odata)
   end
   return nil -- not found; null is valid per spec
-end
+end)
 
 -- Query.viewer: resolve the authenticated user via GET /user.
 -- If the token is absent or rejected, graphql_fetch_or_error records a
 -- FORBIDDEN error and returns nil.
-graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+b:graphql("Query.viewer", function(_parent, _args, ctx)
   local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
   if not data then
     return nil
@@ -3214,37 +3364,37 @@ graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
   local u = graphql_translate_user(translate_user(data))
   u.isViewer = true
   return u
-end
+end)
 
 -- node.Repository: fetch a repository by "owner/repo" local ID.
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/repos/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_repo(translate_repo(data))
-end
+end)
 
 -- node.User: fetch a user by login.
-graphql_resolvers["node.User"] = function(local_id, _ctx)
+b:graphql("node.User", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/users/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_user(translate_user(data))
-end
+end)
 
 -- node.Organization: fetch an organization by login.
-graphql_resolvers["node.Organization"] = function(local_id, _ctx)
+b:graphql("node.Organization", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/orgs/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_org(data)
-end
+end)
 
 -- node.Issue: fetch an issue by "owner/repo/number" local ID.
-graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+b:graphql("node.Issue", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3255,10 +3405,10 @@ graphql_resolvers["node.Issue"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_issue(translate_gitea_issue(data), owner, repo)
-end
+end)
 
 -- node.PullRequest: fetch a pull request by "owner/repo/number" local ID.
-graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
+b:graphql("node.PullRequest", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3269,10 +3419,10 @@ graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_pr(translate_gitea_pull(data), owner, repo)
-end
+end)
 
 -- node.IssueComment: fetch an issue comment by "owner/repo/comment_id" local ID.
-graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
+b:graphql("node.IssueComment", function(local_id, _ctx)
   local owner, repo, cid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3285,11 +3435,11 @@ graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_comment(translate_gitea_issue_comment(data), owner, repo)
-end
+end)
 
 -- Query.user: look up a User by login.
 -- Returns nil (and no error) when the user does not exist.
-graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+b:graphql("Query.user", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "user requires a login argument")
     return nil
@@ -3299,11 +3449,11 @@ graphql_resolvers["Query.user"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_user(translate_user(data))
-end
+end)
 
 -- Query.organization: look up an Organization by login.
 -- Returns nil (and no error) when the organization does not exist.
-graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
+b:graphql("Query.organization", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "organization requires a login argument")
     return nil
@@ -3313,11 +3463,11 @@ graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_org(data)
-end
+end)
 
 -- Query.repository: look up a Repository by owner login and repo name.
 -- Returns nil (and no error) when the repository does not exist.
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -3327,10 +3477,10 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(translate_repo(data))
-end
+end)
 
 -- node.Release: fetch a release by "owner/repo/release_id" local ID.
-graphql_resolvers["node.Release"] = function(local_id, _ctx)
+b:graphql("node.Release", function(local_id, _ctx)
   local owner, repo, rid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3341,10 +3491,10 @@ graphql_resolvers["node.Release"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_release(data, owner, repo)
-end
+end)
 
 -- node.Label: fetch a label by "owner/repo/label_id" local ID.
-graphql_resolvers["node.Label"] = function(local_id, _ctx)
+b:graphql("node.Label", function(local_id, _ctx)
   local owner, repo, lid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3355,10 +3505,10 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_label(translate_gitea_label(data), owner, repo)
-end
+end)
 
 -- node.Milestone: fetch a milestone by "owner/repo/number" local ID.
-graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
+b:graphql("node.Milestone", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3371,10 +3521,10 @@ graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_milestone(data, owner, repo)
-end
+end)
 
 -- node.Commit: fetch a commit by "owner/repo/sha" local ID.
-graphql_resolvers["node.Commit"] = function(local_id, _ctx)
+b:graphql("node.Commit", function(local_id, _ctx)
   local owner, repo, sha = local_id:match("^([^/]+)/([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3385,11 +3535,11 @@ graphql_resolvers["node.Commit"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_commit(data, owner, repo)
-end
+end)
 
 -- node.Ref: fetch a branch ref by "owner/repo/refs/heads/..." local ID.
 -- Gitea branch objects use commit.id for the SHA; normalise to commit.sha before translating.
-graphql_resolvers["node.Ref"] = function(local_id, _ctx)
+b:graphql("node.Ref", function(local_id, _ctx)
   local owner, repo, ref_path = local_id:match("^([^/]+)/([^/]+)/(refs/.+)$")
   if not owner then
     return nil
@@ -3408,11 +3558,11 @@ graphql_resolvers["node.Ref"] = function(local_id, _ctx)
   end
   local repo_stub = { __typename = "Repository", nameWithOwner = owner .. "/" .. repo }
   return graphql_translate_ref(data, repo_stub)
-end
+end)
 
 -- node.Team: fetch a team by "org/slug" local ID.
 -- Gitea teams use numeric IDs; resolve slug → ID via gitea_find_team_id, then fetch /teams/{id}.
-graphql_resolvers["node.Team"] = function(local_id, _ctx)
+b:graphql("node.Team", function(local_id, _ctx)
   local org, slug = local_id:match("^([^/]+)/([^/]+)$")
   if not org then
     return nil
@@ -3426,7 +3576,7 @@ graphql_resolvers["node.Team"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_team(translate_gitea_team(data), org)
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
@@ -3468,7 +3618,7 @@ end
 
 -- Repository.issues: paginated list of issues (excluding pull requests).
 -- Passes type=issues so Gitea omits PRs from the response.
-graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+b:graphql("Repository.issues", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3476,10 +3626,10 @@ graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
   return gitea_repo_connection(owner, name, "/issues?type=issues", args, ctx, function(i)
     return graphql_translate_issue(translate_gitea_issue(i), owner, name)
   end, graphql_issues_connection)
-end
+end)
 
 -- Repository.pullRequests: paginated list of pull requests.
-graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+b:graphql("Repository.pullRequests", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3487,11 +3637,11 @@ graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
   return gitea_repo_connection(owner, name, "/pulls", args, ctx, function(p)
     return graphql_translate_pr(translate_gitea_pull(p), owner, name)
   end, graphql_prs_connection)
-end
+end)
 
 -- Repository.releases: paginated list of releases.
 -- Gitea release objects are already GitHub-REST-compatible; no intermediate translator needed.
-graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
+b:graphql("Repository.releases", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3501,10 +3651,10 @@ graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("Release", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.labels: paginated list of labels.
-graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
+b:graphql("Repository.labels", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3512,10 +3662,10 @@ graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
   return gitea_repo_connection(owner, name, "/labels", args, ctx, function(l)
     return graphql_translate_label(translate_gitea_label(l), owner, name)
   end, graphql_labels_connection)
-end
+end)
 
 -- Repository.milestones: paginated list of milestones.
-graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
+b:graphql("Repository.milestones", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3525,28 +3675,28 @@ graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("Milestone", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.refs: paginated list of branches as Ref objects.
 -- Gitea branch objects use commit.id for the SHA; we normalise to commit.sha before
 -- passing to graphql_translate_ref (which uses r.commit.sha).
-graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+b:graphql("Repository.refs", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
   end
-  return gitea_repo_connection(owner, name, "/branches", args, ctx, function(b)
-    if b.commit then
-      b.commit.sha = b.commit.id
+  return gitea_repo_connection(owner, name, "/branches", args, ctx, function(br)
+    if br.commit then
+      br.commit.sha = br.commit.id
     end
-    return graphql_translate_ref(b, parent)
+    return graphql_translate_ref(br, parent)
   end, graphql_refs_connection)
-end
+end)
 
 -- Issue.comments: paginated list of comments for a single issue.
 -- Decodes the Issue node ID to extract owner/repo/number, then fetches
 -- /api/v1/repos/{owner}/{repo}/issues/{number}/comments.
-graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+b:graphql("Issue.comments", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -3580,12 +3730,12 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_comment(translate_gitea_issue_comment(c), owner, repo)
   end
   return graphql_make_connection("IssueComment", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.commits: paginated commit list for a pull request.
 -- Decodes the PullRequest node ID (PullRequest:owner/repo/number) for coordinates,
 -- then fetches /api/v1/repos/{owner}/{repo}/pulls/{number}/commits.
-graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
+b:graphql("PullRequest.commits", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -3621,10 +3771,10 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     }
   end
   return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.reviews: paginated review list for a pull request.
-graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
+b:graphql("PullRequest.reviews", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -3651,10 +3801,10 @@ graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_review(translate_gitea_review(r), owner, repo)
   end
   return graphql_make_connection("PullRequestReview", nodes, args, total, ctx)
-end
+end)
 
 -- Repository.collaborators: paginated list of collaborators as Users.
-graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
+b:graphql("Repository.collaborators", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3664,14 +3814,14 @@ graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("RepositoryCollaborator", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.defaultBranchRef: enrich the inline stub with full branch data.
 -- The parent already carries {__typename="Ref",name="main"} from graphql_translate_repo.
 -- This resolver makes a second call to get the commit SHA.
 -- Gitea branch objects use commit.id for the SHA; we normalise to commit.sha before
 -- passing to graphql_translate_ref.
-graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
+b:graphql("Repository.defaultBranchRef", function(parent, _args, _ctx)
   local branch = parent.defaultBranchRef and parent.defaultBranchRef.name
   if not branch then
     return nil
@@ -3689,12 +3839,12 @@ graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
     data.commit.sha = data.commit.id
   end
   return graphql_translate_ref(data, parent)
-end
+end)
 
 -- Repository.languages: fetch language byte-count breakdown as a LanguageConnection.
 -- Gitea returns {"Language": bytes, ...}; we convert to the Relay Connection shape.
 -- Language colours are not available from Gitea's API; color is always nil.
-graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
+b:graphql("Repository.languages", function(parent, _args, _ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3731,7 +3881,7 @@ graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
     nodes = nodes,
     edges = edges,
   }
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Query.search
@@ -3753,7 +3903,7 @@ end
 
 -- Query.search: map GitHub GraphQL search to Gitea search endpoints.
 -- Supports REPOSITORY, USER, and ISSUE types; all others return empty.
-graphql_resolvers["Query.search"] = function(_parent, args, ctx)
+b:graphql("Query.search", function(_parent, args, ctx)
   local query = args.query or ""
   local search_type = args.type or "REPOSITORY"
   local per_page = args.first or 30
@@ -3826,7 +3976,7 @@ graphql_resolvers["Query.search"] = function(_parent, args, ctx)
     discussionCount = 0,
     wikiCount = 0,
   }
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- GraphQL mutation resolvers
@@ -3835,7 +3985,7 @@ end
 -- Mutation.createRepository: create a new repository for the authenticated user or an org.
 -- Input fields: name (required), description, visibility, initializeWithReadme, ownerId.
 -- If ownerId decodes to an Organization, uses POST /orgs/{org}/repos; otherwise /user/repos.
-graphql_resolvers["Mutation.createRepository"] = function(_parent, args, ctx)
+b:graphql("Mutation.createRepository", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.name then
     return graphql_error(ctx, "createRepository requires input.name", nil, "BAD_USER_INPUT")
@@ -3863,13 +4013,13 @@ graphql_resolvers["Mutation.createRepository"] = function(_parent, args, ctx)
     repository = graphql_translate_repo(translate_repo(data)),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.updateRepository: update metadata for an existing repository.
 -- Input fields: repositoryId (required, Repository node ID), name, description,
 --   visibility, hasIssuesEnabled, hasWikiEnabled, homepageUrl.
 -- Sends PATCH /repos/{owner}/{repo} with only the supplied fields.
-graphql_resolvers["Mutation.updateRepository"] = function(_parent, args, ctx)
+b:graphql("Mutation.updateRepository", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.repositoryId then
     return graphql_error(ctx, "updateRepository requires input.repositoryId", nil, "BAD_USER_INPUT")
@@ -3902,13 +4052,13 @@ graphql_resolvers["Mutation.updateRepository"] = function(_parent, args, ctx)
     repository = graphql_translate_repo(translate_repo(data)),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.deleteRepository: permanently delete a repository.
 -- Input fields: repositoryId (required, Repository node ID).
 -- Sends DELETE /repos/{owner}/{repo} and expects 204 No Content.
 -- The payload only contains the optional clientMutationId (no body to translate).
-graphql_resolvers["Mutation.deleteRepository"] = function(_parent, args, ctx)
+b:graphql("Mutation.deleteRepository", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.repositoryId then
     return graphql_error(ctx, "deleteRepository requires input.repositoryId", nil, "BAD_USER_INPUT")
@@ -3947,7 +4097,7 @@ graphql_resolvers["Mutation.deleteRepository"] = function(_parent, args, ctx)
     return nil
   end
   return { clientMutationId = cmid }
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Issue mutations
@@ -3958,7 +4108,7 @@ end
 --   body, labelIds (array of Label node IDs), assigneeIds (array of User node IDs),
 --   milestoneId (Milestone node ID).
 -- Sends POST /repos/{owner}/{repo}/issues and returns the created issue.
-graphql_resolvers["Mutation.createIssue"] = function(_parent, args, ctx)
+b:graphql("Mutation.createIssue", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.repositoryId then
     return graphql_error(ctx, "createIssue requires input.repositoryId", nil, "BAD_USER_INPUT")
@@ -4021,12 +4171,12 @@ graphql_resolvers["Mutation.createIssue"] = function(_parent, args, ctx)
     issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.updateIssue: update the title, body, and/or state of an issue.
 -- Input fields: id (required, Issue node ID), title, body, state (OPEN or CLOSED).
 -- Sends PATCH /repos/{owner}/{repo}/issues/{number}.
-graphql_resolvers["Mutation.updateIssue"] = function(_parent, args, ctx)
+b:graphql("Mutation.updateIssue", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.id then
     return graphql_error(ctx, "updateIssue requires input.id", nil, "BAD_USER_INPUT")
@@ -4057,12 +4207,12 @@ graphql_resolvers["Mutation.updateIssue"] = function(_parent, args, ctx)
     issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.closeIssue: close an open issue.
 -- Input fields: issueId (required, Issue node ID).
 -- Sends PATCH /repos/{owner}/{repo}/issues/{number} with state=closed.
-graphql_resolvers["Mutation.closeIssue"] = function(_parent, args, ctx)
+b:graphql("Mutation.closeIssue", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.issueId then
     return graphql_error(ctx, "closeIssue requires input.issueId", nil, "BAD_USER_INPUT")
@@ -4086,12 +4236,12 @@ graphql_resolvers["Mutation.closeIssue"] = function(_parent, args, ctx)
     issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.reopenIssue: reopen a closed issue.
 -- Input fields: issueId (required, Issue node ID).
 -- Sends PATCH /repos/{owner}/{repo}/issues/{number} with state=open.
-graphql_resolvers["Mutation.reopenIssue"] = function(_parent, args, ctx)
+b:graphql("Mutation.reopenIssue", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.issueId then
     return graphql_error(ctx, "reopenIssue requires input.issueId", nil, "BAD_USER_INPUT")
@@ -4115,13 +4265,13 @@ graphql_resolvers["Mutation.reopenIssue"] = function(_parent, args, ctx)
     issue = graphql_translate_issue(translate_gitea_issue(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.createPullRequest: open a new pull request in a repository.
 -- Input fields: repositoryId (required, Repository node ID), title (required),
 --   body, headRefName (required, source branch), baseRefName (required, target branch).
 -- Sends POST /repos/{owner}/{repo}/pulls and returns the created pull request.
-graphql_resolvers["Mutation.createPullRequest"] = function(_parent, args, ctx)
+b:graphql("Mutation.createPullRequest", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.repositoryId then
     return graphql_error(
@@ -4164,12 +4314,12 @@ graphql_resolvers["Mutation.createPullRequest"] = function(_parent, args, ctx)
     pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.updatePullRequest: update the title, body, and/or base branch of a pull request.
 -- Input fields: pullRequestId (required, PullRequest node ID), title, body, baseRefName.
 -- Sends PATCH /repos/{owner}/{repo}/pulls/{number}.
-graphql_resolvers["Mutation.updatePullRequest"] = function(_parent, args, ctx)
+b:graphql("Mutation.updatePullRequest", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.pullRequestId then
     return graphql_error(
@@ -4198,12 +4348,12 @@ graphql_resolvers["Mutation.updatePullRequest"] = function(_parent, args, ctx)
     pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.closePullRequest: close an open pull request.
 -- Input fields: pullRequestId (required, PullRequest node ID).
 -- Sends PATCH /repos/{owner}/{repo}/pulls/{number} with state=closed.
-graphql_resolvers["Mutation.closePullRequest"] = function(_parent, args, ctx)
+b:graphql("Mutation.closePullRequest", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.pullRequestId then
     return graphql_error(
@@ -4232,12 +4382,12 @@ graphql_resolvers["Mutation.closePullRequest"] = function(_parent, args, ctx)
     pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.reopenPullRequest: reopen a closed pull request.
 -- Input fields: pullRequestId (required, PullRequest node ID).
 -- Sends PATCH /repos/{owner}/{repo}/pulls/{number} with state=open.
-graphql_resolvers["Mutation.reopenPullRequest"] = function(_parent, args, ctx)
+b:graphql("Mutation.reopenPullRequest", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.pullRequestId then
     return graphql_error(
@@ -4266,14 +4416,14 @@ graphql_resolvers["Mutation.reopenPullRequest"] = function(_parent, args, ctx)
     pullRequest = graphql_translate_pr(translate_gitea_pull(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.mergePullRequest: merge an open pull request.
 -- Input fields: pullRequestId (required, PullRequest node ID), mergeMethod
 --   (MERGE/SQUASH/REBASE; defaults to MERGE), commitHeadline, commitBody.
 -- Sends POST /repos/{owner}/{repo}/pulls/{number}/merge (Gitea uses POST; GitHub uses PUT).
 -- The merge endpoint returns 204 No Content, so the PR is re-fetched to populate the payload.
-graphql_resolvers["Mutation.mergePullRequest"] = function(_parent, args, ctx)
+b:graphql("Mutation.mergePullRequest", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.pullRequestId then
     return graphql_error(
@@ -4338,7 +4488,7 @@ graphql_resolvers["Mutation.mergePullRequest"] = function(_parent, args, ctx)
     pullRequest = graphql_translate_pr(translate_gitea_pull(pr_data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Comment mutations
@@ -4350,7 +4500,7 @@ end
 -- Both Issue and PullRequest node IDs route to the /issues/{n}/comments path — Gitea
 -- uses the issues endpoint for PR comments too.
 -- The payload returns commentEdge (containing the new IssueComment) and clientMutationId.
-graphql_resolvers["Mutation.addComment"] = function(_parent, args, ctx)
+b:graphql("Mutation.addComment", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.subjectId then
     return graphql_error(ctx, "addComment requires input.subjectId", nil, "BAD_USER_INPUT")
@@ -4382,12 +4532,12 @@ graphql_resolvers["Mutation.addComment"] = function(_parent, args, ctx)
     },
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.updateIssueComment: update the body of an existing issue comment.
 -- Input fields: id (required, IssueComment node ID), body (required).
 -- Sends PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}.
-graphql_resolvers["Mutation.updateIssueComment"] = function(_parent, args, ctx)
+b:graphql("Mutation.updateIssueComment", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.id then
     return graphql_error(ctx, "updateIssueComment requires input.id", nil, "BAD_USER_INPUT")
@@ -4414,13 +4564,13 @@ graphql_resolvers["Mutation.updateIssueComment"] = function(_parent, args, ctx)
     issueComment = graphql_translate_comment(translate_gitea_issue_comment(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
 -- Mutation.deleteIssueComment: delete an issue comment.
 -- Input fields: id (required, IssueComment node ID).
 -- Sends DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}.
 -- Returns 204 No Content on success; the payload only contains the optional clientMutationId.
-graphql_resolvers["Mutation.deleteIssueComment"] = function(_parent, args, ctx)
+b:graphql("Mutation.deleteIssueComment", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.id then
     return graphql_error(ctx, "deleteIssueComment requires input.id", nil, "BAD_USER_INPUT")
@@ -4459,9 +4609,9 @@ graphql_resolvers["Mutation.deleteIssueComment"] = function(_parent, args, ctx)
     return nil
   end
   return { clientMutationId = cmid }
-end
+end)
 
-graphql_resolvers["Mutation.addStar"] = function(_parent, args, ctx)
+b:graphql("Mutation.addStar", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.starrableId then
     return graphql_error(ctx, "addStar requires input.starrableId", nil, "BAD_USER_INPUT")
@@ -4509,9 +4659,9 @@ graphql_resolvers["Mutation.addStar"] = function(_parent, args, ctx)
     starrable = graphql_translate_repo(translate_repo(repo_data)),
     clientMutationId = cmid,
   }
-end
+end)
 
-graphql_resolvers["Mutation.removeStar"] = function(_parent, args, ctx)
+b:graphql("Mutation.removeStar", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.starrableId then
     return graphql_error(ctx, "removeStar requires input.starrableId", nil, "BAD_USER_INPUT")
@@ -4559,9 +4709,9 @@ graphql_resolvers["Mutation.removeStar"] = function(_parent, args, ctx)
     starrable = graphql_translate_repo(translate_repo(repo_data)),
     clientMutationId = cmid,
   }
-end
+end)
 
-graphql_resolvers["Mutation.updateSubscription"] = function(_parent, args, ctx)
+b:graphql("Mutation.updateSubscription", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.subscribableId then
     return graphql_error(
@@ -4628,9 +4778,9 @@ graphql_resolvers["Mutation.updateSubscription"] = function(_parent, args, ctx)
     subscribable = graphql_translate_repo(translate_repo(repo_data)),
     clientMutationId = cmid,
   }
-end
+end)
 
-graphql_resolvers["Mutation.createLabel"] = function(_parent, args, ctx)
+b:graphql("Mutation.createLabel", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.repositoryId then
     return graphql_error(ctx, "createLabel requires input.repositoryId", nil, "BAD_USER_INPUT")
@@ -4665,9 +4815,9 @@ graphql_resolvers["Mutation.createLabel"] = function(_parent, args, ctx)
     label = graphql_translate_label(translate_gitea_label(data), owner, repo),
     clientMutationId = cmid,
   }
-end
+end)
 
-graphql_resolvers["Mutation.addLabelsToLabelable"] = function(_parent, args, ctx)
+b:graphql("Mutation.addLabelsToLabelable", function(_parent, args, ctx)
   local input = args and args.input
   if not input or not input.labelableId then
     return graphql_error(
@@ -4739,4 +4889,7 @@ graphql_resolvers["Mutation.addLabelsToLabelable"] = function(_parent, args, ctx
     labelable = item_data,
     clientMutationId = cmid,
   }
-end
+end)
+
+b:set_allow_anonymous(_allow_anon)
+b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -554,81 +554,99 @@ local GL_STATUS_TO_CHECK_RUN = {
   canceled = { status = "completed", conclusion = "cancelled" },
 }
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
-  end,
+local b = make_backend_builder()
 
-  get_repo = proxy_handler(translate_gl_repo, function(owner, repo_name)
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
+end)
+
+b:rest(
+  "get_repo",
+  proxy_handler(translate_gl_repo, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name)
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    proxy_json(
-      translate_gl_repo,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name),
-        "PUT",
-        translate_gl_req(GetBody())
-      )
+b:rest("patch_repo", function(owner, repo_name)
+  proxy_json(
+    translate_gl_repo,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name),
+      "PUT",
+      translate_gl_req(GetBody())
     )
-  end,
+  )
+end)
 
-  delete_repo = function(owner, repo_name)
-    local url = base() .. "/projects/" .. project_id(owner, repo_name)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    -- GitLab returns 202 Accepted for async deletion
-    proxy_204({ 202 }, pcall(Fetch, url, dopts))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  local url = base() .. "/projects/" .. project_id(owner, repo_name)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  -- GitLab returns 202 Accepted for async deletion
+  proxy_204({ 202 }, pcall(Fetch, url, dopts))
+end)
 
-  get_user_repos = proxy_handler_paged(translate_gl_projects, function()
+b:rest(
+  "get_user_repos",
+  proxy_handler_paged(translate_gl_projects, function()
     return append_page_params(base() .. "/projects?owned=true&membership=true", PAGES)
-  end),
+  end)
+)
 
-  post_user_repos = function()
-    proxy_json_created(
-      translate_gl_repo,
-      fetch_json(base() .. "/projects", "POST", translate_gl_req(GetBody()))
-    )
-  end,
+b:rest("post_user_repos", function()
+  proxy_json_created(
+    translate_gl_repo,
+    fetch_json(base() .. "/projects", "POST", translate_gl_req(GetBody()))
+  )
+end)
 
-  get_org_repos = proxy_handler_paged(translate_gl_projects, function(org)
+b:rest(
+  "get_org_repos",
+  proxy_handler_paged(translate_gl_projects, function(org)
     return append_page_params(base() .. "/groups/" .. org .. "/projects", PAGES)
-  end),
+  end)
+)
 
-  post_org_repos = function(org)
-    local gl_req = translate_gl_req(GetBody())
-    local gl = DecodeJson(gl_req)
-    gl.namespace_id = org
-    proxy_json_created(translate_gl_repo, fetch_json(base() .. "/projects", "POST", EncodeJson(gl)))
-  end,
+b:rest("post_org_repos", function(org)
+  local gl_req = translate_gl_req(GetBody())
+  local gl = DecodeJson(gl_req)
+  gl.namespace_id = org
+  proxy_json_created(translate_gl_repo, fetch_json(base() .. "/projects", "POST", EncodeJson(gl)))
+end)
 
-  get_repo_topics = proxy_handler(function(p)
+b:rest(
+  "get_repo_topics",
+  proxy_handler(function(p)
     return { names = p.topics or {} }
   end, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name)
-  end),
+  end)
+)
 
-  put_repo_topics = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    proxy_json(
-      function(p)
-        return { names = p.topics or {} }
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name),
-        "PUT",
-        EncodeJson({ topics = req.names or {} })
-      )
+b:rest("put_repo_topics", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  proxy_json(
+    function(p)
+      return { names = p.topics or {} }
+    end,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name),
+      "PUT",
+      EncodeJson({ topics = req.names or {} })
     )
-  end,
+  )
+end)
 
-  get_repo_languages = proxy_handler(nil, function(owner, repo_name)
+b:rest(
+  "get_repo_languages",
+  proxy_handler(nil, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/languages"
-  end),
+  end)
+)
 
-  get_repo_contributors = proxy_handler_paged(function(contribs)
+b:rest(
+  "get_repo_contributors",
+  proxy_handler_paged(function(contribs)
     for i, c in ipairs(contribs) do
       contribs[i] = { login = c.name, contributions = c.commits }
     end
@@ -638,9 +656,12 @@ app.backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/contributors",
       PAGES
     )
-  end),
+  end)
+)
 
-  get_repo_tags = proxy_handler_paged(function(tags)
+b:rest(
+  "get_repo_tags",
+  proxy_handler_paged(function(tags)
     for i, t in ipairs(tags) do
       local c = t.commit or {}
       tags[i] = { name = t.name, commit = { sha = c.id, url = "" } }
@@ -651,14 +672,17 @@ app.backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/tags",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- Branches ------------------------------------------------------------------
+-- Branches ------------------------------------------------------------------
 
-  get_repo_branches = proxy_handler_paged(function(branches)
-    for _, b in ipairs(branches or {}) do
-      if b.commit then
-        b.commit.sha = b.commit.id
+b:rest(
+  "get_repo_branches",
+  proxy_handler_paged(function(branches)
+    for _, br in ipairs(branches or {}) do
+      if br.commit then
+        br.commit.sha = br.commit.id
       end
     end
     return branches or {}
@@ -667,24 +691,30 @@ app.backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/branches",
       PAGES
     )
-  end),
+  end)
+)
 
-  get_repo_branch = proxy_handler(function(b)
-    if b and b.commit then
-      b.commit.sha = b.commit.id
+b:rest(
+  "get_repo_branch",
+  proxy_handler(function(br)
+    if br and br.commit then
+      br.commit.sha = br.commit.id
     end
-    return b or {}
+    return br or {}
   end, function(owner, repo_name, branch)
     return base()
       .. "/projects/"
       .. project_id(owner, repo_name)
       .. "/repository/branches/"
       .. branch
-  end),
+  end)
+)
 
-  -- Commits -------------------------------------------------------------------
+-- Commits -------------------------------------------------------------------
 
-  get_repo_commits = proxy_handler_paged(function(commits)
+b:rest(
+  "get_repo_commits",
+  proxy_handler_paged(function(commits)
     local result = {}
     for _, c in ipairs(commits or {}) do
       result[#result + 1] = {
@@ -707,9 +737,12 @@ app.backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/commits",
       PAGES
     )
-  end),
+  end)
+)
 
-  get_repo_commit = proxy_handler(function(c)
+b:rest(
+  "get_repo_commit",
+  proxy_handler(function(c)
     if not c then
       return {}
     end
@@ -729,110 +762,113 @@ app.backend_impl = {
     }
   end, function(owner, repo_name, ref)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/commits/" .. ref
-  end),
+  end)
+)
 
-  -- Statuses ------------------------------------------------------------------
+-- Statuses ------------------------------------------------------------------
 
-  -- GitLab status mapping: running→pending, failed→failure, canceled→error
-  get_commit_statuses = function(owner, repo_name, ref)
-    proxy_json_paged(
-      function(statuses)
-        local result = {}
-        for _, s in ipairs(statuses or {}) do
-          result[#result + 1] = {
-            id = s.id,
-            state = GL_STATUS_TO_GH[s.status] or s.status,
-            description = s.description,
-            target_url = s.target_url,
-            context = s.name,
-            created_at = s.created_at,
-            updated_at = s.updated_at,
-          }
-        end
-        return result
-      end,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base()
-            .. "/projects/"
-            .. project_id(owner, repo_name)
-            .. "/repository/commits/"
-            .. ref
-            .. "/statuses",
-          PAGES
-        )
-      )
-    )
-  end,
-
-  get_commit_combined_status = function(owner, repo_name, ref)
-    -- GitLab has no single-object combined status; return the list as-is
-    -- and wrap in a GitHub-style combined status object.
-    proxy_json(
-      function(statuses)
-        local state = "success"
-        local result = {}
-        for _, s in ipairs(statuses or {}) do
-          local gh_state = GL_STATUS_TO_GH[s.status] or s.status
-          if gh_state == "failure" or gh_state == "error" then
-            state = gh_state
-          end
-          if gh_state == "pending" and state == "success" then
-            state = "pending"
-          end
-          result[#result + 1] = {
-            id = s.id,
-            state = gh_state,
-            context = s.name,
-            description = s.description,
-            target_url = s.target_url,
-          }
-        end
-        return { state = state, statuses = result, total_count = #result }
-      end,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/repository/commits/"
-          .. ref
-          .. "/statuses"
-      )
-    )
-  end,
-
-  post_commit_status = function(owner, repo_name, sha)
-    local req = DecodeJson(GetBody() or "{}")
-    local gh_to_gl =
-      { pending = "pending", success = "success", failure = "failed", error = "failed" }
-    local gl_body = EncodeJson({
-      state = gh_to_gl[req.state] or req.state,
-      name = req.context or "default",
-      description = req.description,
-      target_url = req.target_url,
-    })
-    proxy_json_created(
-      function(s)
-        return {
+-- GitLab status mapping: running→pending, failed→failure, canceled→error
+b:rest("get_commit_statuses", function(owner, repo_name, ref)
+  proxy_json_paged(
+    function(statuses)
+      local result = {}
+      for _, s in ipairs(statuses or {}) do
+        result[#result + 1] = {
           id = s.id,
           state = GL_STATUS_TO_GH[s.status] or s.status,
           description = s.description,
           target_url = s.target_url,
           context = s.name,
+          created_at = s.created_at,
+          updated_at = s.updated_at,
         }
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
-        "POST",
-        gl_body
+      end
+      return result
+    end,
+    PAGES,
+    fetch_json(
+      append_page_params(
+        base()
+          .. "/projects/"
+          .. project_id(owner, repo_name)
+          .. "/repository/commits/"
+          .. ref
+          .. "/statuses",
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  -- Contents ------------------------------------------------------------------
+b:rest("get_commit_combined_status", function(owner, repo_name, ref)
+  -- GitLab has no single-object combined status; return the list as-is
+  -- and wrap in a GitHub-style combined status object.
+  proxy_json(
+    function(statuses)
+      local state = "success"
+      local result = {}
+      for _, s in ipairs(statuses or {}) do
+        local gh_state = GL_STATUS_TO_GH[s.status] or s.status
+        if gh_state == "failure" or gh_state == "error" then
+          state = gh_state
+        end
+        if gh_state == "pending" and state == "success" then
+          state = "pending"
+        end
+        result[#result + 1] = {
+          id = s.id,
+          state = gh_state,
+          context = s.name,
+          description = s.description,
+          target_url = s.target_url,
+        }
+      end
+      return { state = state, statuses = result, total_count = #result }
+    end,
+    fetch_json(
+      base()
+        .. "/projects/"
+        .. project_id(owner, repo_name)
+        .. "/repository/commits/"
+        .. ref
+        .. "/statuses"
+    )
+  )
+end)
 
-  get_repo_readme = proxy_handler(function(f)
+b:rest("post_commit_status", function(owner, repo_name, sha)
+  local req = DecodeJson(GetBody() or "{}")
+  local gh_to_gl =
+    { pending = "pending", success = "success", failure = "failed", error = "failed" }
+  local gl_body = EncodeJson({
+    state = gh_to_gl[req.state] or req.state,
+    name = req.context or "default",
+    description = req.description,
+    target_url = req.target_url,
+  })
+  proxy_json_created(
+    function(s)
+      return {
+        id = s.id,
+        state = GL_STATUS_TO_GH[s.status] or s.status,
+        description = s.description,
+        target_url = s.target_url,
+        context = s.name,
+      }
+    end,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
+      "POST",
+      gl_body
+    )
+  )
+end)
+
+-- Contents ------------------------------------------------------------------
+
+b:rest(
+  "get_repo_readme",
+  proxy_handler(function(f)
     if not f then
       return {}
     end
@@ -850,169 +886,168 @@ app.backend_impl = {
       .. "/projects/"
       .. project_id(owner, repo_name)
       .. "/repository/files/README.md?ref=HEAD"
-  end),
+  end)
+)
 
-  get_repo_readme_dir = function(owner, repo_name, dir)
-    local enc_path = dir:gsub("/", "%%2F") .. "%%2FREADME.md"
-    proxy_json(
-      function(f)
-        if not f then
-          return {}
-        end
-        return {
-          name = f.file_name,
-          path = f.file_path,
-          sha = f.blob_id,
-          size = f.size,
-          type = "file",
-          encoding = f.encoding,
-          content = f.content,
-        }
-      end,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/repository/files/"
-          .. enc_path
-          .. "?ref=HEAD"
-      )
-    )
-  end,
-
-  get_repo_content = function(owner, repo_name, path)
-    local enc_path = path:gsub("/", "%%2F")
-    proxy_json(
-      function(f)
-        if not f then
-          return {}
-        end
-        return {
-          name = f.file_name,
-          path = f.file_path,
-          sha = f.blob_id,
-          size = f.size,
-          type = "file",
-          encoding = f.encoding,
-          content = f.content,
-        }
-      end,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/repository/files/"
-          .. enc_path
-          .. "?ref=HEAD"
-      )
-    )
-  end,
-
-  put_repo_content = function(owner, repo_name, path)
-    local enc_path = path:gsub("/", "%%2F")
-    local req = DecodeJson(GetBody() or "{}")
-    -- Check if file exists to decide create vs update
-    local ok, status = pcall(
-      Fetch,
+b:rest("get_repo_readme_dir", function(owner, repo_name, dir)
+  local enc_path = dir:gsub("/", "%%2F") .. "%%2FREADME.md"
+  proxy_json(
+    function(f)
+      if not f then
+        return {}
+      end
+      return {
+        name = f.file_name,
+        path = f.file_path,
+        sha = f.blob_id,
+        size = f.size,
+        type = "file",
+        encoding = f.encoding,
+        content = f.content,
+      }
+    end,
+    fetch_json(
       base()
         .. "/projects/"
         .. project_id(owner, repo_name)
         .. "/repository/files/"
         .. enc_path
-        .. "?ref="
-        .. (req.branch or "HEAD"),
-      auth()
+        .. "?ref=HEAD"
     )
-    local method = (ok and status == 200) and "PUT" or "POST"
-    local gl_body = EncodeJson({
-      branch = req.branch or "main",
-      content = req.content,
-      commit_message = req.message,
-      encoding = req.encoding or "base64",
-    })
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
-        method,
-        gl_body
-      )
-    )
-  end,
+  )
+end)
 
-  delete_repo_content = function(owner, repo_name, path)
-    local enc_path = path:gsub("/", "%%2F")
-    local req = DecodeJson(GetBody() or "{}")
-    local gl_body = EncodeJson({
-      branch = req.branch or "main",
-      commit_message = req.message,
-      sha = req.sha,
-    })
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
-        "DELETE",
-        gl_body
-      )
-    )
-  end,
-
-  get_repo_tarball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local enc_path = path:gsub("/", "%%2F")
+  proxy_json(
+    function(f)
+      if not f then
+        return {}
+      end
+      return {
+        name = f.file_name,
+        path = f.file_path,
+        sha = f.blob_id,
+        size = f.size,
+        type = "file",
+        encoding = f.encoding,
+        content = f.content,
+      }
+    end,
+    fetch_json(
       base()
         .. "/projects/"
         .. project_id(owner, repo_name)
-        .. "/repository/archive.tar.gz?sha="
-        .. ref
+        .. "/repository/files/"
+        .. enc_path
+        .. "?ref=HEAD"
     )
-    Write("")
-  end,
+  )
+end)
 
-  get_repo_zipball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
+b:rest("put_repo_content", function(owner, repo_name, path)
+  local enc_path = path:gsub("/", "%%2F")
+  local req = DecodeJson(GetBody() or "{}")
+  -- Check if file exists to decide create vs update
+  local ok, status = pcall(
+    Fetch,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/repository/files/"
+      .. enc_path
+      .. "?ref="
+      .. (req.branch or "HEAD"),
+    auth()
+  )
+  local method = (ok and status == 200) and "PUT" or "POST"
+  local gl_body = EncodeJson({
+    branch = req.branch or "main",
+    content = req.content,
+    commit_message = req.message,
+    encoding = req.encoding or "base64",
+  })
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
+      method,
+      gl_body
+    )
+  )
+end)
+
+b:rest("delete_repo_content", function(owner, repo_name, path)
+  local enc_path = path:gsub("/", "%%2F")
+  local req = DecodeJson(GetBody() or "{}")
+  local gl_body = EncodeJson({
+    branch = req.branch or "main",
+    commit_message = req.message,
+    sha = req.sha,
+  })
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
+      "DELETE",
+      gl_body
+    )
+  )
+end)
+
+b:rest("get_repo_tarball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/repository/archive.tar.gz?sha="
+      .. ref
+  )
+  Write("")
+end)
+
+b:rest("get_repo_zipball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/archive.zip?sha=" .. ref
+  )
+  Write("")
+end)
+
+-- Compare -------------------------------------------------------------------
+
+b:rest("get_repo_compare", function(owner, repo_name, basehead)
+  -- Split "base...head" or "base..head"
+  local base_ref, head_ref = basehead:match("^(.-)%.%.%.(.+)$")
+  if not base_ref then
+    base_ref, head_ref = basehead:match("^(.-)%.%.(.+)$")
+  end
+  if not base_ref then
+    base_ref = "HEAD"
+    head_ref = basehead
+  end
+  proxy_json(
+    nil,
+    fetch_json(
       base()
         .. "/projects/"
         .. project_id(owner, repo_name)
-        .. "/repository/archive.zip?sha="
-        .. ref
+        .. "/repository/compare?from="
+        .. base_ref
+        .. "&to="
+        .. head_ref
     )
-    Write("")
-  end,
+  )
+end)
 
-  -- Compare -------------------------------------------------------------------
+-- Collaborators -------------------------------------------------------------
 
-  get_repo_compare = function(owner, repo_name, basehead)
-    -- Split "base...head" or "base..head"
-    local base_ref, head_ref = basehead:match("^(.-)%.%.%.(.+)$")
-    if not base_ref then
-      base_ref, head_ref = basehead:match("^(.-)%.%.(.+)$")
-    end
-    if not base_ref then
-      base_ref = "HEAD"
-      head_ref = basehead
-    end
-    proxy_json(
-      nil,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/repository/compare?from="
-          .. base_ref
-          .. "&to="
-          .. head_ref
-      )
-    )
-  end,
-
-  -- Collaborators -------------------------------------------------------------
-
-  get_repo_collaborators = proxy_handler_paged(function(members)
+b:rest(
+  "get_repo_collaborators",
+  proxy_handler_paged(function(members)
     local result = {}
     for _, m in ipairs(members or {}) do
       result[#result + 1] = {
@@ -1033,133 +1068,137 @@ app.backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/all",
       PAGES
     )
-  end),
+  end)
+)
 
-  get_repo_collaborator = function(owner, repo_name, username)
-    -- Resolve username to user ID, then check membership
-    local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-    if not ok or status ~= 200 then
-      respond_json(404, {})
-      return
-    end
-    local users = DecodeJson(ubody) or {}
-    local uid = users[1] and users[1].id
-    if not uid then
-      respond_json(404, {})
-      return
-    end
-    local ok2, status2 = pcall(
-      Fetch,
+b:rest("get_repo_collaborator", function(owner, repo_name, username)
+  -- Resolve username to user ID, then check membership
+  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
+  if not ok or status ~= 200 then
+    respond_json(404, {})
+    return
+  end
+  local users = DecodeJson(ubody) or {}
+  local uid = users[1] and users[1].id
+  if not uid then
+    respond_json(404, {})
+    return
+  end
+  local ok2, status2 = pcall(
+    Fetch,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
+    auth()
+  )
+  if ok2 and status2 == 200 then
+    SetStatus(204, "No Content")
+  else
+    respond_json(404, { message = "Not a collaborator" })
+  end
+end)
+
+b:rest("put_repo_collaborator", function(owner, repo_name, username)
+  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
+  if not ok or status ~= 200 then
+    respond_json(404, {})
+    return
+  end
+  local users = DecodeJson(ubody) or {}
+  local uid = users[1] and users[1].id
+  if not uid then
+    respond_json(404, {})
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local perm = req.permission or "push"
+  local level_map = { pull = 30, push = 30, admin = 50 }
+  local body = EncodeJson({ user_id = uid, access_level = level_map[perm] or 30 })
+  -- Try add first; if conflict, update
+  local ok2, status2 =
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/members", "POST", body)
+  if ok2 and (status2 == 201 or status2 == 200) then
+    SetStatus(204, "No Content")
+  elseif ok2 and status2 == 409 then
+    -- Already a member — update
+    local ok3, status3 = fetch_json(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
-      auth()
+      "PUT",
+      body
     )
-    if ok2 and status2 == 200 then
+    if ok3 and (status3 == 200 or status3 == 201) then
       SetStatus(204, "No Content")
     else
-      respond_json(404, { message = "Not a collaborator" })
+      respond_json(status3 or 503, {})
     end
-  end,
+  else
+    respond_json(status2 or 503, {})
+  end
+end)
 
-  put_repo_collaborator = function(owner, repo_name, username)
-    local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-    if not ok or status ~= 200 then
-      respond_json(404, {})
-      return
-    end
-    local users = DecodeJson(ubody) or {}
-    local uid = users[1] and users[1].id
-    if not uid then
-      respond_json(404, {})
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local perm = req.permission or "push"
-    local level_map = { pull = 30, push = 30, admin = 50 }
-    local body = EncodeJson({ user_id = uid, access_level = level_map[perm] or 30 })
-    -- Try add first; if conflict, update
-    local ok2, status2 =
-      fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/members", "POST", body)
-    if ok2 and (status2 == 201 or status2 == 200) then
-      SetStatus(204, "No Content")
-    elseif ok2 and status2 == 409 then
-      -- Already a member — update
-      local ok3, status3 = fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
-        "PUT",
-        body
-      )
-      if ok3 and (status3 == 200 or status3 == 201) then
-        SetStatus(204, "No Content")
-      else
-        respond_json(status3 or 503, {})
-      end
-    else
-      respond_json(status2 or 503, {})
-    end
-  end,
+b:rest("delete_repo_collaborator", function(owner, repo_name, username)
+  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
+  if not ok or status ~= 200 then
+    respond_json(404, {})
+    return
+  end
+  local users = DecodeJson(ubody) or {}
+  local uid = users[1] and users[1].id
+  if not uid then
+    respond_json(404, {})
+    return
+  end
+  local ok2, status2 = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
+    "DELETE"
+  )
+  proxy_204({ 200 }, ok2, status2)
+end)
 
-  delete_repo_collaborator = function(owner, repo_name, username)
-    local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-    if not ok or status ~= 200 then
-      respond_json(404, {})
-      return
-    end
-    local users = DecodeJson(ubody) or {}
-    local uid = users[1] and users[1].id
-    if not uid then
-      respond_json(404, {})
-      return
-    end
-    local ok2, status2 = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
-      "DELETE"
-    )
-    proxy_204({ 200 }, ok2, status2)
-  end,
+b:rest("get_repo_collaborator_permission", function(owner, repo_name, username)
+  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
+  if not ok or status ~= 200 then
+    respond_json(404, {})
+    return
+  end
+  local users = DecodeJson(ubody) or {}
+  local uid = users[1] and users[1].id
+  if not uid then
+    respond_json(404, {})
+    return
+  end
+  proxy_json(function(m)
+    local al = m and m.access_level or 0
+    local perm = al >= 50 and "admin" or (al >= 30 and "write" or "read")
+    return { permission = perm, user = { login = username, id = uid } }
+  end, fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid))
+end)
 
-  get_repo_collaborator_permission = function(owner, repo_name, username)
-    local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-    if not ok or status ~= 200 then
-      respond_json(404, {})
-      return
-    end
-    local users = DecodeJson(ubody) or {}
-    local uid = users[1] and users[1].id
-    if not uid then
-      respond_json(404, {})
-      return
-    end
-    proxy_json(function(m)
-      local al = m and m.access_level or 0
-      local perm = al >= 50 and "admin" or (al >= 30 and "write" or "read")
-      return { permission = perm, user = { login = username, id = uid } }
-    end, fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid
-    ))
-  end,
+-- Forks ---------------------------------------------------------------------
 
-  -- Forks ---------------------------------------------------------------------
-
-  get_repo_forks = proxy_handler_paged(translate_gl_projects, function(owner, repo_name)
+b:rest(
+  "get_repo_forks",
+  proxy_handler_paged(translate_gl_projects, function(owner, repo_name)
     return append_page_params(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/forks",
       PAGES
     )
-  end),
+  end)
+)
 
-  post_repo_forks = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local body = req.organization and EncodeJson({ namespace = req.organization }) or "{}"
-    proxy_json_created(
-      translate_gl_repo,
-      fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/fork", "POST", body)
-    )
-  end,
+b:rest("post_repo_forks", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local body = req.organization and EncodeJson({ namespace = req.organization }) or "{}"
+  proxy_json_created(
+    translate_gl_repo,
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/fork", "POST", body)
+  )
+end)
 
-  -- Releases ------------------------------------------------------------------
-  -- GitLab releases use tag_name as identifier rather than an integer ID.
+-- Releases ------------------------------------------------------------------
+-- GitLab releases use tag_name as identifier rather than an integer ID.
 
-  get_repo_releases = proxy_handler_paged(function(rels)
+b:rest(
+  "get_repo_releases",
+  proxy_handler_paged(function(rels)
     local result = {}
     for i, r in ipairs(rels or {}) do
       result[i] = {
@@ -1180,38 +1219,37 @@ app.backend_impl = {
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases",
       PAGES
     )
-  end),
+  end)
+)
 
-  post_repo_releases = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local body = EncodeJson({
-      tag_name = req.tag_name,
-      name = req.name,
-      description = req.body,
-    })
-    proxy_json_created(
-      function(r)
-        return {
-          id = 1,
-          tag_name = r.tag_name,
-          name = r.name,
-          body = r.description,
-          draft = false,
-          prerelease = false,
-          created_at = r.created_at,
-          published_at = r.released_at or r.created_at,
-          assets = {},
-        }
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases",
-        "POST",
-        body
-      )
-    )
-  end,
+b:rest("post_repo_releases", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local body = EncodeJson({
+    tag_name = req.tag_name,
+    name = req.name,
+    description = req.body,
+  })
+  proxy_json_created(
+    function(r)
+      return {
+        id = 1,
+        tag_name = r.tag_name,
+        name = r.name,
+        body = r.description,
+        draft = false,
+        prerelease = false,
+        created_at = r.created_at,
+        published_at = r.released_at or r.created_at,
+        assets = {},
+      }
+    end,
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases", "POST", body)
+  )
+end)
 
-  get_repo_release_latest = proxy_handler(function(r)
+b:rest(
+  "get_repo_release_latest",
+  proxy_handler(function(r)
     return {
       id = 1,
       tag_name = r.tag_name,
@@ -1225,9 +1263,12 @@ app.backend_impl = {
     }
   end, function(owner, repo_name)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/permalink/latest"
-  end),
+  end)
+)
 
-  get_repo_release_by_tag = proxy_handler(function(r)
+b:rest(
+  "get_repo_release_by_tag",
+  proxy_handler(function(r)
     return {
       id = 1,
       tag_name = r.tag_name,
@@ -1241,157 +1282,136 @@ app.backend_impl = {
     }
   end, function(owner, repo_name, tag)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag
-  end),
+  end)
+)
 
-  get_repo_release = function(owner, repo_name, release_id)
-    local tag = gl_tag_by_id(owner, repo_name, release_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(function(r)
+b:rest("get_repo_release", function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(function(r)
+    return translate_gl_release(r, tonumber(release_id))
+  end, fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag))
+end)
+
+b:rest("patch_repo_release", function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local body = EncodeJson({ name = req.name, description = req.body })
+  proxy_json(
+    function(r)
       return translate_gl_release(r, tonumber(release_id))
-    end, fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag
-    ))
-  end,
-
-  patch_repo_release = function(owner, repo_name, release_id)
-    local tag = gl_tag_by_id(owner, repo_name, release_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local body = EncodeJson({ name = req.name, description = req.body })
-    proxy_json(
-      function(r)
-        return translate_gl_release(r, tonumber(release_id))
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
-        "PUT",
-        body
-      )
-    )
-  end,
-
-  delete_repo_release = function(owner, repo_name, release_id)
-    local tag = gl_tag_by_id(owner, repo_name, release_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status = fetch_json(
+    end,
+    fetch_json(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
-      "DELETE"
+      "PUT",
+      body
     )
-    proxy_204({ 200 }, ok, status)
-  end,
+  )
+end)
 
-  get_repo_release_assets = function(owner, repo_name, release_id)
-    local tag = gl_tag_by_id(owner, repo_name, release_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json_paged(
-      function(links)
-        local result = {}
-        for i, l in ipairs(links or {}) do
-          result[i] = translate_gl_link(l)
-        end
-        return result
-      end,
-      PAGES,
-      fetch_json(
-        append_page_params(
-          base()
-            .. "/projects/"
-            .. project_id(owner, repo_name)
-            .. "/releases/"
-            .. tag
-            .. "/assets/links",
-          PAGES
-        )
-      )
-    )
-  end,
+b:rest("delete_repo_release", function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
+    "DELETE"
+  )
+  proxy_204({ 200 }, ok, status)
+end)
 
-  post_repo_release_assets = function(owner, repo_name, release_id)
-    local tag = gl_tag_by_id(owner, repo_name, release_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local body = EncodeJson({ name = req.name, url = req.url or "" })
-    proxy_json_created(
-      translate_gl_link,
-      fetch_json(
+b:rest("get_repo_release_assets", function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json_paged(
+    function(links)
+      local result = {}
+      for i, l in ipairs(links or {}) do
+        result[i] = translate_gl_link(l)
+      end
+      return result
+    end,
+    PAGES,
+    fetch_json(
+      append_page_params(
         base()
           .. "/projects/"
           .. project_id(owner, repo_name)
           .. "/releases/"
           .. tag
           .. "/assets/links",
-        "POST",
-        body
+        PAGES
       )
     )
-  end,
+  )
+end)
 
-  get_repo_release_asset = function(owner, repo_name, asset_id)
-    local tag = gl_find_link(owner, repo_name, asset_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(
-      translate_gl_link,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/releases/"
-          .. tag
-          .. "/assets/links/"
-          .. asset_id
-      )
+b:rest("post_repo_release_assets", function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local body = EncodeJson({ name = req.name, url = req.url or "" })
+  proxy_json_created(
+    translate_gl_link,
+    fetch_json(
+      base()
+        .. "/projects/"
+        .. project_id(owner, repo_name)
+        .. "/releases/"
+        .. tag
+        .. "/assets/links",
+      "POST",
+      body
     )
-  end,
+  )
+end)
 
-  patch_repo_release_asset = function(owner, repo_name, asset_id)
-    local tag = gl_find_link(owner, repo_name, asset_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local body = EncodeJson({ name = req.name })
-    proxy_json(
-      translate_gl_link,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/releases/"
-          .. tag
-          .. "/assets/links/"
-          .. asset_id,
-        "PUT",
-        body
-      )
+b:rest("get_repo_release_asset", function(owner, repo_name, asset_id)
+  local tag = gl_find_link(owner, repo_name, asset_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(
+    translate_gl_link,
+    fetch_json(
+      base()
+        .. "/projects/"
+        .. project_id(owner, repo_name)
+        .. "/releases/"
+        .. tag
+        .. "/assets/links/"
+        .. asset_id
     )
-  end,
+  )
+end)
 
-  delete_repo_release_asset = function(owner, repo_name, asset_id)
-    local tag = gl_find_link(owner, repo_name, asset_id)
-    if not tag then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status = fetch_json(
+b:rest("patch_repo_release_asset", function(owner, repo_name, asset_id)
+  local tag = gl_find_link(owner, repo_name, asset_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local body = EncodeJson({ name = req.name })
+  proxy_json(
+    translate_gl_link,
+    fetch_json(
       base()
         .. "/projects/"
         .. project_id(owner, repo_name)
@@ -1399,133 +1419,176 @@ app.backend_impl = {
         .. tag
         .. "/assets/links/"
         .. asset_id,
-      "DELETE"
+      "PUT",
+      body
     )
-    proxy_204({ 200 }, ok, status)
-  end,
+  )
+end)
 
-  -- Deploy keys ---------------------------------------------------------------
+b:rest("delete_repo_release_asset", function(owner, repo_name, asset_id)
+  local tag = gl_find_link(owner, repo_name, asset_id)
+  if not tag then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/releases/"
+      .. tag
+      .. "/assets/links/"
+      .. asset_id,
+    "DELETE"
+  )
+  proxy_204({ 200 }, ok, status)
+end)
 
-  get_repo_keys = proxy_handler_paged(nil, function(owner, repo_name)
+-- Deploy keys ---------------------------------------------------------------
+
+b:rest(
+  "get_repo_keys",
+  proxy_handler_paged(nil, function(owner, repo_name)
     return append_page_params(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys",
       PAGES
     )
-  end),
+  end)
+)
 
-  post_repo_keys = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local body = EncodeJson({
-      title = req.title,
-      key = req.key,
-      can_push = req.read_only == false,
-    })
-    proxy_json_created(
-      nil,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys",
-        "POST",
-        body
-      )
+b:rest("post_repo_keys", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local body = EncodeJson({
+    title = req.title,
+    key = req.key,
+    can_push = req.read_only == false,
+  })
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys",
+      "POST",
+      body
     )
-  end,
+  )
+end)
 
-  get_repo_key = proxy_handler(nil, function(owner, repo_name, key_id)
+b:rest(
+  "get_repo_key",
+  proxy_handler(nil, function(owner, repo_name, key_id)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys/" .. key_id
-  end),
+  end)
+)
 
-  delete_repo_key = function(owner, repo_name, key_id)
-    local ok, status = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys/" .. key_id,
-      "DELETE"
-    )
-    proxy_204({ 200 }, ok, status)
-  end,
+b:rest("delete_repo_key", function(owner, repo_name, key_id)
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys/" .. key_id,
+    "DELETE"
+  )
+  proxy_204({ 200 }, ok, status)
+end)
 
-  -- Webhooks ------------------------------------------------------------------
+-- Webhooks ------------------------------------------------------------------
 
-  get_repo_hooks = proxy_handler_paged(nil, function(owner, repo_name)
+b:rest(
+  "get_repo_hooks",
+  proxy_handler_paged(nil, function(owner, repo_name)
     return append_page_params(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks",
       PAGES
     )
-  end),
+  end)
+)
 
-  post_repo_hooks = function(owner, repo_name)
-    proxy_json_created(
-      nil,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks",
-        "POST",
-        GetBody()
-      )
+b:rest("post_repo_hooks", function(owner, repo_name)
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks",
+      "POST",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  get_repo_hook = proxy_handler(nil, function(owner, repo_name, hook_id)
+b:rest(
+  "get_repo_hook",
+  proxy_handler(nil, function(owner, repo_name, hook_id)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
-  end),
+  end)
+)
 
-  -- GitLab uses PUT for hook updates
-  patch_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id,
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-
-  delete_repo_hook = function(owner, repo_name, hook_id)
-    local ok, status = fetch_json(
+-- GitLab uses PUT for hook updates
+b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    nil,
+    fetch_json(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id,
-      "DELETE"
+      "PUT",
+      GetBody()
     )
-    proxy_204({ 200 }, ok, status)
-  end,
+  )
+end)
 
-  get_repo_hook_config = proxy_handler(function(h)
+b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id,
+    "DELETE"
+  )
+  proxy_204({ 200 }, ok, status)
+end)
+
+b:rest(
+  "get_repo_hook_config",
+  proxy_handler(function(h)
     return { url = h.url }
   end, function(owner, repo_name, hook_id)
     return base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
-  end),
+  end)
+)
 
-  patch_repo_hook_config = function(owner, repo_name, hook_id)
-    local new_cfg = DecodeJson(GetBody() or "{}")
-    local url = base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
-    local ok, status, _, body = fetch_json(url)
-    if not ok or status ~= 200 then
-      if ok then
-        respond_json(status, {})
-      else
-        respond_json(503, {})
-      end
-      return
+b:rest("patch_repo_hook_config", function(owner, repo_name, hook_id)
+  local new_cfg = DecodeJson(GetBody() or "{}")
+  local url = base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
+  local ok, status, _, body = fetch_json(url)
+  if not ok or status ~= 200 then
+    if ok then
+      respond_json(status, {})
+    else
+      respond_json(503, {})
     end
-    local hook = DecodeJson(body) or {}
-    if new_cfg.url then
-      hook.url = new_cfg.url
-    end
-    proxy_json(function(h)
-      return { url = h.url }
-    end, fetch_json(url, "PUT", EncodeJson(hook)))
-  end,
+    return
+  end
+  local hook = DecodeJson(body) or {}
+  if new_cfg.url then
+    hook.url = new_cfg.url
+  end
+  proxy_json(function(h)
+    return { url = h.url }
+  end, fetch_json(url, "PUT", EncodeJson(hook)))
+end)
 
-  -- GET /users/{username}/repos -----------------------------------------------
-  get_users_repos = proxy_handler_paged(translate_gl_projects, function(username)
+-- GET /users/{username}/repos -----------------------------------------------
+b:rest(
+  "get_users_repos",
+  proxy_handler_paged(translate_gl_projects, function(username)
     return append_page_params(base() .. "/users/" .. username .. "/projects", PAGES)
-  end),
+  end)
+)
 
-  -- GET /repositories (all public projects) -----------------------------------
-  get_repositories = proxy_handler_paged(translate_gl_projects, function()
+-- GET /repositories (all public projects) -----------------------------------
+b:rest(
+  "get_repositories",
+  proxy_handler_paged(translate_gl_projects, function()
     return append_page_params(base() .. "/projects?visibility=public", PAGES)
-  end),
+  end)
+)
 
-  -- Commit comments -----------------------------------------------------------
-  -- GitLab uses notes on commits: /projects/{id}/repository/commits/{sha}/comments
-  get_commit_comments = proxy_handler_paged(nil, function(owner, repo_name, commit_sha)
+-- Commit comments -----------------------------------------------------------
+-- GitLab uses notes on commits: /projects/{id}/repository/commits/{sha}/comments
+b:rest(
+  "get_commit_comments",
+  proxy_handler_paged(nil, function(owner, repo_name, commit_sha)
     return append_page_params(
       base()
         .. "/projects/"
@@ -1535,604 +1598,623 @@ app.backend_impl = {
         .. "/comments",
       PAGES
     )
-  end),
+  end)
+)
 
-  post_commit_comment = function(owner, repo_name, commit_sha)
-    proxy_json_created(
-      nil,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/repository/commits/"
-          .. commit_sha
-          .. "/comments",
-        "POST",
-        GetBody()
-      )
+b:rest("post_commit_comment", function(owner, repo_name, commit_sha)
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base()
+        .. "/projects/"
+        .. project_id(owner, repo_name)
+        .. "/repository/commits/"
+        .. commit_sha
+        .. "/comments",
+      "POST",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- Users ---------------------------------------------------------------------
+-- Users ---------------------------------------------------------------------
 
-  -- GET /user
-  get_user = proxy_handler(translate_gl_user, function()
+-- GET /user
+b:rest(
+  "get_user",
+  proxy_handler(translate_gl_user, function()
     return base() .. "/user"
-  end),
+  end)
+)
 
-  -- PATCH /user
-  patch_user = function()
-    proxy_json(translate_gl_user, fetch_json(base() .. "/user", "PUT", GetBody()))
-  end,
+-- PATCH /user
+b:rest("patch_user", function()
+  proxy_json(translate_gl_user, fetch_json(base() .. "/user", "PUT", GetBody()))
+end)
 
-  -- GET /users/{username}
-  get_users_username = proxy_handler(function(list)
+-- GET /users/{username}
+b:rest(
+  "get_users_username",
+  proxy_handler(function(list)
     local u = (list and list[1]) or {}
     return translate_gl_user(u)
   end, function(username)
     return base() .. "/users?username=" .. username
-  end),
+  end)
+)
 
-  -- GET /users
-  get_users = proxy_handler_paged(translate_gl_users, function()
+-- GET /users
+b:rest(
+  "get_users",
+  proxy_handler_paged(translate_gl_users, function()
     return append_page_params(base() .. "/users", PAGES)
-  end),
+  end)
+)
 
-  -- Emails --------------------------------------------------------------------
+-- Emails --------------------------------------------------------------------
 
-  -- GET /user/emails
-  get_user_emails = proxy_handler(nil, function()
+-- GET /user/emails
+b:rest(
+  "get_user_emails",
+  proxy_handler(nil, function()
     return base() .. "/user/emails"
-  end),
+  end)
+)
 
-  -- POST /user/emails
-  post_user_emails = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/emails", "POST", GetBody()))
-  end,
+-- POST /user/emails
+b:rest("post_user_emails", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/emails", "POST", GetBody()))
+end)
 
-  -- SSH Keys ------------------------------------------------------------------
+-- SSH Keys ------------------------------------------------------------------
 
-  -- GET /user/keys
-  get_user_keys = proxy_handler_paged(nil, function()
+-- GET /user/keys
+b:rest(
+  "get_user_keys",
+  proxy_handler_paged(nil, function()
     return append_page_params(base() .. "/user/keys", PAGES)
-  end),
+  end)
+)
 
-  -- POST /user/keys
-  post_user_keys = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/keys", "POST", GetBody()))
-  end,
+-- POST /user/keys
+b:rest("post_user_keys", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/keys", "POST", GetBody()))
+end)
 
-  -- GET /user/keys/{key_id}
-  get_user_key = proxy_handler(nil, function(key_id)
+-- GET /user/keys/{key_id}
+b:rest(
+  "get_user_key",
+  proxy_handler(nil, function(key_id)
     return base() .. "/user/keys/" .. key_id
-  end),
+  end)
+)
 
-  -- DELETE /user/keys/{key_id}
-  delete_user_key = function(key_id)
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, base() .. "/user/keys/" .. key_id, opts))
-  end,
+-- DELETE /user/keys/{key_id}
+b:rest("delete_user_key", function(key_id)
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, base() .. "/user/keys/" .. key_id, opts))
+end)
 
-  -- GET /users/{username}/keys
-  get_users_keys = function(username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(nil, fetch_json(base() .. "/users/" .. uid .. "/keys"))
-  end,
+-- GET /users/{username}/keys
+b:rest("get_users_keys", function(username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(nil, fetch_json(base() .. "/users/" .. uid .. "/keys"))
+end)
 
-  -- GPG Keys ------------------------------------------------------------------
+-- GPG Keys ------------------------------------------------------------------
 
-  -- GET /user/gpg_keys
-  get_user_gpg_keys = proxy_handler_paged(nil, function()
+-- GET /user/gpg_keys
+b:rest(
+  "get_user_gpg_keys",
+  proxy_handler_paged(nil, function()
     return append_page_params(base() .. "/user/gpg_keys", PAGES)
-  end),
+  end)
+)
 
-  -- POST /user/gpg_keys
-  post_user_gpg_keys = function()
-    proxy_json_created(nil, fetch_json(base() .. "/user/gpg_keys", "POST", GetBody()))
-  end,
+-- POST /user/gpg_keys
+b:rest("post_user_gpg_keys", function()
+  proxy_json_created(nil, fetch_json(base() .. "/user/gpg_keys", "POST", GetBody()))
+end)
 
-  -- GET /user/gpg_keys/{gpg_key_id}
-  get_user_gpg_key = proxy_handler(nil, function(gpg_key_id)
+-- GET /user/gpg_keys/{gpg_key_id}
+b:rest(
+  "get_user_gpg_key",
+  proxy_handler(nil, function(gpg_key_id)
     return base() .. "/user/gpg_keys/" .. gpg_key_id
-  end),
+  end)
+)
 
-  -- DELETE /user/gpg_keys/{gpg_key_id}
-  delete_user_gpg_key = function(gpg_key_id)
-    local opts = auth() or {}
-    opts.method = "DELETE"
-    proxy_204(nil, pcall(Fetch, base() .. "/user/gpg_keys/" .. gpg_key_id, opts))
-  end,
+-- DELETE /user/gpg_keys/{gpg_key_id}
+b:rest("delete_user_gpg_key", function(gpg_key_id)
+  local opts = auth() or {}
+  opts.method = "DELETE"
+  proxy_204(nil, pcall(Fetch, base() .. "/user/gpg_keys/" .. gpg_key_id, opts))
+end)
 
-  -- GET /users/{username}/gpg_keys
-  get_users_gpg_keys = function(username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
+-- GET /users/{username}/gpg_keys
+b:rest("get_users_gpg_keys", function(username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(nil, fetch_json(base() .. "/users/" .. uid .. "/gpg_keys"))
+end)
+
+-- Teams — mapped to GitLab subgroups ----------------------------------------
+-- GitHub: /orgs/{org}/teams/{team_slug}  →  GitLab: /groups/{org}%2F{slug}
+-- GitLab group members have access levels; repos are the group's projects.
+
+-- GET /orgs/{org}/teams
+b:rest("get_org_teams", function(org)
+  proxy_json_paged(function(groups)
+    for i, g in ipairs(groups) do
+      groups[i] = translate_gl_team(g)
     end
-    proxy_json(nil, fetch_json(base() .. "/users/" .. uid .. "/gpg_keys"))
-  end,
+    return groups
+  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. org .. "/subgroups", PAGES)))
+end)
 
-  -- Teams — mapped to GitLab subgroups ----------------------------------------
-  -- GitHub: /orgs/{org}/teams/{team_slug}  →  GitLab: /groups/{org}%2F{slug}
-  -- GitLab group members have access levels; repos are the group's projects.
+-- POST /orgs/{org}/teams
+b:rest("post_org_teams", function(org)
+  local req = DecodeJson(GetBody() or "{}")
+  local parent_ok, parent_status, _, parent_body = fetch_json(base() .. "/groups/" .. org)
+  if not parent_ok or parent_status ~= 200 then
+    respond_json(parent_ok and parent_status or 503, {})
+    return
+  end
+  local parent = DecodeJson(parent_body) or {}
+  local body = {
+    name = req.name,
+    path = (req.name or ""):lower():gsub("[^%w%-]", "-"),
+    parent_id = parent.id,
+    description = req.description,
+    visibility = req.privacy == "secret" and "private" or "internal",
+  }
+  proxy_json_created(translate_gl_team, fetch_json(base() .. "/groups", "POST", EncodeJson(body)))
+end)
 
-  -- GET /orgs/{org}/teams
-  get_org_teams = function(org)
-    proxy_json_paged(function(groups)
+-- GET /orgs/{org}/teams/{team_slug}
+b:rest("get_org_team", function(org, slug)
+  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug))
+end)
+
+-- PATCH /orgs/{org}/teams/{team_slug}
+b:rest("patch_org_team", function(org, slug)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local req = DecodeJson(GetBody() or "{}")
+  local upd = {}
+  if req.name then
+    upd.name = req.name
+  end
+  if req.description then
+    upd.description = req.description
+  end
+  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. gid, "PUT", EncodeJson(upd)))
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}
+b:rest("delete_org_team", function(org, slug)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. gid, dopts))
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/members
+b:rest("get_org_team_members", function(org, slug)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  proxy_json_paged(function(members)
+    local out = {}
+    for _, m in ipairs(members) do
+      out[#out + 1] = translate_gl_member(m)
+    end
+    return out
+  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/members", PAGES)))
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("get_org_team_membership", function(org, slug, username)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local mok, mstatus, _, mbody = fetch_json(base() .. "/groups/" .. gid .. "/members/" .. uid)
+  if mok and mstatus == 200 then
+    local m = DecodeJson(mbody) or {}
+    local role = (m.access_level or 0) >= 50 and "maintainer" or "member"
+    respond_json(200, { url = "", role = role, state = "active" })
+  elseif mok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("put_org_team_membership", function(org, slug, username)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local level = req.role == "maintainer" and 50 or 30
+  local mok, mstatus = fetch_json(
+    base() .. "/groups/" .. gid .. "/members",
+    "POST",
+    EncodeJson({ user_id = uid, access_level = level })
+  )
+  if mok and (mstatus == 200 or mstatus == 201) then
+    respond_json(200, { url = "", role = req.role or "member", state = "active" })
+  elseif mok then
+    respond_json(mstatus, {})
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("delete_org_team_membership", function(org, slug, username)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. gid .. "/members/" .. uid, dopts))
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/repos
+b:rest("get_org_team_repos", function(org, slug)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  proxy_json_paged(
+    translate_gl_projects,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/projects", PAGES))
+  )
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("get_org_team_repo", function(org, slug, owner, repo_name)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local pid = project_id(owner, repo_name)
+  -- Check if the project belongs to this subgroup
+  local pok, pstatus, _, pbody = fetch_json(base() .. "/projects/" .. pid)
+  if not pok or pstatus ~= 200 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local proj = DecodeJson(pbody) or {}
+  local ns = proj.namespace or {}
+  if tostring(ns.id) ~= tostring(gid) then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_gl_repo(proj))
+end)
+
+-- PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("put_org_team_repo", function(org, slug, owner, repo_name)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local pid = project_id(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local access = req.permission == "admin" and 50 or (req.permission == "push" and 30 or 20)
+  local pok, pstatus = fetch_json(
+    base() .. "/projects/" .. pid .. "/share",
+    "POST",
+    EncodeJson({ group_id = gid, group_access = access })
+  )
+  proxy_204({ 200, 201 }, pok, pstatus)
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("delete_org_team_repo", function(org, slug, owner, repo_name)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  local pid = project_id(owner, repo_name)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. gid, dopts))
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/teams — list sub-subgroups
+b:rest("get_org_team_children", function(org, slug)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not ok or status ~= 200 then
+    respond_json(ok and status or 503, {})
+    return
+  end
+  local gid = (DecodeJson(body) or {}).id
+  proxy_json_paged(function(groups)
+    for i, g in ipairs(groups) do
+      groups[i] = translate_gl_team(g)
+    end
+    return groups
+  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/subgroups", PAGES)))
+end)
+
+-- Legacy team-by-id API (/teams/{team_id}) ------------------------------------
+-- team_id maps to GitLab group numeric ID.
+
+-- GET /user/teams — all groups the authenticated user belongs to
+b:rest("get_user_teams", function()
+  proxy_json_paged(function(groups)
+    for i, g in ipairs(groups) do
+      groups[i] = translate_gl_team(g)
+    end
+    return groups
+  end, PAGES, fetch_json(append_page_params(base() .. "/groups?min_access_level=10", PAGES)))
+end)
+
+-- GET /teams/{team_id}
+b:rest("get_team", function(team_id)
+  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. team_id))
+end)
+
+-- PATCH /teams/{team_id}
+b:rest("patch_team", function(team_id)
+  local req = DecodeJson(GetBody() or "{}")
+  local upd = {}
+  if req.name then
+    upd.name = req.name
+  end
+  if req.description then
+    upd.description = req.description
+  end
+  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. team_id, "PUT", EncodeJson(upd)))
+end)
+
+-- DELETE /teams/{team_id}
+b:rest("delete_team", function(team_id)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. team_id, dopts))
+end)
+
+-- GET /teams/{team_id}/members
+b:rest("get_team_members", function(team_id)
+  proxy_json_paged(function(members)
+    local out = {}
+    for _, m in ipairs(members) do
+      out[#out + 1] = translate_gl_member(m)
+    end
+    return out
+  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/members", PAGES)))
+end)
+
+-- GET /teams/{team_id}/members/{username} — deprecated legacy, 204 if member
+b:rest("get_team_member", function(team_id, username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status = pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, auth())
+  if ok and status == 200 then
+    SetStatus(204, "No Content")
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /teams/{team_id}/members/{username} — deprecated legacy
+b:rest("put_team_member", function(team_id, username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status = fetch_json(
+    base() .. "/groups/" .. team_id .. "/members",
+    "POST",
+    EncodeJson({ user_id = uid, access_level = 30 })
+  )
+  proxy_204({ 200, 201 }, ok, status)
+end)
+
+-- DELETE /teams/{team_id}/members/{username} — deprecated legacy
+b:rest("delete_team_member", function(team_id, username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
+end)
+
+-- GET /teams/{team_id}/memberships/{username}
+b:rest("get_team_membership", function(team_id, username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. team_id .. "/members/" .. uid)
+  if ok and status == 200 then
+    local m = DecodeJson(body) or {}
+    local role = (m.access_level or 0) >= 50 and "maintainer" or "member"
+    respond_json(200, { url = "", role = role, state = "active" })
+  elseif ok then
+    respond_json(404, { message = "Not Found" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- PUT /teams/{team_id}/memberships/{username}
+b:rest("put_team_membership", function(team_id, username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local level = req.role == "maintainer" and 50 or 30
+  local ok, status = fetch_json(
+    base() .. "/groups/" .. team_id .. "/members",
+    "POST",
+    EncodeJson({ user_id = uid, access_level = level })
+  )
+  if ok and (status == 200 or status == 201) then
+    respond_json(200, { url = "", role = req.role or "member", state = "active" })
+  elseif ok then
+    respond_json(status, {})
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- DELETE /teams/{team_id}/memberships/{username}
+b:rest("delete_team_membership", function(team_id, username)
+  local uid = gl_user_id(username)
+  if not uid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
+end)
+
+-- GET /teams/{team_id}/repos
+b:rest("get_team_repos", function(team_id)
+  proxy_json_paged(
+    translate_gl_projects,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/projects", PAGES))
+  )
+end)
+
+-- GET /teams/{team_id}/repos/{owner}/{repo}
+b:rest("get_team_repo", function(team_id, owner, repo_name)
+  local pid = project_id(owner, repo_name)
+  local ok, status, _, body = fetch_json(base() .. "/projects/" .. pid)
+  if not ok or status ~= 200 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local proj = DecodeJson(body) or {}
+  local ns = proj.namespace or {}
+  if tostring(ns.id) ~= tostring(team_id) then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_gl_repo(proj))
+end)
+
+-- PUT /teams/{team_id}/repos/{owner}/{repo}
+b:rest("put_team_repo", function(team_id, owner, repo_name)
+  local pid = project_id(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local access = req.permission == "admin" and 50 or (req.permission == "push" and 30 or 20)
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. pid .. "/share",
+    "POST",
+    EncodeJson({ group_id = team_id, group_access = access })
+  )
+  proxy_204({ 200, 201 }, ok, status)
+end)
+
+-- DELETE /teams/{team_id}/repos/{owner}/{repo}
+b:rest("delete_team_repo", function(team_id, owner, repo_name)
+  local pid = project_id(owner, repo_name)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. team_id, dopts))
+end)
+
+-- GET /teams/{team_id}/teams — sub-subgroups
+b:rest("get_team_children", function(team_id)
+  proxy_json_paged(
+    function(groups)
       for i, g in ipairs(groups) do
         groups[i] = translate_gl_team(g)
       end
       return groups
-    end, PAGES, fetch_json(
-      append_page_params(base() .. "/groups/" .. org .. "/subgroups", PAGES)
-    ))
-  end,
+    end,
+    PAGES,
+    fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/subgroups", PAGES))
+  )
+end)
 
-  -- POST /orgs/{org}/teams
-  post_org_teams = function(org)
-    local req = DecodeJson(GetBody() or "{}")
-    local parent_ok, parent_status, _, parent_body = fetch_json(base() .. "/groups/" .. org)
-    if not parent_ok or parent_status ~= 200 then
-      respond_json(parent_ok and parent_status or 503, {})
-      return
-    end
-    local parent = DecodeJson(parent_body) or {}
-    local body = {
-      name = req.name,
-      path = (req.name or ""):lower():gsub("[^%w%-]", "-"),
-      parent_id = parent.id,
-      description = req.description,
-      visibility = req.privacy == "secret" and "private" or "internal",
-    }
-    proxy_json_created(translate_gl_team, fetch_json(base() .. "/groups", "POST", EncodeJson(body)))
-  end,
+-- Issues -------------------------------------------------------------------
 
-  -- GET /orgs/{org}/teams/{team_slug}
-  get_org_team = function(org, slug)
-    proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug))
-  end,
-
-  -- PATCH /orgs/{org}/teams/{team_slug}
-  patch_org_team = function(org, slug)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local req = DecodeJson(GetBody() or "{}")
-    local upd = {}
-    if req.name then
-      upd.name = req.name
-    end
-    if req.description then
-      upd.description = req.description
-    end
-    proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. gid, "PUT", EncodeJson(upd)))
-  end,
-
-  -- DELETE /orgs/{org}/teams/{team_slug}
-  delete_org_team = function(org, slug)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. gid, dopts))
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/members
-  get_org_team_members = function(org, slug)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    proxy_json_paged(function(members)
-      local out = {}
-      for _, m in ipairs(members) do
-        out[#out + 1] = translate_gl_member(m)
-      end
-      return out
-    end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/members", PAGES)))
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/memberships/{username}
-  get_org_team_membership = function(org, slug, username)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local mok, mstatus, _, mbody = fetch_json(base() .. "/groups/" .. gid .. "/members/" .. uid)
-    if mok and mstatus == 200 then
-      local m = DecodeJson(mbody) or {}
-      local role = (m.access_level or 0) >= 50 and "maintainer" or "member"
-      respond_json(200, { url = "", role = role, state = "active" })
-    elseif mok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
-  put_org_team_membership = function(org, slug, username)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local level = req.role == "maintainer" and 50 or 30
-    local mok, mstatus = fetch_json(
-      base() .. "/groups/" .. gid .. "/members",
-      "POST",
-      EncodeJson({ user_id = uid, access_level = level })
-    )
-    if mok and (mstatus == 200 or mstatus == 201) then
-      respond_json(200, { url = "", role = req.role or "member", state = "active" })
-    elseif mok then
-      respond_json(mstatus, {})
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
-  delete_org_team_membership = function(org, slug, username)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. gid .. "/members/" .. uid, dopts))
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/repos
-  get_org_team_repos = function(org, slug)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    proxy_json_paged(
-      translate_gl_projects,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/projects", PAGES))
-    )
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-  get_org_team_repo = function(org, slug, owner, repo_name)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local pid = project_id(owner, repo_name)
-    -- Check if the project belongs to this subgroup
-    local pok, pstatus, _, pbody = fetch_json(base() .. "/projects/" .. pid)
-    if not pok or pstatus ~= 200 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local proj = DecodeJson(pbody) or {}
-    local ns = proj.namespace or {}
-    if tostring(ns.id) ~= tostring(gid) then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_gl_repo(proj))
-  end,
-
-  -- PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-  put_org_team_repo = function(org, slug, owner, repo_name)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local pid = project_id(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local access = req.permission == "admin" and 50 or (req.permission == "push" and 30 or 20)
-    local pok, pstatus = fetch_json(
-      base() .. "/projects/" .. pid .. "/share",
-      "POST",
-      EncodeJson({ group_id = gid, group_access = access })
-    )
-    proxy_204({ 200, 201 }, pok, pstatus)
-  end,
-
-  -- DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-  delete_org_team_repo = function(org, slug, owner, repo_name)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    local pid = project_id(owner, repo_name)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. gid, dopts))
-  end,
-
-  -- GET /orgs/{org}/teams/{team_slug}/teams — list sub-subgroups
-  get_org_team_children = function(org, slug)
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-    if not ok or status ~= 200 then
-      respond_json(ok and status or 503, {})
-      return
-    end
-    local gid = (DecodeJson(body) or {}).id
-    proxy_json_paged(function(groups)
-      for i, g in ipairs(groups) do
-        groups[i] = translate_gl_team(g)
-      end
-      return groups
-    end, PAGES, fetch_json(
-      append_page_params(base() .. "/groups/" .. gid .. "/subgroups", PAGES)
-    ))
-  end,
-
-  -- Legacy team-by-id API (/teams/{team_id}) ------------------------------------
-  -- team_id maps to GitLab group numeric ID.
-
-  -- GET /user/teams — all groups the authenticated user belongs to
-  get_user_teams = function()
-    proxy_json_paged(function(groups)
-      for i, g in ipairs(groups) do
-        groups[i] = translate_gl_team(g)
-      end
-      return groups
-    end, PAGES, fetch_json(append_page_params(base() .. "/groups?min_access_level=10", PAGES)))
-  end,
-
-  -- GET /teams/{team_id}
-  get_team = function(team_id)
-    proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. team_id))
-  end,
-
-  -- PATCH /teams/{team_id}
-  patch_team = function(team_id)
-    local req = DecodeJson(GetBody() or "{}")
-    local upd = {}
-    if req.name then
-      upd.name = req.name
-    end
-    if req.description then
-      upd.description = req.description
-    end
-    proxy_json(
-      translate_gl_team,
-      fetch_json(base() .. "/groups/" .. team_id, "PUT", EncodeJson(upd))
-    )
-  end,
-
-  -- DELETE /teams/{team_id}
-  delete_team = function(team_id)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. team_id, dopts))
-  end,
-
-  -- GET /teams/{team_id}/members
-  get_team_members = function(team_id)
-    proxy_json_paged(
-      function(members)
-        local out = {}
-        for _, m in ipairs(members) do
-          out[#out + 1] = translate_gl_member(m)
-        end
-        return out
-      end,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/members", PAGES))
-    )
-  end,
-
-  -- GET /teams/{team_id}/members/{username} — deprecated legacy, 204 if member
-  get_team_member = function(team_id, username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status = pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, auth())
-    if ok and status == 200 then
-      SetStatus(204, "No Content")
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- PUT /teams/{team_id}/members/{username} — deprecated legacy
-  put_team_member = function(team_id, username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status = fetch_json(
-      base() .. "/groups/" .. team_id .. "/members",
-      "POST",
-      EncodeJson({ user_id = uid, access_level = 30 })
-    )
-    proxy_204({ 200, 201 }, ok, status)
-  end,
-
-  -- DELETE /teams/{team_id}/members/{username} — deprecated legacy
-  delete_team_member = function(team_id, username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
-  end,
-
-  -- GET /teams/{team_id}/memberships/{username}
-  get_team_membership = function(team_id, username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status, _, body = fetch_json(base() .. "/groups/" .. team_id .. "/members/" .. uid)
-    if ok and status == 200 then
-      local m = DecodeJson(body) or {}
-      local role = (m.access_level or 0) >= 50 and "maintainer" or "member"
-      respond_json(200, { url = "", role = role, state = "active" })
-    elseif ok then
-      respond_json(404, { message = "Not Found" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- PUT /teams/{team_id}/memberships/{username}
-  put_team_membership = function(team_id, username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local level = req.role == "maintainer" and 50 or 30
-    local ok, status = fetch_json(
-      base() .. "/groups/" .. team_id .. "/members",
-      "POST",
-      EncodeJson({ user_id = uid, access_level = level })
-    )
-    if ok and (status == 200 or status == 201) then
-      respond_json(200, { url = "", role = req.role or "member", state = "active" })
-    elseif ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- DELETE /teams/{team_id}/memberships/{username}
-  delete_team_membership = function(team_id, username)
-    local uid = gl_user_id(username)
-    if not uid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
-  end,
-
-  -- GET /teams/{team_id}/repos
-  get_team_repos = function(team_id)
-    proxy_json_paged(
-      translate_gl_projects,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/projects", PAGES))
-    )
-  end,
-
-  -- GET /teams/{team_id}/repos/{owner}/{repo}
-  get_team_repo = function(team_id, owner, repo_name)
-    local pid = project_id(owner, repo_name)
-    local ok, status, _, body = fetch_json(base() .. "/projects/" .. pid)
-    if not ok or status ~= 200 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local proj = DecodeJson(body) or {}
-    local ns = proj.namespace or {}
-    if tostring(ns.id) ~= tostring(team_id) then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_gl_repo(proj))
-  end,
-
-  -- PUT /teams/{team_id}/repos/{owner}/{repo}
-  put_team_repo = function(team_id, owner, repo_name)
-    local pid = project_id(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local access = req.permission == "admin" and 50 or (req.permission == "push" and 30 or 20)
-    local ok, status = fetch_json(
-      base() .. "/projects/" .. pid .. "/share",
-      "POST",
-      EncodeJson({ group_id = team_id, group_access = access })
-    )
-    proxy_204({ 200, 201 }, ok, status)
-  end,
-
-  -- DELETE /teams/{team_id}/repos/{owner}/{repo}
-  delete_team_repo = function(team_id, owner, repo_name)
-    local pid = project_id(owner, repo_name)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. team_id, dopts))
-  end,
-
-  -- GET /teams/{team_id}/teams — sub-subgroups
-  get_team_children = function(team_id)
-    proxy_json_paged(
-      function(groups)
-        for i, g in ipairs(groups) do
-          groups[i] = translate_gl_team(g)
-        end
-        return groups
-      end,
-      PAGES,
-      fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/subgroups", PAGES))
-    )
-  end,
-
-  -- Issues -------------------------------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/issues
-  get_repo_issues = proxy_handler_paged(translate_gl_issues, function(o, r)
+-- GET /repos/{owner}/{repo}/issues
+b:rest(
+  "get_repo_issues",
+  proxy_handler_paged(translate_gl_issues, function(o, r)
     return append_page_params(base() .. "/projects/" .. project_id(o, r) .. "/issues", PAGES)
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/issues
-  post_repo_issues = proxy_handler_created(translate_gl_issue, function(o, r)
+-- POST /repos/{owner}/{repo}/issues
+b:rest(
+  "post_repo_issues",
+  proxy_handler_created(translate_gl_issue, function(o, r)
     local req = DecodeJson(GetBody() or "{}")
     local gl = {}
     if req.title then
@@ -2145,15 +2227,21 @@ app.backend_impl = {
       gl.milestone_id = req.milestone
     end
     return base() .. "/projects/" .. project_id(o, r) .. "/issues", "POST", EncodeJson(gl)
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}
-  get_repo_issue = proxy_handler(translate_gl_issue, function(o, r, n)
+-- GET /repos/{owner}/{repo}/issues/{issue_number}
+b:rest(
+  "get_repo_issue",
+  proxy_handler(translate_gl_issue, function(o, r, n)
     return base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n
-  end),
+  end)
+)
 
-  -- PATCH /repos/{owner}/{repo}/issues/{issue_number}
-  patch_repo_issue = proxy_handler(translate_gl_issue, function(o, r, n)
+-- PATCH /repos/{owner}/{repo}/issues/{issue_number}
+b:rest(
+  "patch_repo_issue",
+  proxy_handler(translate_gl_issue, function(o, r, n)
     local req = DecodeJson(GetBody() or "{}")
     local gl = {}
     if req.title then
@@ -2169,235 +2257,247 @@ app.backend_impl = {
       gl.milestone_id = req.milestone
     end
     return base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n, "PUT", EncodeJson(gl)
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-  get_issue_comments = proxy_handler_paged(translate_gl_notes, function(o, r, n)
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
+b:rest(
+  "get_issue_comments",
+  proxy_handler_paged(translate_gl_notes, function(o, r, n)
     return append_page_params(
       base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n .. "/notes",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
-  post_issue_comment = proxy_handler_created(translate_gl_note, function(o, r, n)
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+b:rest(
+  "post_issue_comment",
+  proxy_handler_created(translate_gl_note, function(o, r, n)
     local req = DecodeJson(GetBody() or "{}")
     return base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n .. "/notes",
       "POST",
       EncodeJson({ body = req.body })
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/labels
-  get_issue_labels = function(owner, repo_name, issue_number)
-    -- Fetch the issue and extract its labels.
-    local ok, status, _, body = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number
-    )
-    if not ok then
-      respond_json(503, {})
-      return
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/labels
+b:rest("get_issue_labels", function(owner, repo_name, issue_number)
+  -- Fetch the issue and extract its labels.
+  local ok, status, _, body =
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local issue = DecodeJson(body) or {}
+  local labels = {}
+  for _, l in ipairs(issue.labels or {}) do
+    if type(l) == "table" then
+      labels[#labels + 1] = translate_gl_label(l)
+    else
+      labels[#labels + 1] = {
+        id = 0,
+        node_id = "",
+        url = "",
+        name = l,
+        color = "",
+        description = "",
+        default = false,
+      }
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local issue = DecodeJson(body) or {}
-    local labels = {}
-    for _, l in ipairs(issue.labels or {}) do
-      if type(l) == "table" then
-        labels[#labels + 1] = translate_gl_label(l)
-      else
-        labels[#labels + 1] = {
-          id = 0,
-          node_id = "",
-          url = "",
-          name = l,
-          color = "",
-          description = "",
-          default = false,
-        }
-      end
-    end
-    respond_json(200, labels)
-  end,
+  end
+  respond_json(200, labels)
+end)
 
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/labels
-  post_issue_labels = function(owner, repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local existing_ok, existing_status, _, existing_body = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number
-    )
-    if not existing_ok or existing_status ~= 200 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local issue = DecodeJson(existing_body) or {}
-    local all_labels = issue.labels or {}
-    for _, name in ipairs(req.labels or {}) do
-      all_labels[#all_labels + 1] = name
-    end
-    proxy_json(
-      function(i)
-        local labels = {}
-        for _, l in ipairs(i.labels or {}) do
-          if type(l) == "table" then
-            labels[#labels + 1] = translate_gl_label(l)
-          else
-            labels[#labels + 1] = {
-              id = 0,
-              node_id = "",
-              url = "",
-              name = l,
-              color = "",
-              description = "",
-              default = false,
-            }
-          end
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/labels
+b:rest("post_issue_labels", function(owner, repo_name, issue_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local existing_ok, existing_status, _, existing_body =
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number)
+  if not existing_ok or existing_status ~= 200 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local issue = DecodeJson(existing_body) or {}
+  local all_labels = issue.labels or {}
+  for _, name in ipairs(req.labels or {}) do
+    all_labels[#all_labels + 1] = name
+  end
+  proxy_json(
+    function(i)
+      local labels = {}
+      for _, l in ipairs(i.labels or {}) do
+        if type(l) == "table" then
+          labels[#labels + 1] = translate_gl_label(l)
+        else
+          labels[#labels + 1] = {
+            id = 0,
+            node_id = "",
+            url = "",
+            name = l,
+            color = "",
+            description = "",
+            default = false,
+          }
         end
-        return labels
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-        "PUT",
-        EncodeJson({ labels = all_labels })
-      )
-    )
-  end,
-
-  -- PUT /repos/{owner}/{repo}/issues/{issue_number}/labels  (replace all)
-  put_issue_labels = function(owner, repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}")
-    proxy_json(
-      function(i)
-        local labels = {}
-        for _, l in ipairs(i.labels or {}) do
-          if type(l) == "table" then
-            labels[#labels + 1] = translate_gl_label(l)
-          else
-            labels[#labels + 1] = {
-              id = 0,
-              node_id = "",
-              url = "",
-              name = l,
-              color = "",
-              description = "",
-              default = false,
-            }
-          end
-        end
-        return labels
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-        "PUT",
-        EncodeJson({ labels = req.labels or {} })
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels  (remove all)
-  delete_issue_labels = function(owner, repo_name, issue_number)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-        "PUT",
-        EncodeJson({ labels = {} })
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
-  delete_issue_label = function(owner, repo_name, issue_number, label_name)
-    local ok, status, _, body = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number
-    )
-    if not ok or status ~= 200 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local issue = DecodeJson(body) or {}
-    local labels = {}
-    for _, l in ipairs(issue.labels or {}) do
-      local name = type(l) == "table" and l.name or l
-      if name ~= label_name then
-        labels[#labels + 1] = name
       end
-    end
-    local upok, upstatus = fetch_json(
+      return labels
+    end,
+    fetch_json(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
       "PUT",
-      EncodeJson({ labels = labels })
+      EncodeJson({ labels = all_labels })
     )
-    proxy_204({ 200 }, upok, upstatus)
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/labels
-  get_repo_labels = proxy_handler_paged(translate_gl_labels, function(o, r)
+-- PUT /repos/{owner}/{repo}/issues/{issue_number}/labels  (replace all)
+b:rest("put_issue_labels", function(owner, repo_name, issue_number)
+  local req = DecodeJson(GetBody() or "{}")
+  proxy_json(
+    function(i)
+      local labels = {}
+      for _, l in ipairs(i.labels or {}) do
+        if type(l) == "table" then
+          labels[#labels + 1] = translate_gl_label(l)
+        else
+          labels[#labels + 1] = {
+            id = 0,
+            node_id = "",
+            url = "",
+            name = l,
+            color = "",
+            description = "",
+            default = false,
+          }
+        end
+      end
+      return labels
+    end,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+      "PUT",
+      EncodeJson({ labels = req.labels or {} })
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels  (remove all)
+b:rest("delete_issue_labels", function(owner, repo_name, issue_number)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+      "PUT",
+      EncodeJson({ labels = {} })
+    )
+  )
+end)
+
+-- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
+b:rest("delete_issue_label", function(owner, repo_name, issue_number, label_name)
+  local ok, status, _, body =
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number)
+  if not ok or status ~= 200 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local issue = DecodeJson(body) or {}
+  local labels = {}
+  for _, l in ipairs(issue.labels or {}) do
+    local name = type(l) == "table" and l.name or l
+    if name ~= label_name then
+      labels[#labels + 1] = name
+    end
+  end
+  local upok, upstatus = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+    "PUT",
+    EncodeJson({ labels = labels })
+  )
+  proxy_204({ 200 }, upok, upstatus)
+end)
+
+-- GET /repos/{owner}/{repo}/labels
+b:rest(
+  "get_repo_labels",
+  proxy_handler_paged(translate_gl_labels, function(o, r)
     return append_page_params(base() .. "/projects/" .. project_id(o, r) .. "/labels", PAGES)
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/labels
-  post_repo_labels = proxy_handler_created(translate_gl_label, function(o, r)
+-- POST /repos/{owner}/{repo}/labels
+b:rest(
+  "post_repo_labels",
+  proxy_handler_created(translate_gl_label, function(o, r)
     return base() .. "/projects/" .. project_id(o, r) .. "/labels", "POST", GetBody()
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/labels/{name}
-  get_repo_label = function(owner, repo_name, label_name)
-    local id = gl_find_label_id(owner, repo_name, label_name)
-    if not id then
-      respond_json(404, { message = "Label not found" })
-      return
-    end
-    proxy_json(
-      translate_gl_label,
-      fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id)
-    )
-  end,
+-- GET /repos/{owner}/{repo}/labels/{name}
+b:rest("get_repo_label", function(owner, repo_name, label_name)
+  local id = gl_find_label_id(owner, repo_name, label_name)
+  if not id then
+    respond_json(404, { message = "Label not found" })
+    return
+  end
+  proxy_json(
+    translate_gl_label,
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id)
+  )
+end)
 
-  -- PATCH /repos/{owner}/{repo}/labels/{name}
-  patch_repo_label = function(owner, repo_name, label_name)
-    local id = gl_find_label_id(owner, repo_name, label_name)
-    if not id then
-      respond_json(404, { message = "Label not found" })
-      return
-    end
-    proxy_json(
-      translate_gl_label,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id,
-        "PUT",
-        GetBody()
-      )
-    )
-  end,
-
-  -- DELETE /repos/{owner}/{repo}/labels/{name}
-  delete_repo_label = function(owner, repo_name, label_name)
-    local id = gl_find_label_id(owner, repo_name, label_name)
-    if not id then
-      respond_json(404, { message = "Label not found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    local ok, status = pcall(
-      Fetch,
+-- PATCH /repos/{owner}/{repo}/labels/{name}
+b:rest("patch_repo_label", function(owner, repo_name, label_name)
+  local id = gl_find_label_id(owner, repo_name, label_name)
+  if not id then
+    respond_json(404, { message = "Label not found" })
+    return
+  end
+  proxy_json(
+    translate_gl_label,
+    fetch_json(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id,
-      dopts
+      "PUT",
+      GetBody()
     )
-    proxy_204({ 200 }, ok, status)
-  end,
+  )
+end)
 
-  -- Milestones ----------------------------------------------------------------
+-- DELETE /repos/{owner}/{repo}/labels/{name}
+b:rest("delete_repo_label", function(owner, repo_name, label_name)
+  local id = gl_find_label_id(owner, repo_name, label_name)
+  if not id then
+    respond_json(404, { message = "Label not found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  local ok, status =
+    pcall(Fetch, base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id, dopts)
+  proxy_204({ 200 }, ok, status)
+end)
 
-  -- GET /repos/{owner}/{repo}/milestones
-  get_repo_milestones = proxy_handler_paged(translate_gl_milestones, function(o, r)
+-- Milestones ----------------------------------------------------------------
+
+-- GET /repos/{owner}/{repo}/milestones
+b:rest(
+  "get_repo_milestones",
+  proxy_handler_paged(translate_gl_milestones, function(o, r)
     return append_page_params(base() .. "/projects/" .. project_id(o, r) .. "/milestones", PAGES)
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/milestones
-  post_repo_milestones = proxy_handler_created(translate_gl_milestone, function(o, r)
+-- POST /repos/{owner}/{repo}/milestones
+b:rest(
+  "post_repo_milestones",
+  proxy_handler_created(translate_gl_milestone, function(o, r)
     local req = DecodeJson(GetBody() or "{}")
     local gl = {}
     if req.title then
@@ -2410,15 +2510,21 @@ app.backend_impl = {
       gl.due_date = req.due_on
     end
     return base() .. "/projects/" .. project_id(o, r) .. "/milestones", "POST", EncodeJson(gl)
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/milestones/{milestone_number}
-  get_repo_milestone = proxy_handler(translate_gl_milestone, function(o, r, n)
+-- GET /repos/{owner}/{repo}/milestones/{milestone_number}
+b:rest(
+  "get_repo_milestone",
+  proxy_handler(translate_gl_milestone, function(o, r, n)
     return base() .. "/projects/" .. project_id(o, r) .. "/milestones/" .. n
-  end),
+  end)
+)
 
-  -- PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
-  patch_repo_milestone = proxy_handler(translate_gl_milestone, function(o, r, n)
+-- PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
+b:rest(
+  "patch_repo_milestone",
+  proxy_handler(translate_gl_milestone, function(o, r, n)
     local req = DecodeJson(GetBody() or "{}")
     local gl = {}
     if req.title then
@@ -2434,99 +2540,111 @@ app.backend_impl = {
       gl.due_date = req.due_on
     end
     return base() .. "/projects/" .. project_id(o, r) .. "/milestones/" .. n, "PUT", EncodeJson(gl)
-  end),
+  end)
+)
 
-  -- DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
-  delete_repo_milestone = function(owner, repo_name, milestone_number)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    local ok, status = pcall(
-      Fetch,
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones/" .. milestone_number,
-      dopts
-    )
-    proxy_204({ 200 }, ok, status)
-  end,
+-- DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
+b:rest("delete_repo_milestone", function(owner, repo_name, milestone_number)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  local ok, status = pcall(
+    Fetch,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones/" .. milestone_number,
+    dopts
+  )
+  proxy_204({ 200 }, ok, status)
+end)
 
-  -- Assignees -----------------------------------------------------------------
+-- Assignees -----------------------------------------------------------------
 
-  -- GET /repos/{owner}/{repo}/assignees  (users eligible for assignment)
-  get_repo_assignees = proxy_handler_paged(translate_gl_members, function(o, r)
+-- GET /repos/{owner}/{repo}/assignees  (users eligible for assignment)
+b:rest(
+  "get_repo_assignees",
+  proxy_handler_paged(translate_gl_members, function(o, r)
     return append_page_params(base() .. "/projects/" .. project_id(o, r) .. "/members/all", PAGES)
-  end),
+  end)
+)
 
-  -- Pull Requests (mapped to GitLab Merge Requests) --------------------------
+-- Pull Requests (mapped to GitLab Merge Requests) --------------------------
 
-  -- GET /repos/{owner}/{repo}/pulls
-  get_repo_pulls = proxy_handler_paged(translate_gl_mrs, function(o, r)
+-- GET /repos/{owner}/{repo}/pulls
+b:rest(
+  "get_repo_pulls",
+  proxy_handler_paged(translate_gl_mrs, function(o, r)
     return append_page_params(
       base() .. "/projects/" .. project_id(o, r) .. "/merge_requests",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- POST /repos/{owner}/{repo}/pulls
-  post_repo_pulls = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local gl = {}
-    if req.title then
-      gl.title = req.title
-    end
-    if req.body then
-      gl.description = req.body
-    end
-    if req.head then
-      gl.source_branch = req.head
-    end
-    if req.base then
-      gl.target_branch = req.base
-    end
-    if req.draft ~= nil then
-      gl.draft = req.draft
-    end
-    proxy_json_created(
-      translate_gl_mr,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests",
-        "POST",
-        EncodeJson(gl)
-      )
+-- POST /repos/{owner}/{repo}/pulls
+b:rest("post_repo_pulls", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.body then
+    gl.description = req.body
+  end
+  if req.head then
+    gl.source_branch = req.head
+  end
+  if req.base then
+    gl.target_branch = req.base
+  end
+  if req.draft ~= nil then
+    gl.draft = req.draft
+  end
+  proxy_json_created(
+    translate_gl_mr,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests",
+      "POST",
+      EncodeJson(gl)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}
-  get_repo_pull = proxy_handler(translate_gl_mr, function(o, r, n)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}
+b:rest(
+  "get_repo_pull",
+  proxy_handler(translate_gl_mr, function(o, r, n)
     return base() .. "/projects/" .. project_id(o, r) .. "/merge_requests/" .. n
-  end),
+  end)
+)
 
-  -- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
-  patch_repo_pull = function(owner, repo_name, pull_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local gl = {}
-    if req.title then
-      gl.title = req.title
-    end
-    if req.body then
-      gl.description = req.body
-    end
-    if req.state then
-      gl.state_event = req.state == "closed" and "close" or "reopen"
-    end
-    if req.draft ~= nil then
-      gl.draft = req.draft
-    end
-    proxy_json(
-      translate_gl_mr,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number,
-        "PUT",
-        EncodeJson(gl)
-      )
+-- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
+b:rest("patch_repo_pull", function(owner, repo_name, pull_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.body then
+    gl.description = req.body
+  end
+  if req.state then
+    gl.state_event = req.state == "closed" and "close" or "reopen"
+  end
+  if req.draft ~= nil then
+    gl.draft = req.draft
+  end
+  proxy_json(
+    translate_gl_mr,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number,
+      "PUT",
+      EncodeJson(gl)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
-  get_pull_commits = proxy_handler_paged(function(commits)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
+b:rest(
+  "get_pull_commits",
+  proxy_handler_paged(function(commits)
     local result = {}
     for _, c in ipairs(commits or {}) do
       result[#result + 1] = {
@@ -2549,11 +2667,14 @@ app.backend_impl = {
       base() .. "/projects/" .. project_id(o, r) .. "/merge_requests/" .. n .. "/commits",
       PAGES
     )
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
-  -- GitLab uses /changes which wraps the diff list in a parent object.
-  get_pull_files = proxy_handler(function(mr)
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
+-- GitLab uses /changes which wraps the diff list in a parent object.
+b:rest(
+  "get_pull_files",
+  proxy_handler(function(mr)
     local result = {}
     for _, c in ipairs((mr or {}).changes or {}) do
       local status = "modified"
@@ -2577,670 +2698,667 @@ app.backend_impl = {
     return result
   end, function(o, r, n)
     return base() .. "/projects/" .. project_id(o, r) .. "/merge_requests/" .. n .. "/changes"
-  end),
+  end)
+)
 
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  -- Returns 204 if the MR is merged, 404 if not.
-  get_pull_merge = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number
-    )
-    if not ok then
-      respond_json(503, {})
-      return
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
+-- Returns 204 if the MR is merged, 404 if not.
+b:rest("get_pull_merge", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local mr = DecodeJson(body) or {}
+  if mr.state == "merged" or mr.merged_at ~= nil then
+    SetStatus(204, "No Content")
+  else
+    respond_json(404, { message = "Pull Request is not merged" })
+  end
+end)
+
+-- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
+b:rest("put_pull_merge", function(owner, repo_name, pull_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local gl = {}
+  if req.merge_method then
+    gl.merge_method = req.merge_method
+  end
+  local ok, status = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/merge",
+    "PUT",
+    EncodeJson(gl)
+  )
+  proxy_204({ 200 }, ok, status)
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+-- GitLab: reviewers assigned to the MR.
+b:rest("get_pull_requested_reviewers", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/reviewers"
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local reviewers = DecodeJson(body) or {}
+  local users = {}
+  for _, u in ipairs(reviewers) do
+    users[#users + 1] = translate_gl_user(u)
+  end
+  respond_json(200, { users = users, teams = {} })
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+-- GitLab: MR approvals mapped to GitHub reviews.
+b:rest("get_pull_reviews", function(owner, repo_name, pull_number)
+  local ok, status, _, body = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/approvals"
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local approvals = DecodeJson(body) or {}
+  respond_json(200, translate_gl_approvals_to_reviews(approvals))
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
+b:rest("get_pull_review", function(owner, repo_name, pull_number, review_id)
+  local ok, status, _, body = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/approvals"
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local approvals = DecodeJson(body) or {}
+  local reviews = translate_gl_approvals_to_reviews(approvals)
+  local rid = tonumber(review_id)
+  if rid and reviews[rid] then
+    respond_json(200, reviews[rid])
+  else
+    respond_json(404, { message = "Not Found" })
+  end
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
+-- GitLab has no per-review inline comments; return all inline MR notes.
+b:rest("get_pull_review_comments", function(owner, repo_name, pull_number)
+  local result, status = fetch_gl_mr_review_comments(owner, repo_name, pull_number)
+  if not result then
+    respond_json(status or 503, {})
+    return
+  end
+  respond_json(200, result)
+end)
+
+-- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
+-- GitLab: inline (position-based) MR notes.
+b:rest("get_pull_comments", function(owner, repo_name, pull_number)
+  local result, status = fetch_gl_mr_review_comments(owner, repo_name, pull_number)
+  if not result then
+    respond_json(status or 503, {})
+    return
+  end
+  respond_json(200, result)
+end)
+
+-- Search -----------------------------------------------------------------------
+
+-- GET /search/repositories — maps to GitLab GET /projects?search=<q>
+b:rest("search_repositories", function()
+  local q = GetParam("q") or ""
+  proxy_search_gl(translate_gl_repo, append_page_params(base() .. "/projects?search=" .. q, PAGES))
+end)
+
+-- GET /search/users — maps to GitLab GET /users?search=<q>
+b:rest("search_users", function()
+  local q = GetParam("q") or ""
+  proxy_search_gl(translate_gl_user, append_page_params(base() .. "/users?search=" .. q, PAGES))
+end)
+
+-- Gitignore -----------------------------------------------------------------
+
+-- GET /gitignore/templates → GitLab GET /api/v4/templates/gitignores
+-- GitLab returns [{key,name}, ...]; GitHub returns ["Name", ...]
+b:rest("get_gitignore_templates", function()
+  proxy_json(function(list)
+    local names = {}
+    for i, t in ipairs(list or {}) do
+      names[i] = t.name
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
+    return names
+  end, fetch_json(base() .. "/templates/gitignores"))
+end)
+
+-- GET /gitignore/templates/{name} → GitLab GET /api/v4/templates/gitignores/{name}
+-- GitLab returns {name, content}; GitHub returns {name, source}
+b:rest("get_gitignore_template", function(name)
+  proxy_json(function(t)
+    if not t then
+      return {}
     end
-    local mr = DecodeJson(body) or {}
-    if mr.state == "merged" or mr.merged_at ~= nil then
-      SetStatus(204, "No Content")
-    else
-      respond_json(404, { message = "Pull Request is not merged" })
+    return { name = t.name, source = t.content }
+  end, fetch_json(base() .. "/templates/gitignores/" .. name))
+end)
+
+-- Licenses -----------------------------------------------------------------
+
+-- GET /licenses → GitLab GET /api/v4/templates/licenses
+-- GitLab returns [{key,name,...}]; GitHub returns [{key,name,...}] (license-simple)
+b:rest("get_licenses", function()
+  proxy_json(function(list)
+    local result = {}
+    for i, t in ipairs(list or {}) do
+      result[i] = { key = t.key, name = t.name }
     end
-  end,
+    return result
+  end, fetch_json(base() .. "/templates/licenses"))
+end)
 
-  -- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
-  put_pull_merge = function(owner, repo_name, pull_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local gl = {}
-    if req.merge_method then
-      gl.merge_method = req.merge_method
+-- GET /licenses/{license} → GitLab GET /api/v4/templates/licenses/{key}
+-- GitLab returns {key,name,content,description,conditions,permissions,limitations,html_url}
+-- GitHub returns {key,name,body,description,conditions,permissions,limitations,html_url,...}
+b:rest("get_license", function(license_name)
+  proxy_json(function(t)
+    if not t then
+      return {}
     end
-    local ok, status = fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/merge_requests/"
-        .. pull_number
-        .. "/merge",
-      "PUT",
-      EncodeJson(gl)
-    )
-    proxy_204({ 200 }, ok, status)
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
-  -- GitLab: reviewers assigned to the MR.
-  get_pull_requested_reviewers = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/merge_requests/"
-        .. pull_number
-        .. "/reviewers"
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local reviewers = DecodeJson(body) or {}
-    local users = {}
-    for _, u in ipairs(reviewers) do
-      users[#users + 1] = translate_gl_user(u)
-    end
-    respond_json(200, { users = users, teams = {} })
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
-  -- GitLab: MR approvals mapped to GitHub reviews.
-  get_pull_reviews = function(owner, repo_name, pull_number)
-    local ok, status, _, body = fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/merge_requests/"
-        .. pull_number
-        .. "/approvals"
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local approvals = DecodeJson(body) or {}
-    respond_json(200, translate_gl_approvals_to_reviews(approvals))
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
-  get_pull_review = function(owner, repo_name, pull_number, review_id)
-    local ok, status, _, body = fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/merge_requests/"
-        .. pull_number
-        .. "/approvals"
-    )
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local approvals = DecodeJson(body) or {}
-    local reviews = translate_gl_approvals_to_reviews(approvals)
-    local rid = tonumber(review_id)
-    if rid and reviews[rid] then
-      respond_json(200, reviews[rid])
-    else
-      respond_json(404, { message = "Not Found" })
-    end
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
-  -- GitLab has no per-review inline comments; return all inline MR notes.
-  get_pull_review_comments = function(owner, repo_name, pull_number)
-    local result, status = fetch_gl_mr_review_comments(owner, repo_name, pull_number)
-    if not result then
-      respond_json(status or 503, {})
-      return
-    end
-    respond_json(200, result)
-  end,
-
-  -- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
-  -- GitLab: inline (position-based) MR notes.
-  get_pull_comments = function(owner, repo_name, pull_number)
-    local result, status = fetch_gl_mr_review_comments(owner, repo_name, pull_number)
-    if not result then
-      respond_json(status or 503, {})
-      return
-    end
-    respond_json(200, result)
-  end,
-
-  -- Search -----------------------------------------------------------------------
-
-  -- GET /search/repositories — maps to GitLab GET /projects?search=<q>
-  search_repositories = function()
-    local q = GetParam("q") or ""
-    proxy_search_gl(
-      translate_gl_repo,
-      append_page_params(base() .. "/projects?search=" .. q, PAGES)
-    )
-  end,
-
-  -- GET /search/users — maps to GitLab GET /users?search=<q>
-  search_users = function()
-    local q = GetParam("q") or ""
-    proxy_search_gl(translate_gl_user, append_page_params(base() .. "/users?search=" .. q, PAGES))
-  end,
-
-  -- Gitignore -----------------------------------------------------------------
-
-  -- GET /gitignore/templates → GitLab GET /api/v4/templates/gitignores
-  -- GitLab returns [{key,name}, ...]; GitHub returns ["Name", ...]
-  get_gitignore_templates = function()
-    proxy_json(function(list)
-      local names = {}
-      for i, t in ipairs(list or {}) do
-        names[i] = t.name
-      end
-      return names
-    end, fetch_json(base() .. "/templates/gitignores"))
-  end,
-
-  -- GET /gitignore/templates/{name} → GitLab GET /api/v4/templates/gitignores/{name}
-  -- GitLab returns {name, content}; GitHub returns {name, source}
-  get_gitignore_template = function(name)
-    proxy_json(function(t)
-      if not t then
-        return {}
-      end
-      return { name = t.name, source = t.content }
-    end, fetch_json(base() .. "/templates/gitignores/" .. name))
-  end,
-
-  -- Licenses -----------------------------------------------------------------
-
-  -- GET /licenses → GitLab GET /api/v4/templates/licenses
-  -- GitLab returns [{key,name,...}]; GitHub returns [{key,name,...}] (license-simple)
-  get_licenses = function()
-    proxy_json(function(list)
-      local result = {}
-      for i, t in ipairs(list or {}) do
-        result[i] = { key = t.key, name = t.name }
-      end
-      return result
-    end, fetch_json(base() .. "/templates/licenses"))
-  end,
-
-  -- GET /licenses/{license} → GitLab GET /api/v4/templates/licenses/{key}
-  -- GitLab returns {key,name,content,description,conditions,permissions,limitations,html_url}
-  -- GitHub returns {key,name,body,description,conditions,permissions,limitations,html_url,...}
-  get_license = function(license_name)
-    proxy_json(function(t)
-      if not t then
-        return {}
-      end
-      return {
-        key = t.key,
-        name = t.name,
-        html_url = t.html_url,
-        description = t.description,
-        body = t.content,
-        permissions = t.permissions or {},
-        conditions = t.conditions or {},
-        limitations = t.limitations or {},
-      }
-    end, fetch_json(base() .. "/templates/licenses/" .. license_name))
-  end,
-
-  -- GET /repos/{owner}/{repo}/license
-  -- Combines /repository/files/LICENSE content with project license metadata.
-  get_repo_license = function(owner, repo_name)
-    local pid = project_id(owner, repo_name)
-    local ok, status, _, body =
-      fetch_json(base() .. "/projects/" .. pid .. "/repository/files/LICENSE?ref=HEAD")
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local f = DecodeJson(body) or {}
-    local rok, rstatus, _, rbody = fetch_json(base() .. "/projects/" .. pid)
-    local license_meta = nil
-    if rok and rstatus == 200 then
-      local lic = (DecodeJson(rbody) or {}).license
-      if lic then
-        license_meta = { key = lic.key, name = lic.name }
-      end
-    end
-    respond_json(200, {
-      name = f.file_name,
-      path = f.file_path,
-      sha = f.blob_id,
-      size = f.size,
-      type = "file",
-      content = f.content,
-      encoding = f.encoding,
-      license = license_meta,
-    })
-  end,
-
-  -- Checks (via GitLab commit statuses and pipelines) -------------------------
-  --
-  -- GitHub Check Runs map onto GitLab commit statuses.  GitLab has no concept
-  -- of a check run independent of a commit SHA, so:
-  --   • POST check-runs → POST /projects/{id}/statuses/{sha}
-  --   • GET check-runs/{id} → minimal stub (no reverse lookup by ID)
-  --   • PATCH check-runs/{id} → minimal stub
-  --   • GET commits/{ref}/check-runs → commit statuses list
-  --   • Check Suites have no GitLab equivalent; all suite endpoints are stubs.
-  --   • Annotations are always empty.
-  --
-  -- Status mapping (GitHub → GitLab):
-  --   queued/in_progress     → running
-  --   completed/success      → success
-  --   completed/failure      → failed
-  --   completed/neutral      → success
-  --   completed/skipped      → success
-  --   completed/(other)      → failed
-  --
-  -- Status mapping (GitLab → GitHub):
-  --   pending → status=queued,      conclusion=null
-  --   running → status=in_progress, conclusion=null
-  --   success → status=completed,   conclusion=success
-  --   failed  → status=completed,   conclusion=failure
-  --   canceled→ status=completed,   conclusion=cancelled
-  --   other   → status=completed,   conclusion=failure
-
-  -- Translate a GitLab commit status object to a GitHub check run object.
-  -- id is taken from the GitLab status.id field (used as check_run_id).
-  post_check_runs = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local sha = req.head_sha or ""
-    local status = req.status or "queued"
-    local conclusion = req.conclusion
-    local gh_conclusion_to_gl = {
-      success = "success",
-      neutral = "success",
-      skipped = "success",
+    return {
+      key = t.key,
+      name = t.name,
+      html_url = t.html_url,
+      description = t.description,
+      body = t.content,
+      permissions = t.permissions or {},
+      conditions = t.conditions or {},
+      limitations = t.limitations or {},
     }
-    local gl_state = status == "completed" and (gh_conclusion_to_gl[conclusion] or "failed")
-      or "running"
-    local gl_body = EncodeJson({
-      state = gl_state,
-      target_url = req.details_url or "",
-      description = (req.output and req.output.summary) or req.name or "",
-      name = req.name or "",
-      context = req.name or "",
-      ref = sha,
-    })
-    local function translate(s)
-      if not s then
-        return {}
-      end
-      local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
-        or { status = "completed", conclusion = "failure" }
-      return {
-        id = s.id,
-        node_id = "",
-        head_sha = sha,
-        name = s.name or "",
-        status = mapped.status,
-        conclusion = mapped.conclusion,
-        started_at = s.created_at,
-        completed_at = mapped.status == "completed" and s.updated_at or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.target_url or "",
-        details_url = s.target_url or "",
-      }
-    end
-    proxy_json_created(
-      translate,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
-        "POST",
-        gl_body
-      )
-    )
-  end,
+  end, fetch_json(base() .. "/templates/licenses/" .. license_name))
+end)
 
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- Uses GitLab commit statuses.
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local ok, status, _, body = fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/repository/commits/"
-        .. ref
-        .. "/statuses"
-    )
-    if not ok then
-      respond_json(503, {})
-      return
+-- GET /repos/{owner}/{repo}/license
+-- Combines /repository/files/LICENSE content with project license metadata.
+b:rest("get_repo_license", function(owner, repo_name)
+  local pid = project_id(owner, repo_name)
+  local ok, status, _, body =
+    fetch_json(base() .. "/projects/" .. pid .. "/repository/files/LICENSE?ref=HEAD")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local f = DecodeJson(body) or {}
+  local rok, rstatus, _, rbody = fetch_json(base() .. "/projects/" .. pid)
+  local license_meta = nil
+  if rok and rstatus == 200 then
+    local lic = (DecodeJson(rbody) or {}).license
+    if lic then
+      license_meta = { key = lic.key, name = lic.name }
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local statuses = DecodeJson(body) or {}
-    local runs = {}
-    for i, s in ipairs(statuses) do
-      local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
-        or { status = "completed", conclusion = "failure" }
-      runs[i] = {
-        id = s.id,
-        node_id = "",
-        head_sha = ref,
-        name = s.name or "",
-        status = mapped.status,
-        conclusion = mapped.conclusion,
-        started_at = s.created_at,
-        completed_at = mapped.status == "completed" and s.updated_at or nil,
-        output = {
-          title = s.description or "",
-          summary = s.description or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = s.target_url or "",
-        details_url = s.target_url or "",
-      }
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
+  end
+  respond_json(200, {
+    name = f.file_name,
+    path = f.file_path,
+    sha = f.blob_id,
+    size = f.size,
+    type = "file",
+    content = f.content,
+    encoding = f.encoding,
+    license = license_meta,
+  })
+end)
 
-  -- Check suites have no GitLab equivalent; all suite endpoints fall back to
-  -- the route_defaults stubs defined in .init.lua.
+-- Checks (via GitLab commit statuses and pipelines) -------------------------
+--
+-- GitHub Check Runs map onto GitLab commit statuses.  GitLab has no concept
+-- of a check run independent of a commit SHA, so:
+--   • POST check-runs → POST /projects/{id}/statuses/{sha}
+--   • GET check-runs/{id} → minimal stub (no reverse lookup by ID)
+--   • PATCH check-runs/{id} → minimal stub
+--   • GET commits/{ref}/check-runs → commit statuses list
+--   • Check Suites have no GitLab equivalent; all suite endpoints are stubs.
+--   • Annotations are always empty.
+--
+-- Status mapping (GitHub → GitLab):
+--   queued/in_progress     → running
+--   completed/success      → success
+--   completed/failure      → failed
+--   completed/neutral      → success
+--   completed/skipped      → success
+--   completed/(other)      → failed
+--
+-- Status mapping (GitLab → GitHub):
+--   pending → status=queued,      conclusion=null
+--   running → status=in_progress, conclusion=null
+--   success → status=completed,   conclusion=success
+--   failed  → status=completed,   conclusion=failure
+--   canceled→ status=completed,   conclusion=cancelled
+--   other   → status=completed,   conclusion=failure
 
-  -- Packages (org via GitLab group packages API) --------------------------------
-
-  get_org_packages = function(org)
-    local pkg_type = GetParam("package_type") or ""
-    local url = base() .. "/groups/" .. org .. "/packages"
-    if pkg_type ~= "" then
-      url = url .. "?package_type=" .. pkg_type
+-- Translate a GitLab commit status object to a GitHub check run object.
+-- id is taken from the GitLab status.id field (used as check_run_id).
+b:rest("post_check_runs", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local sha = req.head_sha or ""
+  local status = req.status or "queued"
+  local conclusion = req.conclusion
+  local gh_conclusion_to_gl = {
+    success = "success",
+    neutral = "success",
+    skipped = "success",
+  }
+  local gl_state = status == "completed" and (gh_conclusion_to_gl[conclusion] or "failed")
+    or "running"
+  local gl_body = EncodeJson({
+    state = gl_state,
+    target_url = req.details_url or "",
+    description = (req.output and req.output.summary) or req.name or "",
+    name = req.name or "",
+    context = req.name or "",
+    ref = sha,
+  })
+  local function translate(s)
+    if not s then
+      return {}
     end
-    url = append_page_params(url, PAGES)
-    proxy_json_paged(function(entries)
-      local pkgs = {}
-      for i, p in ipairs(entries) do
-        pkgs[i] = {
-          id = p.id,
-          name = p.name or "",
-          package_type = p.package_type or "",
-          url = "",
-          html_url = p._links and p._links.web_path or "",
-          version_count = 1,
-          visibility = "public",
-          owner = nil,
-          repository = nil,
-          created_at = p.created_at,
-          updated_at = p.created_at,
-        }
-      end
-      return pkgs
-    end, PAGES, fetch_json(url))
-  end,
-
-  get_org_package = function(org, pkg_type, pkg_name)
-    local url = base()
-      .. "/groups/"
-      .. org
-      .. "/packages?package_type="
-      .. pkg_type
-      .. "&package_name="
-      .. pkg_name
-      .. "&per_page=100"
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local entries = DecodeJson(body) or {}
-    if #entries == 0 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local p = entries[1]
-    respond_json(200, {
-      id = p.id,
-      name = p.name or "",
-      package_type = p.package_type or "",
+    local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
+      or { status = "completed", conclusion = "failure" }
+    return {
+      id = s.id,
+      node_id = "",
+      head_sha = sha,
+      name = s.name or "",
+      status = mapped.status,
+      conclusion = mapped.conclusion,
+      started_at = s.created_at,
+      completed_at = mapped.status == "completed" and s.updated_at or nil,
+      output = {
+        title = s.description or "",
+        summary = s.description or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
       url = "",
-      html_url = p._links and p._links.web_path or "",
-      version_count = #entries,
-      visibility = "public",
-      owner = nil,
-      repository = nil,
-      created_at = p.created_at,
-      updated_at = p.created_at,
-    })
-  end,
-
-  delete_org_package = function(org, pkg_type, pkg_name)
-    local url = base()
-      .. "/groups/"
-      .. org
-      .. "/packages?package_type="
-      .. pkg_type
-      .. "&package_name="
-      .. pkg_name
-      .. "&per_page=100"
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local entries = DecodeJson(body) or {}
-    if #entries == 0 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    for _, p in ipairs(entries) do
-      fetch_json(base() .. "/projects/" .. p.project_id .. "/packages/" .. p.id, "DELETE")
-    end
-    set_preamble(204)
-  end,
-
-  get_org_package_versions = function(org, pkg_type, pkg_name)
-    local url = base()
-      .. "/groups/"
-      .. org
-      .. "/packages?package_type="
-      .. pkg_type
-      .. "&package_name="
-      .. pkg_name
-    url = append_page_params(url, PAGES)
-    proxy_json_paged(function(entries)
-      local versions = {}
-      for i, p in ipairs(entries) do
-        versions[i] = {
-          id = p.id,
-          name = p.version or "",
-          url = "",
-          package_html_url = "",
-          html_url = p._links and p._links.web_path or "",
-          license = "",
-          description = "",
-          created_at = p.created_at,
-          updated_at = p.created_at,
-          deleted_at = nil,
-          metadata = { package_type = p.package_type or "" },
-        }
-      end
-      return versions
-    end, PAGES, fetch_json(url))
-  end,
-
-  get_org_package_version = function(org, pkg_type, pkg_name, version_id)
-    local url = base()
-      .. "/groups/"
-      .. org
-      .. "/packages?package_type="
-      .. pkg_type
-      .. "&package_name="
-      .. pkg_name
-      .. "&per_page=100"
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local vid = tonumber(version_id)
-    for _, p in ipairs(DecodeJson(body) or {}) do
-      if p.id == vid then
-        respond_json(200, {
-          id = p.id,
-          name = p.version or "",
-          url = "",
-          package_html_url = "",
-          html_url = p._links and p._links.web_path or "",
-          license = "",
-          description = "",
-          created_at = p.created_at,
-          updated_at = p.created_at,
-          deleted_at = nil,
-          metadata = { package_type = p.package_type or "" },
-        })
-        return
-      end
-    end
-    respond_json(404, { message = "Not Found" })
-  end,
-
-  delete_org_package_version = function(org, pkg_type, pkg_name, version_id)
-    local url = base()
-      .. "/groups/"
-      .. org
-      .. "/packages?package_type="
-      .. pkg_type
-      .. "&package_name="
-      .. pkg_name
-      .. "&per_page=100"
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local vid = tonumber(version_id)
-    for _, p in ipairs(DecodeJson(body) or {}) do
-      if p.id == vid then
-        local dopts = auth() or {}
-        dopts.method = "DELETE"
-        local dok, dstatus =
-          pcall(Fetch, base() .. "/projects/" .. p.project_id .. "/packages/" .. p.id, dopts)
-        if dok and dstatus == 204 then
-          set_preamble(204)
-        elseif dok then
-          respond_json(dstatus, {})
-        else
-          respond_json(503, {})
-        end
-        return
-      end
-    end
-    respond_json(404, { message = "Not Found" })
-  end,
-
-  -- Markdown -------------------------------------------------------------------
-
-  -- POST /markdown → POST /api/v4/markdown
-  -- GitLab returns {"html": "..."} JSON; extract the html field.
-  render_markdown = function()
-    local incoming = DecodeJson(GetBody() or "{}") or {}
-    local payload = EncodeJson({ text = incoming.text or "", gfm = true })
-    local opts = auth() or {}
-    opts.method = "POST"
-    opts.body = payload
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "application/json"
-    local ok, status, _, body = pcall(Fetch, base() .. "/markdown", opts)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    local parsed = DecodeJson(body or "{}") or {}
-    set_preamble(status, "text/html; charset=utf-8")
-    Write(parsed.html or "")
-  end,
-
-  -- Git database (https://docs.github.com/en/rest/git) -----------------------
-
-  -- GET /repos/{owner}/{repo}/git/blobs/{file_sha}
-  -- GitLab: GET /projects/:id/repository/blobs/:sha
-  -- Returns {size, encoding, content, sha} — translate to GitHub blob shape.
-  get_git_blob = function(owner, repo_name, file_sha)
-    proxy_json(
-      function(b)
-        return {
-          content = b.content,
-          encoding = b.encoding,
-          url = "",
-          sha = b.sha,
-          size = b.size,
-          node_id = "",
-        }
-      end,
-      fetch_json(
-        base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/blobs/" .. file_sha
-      )
+      html_url = s.target_url or "",
+      details_url = s.target_url or "",
+    }
+  end
+  proxy_json_created(
+    translate,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
+      "POST",
+      gl_body
     )
-  end,
+  )
+end)
 
-  -- POST /markdown/raw → POST /api/v4/markdown
-  -- GitLab has no separate raw endpoint; wrap the plain-text body in JSON.
-  render_markdown_raw = function()
-    local raw = GetBody() or ""
-    local payload = EncodeJson({ text = raw, gfm = true })
-    local opts = auth() or {}
-    opts.method = "POST"
-    opts.body = payload
-    opts.headers = opts.headers or {}
-    opts.headers["Content-Type"] = "application/json"
-    local ok, status, _, body = pcall(Fetch, base() .. "/markdown", opts)
-    if not ok then
-      respond_json(503, {})
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- Uses GitLab commit statuses.
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local ok, status, _, body = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/repository/commits/"
+      .. ref
+      .. "/statuses"
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local statuses = DecodeJson(body) or {}
+  local runs = {}
+  for i, s in ipairs(statuses) do
+    local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
+      or { status = "completed", conclusion = "failure" }
+    runs[i] = {
+      id = s.id,
+      node_id = "",
+      head_sha = ref,
+      name = s.name or "",
+      status = mapped.status,
+      conclusion = mapped.conclusion,
+      started_at = s.created_at,
+      completed_at = mapped.status == "completed" and s.updated_at or nil,
+      output = {
+        title = s.description or "",
+        summary = s.description or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = s.target_url or "",
+      details_url = s.target_url or "",
+    }
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
+
+-- Check suites have no GitLab equivalent; all suite endpoints fall back to
+-- the route_defaults stubs defined in .init.lua.
+
+-- Packages (org via GitLab group packages API) --------------------------------
+
+b:rest("get_org_packages", function(org)
+  local pkg_type = GetParam("package_type") or ""
+  local url = base() .. "/groups/" .. org .. "/packages"
+  if pkg_type ~= "" then
+    url = url .. "?package_type=" .. pkg_type
+  end
+  url = append_page_params(url, PAGES)
+  proxy_json_paged(function(entries)
+    local pkgs = {}
+    for i, p in ipairs(entries) do
+      pkgs[i] = {
+        id = p.id,
+        name = p.name or "",
+        package_type = p.package_type or "",
+        url = "",
+        html_url = p._links and p._links.web_path or "",
+        version_count = 1,
+        visibility = "public",
+        owner = nil,
+        repository = nil,
+        created_at = p.created_at,
+        updated_at = p.created_at,
+      }
+    end
+    return pkgs
+  end, PAGES, fetch_json(url))
+end)
+
+b:rest("get_org_package", function(org, pkg_type, pkg_name)
+  local url = base()
+    .. "/groups/"
+    .. org
+    .. "/packages?package_type="
+    .. pkg_type
+    .. "&package_name="
+    .. pkg_name
+    .. "&per_page=100"
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local entries = DecodeJson(body) or {}
+  if #entries == 0 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local p = entries[1]
+  respond_json(200, {
+    id = p.id,
+    name = p.name or "",
+    package_type = p.package_type or "",
+    url = "",
+    html_url = p._links and p._links.web_path or "",
+    version_count = #entries,
+    visibility = "public",
+    owner = nil,
+    repository = nil,
+    created_at = p.created_at,
+    updated_at = p.created_at,
+  })
+end)
+
+b:rest("delete_org_package", function(org, pkg_type, pkg_name)
+  local url = base()
+    .. "/groups/"
+    .. org
+    .. "/packages?package_type="
+    .. pkg_type
+    .. "&package_name="
+    .. pkg_name
+    .. "&per_page=100"
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local entries = DecodeJson(body) or {}
+  if #entries == 0 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  for _, p in ipairs(entries) do
+    fetch_json(base() .. "/projects/" .. p.project_id .. "/packages/" .. p.id, "DELETE")
+  end
+  set_preamble(204)
+end)
+
+b:rest("get_org_package_versions", function(org, pkg_type, pkg_name)
+  local url = base()
+    .. "/groups/"
+    .. org
+    .. "/packages?package_type="
+    .. pkg_type
+    .. "&package_name="
+    .. pkg_name
+  url = append_page_params(url, PAGES)
+  proxy_json_paged(function(entries)
+    local versions = {}
+    for i, p in ipairs(entries) do
+      versions[i] = {
+        id = p.id,
+        name = p.version or "",
+        url = "",
+        package_html_url = "",
+        html_url = p._links and p._links.web_path or "",
+        license = "",
+        description = "",
+        created_at = p.created_at,
+        updated_at = p.created_at,
+        deleted_at = nil,
+        metadata = { package_type = p.package_type or "" },
+      }
+    end
+    return versions
+  end, PAGES, fetch_json(url))
+end)
+
+b:rest("get_org_package_version", function(org, pkg_type, pkg_name, version_id)
+  local url = base()
+    .. "/groups/"
+    .. org
+    .. "/packages?package_type="
+    .. pkg_type
+    .. "&package_name="
+    .. pkg_name
+    .. "&per_page=100"
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local vid = tonumber(version_id)
+  for _, p in ipairs(DecodeJson(body) or {}) do
+    if p.id == vid then
+      respond_json(200, {
+        id = p.id,
+        name = p.version or "",
+        url = "",
+        package_html_url = "",
+        html_url = p._links and p._links.web_path or "",
+        license = "",
+        description = "",
+        created_at = p.created_at,
+        updated_at = p.created_at,
+        deleted_at = nil,
+        metadata = { package_type = p.package_type or "" },
+      })
       return
     end
-    local parsed = DecodeJson(body or "{}") or {}
-    set_preamble(status, "text/html; charset=utf-8")
-    Write(parsed.html or "")
-  end,
-}
+  end
+  respond_json(404, { message = "Not Found" })
+end)
+
+b:rest("delete_org_package_version", function(org, pkg_type, pkg_name, version_id)
+  local url = base()
+    .. "/groups/"
+    .. org
+    .. "/packages?package_type="
+    .. pkg_type
+    .. "&package_name="
+    .. pkg_name
+    .. "&per_page=100"
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local vid = tonumber(version_id)
+  for _, p in ipairs(DecodeJson(body) or {}) do
+    if p.id == vid then
+      local dopts = auth() or {}
+      dopts.method = "DELETE"
+      local dok, dstatus =
+        pcall(Fetch, base() .. "/projects/" .. p.project_id .. "/packages/" .. p.id, dopts)
+      if dok and dstatus == 204 then
+        set_preamble(204)
+      elseif dok then
+        respond_json(dstatus, {})
+      else
+        respond_json(503, {})
+      end
+      return
+    end
+  end
+  respond_json(404, { message = "Not Found" })
+end)
+
+-- Markdown -------------------------------------------------------------------
+
+-- POST /markdown → POST /api/v4/markdown
+-- GitLab returns {"html": "..."} JSON; extract the html field.
+b:rest("render_markdown", function()
+  local incoming = DecodeJson(GetBody() or "{}") or {}
+  local payload = EncodeJson({ text = incoming.text or "", gfm = true })
+  local opts = auth() or {}
+  opts.method = "POST"
+  opts.body = payload
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "application/json"
+  local ok, status, _, body = pcall(Fetch, base() .. "/markdown", opts)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  local parsed = DecodeJson(body or "{}") or {}
+  set_preamble(status, "text/html; charset=utf-8")
+  Write(parsed.html or "")
+end)
+
+-- Git database (https://docs.github.com/en/rest/git) -----------------------
+
+-- GET /repos/{owner}/{repo}/git/blobs/{file_sha}
+-- GitLab: GET /projects/:id/repository/blobs/:sha
+-- Returns {size, encoding, content, sha} — translate to GitHub blob shape.
+b:rest("get_git_blob", function(owner, repo_name, file_sha)
+  proxy_json(
+    function(br)
+      return {
+        content = br.content,
+        encoding = br.encoding,
+        url = "",
+        sha = br.sha,
+        size = br.size,
+        node_id = "",
+      }
+    end,
+    fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/blobs/" .. file_sha
+    )
+  )
+end)
+
+-- POST /markdown/raw → POST /api/v4/markdown
+-- GitLab has no separate raw endpoint; wrap the plain-text body in JSON.
+b:rest("render_markdown_raw", function()
+  local raw = GetBody() or ""
+  local payload = EncodeJson({ text = raw, gfm = true })
+  local opts = auth() or {}
+  opts.method = "POST"
+  opts.body = payload
+  opts.headers = opts.headers or {}
+  opts.headers["Content-Type"] = "application/json"
+  local ok, status, _, body = pcall(Fetch, base() .. "/markdown", opts)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  local parsed = DecodeJson(body or "{}") or {}
+  set_preamble(status, "text/html; charset=utf-8")
+  Write(parsed.html or "")
+end)
 
 -- Dependabot alerts via GitLab Vulnerabilities API (requires Ultimate tier).
 --
@@ -3334,26 +3452,24 @@ local function translate_gl_vuln_list(arr)
   return result
 end
 
-local _b = app.backend_impl
-
-_b.list_repo_dependabot_alerts = function(owner, repo_name)
+b:rest("list_repo_dependabot_alerts", function(owner, repo_name)
   proxy_json_paged(
     translate_gl_vuln_list,
     PAGES,
     fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities")
   )
-end
+end)
 
-_b.get_repo_dependabot_alert = function(owner, repo_name, alert_number)
+b:rest("get_repo_dependabot_alert", function(owner, repo_name, alert_number)
   proxy_json(
     translate_gl_vulnerability,
     fetch_json(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
     )
   )
-end
+end)
 
-_b.update_repo_dependabot_alert = function(_owner, _repo_name, alert_number)
+b:rest("update_repo_dependabot_alert", function(_owner, _repo_name, alert_number)
   local req = DecodeJson(GetBody() or "{}")
   local action = GH_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
   local gl_url = base() .. "/vulnerabilities/" .. alert_number .. "/" .. action
@@ -3367,15 +3483,15 @@ _b.update_repo_dependabot_alert = function(_owner, _repo_name, alert_number)
     return
   end
   respond_json(200, translate_gl_vulnerability(DecodeJson(body) or {}))
-end
+end)
 
-_b.list_org_dependabot_alerts = function(org)
+b:rest("list_org_dependabot_alerts", function(org)
   proxy_json_paged(
     translate_gl_vuln_list,
     PAGES,
     fetch_json(base() .. "/groups/" .. org .. "/vulnerabilities")
   )
-end
+end)
 
 -- Secret Scanning via GitLab Secret Detection ----------------------------------
 --
@@ -3462,7 +3578,7 @@ local function translate_gl_secret_list(arr)
   return result
 end
 
-_b.list_repo_secret_scanning_alerts = function(owner, repo_name)
+b:rest("list_repo_secret_scanning_alerts", function(owner, repo_name)
   proxy_json_paged(
     translate_gl_secret_list,
     PAGES,
@@ -3473,26 +3589,26 @@ _b.list_repo_secret_scanning_alerts = function(owner, repo_name)
         .. "/vulnerabilities?report_type=secret_detection"
     )
   )
-end
+end)
 
-_b.list_org_secret_scanning_alerts = function(org)
+b:rest("list_org_secret_scanning_alerts", function(org)
   proxy_json_paged(
     translate_gl_secret_list,
     PAGES,
     fetch_json(base() .. "/groups/" .. org .. "/vulnerabilities?report_type=secret_detection")
   )
-end
+end)
 
-_b.get_secret_scanning_alert = function(owner, repo_name, alert_number)
+b:rest("get_secret_scanning_alert", function(owner, repo_name, alert_number)
   proxy_json(
     translate_gl_secret_alert,
     fetch_json(
       base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
     )
   )
-end
+end)
 
-_b.update_secret_scanning_alert = function(_owner, _repo_name, alert_number)
+b:rest("update_secret_scanning_alert", function(_owner, _repo_name, alert_number)
   local req = DecodeJson(GetBody() or "{}")
   local action = GH_SECRET_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
   local gl_url = base() .. "/vulnerabilities/" .. alert_number .. "/" .. action
@@ -3506,7 +3622,7 @@ _b.update_secret_scanning_alert = function(_owner, _repo_name, alert_number)
     return
   end
   respond_json(200, translate_gl_secret_alert(DecodeJson(body) or {}))
-end
+end)
 
 -- Gists (GitLab Snippets) ----------------------------------------------------
 
@@ -3602,43 +3718,43 @@ local function delete_snippet(url)
   proxy_204({ 200 }, pcall(Fetch, url, opts))
 end
 
-_b.get_gists = function()
+b:rest("get_gists", function()
   proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets"))
-end
+end)
 
-_b.get_gists_public = function()
+b:rest("get_gists_public", function()
   proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets/public"))
-end
+end)
 
-_b.post_gists = function()
+b:rest("post_gists", function()
   local req = DecodeJson(GetBody() or "{}") or {}
   proxy_json_created(
     translate_gl_snippet,
     fetch_json(base() .. "/snippets", "POST", gl_snippet_req(req))
   )
-end
+end)
 
-_b.get_gist = function(id)
+b:rest("get_gist", function(id)
   proxy_json(translate_gl_snippet, fetch_json(base() .. "/snippets/" .. id))
-end
+end)
 
-_b.patch_gist = function(id)
+b:rest("patch_gist", function(id)
   local req = DecodeJson(GetBody() or "{}") or {}
   proxy_json(
     translate_gl_snippet,
     fetch_json(base() .. "/snippets/" .. id, "PUT", gl_snippet_req(req))
   )
-end
+end)
 
-_b.delete_gist = function(id)
+b:rest("delete_gist", function(id)
   delete_snippet(base() .. "/snippets/" .. id)
-end
+end)
 
-_b.get_gist_comments = function(id)
+b:rest("get_gist_comments", function(id)
   proxy_json_list(translate_gl_snippet_notes, fetch_json(base() .. "/snippets/" .. id .. "/notes"))
-end
+end)
 
-_b.post_gist_comment = function(id)
+b:rest("post_gist_comment", function(id)
   local req = DecodeJson(GetBody() or "{}") or {}
   proxy_json_created(
     translate_gl_snippet_note,
@@ -3648,16 +3764,16 @@ _b.post_gist_comment = function(id)
       EncodeJson({ body = req.body or "" })
     )
   )
-end
+end)
 
-_b.get_gist_comment = function(id, comment_id)
+b:rest("get_gist_comment", function(id, comment_id)
   proxy_json(
     translate_gl_snippet_note,
     fetch_json(base() .. "/snippets/" .. id .. "/notes/" .. comment_id)
   )
-end
+end)
 
-_b.patch_gist_comment = function(id, comment_id)
+b:rest("patch_gist_comment", function(id, comment_id)
   local req = DecodeJson(GetBody() or "{}") or {}
   proxy_json(
     translate_gl_snippet_note,
@@ -3667,16 +3783,16 @@ _b.patch_gist_comment = function(id, comment_id)
       EncodeJson({ body = req.body or "" })
     )
   )
-end
+end)
 
-_b.delete_gist_comment = function(id, comment_id)
+b:rest("delete_gist_comment", function(id, comment_id)
   delete_snippet(base() .. "/snippets/" .. id .. "/notes/" .. comment_id)
-end
+end)
 
-_b.get_user_gists = function(_username)
+b:rest("get_user_gists", function(_username)
   -- GitLab doesn't expose per-user public snippet lists; approximate with own snippets.
   proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets"))
-end
+end)
 
 -- ── Reactions (GitLab award emoji) ────────────────────────────────────────────
 -- GitLab award emoji → GitHub reaction content (8 supported types).
@@ -3720,9 +3836,9 @@ local function translate_gl_awards(awards)
 end
 
 -- Issue reactions: GitLab has full award_emoji support on issues.
-_b.get_issue_reactions = proxy_handler_paged(
-  translate_gl_awards,
-  function(owner, repo_name, issue_number)
+b:rest(
+  "get_issue_reactions",
+  proxy_handler_paged(translate_gl_awards, function(owner, repo_name, issue_number)
     return append_page_params(
       base()
         .. "/projects/"
@@ -3732,12 +3848,12 @@ _b.get_issue_reactions = proxy_handler_paged(
         .. "/award_emoji",
       PAGES
     )
-  end
+  end)
 )
 
-_b.post_issue_reaction = proxy_handler_created(
-  translate_gl_award,
-  function(owner, repo_name, issue_number)
+b:rest(
+  "post_issue_reaction",
+  proxy_handler_created(translate_gl_award, function(owner, repo_name, issue_number)
     local req = DecodeJson(GetBody() or "{}") or {}
     local emoji = CONTENT_TO_GL_EMOJI[req.content or ""] or req.content or ""
     return base()
@@ -3748,10 +3864,10 @@ _b.post_issue_reaction = proxy_handler_created(
       .. "/award_emoji",
       "POST",
       EncodeJson({ name = emoji })
-  end
+  end)
 )
 
-_b.delete_issue_reaction = function(owner, repo_name, issue_number, reaction_id)
+b:rest("delete_issue_reaction", function(owner, repo_name, issue_number, reaction_id)
   local url = base()
     .. "/projects/"
     .. project_id(owner, repo_name)
@@ -3769,7 +3885,7 @@ _b.delete_issue_reaction = function(owner, repo_name, issue_number, reaction_id)
   else
     respond_json(503, {})
   end
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- GraphQL resolvers — Query root fields and node resolvers
@@ -3809,7 +3925,7 @@ local function gl_fetch_user(username)
 end
 
 -- Query.repositoryOwner: look up a User or Organization (GitLab group) by login.
-graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
+b:graphql("Query.repositoryOwner", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "repositoryOwner requires a login argument")
     return nil
@@ -3823,10 +3939,10 @@ graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
     return graphql_translate_org(translate_gl_group_to_org(gdata))
   end
   return nil
-end
+end)
 
 -- Query.viewer: resolve the authenticated user via GET /user.
-graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+b:graphql("Query.viewer", function(_parent, _args, ctx)
   local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
   if not data then
     return nil
@@ -3834,10 +3950,10 @@ graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
   local u = graphql_translate_user(translate_gl_user(data))
   u.isViewer = true
   return u
-end
+end)
 
 -- Query.user: look up a User by login.
-graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+b:graphql("Query.user", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "user requires a login argument")
     return nil
@@ -3847,10 +3963,10 @@ graphql_resolvers["Query.user"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_user(translate_gl_user(udata))
-end
+end)
 
 -- Query.organization: look up a GitLab group by path.
-graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
+b:graphql("Query.organization", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "organization requires a login argument")
     return nil
@@ -3860,10 +3976,10 @@ graphql_resolvers["Query.organization"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_org(translate_gl_group_to_org(data))
-end
+end)
 
 -- Query.repository: look up a Repository by owner and name.
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -3874,10 +3990,10 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(translate_gl_repo(data))
-end
+end)
 
 -- node.Repository: fetch a repository by "owner/repo" local ID.
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local owner, repo = local_id:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3887,28 +4003,28 @@ graphql_resolvers["node.Repository"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_repo(translate_gl_repo(data))
-end
+end)
 
 -- node.User: fetch a user by login.
-graphql_resolvers["node.User"] = function(local_id, _ctx)
+b:graphql("node.User", function(local_id, _ctx)
   local udata, _ = gl_fetch_user(local_id)
   if not udata then
     return nil
   end
   return graphql_translate_user(translate_gl_user(udata))
-end
+end)
 
 -- node.Organization: fetch a group by path.
-graphql_resolvers["node.Organization"] = function(local_id, _ctx)
+b:graphql("node.Organization", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/groups/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_org(translate_gl_group_to_org(data))
-end
+end)
 
 -- node.Issue: fetch an issue by "owner/repo/iid" local ID.
-graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+b:graphql("node.Issue", function(local_id, _ctx)
   local owner, repo, iid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3921,10 +4037,10 @@ graphql_resolvers["node.Issue"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_issue(translate_gl_issue(data), owner, repo)
-end
+end)
 
 -- node.PullRequest: fetch a merge request by "owner/repo/iid" local ID.
-graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
+b:graphql("node.PullRequest", function(local_id, _ctx)
   local owner, repo, iid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3937,11 +4053,11 @@ graphql_resolvers["node.PullRequest"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_pr(translate_gl_mr(data), owner, repo)
-end
+end)
 
 -- node.IssueComment: fetch an issue note by "owner/repo/iid/note_id" local ID.
 -- GitLab notes require the issue iid in the path, so the local ID encodes four segments.
-graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
+b:graphql("node.IssueComment", function(local_id, _ctx)
   local owner, repo, iid, nid = local_id:match("^([^/]+)/([^/]+)/(%d+)/(%d+)$")
   if not owner then
     return nil
@@ -3954,11 +4070,11 @@ graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_comment(translate_gl_note(data), owner, repo)
-end
+end)
 
 -- node.Release: fetch a release by "owner/repo/tag_name" local ID.
 -- GitLab identifies releases by tag_name, not integer ID.
-graphql_resolvers["node.Release"] = function(local_id, _ctx)
+b:graphql("node.Release", function(local_id, _ctx)
   local owner, repo, tag = local_id:match("^([^/]+)/([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -3971,10 +4087,10 @@ graphql_resolvers["node.Release"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_release(translate_gl_release(data), owner, repo)
-end
+end)
 
 -- node.Label: fetch a label by "owner/repo/label_id" local ID.
-graphql_resolvers["node.Label"] = function(local_id, _ctx)
+b:graphql("node.Label", function(local_id, _ctx)
   local owner, repo, lid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -3987,11 +4103,11 @@ graphql_resolvers["node.Label"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_label(translate_gl_label(data), owner, repo)
-end
+end)
 
 -- node.Milestone: fetch a milestone by "owner/repo/number" local ID.
 -- GitLab milestone numbers are iid (project-local); stored as number in the node ID.
-graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
+b:graphql("node.Milestone", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -4004,11 +4120,11 @@ graphql_resolvers["node.Milestone"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_milestone(translate_gl_milestone(data), owner, repo)
-end
+end)
 
 -- node.Commit: fetch a commit by "owner/repo/sha" local ID.
 -- GitLab returns a flat commit object; translate to REST shape before passing to the shared translator.
-graphql_resolvers["node.Commit"] = function(local_id, _ctx)
+b:graphql("node.Commit", function(local_id, _ctx)
   local owner, repo, sha = local_id:match("^([^/]+)/([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4034,11 +4150,11 @@ graphql_resolvers["node.Commit"] = function(local_id, _ctx)
     },
   }
   return graphql_translate_commit(rest_commit, owner, repo)
-end
+end)
 
 -- node.Ref: fetch a branch ref by "owner/repo/refs/heads/..." local ID.
 -- GitLab branch objects use commit.id for the SHA; normalise to commit.sha before translating.
-graphql_resolvers["node.Ref"] = function(local_id, _ctx)
+b:graphql("node.Ref", function(local_id, _ctx)
   local owner, repo, ref_path = local_id:match("^([^/]+)/([^/]+)/(refs/.+)$")
   if not owner then
     return nil
@@ -4059,11 +4175,11 @@ graphql_resolvers["node.Ref"] = function(local_id, _ctx)
   end
   local repo_stub = { __typename = "Repository", nameWithOwner = owner .. "/" .. repo }
   return graphql_translate_ref(data, repo_stub)
-end
+end)
 
 -- node.Team: fetch a team (subgroup) by "org/slug" local ID.
 -- GitLab teams map to subgroups; fetch by URL-encoded path /groups/{org}%2F{slug}.
-graphql_resolvers["node.Team"] = function(local_id, _ctx)
+b:graphql("node.Team", function(local_id, _ctx)
   local org, slug = local_id:match("^([^/]+)/([^/]+)$")
   if not org then
     return nil
@@ -4073,7 +4189,7 @@ graphql_resolvers["node.Team"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_team(translate_gl_team(data), org)
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Repository connection sub-resolvers
@@ -4107,7 +4223,7 @@ end
 
 -- Repository.issues: paginated list of issues.
 -- GitLab issues are always real issues (no PR/issue mixing like Gitea).
-graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+b:graphql("Repository.issues", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4115,10 +4231,10 @@ graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
   return gitlab_repo_connection(owner, name, "/issues", args, ctx, function(i)
     return graphql_translate_issue(translate_gl_issue(i), owner, name)
   end, graphql_issues_connection)
-end
+end)
 
 -- Repository.pullRequests: paginated list of merge requests.
-graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
+b:graphql("Repository.pullRequests", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4126,11 +4242,11 @@ graphql_resolvers["Repository.pullRequests"] = function(parent, args, ctx)
   return gitlab_repo_connection(owner, name, "/merge_requests", args, ctx, function(mr)
     return graphql_translate_pr(translate_gl_mr(mr), owner, name)
   end, graphql_prs_connection)
-end
+end)
 
 -- Repository.releases: paginated list of releases.
 -- GitLab releases use tag_name as identifier; we assign a synthetic integer id.
-graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
+b:graphql("Repository.releases", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4143,10 +4259,10 @@ graphql_resolvers["Repository.releases"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("Release", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.labels: paginated list of labels.
-graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
+b:graphql("Repository.labels", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4154,10 +4270,10 @@ graphql_resolvers["Repository.labels"] = function(parent, args, ctx)
   return gitlab_repo_connection(owner, name, "/labels", args, ctx, function(l)
     return graphql_translate_label(translate_gl_label(l), owner, name)
   end, graphql_labels_connection)
-end
+end)
 
 -- Repository.milestones: paginated list of milestones.
-graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
+b:graphql("Repository.milestones", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4167,26 +4283,26 @@ graphql_resolvers["Repository.milestones"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("Milestone", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.refs: paginated list of branches as Ref objects.
 -- GitLab branch objects use commit.id for the SHA; normalise to commit.sha.
-graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+b:graphql("Repository.refs", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
   end
-  return gitlab_repo_connection(owner, name, "/repository/branches", args, ctx, function(b)
-    if b.commit then
-      b.commit.sha = b.commit.id
+  return gitlab_repo_connection(owner, name, "/repository/branches", args, ctx, function(br)
+    if br.commit then
+      br.commit.sha = br.commit.id
     end
-    return graphql_translate_ref(b, parent)
+    return graphql_translate_ref(br, parent)
   end, graphql_refs_connection)
-end
+end)
 
 -- Repository.collaborators: paginated list of project members as Users.
 -- GitLab uses /members/all (not /collaborators) — consistent with the REST handler.
-graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
+b:graphql("Repository.collaborators", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4196,12 +4312,12 @@ graphql_resolvers["Repository.collaborators"] = function(parent, args, ctx)
   end, function(n, a, t, c)
     return graphql_make_connection("RepositoryCollaborator", n, a, t, c)
   end)
-end
+end)
 
 -- Repository.defaultBranchRef: enrich the inline stub with full branch data.
 -- The parent already carries {__typename="Ref",name="main"} from graphql_translate_repo.
 -- GitLab branch objects use commit.id for the SHA; normalise to commit.sha.
-graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
+b:graphql("Repository.defaultBranchRef", function(parent, _args, _ctx)
   local branch = parent.defaultBranchRef and parent.defaultBranchRef.name
   if not branch then
     return nil
@@ -4221,7 +4337,7 @@ graphql_resolvers["Repository.defaultBranchRef"] = function(parent, _args, _ctx)
     data.commit.sha = data.commit.id
   end
   return graphql_translate_ref(data, parent)
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Issue and PullRequest sub-resolvers
@@ -4231,7 +4347,7 @@ end
 -- GitLab notes are fetched from /projects/{id}/issues/{iid}/notes.
 -- Comment node IDs encode four segments (owner/repo/iid/note_id) so the
 -- node.IssueComment resolver can reconstruct the GitLab API path.
-graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+b:graphql("Issue.comments", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -4268,11 +4384,11 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
     end
   end
   return graphql_make_connection("IssueComment", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.commits: paginated commit list for a merge request.
 -- GitLab MR commits use .id for the SHA and flat author/committer fields.
-graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
+b:graphql("PullRequest.commits", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -4322,12 +4438,12 @@ graphql_resolvers["PullRequest.commits"] = function(parent, args, ctx)
     }
   end
   return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
-end
+end)
 
 -- PullRequest.reviews: MR approvals mapped to review objects.
 -- GitLab's approvals endpoint returns a single object (not a paginated list),
 -- so we fetch it directly and build an inline connection.
-graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
+b:graphql("PullRequest.reviews", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -4350,12 +4466,12 @@ graphql_resolvers["PullRequest.reviews"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_review(r, owner, repo)
   end
   return graphql_make_connection("PullRequestReview", nodes, args, #nodes, ctx)
-end
+end)
 
 -- Repository.languages: fetch language breakdown as a LanguageConnection.
 -- GitLab returns {"Language": percentage, ...} (percentages, not byte counts).
 -- We use the percentage as the "size" in edges since byte counts are unavailable.
-graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
+b:graphql("Repository.languages", function(parent, _args, _ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -4392,7 +4508,7 @@ graphql_resolvers["Repository.languages"] = function(parent, _args, _ctx)
     nodes = nodes,
     edges = edges,
   }
-end
+end)
 
 -- ---------------------------------------------------------------------------
 -- Query.search
@@ -4401,7 +4517,7 @@ end
 -- Query.search: map GitHub GraphQL search to GitLab search endpoints.
 -- Supports REPOSITORY, USER, and ISSUE types; all others return empty.
 -- GitLab uses /projects?search=, /users?search=, and /issues?search=.
-graphql_resolvers["Query.search"] = function(_parent, args, ctx)
+b:graphql("Query.search", function(_parent, args, ctx)
   local query = args.query or ""
   local search_type = args.type or "REPOSITORY"
   local per_page = args.first or 30
@@ -4478,4 +4594,6 @@ graphql_resolvers["Query.search"] = function(_parent, args, ctx)
     discussionCount = 0,
     wikiCount = 0,
   }
-end
+end)
+
+b:build()

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -184,479 +184,510 @@ local function translate_harness_hook_req(body_str)
   })
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base(), auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base(), auth()))
+end)
 
-  get_repo = proxy_handler(translate_harness_repo, function(owner, repo_name)
+b:rest(
+  "get_repo",
+  proxy_handler(translate_harness_repo, function(owner, repo_name)
     return base() .. "/repos/" .. repo_ref(owner, repo_name)
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    proxy_json(
-      translate_harness_repo,
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name),
-        "PATCH",
-        translate_harness_req(GetBody())
-      )
+b:rest("patch_repo", function(owner, repo_name)
+  proxy_json(
+    translate_harness_repo,
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name),
+      "PATCH",
+      translate_harness_req(GetBody())
     )
-  end,
+  )
+end)
 
-  delete_repo = function(owner, repo_name)
-    local url = base() .. "/repos/" .. repo_ref(owner, repo_name)
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, url, dopts))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  local url = base() .. "/repos/" .. repo_ref(owner, repo_name)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, url, dopts))
+end)
 
-  get_user_repos = proxy_handler(translate_harness_repos, function()
+b:rest(
+  "get_user_repos",
+  proxy_handler(translate_harness_repos, function()
     return append_page_params(base() .. "/repos", PAGES)
-  end),
+  end)
+)
 
-  post_user_repos = function()
-    proxy_json_created(
-      translate_harness_repo,
-      fetch_json(base() .. "/repos", "POST", translate_harness_req(GetBody()))
-    )
-  end,
+b:rest("post_user_repos", function()
+  proxy_json_created(
+    translate_harness_repo,
+    fetch_json(base() .. "/repos", "POST", translate_harness_req(GetBody()))
+  )
+end)
 
-  get_org_repos = proxy_handler(translate_harness_repos, function(space)
+b:rest(
+  "get_org_repos",
+  proxy_handler(translate_harness_repos, function(space)
     return append_page_params(base() .. "/spaces/" .. space .. "/repos", PAGES)
-  end),
+  end)
+)
 
-  post_org_repos = function(space)
-    local req = DecodeJson(GetBody() or "{}")
-    req.parent_ref = space
-    proxy_json_created(
-      translate_harness_repo,
-      fetch_json(base() .. "/repos", "POST", EncodeJson(req))
+b:rest("post_org_repos", function(space)
+  local req = DecodeJson(GetBody() or "{}")
+  req.parent_ref = space
+  proxy_json_created(
+    translate_harness_repo,
+    fetch_json(base() .. "/repos", "POST", EncodeJson(req))
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/tags
+b:rest("get_repo_tags", function(owner, repo_name)
+  proxy_json(
+    function(tags)
+      tags = tags or {}
+      for i, t in ipairs(tags) do
+        tags[i] = { name = t.name, commit = { sha = t.sha or t.target or "", url = "" } }
+      end
+      return tags
+    end,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/tags", PAGES)
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/tags
-  get_repo_tags = function(owner, repo_name)
-    proxy_json(
-      function(tags)
-        tags = tags or {}
-        for i, t in ipairs(tags) do
-          tags[i] = { name = t.name, commit = { sha = t.sha or t.target or "", url = "" } }
-        end
-        return tags
-      end,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/tags", PAGES)
-      )
+-- Branches ------------------------------------------------------------------
+
+b:rest("get_repo_branches", function(owner, repo_name)
+  proxy_json(
+    function(branches)
+      branches = branches or {}
+      for i, br in ipairs(branches) do
+        branches[i] = translate_harness_branch(br)
+      end
+      return branches
+    end,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/branches", PAGES)
     )
-  end,
+  )
+end)
 
-  -- Branches ------------------------------------------------------------------
-
-  get_repo_branches = function(owner, repo_name)
-    proxy_json(
-      function(branches)
-        branches = branches or {}
-        for i, b in ipairs(branches) do
-          branches[i] = translate_harness_branch(b)
-        end
-        return branches
-      end,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/branches", PAGES)
-      )
-    )
-  end,
-
-  get_repo_branch = proxy_handler(translate_harness_branch, function(owner, repo_name, branch)
+b:rest(
+  "get_repo_branch",
+  proxy_handler(translate_harness_branch, function(owner, repo_name, branch)
     return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/branches/" .. branch
-  end),
+  end)
+)
 
-  -- Commits -------------------------------------------------------------------
+-- Commits -------------------------------------------------------------------
 
-  get_repo_commits = function(owner, repo_name)
-    local ref = GetParam("sha") or ""
-    local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/commits"
-    if ref ~= "" then
-      url = url .. "?git_ref=" .. ref
+b:rest("get_repo_commits", function(owner, repo_name)
+  local ref = GetParam("sha") or ""
+  local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/commits"
+  if ref ~= "" then
+    url = url .. "?git_ref=" .. ref
+  end
+  url = append_page_params(url, PAGES)
+  proxy_json(function(commits)
+    commits = commits or {}
+    for i, c in ipairs(commits) do
+      commits[i] = translate_harness_commit(c)
     end
-    url = append_page_params(url, PAGES)
-    proxy_json(function(commits)
-      commits = commits or {}
-      for i, c in ipairs(commits) do
-        commits[i] = translate_harness_commit(c)
-      end
-      return commits
-    end, fetch_json(url))
-  end,
+    return commits
+  end, fetch_json(url))
+end)
 
-  get_repo_commit = proxy_handler(translate_harness_commit, function(owner, repo_name, ref)
+b:rest(
+  "get_repo_commit",
+  proxy_handler(translate_harness_commit, function(owner, repo_name, ref)
     return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/commits/" .. ref
-  end),
+  end)
+)
 
-  -- Statuses ------------------------------------------------------------------
-  -- Harness uses /check/commits/{sha} for CI results.
+-- Statuses ------------------------------------------------------------------
+-- Harness uses /check/commits/{sha} for CI results.
 
-  get_commit_statuses = proxy_handler(nil, function(owner, repo_name, ref)
+b:rest(
+  "get_commit_statuses",
+  proxy_handler(nil, function(owner, repo_name, ref)
     return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/check/commits/" .. ref
-  end),
+  end)
+)
 
-  get_commit_combined_status = proxy_handler(nil, function(owner, repo_name, ref)
+b:rest(
+  "get_commit_combined_status",
+  proxy_handler(nil, function(owner, repo_name, ref)
     return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/check/commits/" .. ref
-  end),
+  end)
+)
 
-  post_commit_status = function(owner, repo_name, sha)
-    proxy_json_created(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/check/commits/" .. sha,
-        "POST",
-        GetBody()
-      )
+b:rest("post_commit_status", function(owner, repo_name, sha)
+  proxy_json_created(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/check/commits/" .. sha,
+      "POST",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- Contents ------------------------------------------------------------------
-  -- Harness content API returns the same shape as GitHub (type, name, path, sha, encoding, content).
+-- Contents ------------------------------------------------------------------
+-- Harness content API returns the same shape as GitHub (type, name, path, sha, encoding, content).
 
-  get_repo_readme = function(owner, repo_name)
-    -- Harness has no dedicated readme endpoint; fetch root contents and find README.
-    local ref = GetParam("ref") or ""
-    local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/README.md"
-    if ref ~= "" then
-      url = url .. "?git_ref=" .. ref
+b:rest("get_repo_readme", function(owner, repo_name)
+  -- Harness has no dedicated readme endpoint; fetch root contents and find README.
+  local ref = GetParam("ref") or ""
+  local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/README.md"
+  if ref ~= "" then
+    url = url .. "?git_ref=" .. ref
+  end
+  proxy_json(nil, fetch_json(url))
+end)
+
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local ref = GetParam("ref") or ""
+  local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/" .. path
+  if ref ~= "" then
+    url = url .. "?git_ref=" .. ref
+  end
+  proxy_json(function(data)
+    -- Directory listing: Harness returns { type="dir", entries=[...] }; GitHub expects array.
+    if data and data.type == "dir" then
+      return data.entries or {}
     end
-    proxy_json(nil, fetch_json(url))
-  end,
+    return data or {}
+  end, fetch_json(url))
+end)
 
-  get_repo_content = function(owner, repo_name, path)
-    local ref = GetParam("ref") or ""
-    local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/" .. path
-    if ref ~= "" then
-      url = url .. "?git_ref=" .. ref
-    end
-    proxy_json(function(data)
-      -- Directory listing: Harness returns { type="dir", entries=[...] }; GitHub expects array.
-      if data and data.type == "dir" then
-        return data.entries or {}
-      end
-      return data or {}
-    end, fetch_json(url))
-  end,
-
-  put_repo_content = function(owner, repo_name, path)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/" .. path,
-        "PUT",
-        GetBody()
-      )
+b:rest("put_repo_content", function(owner, repo_name, path)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/" .. path,
+      "PUT",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  delete_repo_content = function(owner, repo_name, path)
-    proxy_json(
-      nil,
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/" .. path,
-        "DELETE",
-        GetBody()
-      )
+b:rest("delete_repo_content", function(owner, repo_name, path)
+  proxy_json(
+    nil,
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/content/" .. path,
+      "DELETE",
+      GetBody()
     )
-  end,
+  )
+end)
 
-  -- Forks ---------------------------------------------------------------------
+-- Forks ---------------------------------------------------------------------
 
-  get_repo_forks = proxy_handler(translate_harness_repos, function(owner, repo_name)
+b:rest(
+  "get_repo_forks",
+  proxy_handler(translate_harness_repos, function(owner, repo_name)
     return append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/forks", PAGES)
-  end),
+  end)
+)
 
-  post_repo_forks = function(owner, repo_name)
-    proxy_json_created(
-      translate_harness_repo,
-      fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/fork", "POST", GetBody())
+b:rest("post_repo_forks", function(owner, repo_name)
+  proxy_json_created(
+    translate_harness_repo,
+    fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/fork", "POST", GetBody())
+  )
+end)
+
+-- Deploy keys ---------------------------------------------------------------
+
+b:rest("get_repo_keys", function(owner, repo_name)
+  proxy_json(
+    function(keys)
+      keys = keys or {}
+      for i, k in ipairs(keys) do
+        keys[i] = translate_harness_key(k)
+      end
+      return keys
+    end,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys", PAGES)
     )
-  end,
+  )
+end)
 
-  -- Deploy keys ---------------------------------------------------------------
+b:rest("post_repo_keys", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local h = {
+    identifier = req.title or "",
+    public_key = req.key or "",
+    usage = req.read_only and "read" or "readwrite",
+  }
+  proxy_json_created(
+    translate_harness_key,
+    fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys", "POST", EncodeJson(h))
+  )
+end)
 
-  get_repo_keys = function(owner, repo_name)
-    proxy_json(
-      function(keys)
-        keys = keys or {}
-        for i, k in ipairs(keys) do
-          keys[i] = translate_harness_key(k)
-        end
-        return keys
-      end,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys", PAGES)
-      )
-    )
-  end,
-
-  post_repo_keys = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local h = {
-      identifier = req.title or "",
-      public_key = req.key or "",
-      usage = req.read_only and "read" or "readwrite",
-    }
-    proxy_json_created(
-      translate_harness_key,
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys",
-        "POST",
-        EncodeJson(h)
-      )
-    )
-  end,
-
-  get_repo_key = proxy_handler(translate_harness_key, function(owner, repo_name, key_id)
+b:rest(
+  "get_repo_key",
+  proxy_handler(translate_harness_key, function(owner, repo_name, key_id)
     return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys/" .. key_id
-  end),
+  end)
+)
 
-  delete_repo_key = function(owner, repo_name, key_id)
-    proxy_204(
-      { 200 },
-      fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys/" .. key_id, "DELETE")
+b:rest("delete_repo_key", function(owner, repo_name, key_id)
+  proxy_204(
+    { 200 },
+    fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/keys/" .. key_id, "DELETE")
+  )
+end)
+
+-- Webhooks ------------------------------------------------------------------
+
+b:rest("get_repo_hooks", function(owner, repo_name)
+  proxy_json(
+    function(hooks)
+      hooks = hooks or {}
+      for i, h in ipairs(hooks) do
+        hooks[i] = translate_harness_hook(h)
+      end
+      return hooks
+    end,
+    fetch_json(
+      append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks", PAGES)
     )
-  end,
+  )
+end)
 
-  -- Webhooks ------------------------------------------------------------------
-
-  get_repo_hooks = function(owner, repo_name)
-    proxy_json(
-      function(hooks)
-        hooks = hooks or {}
-        for i, h in ipairs(hooks) do
-          hooks[i] = translate_harness_hook(h)
-        end
-        return hooks
-      end,
-      fetch_json(
-        append_page_params(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks", PAGES)
-      )
+b:rest("post_repo_hooks", function(owner, repo_name)
+  proxy_json_created(
+    translate_harness_hook,
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks",
+      "POST",
+      translate_harness_hook_req(GetBody())
     )
-  end,
+  )
+end)
 
-  post_repo_hooks = function(owner, repo_name)
-    proxy_json_created(
-      translate_harness_hook,
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks",
-        "POST",
-        translate_harness_hook_req(GetBody())
-      )
-    )
-  end,
-
-  get_repo_hook = proxy_handler(translate_harness_hook, function(owner, repo_name, hook_id)
+b:rest(
+  "get_repo_hook",
+  proxy_handler(translate_harness_hook, function(owner, repo_name, hook_id)
     return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id
-  end),
+  end)
+)
 
-  patch_repo_hook = function(owner, repo_name, hook_id)
-    proxy_json(
-      translate_harness_hook,
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id,
-        "PATCH",
-        translate_harness_hook_req(GetBody())
-      )
+b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
+  proxy_json(
+    translate_harness_hook,
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id,
+      "PATCH",
+      translate_harness_hook_req(GetBody())
     )
-  end,
+  )
+end)
 
-  delete_repo_hook = function(owner, repo_name, hook_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id,
-        "DELETE"
-      )
+b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id,
+      "DELETE"
     )
-  end,
+  )
+end)
 
-  -- Hook config ---------------------------------------------------------------
+-- Hook config ---------------------------------------------------------------
 
-  get_repo_hook_config = function(owner, repo_name, hook_id)
-    proxy_json(function(h)
-      return (translate_harness_hook(h)).config or {}
-    end, fetch_json(
-      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id
-    ))
-  end,
+b:rest("get_repo_hook_config", function(owner, repo_name, hook_id)
+  proxy_json(function(h)
+    return (translate_harness_hook(h)).config or {}
+  end, fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id))
+end)
 
-  patch_repo_hook_config = function(owner, repo_name, hook_id)
-    local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id
-    local ok, status, _, body = fetch_json(url)
-    if not ok or status ~= 200 then
-      if ok then
-        respond_json(status, {})
-      else
-        respond_json(503, {})
-      end
-      return
-    end
-    local hook = DecodeJson(body) or {}
-    local new_cfg = DecodeJson(GetBody() or "{}")
-    if new_cfg.url then
-      hook.url = new_cfg.url
-    end
-    proxy_json(function(h)
-      return (translate_harness_hook(h)).config or {}
-    end, fetch_json(url, "PATCH", EncodeJson(hook)))
-  end,
-
-  post_repo_hook_test = function(owner, repo_name, hook_id)
-    proxy_204(
-      { 200 },
-      fetch_json(
-        base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id .. "/test",
-        "POST"
-      )
-    )
-  end,
-
-  -- Languages -----------------------------------------------------------------
-
-  get_repo_languages = proxy_handler(nil, function(owner, repo_name)
-    return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/languages"
-  end),
-
-  -- Archive -------------------------------------------------------------------
-
-  get_repo_tarball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
-      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/archive?format=tar.gz&git_ref=" .. ref
-    )
-    Write("")
-  end,
-
-  get_repo_zipball = function(owner, repo_name, ref)
-    SetStatus(302, "Found")
-    SetHeader(
-      "Location",
-      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/archive?format=zip&git_ref=" .. ref
-    )
-    Write("")
-  end,
-
-  -- Users' repos --------------------------------------------------------------
-
-  get_users_repos = proxy_handler(translate_harness_repos, function(username)
-    return append_page_params(base() .. "/spaces/" .. username .. "/repos", PAGES)
-  end),
-
-  -- Users ---------------------------------------------------------------------
-
-  -- GET /user
-  get_user = function()
-    proxy_json(function(u)
-      if not u then
-        return {}
-      end
-      return {
-        login = u.uid or "",
-        id = u.id or 0,
-        node_id = "",
-        avatar_url = u.url or "",
-        html_url = "",
-        type = "User",
-        site_admin = u.admin or false,
-        name = u.display_name or "",
-        email = u.email or "",
-      }
-    end, fetch_json(base() .. "/user"))
-  end,
-
-  -- Checks (via Harness Code /check/commits/{sha}) --------------------------------
-  --
-  -- Harness Code stores CI results as check statuses on commit SHAs.  Each check
-  -- entry has id, status, check_suite_name, started, and ended fields.
-  --   • GET commits/{ref}/check-runs → GET /check/commits/{sha}
-  --   • Check Suites have no native equivalent; all suite endpoints are stubs.
-  --
-  -- Status mapping (Harness → GitHub):
-  --   running/pending → status=in_progress, conclusion=null
-  --   success         → status=completed,   conclusion=success
-  --   failure/error   → status=completed,   conclusion=failure
-  --   cancelled       → status=completed,   conclusion=cancelled
-
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- Maps to Harness Code GET /check/commits/{sha}.
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local ok, status, _, body =
-      fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/check/commits/" .. ref)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
+b:rest("patch_repo_hook_config", function(owner, repo_name, hook_id)
+  local url = base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id
+  local ok, status, _, body = fetch_json(url)
+  if not ok or status ~= 200 then
+    if ok then
       respond_json(status, {})
-      return
+    else
+      respond_json(503, {})
     end
-    local list = DecodeJson(body) or {}
-    local runs = {}
-    for _, c in ipairs(list) do
-      local s = c.status or "pending"
-      local harness_to_gh = {
-        success = { status = "completed", conclusion = "success" },
-        failure = { status = "completed", conclusion = "failure" },
-        error = { status = "completed", conclusion = "failure" },
-        cancelled = { status = "completed", conclusion = "cancelled" },
-      }
-      local mapped = harness_to_gh[s] or { status = "in_progress", conclusion = nil }
-      local gh_status, gh_conclusion = mapped.status, mapped.conclusion
-      runs[#runs + 1] = {
-        id = c.id or 0,
-        node_id = "",
-        head_sha = ref,
-        name = c.check_suite_name or tostring(c.id or 0),
-        status = gh_status,
-        conclusion = gh_conclusion,
-        started_at = c.started,
-        completed_at = gh_status == "completed" and (c.ended or c.started) or nil,
-        output = {
-          title = c.check_suite_name or "",
-          summary = c.check_suite_name or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = "",
-        details_url = "",
-      }
+    return
+  end
+  local hook = DecodeJson(body) or {}
+  local new_cfg = DecodeJson(GetBody() or "{}")
+  if new_cfg.url then
+    hook.url = new_cfg.url
+  end
+  proxy_json(function(h)
+    return (translate_harness_hook(h)).config or {}
+  end, fetch_json(url, "PATCH", EncodeJson(hook)))
+end)
+
+b:rest("post_repo_hook_test", function(owner, repo_name, hook_id)
+  proxy_204(
+    { 200 },
+    fetch_json(
+      base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/webhooks/" .. hook_id .. "/test",
+      "POST"
+    )
+  )
+end)
+
+-- Languages -----------------------------------------------------------------
+
+b:rest(
+  "get_repo_languages",
+  proxy_handler(nil, function(owner, repo_name)
+    return base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/languages"
+  end)
+)
+
+-- Archive -------------------------------------------------------------------
+
+b:rest("get_repo_tarball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/archive?format=tar.gz&git_ref=" .. ref
+  )
+  Write("")
+end)
+
+b:rest("get_repo_zipball", function(owner, repo_name, ref)
+  SetStatus(302, "Found")
+  SetHeader(
+    "Location",
+    base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/archive?format=zip&git_ref=" .. ref
+  )
+  Write("")
+end)
+
+-- Users' repos --------------------------------------------------------------
+
+b:rest(
+  "get_users_repos",
+  proxy_handler(translate_harness_repos, function(username)
+    return append_page_params(base() .. "/spaces/" .. username .. "/repos", PAGES)
+  end)
+)
+
+-- Users ---------------------------------------------------------------------
+
+-- GET /user
+b:rest("get_user", function()
+  proxy_json(function(u)
+    if not u then
+      return {}
     end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
+    return {
+      login = u.uid or "",
+      id = u.id or 0,
+      node_id = "",
+      avatar_url = u.url or "",
+      html_url = "",
+      type = "User",
+      site_admin = u.admin or false,
+      name = u.display_name or "",
+      email = u.email or "",
+    }
+  end, fetch_json(base() .. "/user"))
+end)
 
-  -- Issues -----------------------------------------------------------------------
-  -- Harness Code has no native issue tracker.
-  -- Issue management in the Harness platform is handled via Jira integration.
-  -- All issues, labels, milestones, and assignees endpoints fall back to the
-  -- default empty-list / 404 handlers defined in .init.lua.
+-- Checks (via Harness Code /check/commits/{sha}) --------------------------------
+--
+-- Harness Code stores CI results as check statuses on commit SHAs.  Each check
+-- entry has id, status, check_suite_name, started, and ended fields.
+--   • GET commits/{ref}/check-runs → GET /check/commits/{sha}
+--   • Check Suites have no native equivalent; all suite endpoints are stubs.
+--
+-- Status mapping (Harness → GitHub):
+--   running/pending → status=in_progress, conclusion=null
+--   success         → status=completed,   conclusion=success
+--   failure/error   → status=completed,   conclusion=failure
+--   cancelled       → status=completed,   conclusion=cancelled
 
-  -- PATCH /user
-  patch_user = function()
-    proxy_json(function(u)
-      if not u then
-        return {}
-      end
-      return {
-        login = u.uid or "",
-        id = u.id or 0,
-        node_id = "",
-        avatar_url = u.url or "",
-        html_url = "",
-        type = "User",
-        site_admin = u.admin or false,
-        name = u.display_name or "",
-        email = u.email or "",
-      }
-    end, fetch_json(base() .. "/user", "PATCH", GetBody()))
-  end,
-}
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- Maps to Harness Code GET /check/commits/{sha}.
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local ok, status, _, body =
+    fetch_json(base() .. "/repos/" .. repo_ref(owner, repo_name) .. "/check/commits/" .. ref)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local list = DecodeJson(body) or {}
+  local runs = {}
+  for _, c in ipairs(list) do
+    local s = c.status or "pending"
+    local harness_to_gh = {
+      success = { status = "completed", conclusion = "success" },
+      failure = { status = "completed", conclusion = "failure" },
+      error = { status = "completed", conclusion = "failure" },
+      cancelled = { status = "completed", conclusion = "cancelled" },
+    }
+    local mapped = harness_to_gh[s] or { status = "in_progress", conclusion = nil }
+    local gh_status, gh_conclusion = mapped.status, mapped.conclusion
+    runs[#runs + 1] = {
+      id = c.id or 0,
+      node_id = "",
+      head_sha = ref,
+      name = c.check_suite_name or tostring(c.id or 0),
+      status = gh_status,
+      conclusion = gh_conclusion,
+      started_at = c.started,
+      completed_at = gh_status == "completed" and (c.ended or c.started) or nil,
+      output = {
+        title = c.check_suite_name or "",
+        summary = c.check_suite_name or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = "",
+      details_url = "",
+    }
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
+
+-- Issues -----------------------------------------------------------------------
+-- Harness Code has no native issue tracker.
+-- Issue management in the Harness platform is handled via Jira integration.
+-- All issues, labels, milestones, and assignees endpoints fall back to the
+-- default empty-list / 404 handlers defined in .init.lua.
+
+-- PATCH /user
+b:rest("patch_user", function()
+  proxy_json(function(u)
+    if not u then
+      return {}
+    end
+    return {
+      login = u.uid or "",
+      id = u.id or 0,
+      node_id = "",
+      avatar_url = u.url or "",
+      html_url = "",
+      type = "User",
+      site_admin = u.admin or false,
+      name = u.display_name or "",
+      email = u.email or "",
+    }
+  end, fetch_json(base() .. "/user", "PATCH", GetBody()))
+end)
+
+b:build()

--- a/backends/kallithea.lua
+++ b/backends/kallithea.lua
@@ -1,11 +1,12 @@
 -- Kallithea backend handler overrides.
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
+end)
 
-  -- Issues -----------------------------------------------------------------------
-  -- Kallithea has no native issue tracker.
-  -- All issues, labels, milestones, and assignees endpoints fall back to the
-  -- default empty-list / 404 handlers defined in .init.lua.
-}
+-- Issues -----------------------------------------------------------------------
+-- Kallithea has no native issue tracker.
+-- All issues, labels, milestones, and assignees endpoints fall back to the
+-- default empty-list / 404 handlers defined in .init.lua.
+
+b:build()

--- a/backends/launchpad.lua
+++ b/backends/launchpad.lua
@@ -90,106 +90,106 @@ local function translate_lp_bug(bug, task)
   }
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, config.base_url .. "/devel/"))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, config.base_url .. "/devel/"))
+end)
 
-  -- Issues --------------------------------------------------------------------
-  -- Launchpad: GET /devel/~{owner}/{repo}?ws.op=searchTasks
+-- Issues --------------------------------------------------------------------
+-- Launchpad: GET /devel/~{owner}/{repo}?ws.op=searchTasks
 
-  get_repo_issues = function(owner, repo_name)
-    local state = GetParam("state") or "open"
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    local url = config.base_url
-      .. "/devel/~"
-      .. owner
-      .. "/"
-      .. repo_name
-      .. "?ws.op=searchTasks"
-      .. "&start="
-      .. ((page - 1) * count)
-      .. "&limit="
-      .. count
-    if state == "closed" then
-      url = url .. "&status=Fix+Released&status=Invalid&status=Won%27t+Fix&status=Fix+Committed"
-    elseif state ~= "all" then
-      url = url
-        .. "&status=New&status=Incomplete&status=Confirmed&status=Triaged&status=In+Progress"
-    end
-    proxy_json(function(data)
-      return translate_list(translate_lp_task, data.entries)
-    end, fetch_json(url))
-  end,
+b:rest("get_repo_issues", function(owner, repo_name)
+  local state = GetParam("state") or "open"
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  local url = config.base_url
+    .. "/devel/~"
+    .. owner
+    .. "/"
+    .. repo_name
+    .. "?ws.op=searchTasks"
+    .. "&start="
+    .. ((page - 1) * count)
+    .. "&limit="
+    .. count
+  if state == "closed" then
+    url = url .. "&status=Fix+Released&status=Invalid&status=Won%27t+Fix&status=Fix+Committed"
+  elseif state ~= "all" then
+    url = url .. "&status=New&status=Incomplete&status=Confirmed&status=Triaged&status=In+Progress"
+  end
+  proxy_json(function(data)
+    return translate_list(translate_lp_task, data.entries)
+  end, fetch_json(url))
+end)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}
-  -- Fetch the bug object (title/description) and its project task (status).
-  get_repo_issue = function(owner, repo_name, issue_number)
-    local ok, status, _, body = fetch_json(config.base_url .. "/devel/bugs/" .. issue_number)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status == 404 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local bug = DecodeJson(body)
-    local task_url = config.base_url
-      .. "/devel/~"
-      .. owner
-      .. "/"
-      .. repo_name
-      .. "/+bug/"
-      .. issue_number
-    local ok2, status2, _, body2 = fetch_json(task_url)
-    local task = (ok2 and status2 == 200) and DecodeJson(body2) or nil
-    respond_json(200, translate_lp_bug(bug, task))
-  end,
+-- GET /repos/{owner}/{repo}/issues/{issue_number}
+-- Fetch the bug object (title/description) and its project task (status).
+b:rest("get_repo_issue", function(owner, repo_name, issue_number)
+  local ok, status, _, body = fetch_json(config.base_url .. "/devel/bugs/" .. issue_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status == 404 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local bug = DecodeJson(body)
+  local task_url = config.base_url
+    .. "/devel/~"
+    .. owner
+    .. "/"
+    .. repo_name
+    .. "/+bug/"
+    .. issue_number
+  local ok2, status2, _, body2 = fetch_json(task_url)
+  local task = (ok2 and status2 == 200) and DecodeJson(body2) or nil
+  respond_json(200, translate_lp_bug(bug, task))
+end)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-  -- Launchpad: GET /devel/bugs/{id}/messages
-  -- The first message (index 0) is the bug description, so skip it.
-  get_issue_comments = function(_owner, _repo_name, issue_number)
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    -- Offset by 1 to skip the description message (always first in the collection).
-    local start = (page - 1) * count + 1
-    local url = config.base_url
-      .. "/devel/bugs/"
-      .. issue_number
-      .. "/messages?start="
-      .. start
-      .. "&limit="
-      .. count
-    proxy_json(function(data)
-      local entries = data.entries or {}
-      local result = {}
-      for _, m in ipairs(entries) do
-        result[#result + 1] = {
-          id = m.index or 0,
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
+-- Launchpad: GET /devel/bugs/{id}/messages
+-- The first message (index 0) is the bug description, so skip it.
+b:rest("get_issue_comments", function(_owner, _repo_name, issue_number)
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  -- Offset by 1 to skip the description message (always first in the collection).
+  local start = (page - 1) * count + 1
+  local url = config.base_url
+    .. "/devel/bugs/"
+    .. issue_number
+    .. "/messages?start="
+    .. start
+    .. "&limit="
+    .. count
+  proxy_json(function(data)
+    local entries = data.entries or {}
+    local result = {}
+    for _, m in ipairs(entries) do
+      result[#result + 1] = {
+        id = m.index or 0,
+        node_id = "",
+        url = "",
+        body = m.content or "",
+        user = {
+          login = lp_login(m.owner_link),
+          id = 0,
           node_id = "",
+          avatar_url = "",
           url = "",
-          body = m.content or "",
-          user = {
-            login = lp_login(m.owner_link),
-            id = 0,
-            node_id = "",
-            avatar_url = "",
-            url = "",
-            type = "User",
-          },
-          created_at = m.date_created or "",
-          updated_at = m.date_created or "",
-          html_url = "",
-        }
-      end
-      return result
-    end, fetch_json(url))
-  end,
-}
+          type = "User",
+        },
+        created_at = m.date_created or "",
+        updated_at = m.date_created or "",
+        html_url = "",
+      }
+    end
+    return result
+  end, fetch_json(url))
+end)
+
+b:build()

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -204,514 +204,507 @@ local function translate_onedev_commit(c)
   }
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/server-version", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/server-version", auth()))
+end)
 
-  get_repo = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(translate_onedev_repo, fetch_json(base() .. "/projects/" .. id))
-  end,
+b:rest("get_repo", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(translate_onedev_repo, fetch_json(base() .. "/projects/" .. id))
+end)
 
-  patch_repo = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(
-      translate_onedev_repo,
-      fetch_json(base() .. "/projects/" .. id, "PATCH", translate_onedev_req(GetBody()))
-    )
-  end,
+b:rest("patch_repo", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(
+    translate_onedev_repo,
+    fetch_json(base() .. "/projects/" .. id, "PATCH", translate_onedev_req(GetBody()))
+  )
+end)
 
-  delete_repo = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. id, dopts))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. id, dopts))
+end)
 
-  get_user_repos = function()
-    -- OneDev uses offset-based pagination: count=N, offset=(page-1)*N
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    proxy_json(
-      translate_onedev_repos,
-      fetch_json(base() .. "/projects?count=" .. count .. "&offset=" .. ((page - 1) * count))
-    )
-  end,
+b:rest("get_user_repos", function()
+  -- OneDev uses offset-based pagination: count=N, offset=(page-1)*N
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  proxy_json(
+    translate_onedev_repos,
+    fetch_json(base() .. "/projects?count=" .. count .. "&offset=" .. ((page - 1) * count))
+  )
+end)
 
-  post_user_repos = function()
-    proxy_json_created(
-      translate_onedev_repo,
-      fetch_json(base() .. "/projects", "POST", translate_onedev_req(GetBody()))
-    )
-  end,
+b:rest("post_user_repos", function()
+  proxy_json_created(
+    translate_onedev_repo,
+    fetch_json(base() .. "/projects", "POST", translate_onedev_req(GetBody()))
+  )
+end)
 
-  get_org_repos = function(org)
-    -- OneDev groups/orgs map to parent projects; query by parent path.
-    local query = "%22Parent%22+is+%22" .. org .. "%22"
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    proxy_json(
-      translate_onedev_repos,
-      fetch_json(
-        base()
-          .. "/projects?query="
-          .. query
-          .. "&count="
-          .. count
-          .. "&offset="
-          .. ((page - 1) * count)
-      )
-    )
-  end,
-
-  post_org_repos = function(org)
-    local req = DecodeJson(GetBody() or "{}")
-    local od = {
-      name = req.name,
-      description = req.description or "",
-      public = not (req.private or false),
-      parent = { path = org },
-    }
-    proxy_json_created(
-      translate_onedev_repo,
-      fetch_json(base() .. "/projects", "POST", EncodeJson(od))
-    )
-  end,
-
-  -- Branches ------------------------------------------------------------------
-  -- OneDev: GET /~api/projects/{id}/branches → [{ name, commitHash }]
-
-  get_repo_branches = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    proxy_json(
-      function(branches)
-        return translate_list(translate_onedev_branch, branches)
-      end,
-      fetch_json(
-        base()
-          .. "/projects/"
-          .. id
-          .. "/branches?count="
-          .. count
-          .. "&offset="
-          .. ((page - 1) * count)
-      )
-    )
-  end,
-
-  get_repo_branch = function(owner, repo_name, branch)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    -- OneDev: GET /~api/projects/{id}/branches?query=name+is+{branch}&count=1
-    local query = "%22Name%22+is+%22" .. branch .. "%22"
-    proxy_json(function(branches)
-      local b = (branches or {})[1]
-      if not b then
-        return {}
-      end
-      return translate_onedev_branch(b)
-    end, fetch_json(base() .. "/projects/" .. id .. "/branches?query=" .. query .. "&count=1"))
-  end,
-
-  -- Commits -------------------------------------------------------------------
-  -- OneDev: GET /~api/projects/{id}/commits?revision={ref}&count={n}&offset={offset}
-  -- Returns [{ hash, message, author, committer }]
-
-  get_repo_commits = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ref = GetParam("sha") or ""
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    local url = base()
-      .. "/projects/"
-      .. id
-      .. "/commits?count="
-      .. count
-      .. "&offset="
-      .. ((page - 1) * count)
-    if ref ~= "" then
-      url = url .. "&revision=" .. ref
-    end
-    proxy_json(function(commits)
-      return translate_list(translate_onedev_commit, commits)
-    end, fetch_json(url))
-  end,
-
-  get_repo_commit = function(owner, repo_name, ref)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(
-      translate_onedev_commit,
-      fetch_json(base() .. "/projects/" .. id .. "/commits/" .. ref)
-    )
-  end,
-
-  -- Tags ----------------------------------------------------------------------
-
-  get_repo_tags = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    -- OneDev returns [{ name, commitHash }]
-    proxy_json(function(tags)
-      tags = tags or {}
-      local result = {}
-      for _, t in ipairs(tags) do
-        result[#result + 1] =
-          { name = t.name or "", commit = { sha = t.commitHash or "", url = "" } }
-      end
-      return result
-    end, fetch_json(base() .. "/projects/" .. id .. "/tags"))
-  end,
-
-  -- Contents ------------------------------------------------------------------
-  -- OneDev: GET /~api/blobs/{projectId}/{revision}/{path}
-  -- Returns raw file content; we wrap it in a GitHub-shaped object.
-
-  get_repo_content = function(owner, repo_name, path)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ref = GetParam("ref") or "HEAD"
-    local url = base() .. "/blobs/" .. id .. "/" .. ref .. "/" .. path
-    local ok, status, _, body = fetch_json(url)
-    if ok and status == 200 then
-      respond_json(200, {
-        type = "file",
-        name = path:match("[^/]+$") or path,
-        path = path,
-        sha = "",
-        size = #body,
-        encoding = "base64",
-        content = EncodeBase64(body),
-      })
-    elseif ok then
-      respond_json(status, { message = "Error" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- Forks ---------------------------------------------------------------------
-
-  post_repo_forks = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json_created(
-      translate_onedev_repo,
-      fetch_json(base() .. "/projects/" .. id .. "/forks", "POST", GetBody())
-    )
-  end,
-
-  -- Users' repos --------------------------------------------------------------
-
-  get_users_repos = function(username)
-    local query = "%22Owner%22+is+%22" .. username .. "%22"
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    proxy_json(
-      translate_onedev_repos,
-      fetch_json(
-        base()
-          .. "/projects?query="
-          .. query
-          .. "&count="
-          .. count
-          .. "&offset="
-          .. ((page - 1) * count)
-      )
-    )
-  end,
-
-  -- Public repos list ---------------------------------------------------------
-
-  get_repositories = function()
-    local query = "%22Public%22+is+%22true%22"
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    proxy_json(
-      translate_onedev_repos,
-      fetch_json(
-        base()
-          .. "/projects?query="
-          .. query
-          .. "&count="
-          .. count
-          .. "&offset="
-          .. ((page - 1) * count)
-      )
-    )
-  end,
-
-  -- Users ---------------------------------------------------------------------
-
-  -- GET /users
-  get_users = function()
-    local count = GetParam("per_page") or "30"
-    local page = tonumber(GetParam("page")) or 1
-    local offset = (page - 1) * (tonumber(count) or 30)
-    proxy_json(function(users)
-      return translate_list(translate_onedev_user, users)
-    end, fetch_json(base() .. "/users?offset=" .. offset .. "&count=" .. count))
-  end,
-
-  -- GET /users/{username} — query by name, take first match
-  get_users_username = proxy_handler(function(users)
-    local u = (users and users[1]) or {}
-    return translate_onedev_user(u)
-  end, function(username)
-    return base() .. "/users?query=name+is+%22" .. username .. "%22&count=1"
-  end),
-
-  -- Issues --------------------------------------------------------------------
-  -- OneDev: GET /~api/issues?query="Project" is "owner/repo"&count=N&offset=O
-
-  get_repo_issues = function(owner, repo_name)
-    local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    local state = GetParam("state") or "open"
-    local query = "%22Project%22+is+%22" .. path .. "%22"
-    if state == "closed" then
-      query = query .. "+%22State%22+is+%22Closed%22"
-    elseif state ~= "all" then
-      query = query .. "+%22State%22+is+%22Open%22"
-    end
-    proxy_json(
-      function(issues)
-        return translate_list(translate_onedev_issue, issues)
-      end,
-      fetch_json(
-        base()
-          .. "/issues?query="
-          .. query
-          .. "&count="
-          .. count
-          .. "&offset="
-          .. ((page - 1) * count)
-      )
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}
-  -- OneDev: query by project path + per-project number, take first result.
-  get_repo_issue = function(owner, repo_name, issue_number)
-    local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
-    local query = "%22Project%22+is+%22"
-      .. path
-      .. "%22+%22Number%22+is+%22"
-      .. issue_number
-      .. "%22"
-    local ok, status, _, body = fetch_json(base() .. "/issues?query=" .. query .. "&count=1")
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local issues = DecodeJson(body) or {}
-    if not issues[1] then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_onedev_issue(issues[1]))
-  end,
-
-  -- POST /repos/{owner}/{repo}/issues
-  post_repo_issues = function(owner, repo_name)
-    local id = resolve_project_id(owner, repo_name)
-    if not id then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local req = DecodeJson(GetBody() or "{}")
-    local od = { projectId = id, title = req.title or "", description = req.body or "" }
-    proxy_json_created(
-      translate_onedev_issue,
-      fetch_json(base() .. "/issues", "POST", EncodeJson(od))
-    )
-  end,
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-  -- OneDev: resolve global issue ID first, then query /~api/issue-comments.
-  get_issue_comments = function(owner, repo_name, issue_number)
-    local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
-    local nq = "%22Project%22+is+%22" .. path .. "%22+%22Number%22+is+%22" .. issue_number .. "%22"
-    local ok, status, _, body = fetch_json(base() .. "/issues?query=" .. nq .. "&count=1")
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local issues = DecodeJson(body) or {}
-    if not issues[1] then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local issue_id = issues[1].id
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    local cq = "%22Issue%22+is+%22" .. issue_id .. "%22"
-    proxy_json(
-      function(comments)
-        return translate_list(translate_onedev_issue_comment, comments)
-      end,
-      fetch_json(
-        base()
-          .. "/issue-comments?query="
-          .. cq
-          .. "&count="
-          .. count
-          .. "&offset="
-          .. ((page - 1) * count)
-      )
-    )
-  end,
-
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
-  post_issue_comment = function(owner, repo_name, issue_number)
-    local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
-    local nq = "%22Project%22+is+%22" .. path .. "%22+%22Number%22+is+%22" .. issue_number .. "%22"
-    local ok, status, _, body = fetch_json(base() .. "/issues?query=" .. nq .. "&count=1")
-    if not ok or status ~= 200 then
-      respond_json(status or 503, {})
-      return
-    end
-    local issues = DecodeJson(body) or {}
-    if not issues[1] then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local issue_id = issues[1].id
-    local req = DecodeJson(GetBody() or "{}")
-    local od = { issueId = issue_id, content = req.body or "" }
-    proxy_json_created(
-      translate_onedev_issue_comment,
-      fetch_json(base() .. "/issue-comments", "POST", EncodeJson(od))
-    )
-  end,
-
-  -- Checks (via OneDev CI builds) -----------------------------------------------
-  --
-  -- OneDev CI builds are the natural mapping for GitHub Check Runs.
-  --   • GET commits/{ref}/check-runs → query /~api/builds by project + commit hash.
-  --   • POST check-runs              → stub (no API to push an external check status).
-  --   • GET/PATCH by check_run_id   → minimal stub (would need a reverse-lookup).
-  --   • Check Suites have no OneDev equivalent; all suite endpoints are stubs.
-  --   • Annotations are always empty.
-  --
-  -- OneDev build status → GitHub status/conclusion mapping:
-  --   WAITING    → status=queued,      conclusion=null
-  --   RUNNING    → status=in_progress, conclusion=null
-  --   SUCCESSFUL → status=completed,   conclusion=success
-  --   FAILED     → status=completed,   conclusion=failure
-  --   CANCELLED  → status=completed,   conclusion=cancelled
-  --   TIMED_OUT  → status=completed,   conclusion=timed_out
-
-  -- POST /repos/{owner}/{repo}/check-runs
-  -- OneDev has no external check-status push API; falls back to route_default stub.
-
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- Maps to OneDev GET /~api/builds?query="Project" is "owner/repo" "Commit" is "{ref}".
-  -- OneDev build objects: { id, number, jobName, status, commitHash, refName, project }
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
-    local query = "%22Project%22+is+%22" .. path .. "%22+%22Commit%22+is+%22" .. ref .. "%22"
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    local ok, status, _, body = fetch_json(
+b:rest("get_org_repos", function(org)
+  -- OneDev groups/orgs map to parent projects; query by parent path.
+  local query = "%22Parent%22+is+%22" .. org .. "%22"
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  proxy_json(
+    translate_onedev_repos,
+    fetch_json(
       base()
-        .. "/builds?query="
+        .. "/projects?query="
         .. query
         .. "&count="
         .. count
         .. "&offset="
         .. ((page - 1) * count)
     )
-    if not ok then
-      respond_json(503, {})
-      return
+  )
+end)
+
+b:rest("post_org_repos", function(org)
+  local req = DecodeJson(GetBody() or "{}")
+  local od = {
+    name = req.name,
+    description = req.description or "",
+    public = not (req.private or false),
+    parent = { path = org },
+  }
+  proxy_json_created(
+    translate_onedev_repo,
+    fetch_json(base() .. "/projects", "POST", EncodeJson(od))
+  )
+end)
+
+-- Branches ------------------------------------------------------------------
+-- OneDev: GET /~api/projects/{id}/branches → [{ name, commitHash }]
+
+b:rest("get_repo_branches", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  proxy_json(
+    function(branches)
+      return translate_list(translate_onedev_branch, branches)
+    end,
+    fetch_json(
+      base()
+        .. "/projects/"
+        .. id
+        .. "/branches?count="
+        .. count
+        .. "&offset="
+        .. ((page - 1) * count)
+    )
+  )
+end)
+
+b:rest("get_repo_branch", function(owner, repo_name, branch)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  -- OneDev: GET /~api/projects/{id}/branches?query=name+is+{branch}&count=1
+  local query = "%22Name%22+is+%22" .. branch .. "%22"
+  proxy_json(function(branches)
+    local br = (branches or {})[1]
+    if not br then
+      return {}
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
+    return translate_onedev_branch(br)
+  end, fetch_json(base() .. "/projects/" .. id .. "/branches?query=" .. query .. "&count=1"))
+end)
+
+-- Commits -------------------------------------------------------------------
+-- OneDev: GET /~api/projects/{id}/commits?revision={ref}&count={n}&offset={offset}
+-- Returns [{ hash, message, author, committer }]
+
+b:rest("get_repo_commits", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ref = GetParam("sha") or ""
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  local url = base()
+    .. "/projects/"
+    .. id
+    .. "/commits?count="
+    .. count
+    .. "&offset="
+    .. ((page - 1) * count)
+  if ref ~= "" then
+    url = url .. "&revision=" .. ref
+  end
+  proxy_json(function(commits)
+    return translate_list(translate_onedev_commit, commits)
+  end, fetch_json(url))
+end)
+
+b:rest("get_repo_commit", function(owner, repo_name, ref)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json(
+    translate_onedev_commit,
+    fetch_json(base() .. "/projects/" .. id .. "/commits/" .. ref)
+  )
+end)
+
+-- Tags ----------------------------------------------------------------------
+
+b:rest("get_repo_tags", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  -- OneDev returns [{ name, commitHash }]
+  proxy_json(function(tags)
+    tags = tags or {}
+    local result = {}
+    for _, t in ipairs(tags) do
+      result[#result + 1] = { name = t.name or "", commit = { sha = t.commitHash or "", url = "" } }
     end
-    local builds = DecodeJson(body) or {}
-    local runs = {}
-    for _, b in ipairs(builds) do
-      local od_status = b.status or "WAITING"
-      local od_to_gh = {
-        WAITING = { status = "queued", conclusion = nil },
-        RUNNING = { status = "in_progress", conclusion = nil },
-        SUCCESSFUL = { status = "completed", conclusion = "success" },
-        CANCELLED = { status = "completed", conclusion = "cancelled" },
-        TIMED_OUT = { status = "completed", conclusion = "timed_out" },
-      }
-      local mapped = od_to_gh[od_status] or { status = "completed", conclusion = "failure" }
-      local gh_status, gh_conclusion = mapped.status, mapped.conclusion
-      runs[#runs + 1] = {
-        id = b.id or 0,
-        node_id = "",
-        head_sha = b.commitHash or ref,
-        name = b.jobName or tostring(b.number or b.id or 0),
-        status = gh_status,
-        conclusion = gh_conclusion,
-        started_at = nil,
-        completed_at = gh_status == "completed" and "" or nil,
-        output = {
-          title = b.jobName or "",
-          summary = b.jobName or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = b.id and (config.base_url .. "/" .. path .. "/~builds/" .. (b.number or b.id))
-          or "",
-        details_url = "",
-      }
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
-}
+    return result
+  end, fetch_json(base() .. "/projects/" .. id .. "/tags"))
+end)
+
+-- Contents ------------------------------------------------------------------
+-- OneDev: GET /~api/blobs/{projectId}/{revision}/{path}
+-- Returns raw file content; we wrap it in a GitHub-shaped object.
+
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local ref = GetParam("ref") or "HEAD"
+  local url = base() .. "/blobs/" .. id .. "/" .. ref .. "/" .. path
+  local ok, status, _, body = fetch_json(url)
+  if ok and status == 200 then
+    respond_json(200, {
+      type = "file",
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = #body,
+      encoding = "base64",
+      content = EncodeBase64(body),
+    })
+  elseif ok then
+    respond_json(status, { message = "Error" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- Forks ---------------------------------------------------------------------
+
+b:rest("post_repo_forks", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  proxy_json_created(
+    translate_onedev_repo,
+    fetch_json(base() .. "/projects/" .. id .. "/forks", "POST", GetBody())
+  )
+end)
+
+-- Users' repos --------------------------------------------------------------
+
+b:rest("get_users_repos", function(username)
+  local query = "%22Owner%22+is+%22" .. username .. "%22"
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  proxy_json(
+    translate_onedev_repos,
+    fetch_json(
+      base()
+        .. "/projects?query="
+        .. query
+        .. "&count="
+        .. count
+        .. "&offset="
+        .. ((page - 1) * count)
+    )
+  )
+end)
+
+-- Public repos list ---------------------------------------------------------
+
+b:rest("get_repositories", function()
+  local query = "%22Public%22+is+%22true%22"
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  proxy_json(
+    translate_onedev_repos,
+    fetch_json(
+      base()
+        .. "/projects?query="
+        .. query
+        .. "&count="
+        .. count
+        .. "&offset="
+        .. ((page - 1) * count)
+    )
+  )
+end)
+
+-- Users ---------------------------------------------------------------------
+
+-- GET /users
+b:rest("get_users", function()
+  local count = GetParam("per_page") or "30"
+  local page = tonumber(GetParam("page")) or 1
+  local offset = (page - 1) * (tonumber(count) or 30)
+  proxy_json(function(users)
+    return translate_list(translate_onedev_user, users)
+  end, fetch_json(base() .. "/users?offset=" .. offset .. "&count=" .. count))
+end)
+
+-- GET /users/{username} — query by name, take first match
+b:rest(
+  "get_users_username",
+  proxy_handler(function(users)
+    local u = (users and users[1]) or {}
+    return translate_onedev_user(u)
+  end, function(username)
+    return base() .. "/users?query=name+is+%22" .. username .. "%22&count=1"
+  end)
+)
+
+-- Issues --------------------------------------------------------------------
+-- OneDev: GET /~api/issues?query="Project" is "owner/repo"&count=N&offset=O
+
+b:rest("get_repo_issues", function(owner, repo_name)
+  local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  local state = GetParam("state") or "open"
+  local query = "%22Project%22+is+%22" .. path .. "%22"
+  if state == "closed" then
+    query = query .. "+%22State%22+is+%22Closed%22"
+  elseif state ~= "all" then
+    query = query .. "+%22State%22+is+%22Open%22"
+  end
+  proxy_json(
+    function(issues)
+      return translate_list(translate_onedev_issue, issues)
+    end,
+    fetch_json(
+      base()
+        .. "/issues?query="
+        .. query
+        .. "&count="
+        .. count
+        .. "&offset="
+        .. ((page - 1) * count)
+    )
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}
+-- OneDev: query by project path + per-project number, take first result.
+b:rest("get_repo_issue", function(owner, repo_name, issue_number)
+  local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
+  local query = "%22Project%22+is+%22" .. path .. "%22+%22Number%22+is+%22" .. issue_number .. "%22"
+  local ok, status, _, body = fetch_json(base() .. "/issues?query=" .. query .. "&count=1")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local issues = DecodeJson(body) or {}
+  if not issues[1] then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_onedev_issue(issues[1]))
+end)
+
+-- POST /repos/{owner}/{repo}/issues
+b:rest("post_repo_issues", function(owner, repo_name)
+  local id = resolve_project_id(owner, repo_name)
+  if not id then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local req = DecodeJson(GetBody() or "{}")
+  local od = { projectId = id, title = req.title or "", description = req.body or "" }
+  proxy_json_created(
+    translate_onedev_issue,
+    fetch_json(base() .. "/issues", "POST", EncodeJson(od))
+  )
+end)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
+-- OneDev: resolve global issue ID first, then query /~api/issue-comments.
+b:rest("get_issue_comments", function(owner, repo_name, issue_number)
+  local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
+  local nq = "%22Project%22+is+%22" .. path .. "%22+%22Number%22+is+%22" .. issue_number .. "%22"
+  local ok, status, _, body = fetch_json(base() .. "/issues?query=" .. nq .. "&count=1")
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local issues = DecodeJson(body) or {}
+  if not issues[1] then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local issue_id = issues[1].id
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  local cq = "%22Issue%22+is+%22" .. issue_id .. "%22"
+  proxy_json(
+    function(comments)
+      return translate_list(translate_onedev_issue_comment, comments)
+    end,
+    fetch_json(
+      base()
+        .. "/issue-comments?query="
+        .. cq
+        .. "&count="
+        .. count
+        .. "&offset="
+        .. ((page - 1) * count)
+    )
+  )
+end)
+
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+b:rest("post_issue_comment", function(owner, repo_name, issue_number)
+  local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
+  local nq = "%22Project%22+is+%22" .. path .. "%22+%22Number%22+is+%22" .. issue_number .. "%22"
+  local ok, status, _, body = fetch_json(base() .. "/issues?query=" .. nq .. "&count=1")
+  if not ok or status ~= 200 then
+    respond_json(status or 503, {})
+    return
+  end
+  local issues = DecodeJson(body) or {}
+  if not issues[1] then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local issue_id = issues[1].id
+  local req = DecodeJson(GetBody() or "{}")
+  local od = { issueId = issue_id, content = req.body or "" }
+  proxy_json_created(
+    translate_onedev_issue_comment,
+    fetch_json(base() .. "/issue-comments", "POST", EncodeJson(od))
+  )
+end)
+
+-- Checks (via OneDev CI builds) -----------------------------------------------
+--
+-- OneDev CI builds are the natural mapping for GitHub Check Runs.
+--   • GET commits/{ref}/check-runs → query /~api/builds by project + commit hash.
+--   • POST check-runs              → stub (no API to push an external check status).
+--   • GET/PATCH by check_run_id   → minimal stub (would need a reverse-lookup).
+--   • Check Suites have no OneDev equivalent; all suite endpoints are stubs.
+--   • Annotations are always empty.
+--
+-- OneDev build status → GitHub status/conclusion mapping:
+--   WAITING    → status=queued,      conclusion=null
+--   RUNNING    → status=in_progress, conclusion=null
+--   SUCCESSFUL → status=completed,   conclusion=success
+--   FAILED     → status=completed,   conclusion=failure
+--   CANCELLED  → status=completed,   conclusion=cancelled
+--   TIMED_OUT  → status=completed,   conclusion=timed_out
+
+-- POST /repos/{owner}/{repo}/check-runs
+-- OneDev has no external check-status push API; falls back to route_default stub.
+
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- Maps to OneDev GET /~api/builds?query="Project" is "owner/repo" "Commit" is "{ref}".
+-- OneDev build objects: { id, number, jobName, status, commitHash, refName, project }
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local path = owner ~= "" and (owner .. "/" .. repo_name) or repo_name
+  local query = "%22Project%22+is+%22" .. path .. "%22+%22Commit%22+is+%22" .. ref .. "%22"
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  local ok, status, _, body = fetch_json(
+    base() .. "/builds?query=" .. query .. "&count=" .. count .. "&offset=" .. ((page - 1) * count)
+  )
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local builds = DecodeJson(body) or {}
+  local runs = {}
+  for _, br in ipairs(builds) do
+    local od_status = br.status or "WAITING"
+    local od_to_gh = {
+      WAITING = { status = "queued", conclusion = nil },
+      RUNNING = { status = "in_progress", conclusion = nil },
+      SUCCESSFUL = { status = "completed", conclusion = "success" },
+      CANCELLED = { status = "completed", conclusion = "cancelled" },
+      TIMED_OUT = { status = "completed", conclusion = "timed_out" },
+    }
+    local mapped = od_to_gh[od_status] or { status = "completed", conclusion = "failure" }
+    local gh_status, gh_conclusion = mapped.status, mapped.conclusion
+    runs[#runs + 1] = {
+      id = br.id or 0,
+      node_id = "",
+      head_sha = br.commitHash or ref,
+      name = br.jobName or tostring(br.number or br.id or 0),
+      status = gh_status,
+      conclusion = gh_conclusion,
+      started_at = nil,
+      completed_at = gh_status == "completed" and "" or nil,
+      output = {
+        title = br.jobName or "",
+        summary = br.jobName or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = br.id and (config.base_url .. "/" .. path .. "/~builds/" .. (br.number or br.id))
+        or "",
+      details_url = "",
+    }
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
+
+b:build()

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -190,141 +190,155 @@ local pagure_to_gh = {
   canceled = { status = "completed", conclusion = "cancelled" },
 }
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
+end)
 
-  get_repo = proxy_handler(translate_pagure_repo, function(owner, repo_name)
+b:rest(
+  "get_repo",
+  proxy_handler(translate_pagure_repo, function(owner, repo_name)
     return base() .. "/" .. owner .. "/" .. repo_name
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    -- Pagure: update project description via POST /api/0/{owner}/{repo}/modify
-    local url = base() .. "/" .. owner .. "/" .. repo_name .. "/modify"
-    local req = DecodeJson(GetBody() or "{}")
-    local pg = {}
-    if req.description then
-      pg.description = req.description
-    end
-    if req.private ~= nil then
-      pg.private = req.private
-    end
-    -- Pagure /modify returns { "repo": {...} }
-    proxy_json(function(resp)
-      return translate_pagure_repo(resp.repo or resp)
-    end, fetch_json(url, "POST", EncodeJson(pg)))
-  end,
+b:rest("patch_repo", function(owner, repo_name)
+  -- Pagure: update project description via POST /api/0/{owner}/{repo}/modify
+  local url = base() .. "/" .. owner .. "/" .. repo_name .. "/modify"
+  local req = DecodeJson(GetBody() or "{}")
+  local pg = {}
+  if req.description then
+    pg.description = req.description
+  end
+  if req.private ~= nil then
+    pg.private = req.private
+  end
+  -- Pagure /modify returns { "repo": {...} }
+  proxy_json(function(resp)
+    return translate_pagure_repo(resp.repo or resp)
+  end, fetch_json(url, "POST", EncodeJson(pg)))
+end)
 
-  delete_repo = function(owner, repo_name)
-    -- Pagure: delete project via POST /api/0/{owner}/{repo}/delete
-    local url = base() .. "/" .. owner .. "/" .. repo_name .. "/delete"
-    proxy_204({ 200 }, fetch_json(url, "POST", "{}"))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  -- Pagure: delete project via POST /api/0/{owner}/{repo}/delete
+  local url = base() .. "/" .. owner .. "/" .. repo_name .. "/delete"
+  proxy_204({ 200 }, fetch_json(url, "POST", "{}"))
+end)
 
-  get_user_repos = function()
-    -- Pagure: /api/0/projects?author={user} — need to know the authenticated user first
-    local ok, status, _, ubody = fetch_json(base() .. "/-/whoami")
-    if not ok or status ~= 200 then
-      respond_json(503, {})
-      return
-    end
-    local me = DecodeJson(ubody)
-    local username = me.username or me.name or ""
-    proxy_json(function(data)
-      return translate_list(translate_pagure_repo, data.projects)
-    end, fetch_json(append_page_params(base() .. "/user/" .. username .. "/projects", PAGES)))
-  end,
+b:rest("get_user_repos", function()
+  -- Pagure: /api/0/projects?author={user} — need to know the authenticated user first
+  local ok, status, _, ubody = fetch_json(base() .. "/-/whoami")
+  if not ok or status ~= 200 then
+    respond_json(503, {})
+    return
+  end
+  local me = DecodeJson(ubody)
+  local username = me.username or me.name or ""
+  proxy_json(function(data)
+    return translate_list(translate_pagure_repo, data.projects)
+  end, fetch_json(append_page_params(base() .. "/user/" .. username .. "/projects", PAGES)))
+end)
 
-  post_user_repos = function()
-    -- Pagure: create project via POST /api/0/new
-    local req = DecodeJson(GetBody() or "{}")
-    local pg = {
-      name = req.name,
-      description = req.description or "",
-      private = req.private or false,
-    }
-    proxy_json_created(function(resp)
-      return translate_pagure_repo(resp.project or resp)
-    end, fetch_json(base() .. "/new", "POST", EncodeJson(pg)))
-  end,
+b:rest("post_user_repos", function()
+  -- Pagure: create project via POST /api/0/new
+  local req = DecodeJson(GetBody() or "{}")
+  local pg = {
+    name = req.name,
+    description = req.description or "",
+    private = req.private or false,
+  }
+  proxy_json_created(function(resp)
+    return translate_pagure_repo(resp.project or resp)
+  end, fetch_json(base() .. "/new", "POST", EncodeJson(pg)))
+end)
 
-  get_org_repos = proxy_handler(function(data)
+b:rest(
+  "get_org_repos",
+  proxy_handler(function(data)
     return translate_list(translate_pagure_repo, data.projects)
   end, function(namespace)
     return append_page_params(base() .. "/projects?namespace=" .. namespace, PAGES)
-  end),
+  end)
+)
 
-  post_org_repos = function(namespace)
-    -- Pagure: create project with namespace
-    local req = DecodeJson(GetBody() or "{}")
-    local pg = {
-      name = req.name,
-      description = req.description or "",
-      private = req.private or false,
-      namespace = namespace,
-    }
-    proxy_json_created(function(resp)
-      return translate_pagure_repo(resp.project or resp)
-    end, fetch_json(base() .. "/new", "POST", EncodeJson(pg)))
-  end,
+b:rest("post_org_repos", function(namespace)
+  -- Pagure: create project with namespace
+  local req = DecodeJson(GetBody() or "{}")
+  local pg = {
+    name = req.name,
+    description = req.description or "",
+    private = req.private or false,
+    namespace = namespace,
+  }
+  proxy_json_created(function(resp)
+    return translate_pagure_repo(resp.project or resp)
+  end, fetch_json(base() .. "/new", "POST", EncodeJson(pg)))
+end)
 
-  get_repo_topics = proxy_handler(function(r)
+b:rest(
+  "get_repo_topics",
+  proxy_handler(function(r)
     return { names = r.tags or {} }
   end, function(owner, repo_name)
     return base() .. "/" .. owner .. "/" .. repo_name
-  end),
+  end)
+)
 
-  put_repo_topics = function(owner, repo_name)
-    -- Pagure: set tags via POST /api/0/{owner}/{repo}/modify with tags field
-    local url = base() .. "/" .. owner .. "/" .. repo_name .. "/modify"
-    local req = DecodeJson(GetBody() or "{}")
-    proxy_json(function(resp)
-      local r = resp.repo or resp
-      return { names = r.tags or {} }
-    end, fetch_json(url, "POST", EncodeJson({ tags = req.names or {} })))
-  end,
+b:rest("put_repo_topics", function(owner, repo_name)
+  -- Pagure: set tags via POST /api/0/{owner}/{repo}/modify with tags field
+  local url = base() .. "/" .. owner .. "/" .. repo_name .. "/modify"
+  local req = DecodeJson(GetBody() or "{}")
+  proxy_json(function(resp)
+    local r = resp.repo or resp
+    return { names = r.tags or {} }
+  end, fetch_json(url, "POST", EncodeJson({ tags = req.names or {} })))
+end)
 
-  -- Branches ------------------------------------------------------------------
-  -- Pagure: GET /api/0/{owner}/{repo}/git/branches → { branches: ["main", ...] }
-  -- No commit SHAs in branch list response.
+-- Branches ------------------------------------------------------------------
+-- Pagure: GET /api/0/{owner}/{repo}/git/branches → { branches: ["main", ...] }
+-- No commit SHAs in branch list response.
 
-  get_repo_branches = proxy_handler(function(data)
+b:rest(
+  "get_repo_branches",
+  proxy_handler(function(data)
     return translate_list(translate_pagure_branch, data.branches)
   end, function(owner, repo_name)
     return base() .. "/" .. owner .. "/" .. repo_name .. "/git/branches"
-  end),
+  end)
+)
 
-  -- Commits -------------------------------------------------------------------
-  -- Pagure: GET /api/0/{owner}/{repo}/commits?branch={branch}&limit={n}&start={offset}
+-- Commits -------------------------------------------------------------------
+-- Pagure: GET /api/0/{owner}/{repo}/commits?branch={branch}&limit={n}&start={offset}
 
-  get_repo_commits = function(owner, repo_name)
-    local branch = GetParam("sha") or GetParam("branch") or ""
-    local limit = GetParam("per_page") or "30"
-    local page = tonumber(GetParam("page")) or 1
-    local limit_n = tonumber(limit) or 30
-    local start = (page - 1) * limit_n
-    local url = base()
-      .. "/"
-      .. owner
-      .. "/"
-      .. repo_name
-      .. "/commits?limit="
-      .. limit
-      .. "&start="
-      .. start
-    if branch ~= "" then
-      url = url .. "&branch=" .. branch
-    end
-    proxy_json(function(data)
-      return translate_list(translate_pagure_commit, data.commits)
-    end, fetch_json(url))
-  end,
+b:rest("get_repo_commits", function(owner, repo_name)
+  local branch = GetParam("sha") or GetParam("branch") or ""
+  local limit = GetParam("per_page") or "30"
+  local page = tonumber(GetParam("page")) or 1
+  local limit_n = tonumber(limit) or 30
+  local start = (page - 1) * limit_n
+  local url = base()
+    .. "/"
+    .. owner
+    .. "/"
+    .. repo_name
+    .. "/commits?limit="
+    .. limit
+    .. "&start="
+    .. start
+  if branch ~= "" then
+    url = url .. "&branch=" .. branch
+  end
+  proxy_json(function(data)
+    return translate_list(translate_pagure_commit, data.commits)
+  end, fetch_json(url))
+end)
 
-  -- Tags ----------------------------------------------------------------------
-  -- Pagure returns { "tags": ["v1.0", ...] } — just tag names, no commit info
+-- Tags ----------------------------------------------------------------------
+-- Pagure returns { "tags": ["v1.0", ...] } — just tag names, no commit info
 
-  get_repo_tags = proxy_handler(function(data)
+b:rest(
+  "get_repo_tags",
+  proxy_handler(function(data)
     local tags = {}
     for _, name in ipairs(data.tags or {}) do
       tags[#tags + 1] = { name = name, commit = { sha = "", url = "" } }
@@ -332,41 +346,19 @@ app.backend_impl = {
     return tags
   end, function(owner, repo_name)
     return base() .. "/" .. owner .. "/" .. repo_name .. "/git/tags"
-  end),
+  end)
+)
 
-  -- Contents ------------------------------------------------------------------
-  -- Pagure: GET /api/0/{owner}/{repo}/raw/{path}?ref={ref} — returns raw bytes.
-  -- We base64-encode and return a GitHub-shaped content object.
+-- Contents ------------------------------------------------------------------
+-- Pagure: GET /api/0/{owner}/{repo}/raw/{path}?ref={ref} — returns raw bytes.
+-- We base64-encode and return a GitHub-shaped content object.
 
-  get_repo_readme = function(owner, repo_name)
-    local ref = GetParam("ref") or ""
-    -- Try common README filenames in order.
-    local candidates = { "README.md", "README", "readme.md", "README.rst" }
-    for _, fname in ipairs(candidates) do
-      local url = base() .. "/" .. owner .. "/" .. repo_name .. "/raw/" .. fname
-      if ref ~= "" then
-        url = url .. "?ref=" .. ref
-      end
-      local ok, status, _, body = fetch_json(url)
-      if ok and status == 200 then
-        respond_json(200, {
-          type = "file",
-          name = fname,
-          path = fname,
-          sha = "",
-          size = #body,
-          encoding = "base64",
-          content = EncodeBase64(body),
-        })
-        return
-      end
-    end
-    respond_json(404, { message = "Not Found" })
-  end,
-
-  get_repo_content = function(owner, repo_name, path)
-    local ref = GetParam("ref") or ""
-    local url = base() .. "/" .. owner .. "/" .. repo_name .. "/raw/" .. path
+b:rest("get_repo_readme", function(owner, repo_name)
+  local ref = GetParam("ref") or ""
+  -- Try common README filenames in order.
+  local candidates = { "README.md", "README", "readme.md", "README.rst" }
+  for _, fname in ipairs(candidates) do
+    local url = base() .. "/" .. owner .. "/" .. repo_name .. "/raw/" .. fname
     if ref ~= "" then
       url = url .. "?ref=" .. ref
     end
@@ -374,78 +366,106 @@ app.backend_impl = {
     if ok and status == 200 then
       respond_json(200, {
         type = "file",
-        name = path:match("[^/]+$") or path,
-        path = path,
+        name = fname,
+        path = fname,
         sha = "",
         size = #body,
         encoding = "base64",
         content = EncodeBase64(body),
       })
-    elseif ok then
-      respond_json(status, { message = "Error" })
-    else
-      respond_json(503, {})
+      return
     end
-  end,
+  end
+  respond_json(404, { message = "Not Found" })
+end)
 
-  -- Forks ---------------------------------------------------------------------
-  -- Pagure: POST /api/0/fork with form body
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local ref = GetParam("ref") or ""
+  local url = base() .. "/" .. owner .. "/" .. repo_name .. "/raw/" .. path
+  if ref ~= "" then
+    url = url .. "?ref=" .. ref
+  end
+  local ok, status, _, body = fetch_json(url)
+  if ok and status == 200 then
+    respond_json(200, {
+      type = "file",
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = #body,
+      encoding = "base64",
+      content = EncodeBase64(body),
+    })
+  elseif ok then
+    respond_json(status, { message = "Error" })
+  else
+    respond_json(503, {})
+  end
+end)
 
-  get_repo_forks = proxy_handler(function(data)
+-- Forks ---------------------------------------------------------------------
+-- Pagure: POST /api/0/fork with form body
+
+b:rest(
+  "get_repo_forks",
+  proxy_handler(function(data)
     return translate_list(translate_pagure_repo, data.forks)
   end, function(owner, repo_name)
     return base() .. "/" .. owner .. "/" .. repo_name
-  end),
+  end)
+)
 
-  post_repo_forks = function(owner, repo_name)
-    -- Pagure fork endpoint expects form-encoded body
-    local req = DecodeJson(GetBody() or "{}")
-    local fopts = auth() or {}
-    fopts.method = "POST"
-    fopts.body = "repo=" .. repo_name .. "&namespace=" .. owner
-    if req.organization then
-      fopts.body = fopts.body .. "&username=" .. req.organization
-    end
-    fopts.headers = fopts.headers or {}
-    fopts.headers["Content-Type"] = "application/x-www-form-urlencoded"
-    proxy_json_created(function(resp)
-      return translate_pagure_repo(resp.project or resp)
-    end, pcall(Fetch, base() .. "/fork", fopts))
-  end,
+b:rest("post_repo_forks", function(owner, repo_name)
+  -- Pagure fork endpoint expects form-encoded body
+  local req = DecodeJson(GetBody() or "{}")
+  local fopts = auth() or {}
+  fopts.method = "POST"
+  fopts.body = "repo=" .. repo_name .. "&namespace=" .. owner
+  if req.organization then
+    fopts.body = fopts.body .. "&username=" .. req.organization
+  end
+  fopts.headers = fopts.headers or {}
+  fopts.headers["Content-Type"] = "application/x-www-form-urlencoded"
+  proxy_json_created(function(resp)
+    return translate_pagure_repo(resp.project or resp)
+  end, pcall(Fetch, base() .. "/fork", fopts))
+end)
 
-  -- Users ---------------------------------------------------------------------
+-- Users ---------------------------------------------------------------------
 
-  -- GET /user — two-step: whoami then full profile
-  get_user = function()
-    local ok, status, _, ubody = fetch_json(base() .. "/-/whoami")
-    if not ok or status ~= 200 then
-      respond_json(503, {})
-      return
-    end
-    local me = DecodeJson(ubody) or {}
-    local username = me.username or ""
-    if username == "" then
-      respond_json(503, {})
-      return
-    end
-    proxy_json(function(data)
-      local u = data.user or data
-      return {
-        login = u.username or "",
-        id = 0,
-        node_id = "",
-        avatar_url = u.avatar_url or "",
-        html_url = config.base_url .. "/" .. (u.username or ""),
-        type = "User",
-        site_admin = false,
-        name = u.fullname or "",
-        email = (u.emails and u.emails[1]) or "",
-      }
-    end, fetch_json(base() .. "/user/" .. username))
-  end,
+-- GET /user — two-step: whoami then full profile
+b:rest("get_user", function()
+  local ok, status, _, ubody = fetch_json(base() .. "/-/whoami")
+  if not ok or status ~= 200 then
+    respond_json(503, {})
+    return
+  end
+  local me = DecodeJson(ubody) or {}
+  local username = me.username or ""
+  if username == "" then
+    respond_json(503, {})
+    return
+  end
+  proxy_json(function(data)
+    local u = data.user or data
+    return {
+      login = u.username or "",
+      id = 0,
+      node_id = "",
+      avatar_url = u.avatar_url or "",
+      html_url = config.base_url .. "/" .. (u.username or ""),
+      type = "User",
+      site_admin = false,
+      name = u.fullname or "",
+      email = (u.emails and u.emails[1]) or "",
+    }
+  end, fetch_json(base() .. "/user/" .. username))
+end)
 
-  -- GET /users/{username}
-  get_users_username = proxy_handler(function(data)
+-- GET /users/{username}
+b:rest(
+  "get_users_username",
+  proxy_handler(function(data)
     local u = data.user or data
     return {
       login = u.username or "",
@@ -459,10 +479,13 @@ app.backend_impl = {
     }
   end, function(username)
     return base() .. "/user/" .. username
-  end),
+  end)
+)
 
-  -- GET /users
-  get_users = proxy_handler(function(data)
+-- GET /users
+b:rest(
+  "get_users",
+  proxy_handler(function(data)
     local users = {}
     for _, name in ipairs(data.users or {}) do
       users[#users + 1] = {
@@ -478,197 +501,206 @@ app.backend_impl = {
     return users
   end, function()
     return base() .. "/users"
-  end),
+  end)
+)
 
-  -- Users' repos --------------------------------------------------------------
+-- Users' repos --------------------------------------------------------------
 
-  get_users_repos = proxy_handler(function(data)
+b:rest(
+  "get_users_repos",
+  proxy_handler(function(data)
     return translate_list(translate_pagure_repo, data.repos or data.projects)
   end, function(username)
     return append_page_params(base() .. "/user/" .. username .. "/projects", PAGES)
-  end),
+  end)
+)
 
-  -- Public repos list ---------------------------------------------------------
+-- Public repos list ---------------------------------------------------------
 
-  get_repositories = function()
-    proxy_json(function(data)
-      return translate_list(translate_pagure_repo, data.projects)
-    end, fetch_json(append_page_params(base() .. "/repos", PAGES)))
-  end,
+b:rest("get_repositories", function()
+  proxy_json(function(data)
+    return translate_list(translate_pagure_repo, data.projects)
+  end, fetch_json(append_page_params(base() .. "/repos", PAGES)))
+end)
 
-  -- Issues --------------------------------------------------------------------
+-- Issues --------------------------------------------------------------------
 
-  get_repo_issues = proxy_handler(translate_pagure_issues, function(o, r)
+b:rest(
+  "get_repo_issues",
+  proxy_handler(translate_pagure_issues, function(o, r)
     return append_page_params(base() .. "/" .. o .. "/" .. r .. "/issues", PAGES)
-  end),
+  end)
+)
 
-  -- Pagure uses /issue/{id} (singular) for individual issues
-  get_repo_issue = proxy_handler(translate_pagure_issue, function(o, r, n)
+-- Pagure uses /issue/{id} (singular) for individual issues
+b:rest(
+  "get_repo_issue",
+  proxy_handler(translate_pagure_issue, function(o, r, n)
     return base() .. "/" .. o .. "/" .. r .. "/issue/" .. n
-  end),
+  end)
+)
 
-  get_issue_comments = function(owner, repo_name, issue_number)
-    -- Pagure returns comments embedded in the issue object
-    local ok, status, _, body =
-      fetch_json(base() .. "/" .. owner .. "/" .. repo_name .. "/issue/" .. issue_number)
-    if not ok then
-      respond_json(503, {})
-      return
+b:rest("get_issue_comments", function(owner, repo_name, issue_number)
+  -- Pagure returns comments embedded in the issue object
+  local ok, status, _, body =
+    fetch_json(base() .. "/" .. owner .. "/" .. repo_name .. "/issue/" .. issue_number)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local issue = DecodeJson(body or "{}") or {}
+  respond_json(200, translate_list(translate_pagure_comment, issue.comments))
+end)
+
+b:rest("get_repo_labels", function(_owner, _repo_name)
+  -- Pagure has no repo-level label list endpoint; return empty list
+  respond_json(200, {})
+end)
+
+-- Checks (via Pagure commit flags) ------------------------------------------
+--
+-- Pagure exposes a flags API for CI status at:
+--   GET  /api/0/{owner}/{repo}/c/{commit}/flag  — list flags on a commit
+--   POST /api/0/{owner}/{repo}/c/{commit}/flag  — create/update a flag
+--
+-- Pagure flag fields: uid, username, percent, comment, url, status,
+--   date_created, date_updated
+-- Pagure flag statuses: "success", "failure", "error", "pending", "canceled"
+--
+-- GitHub → Pagure state:
+--   queued/in_progress          → pending
+--   completed/success|neutral|skipped → success
+--   completed/failure           → failure
+--   completed/(other)           → error
+--
+-- Pagure → GitHub:
+--   pending   → status=in_progress, conclusion=nil
+--   success   → status=completed,   conclusion=success
+--   failure   → status=completed,   conclusion=failure
+--   error     → status=completed,   conclusion=failure
+--   canceled  → status=completed,   conclusion=cancelled
+
+b:rest("post_check_runs", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}") or {}
+  local sha = req.head_sha or ""
+  local status = req.status or "queued"
+  local conclusion = req.conclusion
+  local gh_conclusion_to_pagure = {
+    success = "success",
+    neutral = "success",
+    skipped = "success",
+    cancelled = "canceled",
+    failure = "failure",
+  }
+  local pg_status = status == "completed" and (gh_conclusion_to_pagure[conclusion] or "error")
+    or "pending"
+  local url = base() .. "/" .. owner .. "/" .. repo_name .. "/c/" .. sha .. "/flag"
+  local flag = {
+    username = req.name or "",
+    percent = (pg_status == "success") and 100 or (pg_status == "pending" and 0 or 0),
+    comment = (req.output and req.output.summary) or req.name or "",
+    url = req.details_url or "",
+    uid = req.name or sha,
+    status = pg_status,
+  }
+  local function translate(f)
+    if not f then
+      return {}
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local issue = DecodeJson(body or "{}") or {}
-    respond_json(200, translate_list(translate_pagure_comment, issue.comments))
-  end,
-
-  get_repo_labels = function(_owner, _repo_name)
-    -- Pagure has no repo-level label list endpoint; return empty list
-    respond_json(200, {})
-  end,
-
-  -- Checks (via Pagure commit flags) ------------------------------------------
-  --
-  -- Pagure exposes a flags API for CI status at:
-  --   GET  /api/0/{owner}/{repo}/c/{commit}/flag  — list flags on a commit
-  --   POST /api/0/{owner}/{repo}/c/{commit}/flag  — create/update a flag
-  --
-  -- Pagure flag fields: uid, username, percent, comment, url, status,
-  --   date_created, date_updated
-  -- Pagure flag statuses: "success", "failure", "error", "pending", "canceled"
-  --
-  -- GitHub → Pagure state:
-  --   queued/in_progress          → pending
-  --   completed/success|neutral|skipped → success
-  --   completed/failure           → failure
-  --   completed/(other)           → error
-  --
-  -- Pagure → GitHub:
-  --   pending   → status=in_progress, conclusion=nil
-  --   success   → status=completed,   conclusion=success
-  --   failure   → status=completed,   conclusion=failure
-  --   error     → status=completed,   conclusion=failure
-  --   canceled  → status=completed,   conclusion=cancelled
-
-  post_check_runs = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}") or {}
-    local sha = req.head_sha or ""
-    local status = req.status or "queued"
-    local conclusion = req.conclusion
-    local gh_conclusion_to_pagure = {
-      success = "success",
-      neutral = "success",
-      skipped = "success",
-      cancelled = "canceled",
-      failure = "failure",
+    local s = f.status or "pending"
+    local mapped = pagure_to_gh[s] or { status = "completed", conclusion = "failure" }
+    local gh_status, gh_conclusion = mapped.status, mapped.conclusion
+    return {
+      id = 1,
+      node_id = "",
+      head_sha = sha,
+      name = f.username or req.name or "",
+      status = gh_status,
+      conclusion = gh_conclusion,
+      started_at = f.date_created,
+      completed_at = gh_status == "completed" and f.date_updated or nil,
+      output = {
+        title = f.comment or "",
+        summary = f.comment or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = f.url or "",
+      details_url = f.url or "",
     }
-    local pg_status = status == "completed" and (gh_conclusion_to_pagure[conclusion] or "error")
-      or "pending"
-    local url = base() .. "/" .. owner .. "/" .. repo_name .. "/c/" .. sha .. "/flag"
-    local flag = {
-      username = req.name or "",
-      percent = (pg_status == "success") and 100 or (pg_status == "pending" and 0 or 0),
-      comment = (req.output and req.output.summary) or req.name or "",
-      url = req.details_url or "",
-      uid = req.name or sha,
-      status = pg_status,
+  end
+  local ok, pg_status_code, _, body = fetch_json(url, "POST", EncodeJson(flag))
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  -- Pagure returns the created flag object
+  local resp = DecodeJson(body or "{}") or {}
+  local flag_obj = resp.flag or flag
+  if pg_status_code == 200 or pg_status_code == 201 then
+    respond_json(201, translate(flag_obj))
+  else
+    respond_json(pg_status_code, {})
+  end
+end)
+
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  local url = base() .. "/" .. owner .. "/" .. repo_name .. "/c/" .. ref .. "/flag"
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body or "{}") or {}
+  local flags = data.flags or {}
+  local runs = {}
+  for i, f in ipairs(flags) do
+    local s = f.status or "pending"
+    local mapped = pagure_to_gh[s] or { status = "completed", conclusion = "failure" }
+    local gh_status, gh_conclusion = mapped.status, mapped.conclusion
+    runs[i] = {
+      id = i,
+      node_id = "",
+      head_sha = ref,
+      name = f.username or "",
+      status = gh_status,
+      conclusion = gh_conclusion,
+      started_at = f.date_created,
+      completed_at = gh_status == "completed" and f.date_updated or nil,
+      output = {
+        title = f.comment or "",
+        summary = f.comment or "",
+        text = "",
+        annotations_count = 0,
+        annotations_url = "",
+      },
+      url = "",
+      html_url = f.url or "",
+      details_url = f.url or "",
     }
-    local function translate(f)
-      if not f then
-        return {}
-      end
-      local s = f.status or "pending"
-      local mapped = pagure_to_gh[s] or { status = "completed", conclusion = "failure" }
-      local gh_status, gh_conclusion = mapped.status, mapped.conclusion
-      return {
-        id = 1,
-        node_id = "",
-        head_sha = sha,
-        name = f.username or req.name or "",
-        status = gh_status,
-        conclusion = gh_conclusion,
-        started_at = f.date_created,
-        completed_at = gh_status == "completed" and f.date_updated or nil,
-        output = {
-          title = f.comment or "",
-          summary = f.comment or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = f.url or "",
-        details_url = f.url or "",
-      }
-    end
-    local ok, pg_status_code, _, body = fetch_json(url, "POST", EncodeJson(flag))
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    -- Pagure returns the created flag object
-    local resp = DecodeJson(body or "{}") or {}
-    local flag_obj = resp.flag or flag
-    if pg_status_code == 200 or pg_status_code == 201 then
-      respond_json(201, translate(flag_obj))
-    else
-      respond_json(pg_status_code, {})
-    end
-  end,
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
 
-  get_commit_check_runs = function(owner, repo_name, ref)
-    local url = base() .. "/" .. owner .. "/" .. repo_name .. "/c/" .. ref .. "/flag"
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body or "{}") or {}
-    local flags = data.flags or {}
-    local runs = {}
-    for i, f in ipairs(flags) do
-      local s = f.status or "pending"
-      local mapped = pagure_to_gh[s] or { status = "completed", conclusion = "failure" }
-      local gh_status, gh_conclusion = mapped.status, mapped.conclusion
-      runs[i] = {
-        id = i,
-        node_id = "",
-        head_sha = ref,
-        name = f.username or "",
-        status = gh_status,
-        conclusion = gh_conclusion,
-        started_at = f.date_created,
-        completed_at = gh_status == "completed" and f.date_updated or nil,
-        output = {
-          title = f.comment or "",
-          summary = f.comment or "",
-          text = "",
-          annotations_count = 0,
-          annotations_url = "",
-        },
-        url = "",
-        html_url = f.url or "",
-        details_url = f.url or "",
-      }
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
-
-  -- Check suites have no Pagure equivalent; all suite endpoints fall back to
-  -- the route_defaults stubs defined in .init.lua.
-}
+-- Check suites have no Pagure equivalent; all suite endpoints fall back to
+-- the route_defaults stubs defined in .init.lua.
 
 -- ---------------------------------------------------------------------------
 -- GraphQL resolvers
 -- ---------------------------------------------------------------------------
 
 -- Query.viewer: resolve the authenticated user via whoami then /user/{username}.
-graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+b:graphql("Query.viewer", function(_parent, _args, ctx)
   local whoami, _ = graphql_fetch(fetch_json, base() .. "/-/whoami")
   if not whoami then
     graphql_error(ctx, "could not determine authenticated user", nil, "FORBIDDEN")
@@ -689,10 +721,10 @@ graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
   local result = graphql_translate_user(gh_user)
   result.isViewer = true
   return result
-end
+end)
 
 -- Query.user: look up a User by login.
-graphql_resolvers["Query.user"] = function(_parent, args, ctx)
+b:graphql("Query.user", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "user requires a login argument")
     return nil
@@ -705,11 +737,11 @@ graphql_resolvers["Query.user"] = function(_parent, args, ctx)
   local gh_user = translate_pagure_user(u)
   gh_user.email = (u.emails and u.emails[1]) or ""
   return graphql_translate_user(gh_user)
-end
+end)
 
 -- Query.repositoryOwner: look up a user by login.
 -- Pagure has no organization concept; all owners are users.
-graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
+b:graphql("Query.repositoryOwner", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "repositoryOwner requires a login argument")
     return nil
@@ -722,10 +754,10 @@ graphql_resolvers["Query.repositoryOwner"] = function(_parent, args, ctx)
   local gh_user = translate_pagure_user(u)
   gh_user.email = (u.emails and u.emails[1]) or ""
   return graphql_translate_user(gh_user)
-end
+end)
 
 -- Query.repository: look up a Repository by owner and name.
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -735,19 +767,19 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(translate_pagure_repo(data))
-end
+end)
 
 -- node.Repository: fetch a repository by "owner/repo" local ID.
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/" .. local_id)
   if not data then
     return nil
   end
   return graphql_translate_repo(translate_pagure_repo(data))
-end
+end)
 
 -- node.User: fetch a user by login.
-graphql_resolvers["node.User"] = function(local_id, _ctx)
+b:graphql("node.User", function(local_id, _ctx)
   local data, _ = graphql_fetch(fetch_json, base() .. "/user/" .. local_id)
   if not data then
     return nil
@@ -756,11 +788,11 @@ graphql_resolvers["node.User"] = function(local_id, _ctx)
   local gh_user = translate_pagure_user(u)
   gh_user.email = (u.emails and u.emails[1]) or ""
   return graphql_translate_user(gh_user)
-end
+end)
 
 -- node.Issue: fetch an issue by "owner/repo/number" local ID.
 -- Pagure uses /issue/{number} (singular) for individual issues.
-graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+b:graphql("node.Issue", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -771,11 +803,11 @@ graphql_resolvers["node.Issue"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_issue(translate_pagure_issue(data), owner, repo)
-end
+end)
 
 -- node.IssueComment: fetch a comment by "owner/repo/issue_number/comment_id" local ID.
 -- Pagure embeds comments in the issue; we fetch the issue and find the comment by id.
-graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
+b:graphql("node.IssueComment", function(local_id, _ctx)
   local owner, repo, issue_num, cid = local_id:match("^([^/]+)/([^/]+)/(%d+)/(%d+)$")
   if not owner then
     return nil
@@ -796,11 +828,11 @@ graphql_resolvers["node.IssueComment"] = function(local_id, _ctx)
     end
   end
   return nil
-end
+end)
 
 -- Repository.issues: paginated list of issues.
 -- Pagure returns {"issues": [...], "total_issues": N}.
-graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+b:graphql("Repository.issues", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -827,11 +859,11 @@ graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_issue(translate_pagure_issue(i), owner, name)
   end
   return graphql_issues_connection(nodes, args, total, ctx)
-end
+end)
 
 -- Repository.refs: paginated list of branches as Ref objects.
 -- Pagure returns {"branches": ["name1", ...], "total_branches": N} — no commit SHAs.
-graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
+b:graphql("Repository.refs", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -859,12 +891,12 @@ graphql_resolvers["Repository.refs"] = function(parent, args, ctx)
     nodes[#nodes + 1] = graphql_translate_ref({ name = b_name }, parent)
   end
   return graphql_refs_connection(nodes, args, total, ctx)
-end
+end)
 
 -- Issue.comments: extract embedded comments from a Pagure issue.
 -- Pagure embeds all comments in the issue object; we re-fetch to get them.
 -- IssueComment node IDs use "owner/repo/issue_number/comment_id" for resolvability.
-graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
+b:graphql("Issue.comments", function(parent, args, ctx)
   local _, local_id = decode_node_id(parent.id)
   if not local_id then
     return nil
@@ -891,13 +923,13 @@ graphql_resolvers["Issue.comments"] = function(parent, args, ctx)
     nodes[#nodes + 1] = comment_node
   end
   return graphql_make_connection("IssueComment", nodes, args, #nodes, ctx)
-end
+end)
 
 -- Query.search: map GitHub GraphQL search to Pagure search endpoints.
 -- REPOSITORY: GET /projects?search={query}
 -- USER: GET /users?username={query}  (returns name list; build minimal user objects)
 -- ISSUE: Pagure has no simple keyword issue search; returns empty.
-graphql_resolvers["Query.search"] = function(_parent, args, ctx)
+b:graphql("Query.search", function(_parent, args, ctx)
   local query = args.query or ""
   local search_type = args.type or "REPOSITORY"
   local per_page = args.first or 30
@@ -971,4 +1003,6 @@ graphql_resolvers["Query.search"] = function(_parent, args, ctx)
     discussionCount = 0,
     wikiCount = 0,
   }
-end
+end)
+
+b:build()

--- a/backends/phabricator.lua
+++ b/backends/phabricator.lua
@@ -204,148 +204,149 @@ local function translate_harbormaster_build(b, ref)
   }
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, config.base_url .. "/api/conduit.ping"))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, config.base_url .. "/api/conduit.ping"))
+end)
 
-  -- Issues --------------------------------------------------------------------
-  -- GET /repos/{owner}/{repo}/issues
-  -- Phabricator: POST /api/maniphest.search with constraints[projects][0]=PHID
+-- Issues --------------------------------------------------------------------
+-- GET /repos/{owner}/{repo}/issues
+-- Phabricator: POST /api/maniphest.search with constraints[projects][0]=PHID
 
-  get_repo_issues = function(owner, repo_name)
-    local phid = resolve_project_phid(owner, repo_name)
-    if not phid then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    local state = GetParam("state") or "open"
-    local params = {
-      ["constraints[projects][0]"] = phid,
-      ["limit"] = count,
-    }
-    -- Phabricator cursor pagination: compute after cursor for page > 1.
-    -- Each page has 'count' items; after = (page-1)*count as a numeric cursor string.
-    if page > 1 then
-      params["after"] = tostring((page - 1) * count)
-    end
-    if state == "open" then
-      params["constraints[statuses][0]"] = "open"
-    elseif state == "closed" then
-      params["constraints[statuses][0]"] = "resolved"
-      params["constraints[statuses][1]"] = "wontfix"
-      params["constraints[statuses][2]"] = "invalid"
-      params["constraints[statuses][3]"] = "spite"
-    end
-    -- state == "all": no status constraint
-    local ok, status, _, body = conduit("maniphest.search", params)
-    local result, err = conduit_result(ok, status, nil, body)
-    if not result then
-      respond_json(err or 503, {})
-      return
-    end
-    local issues = {}
-    for _, t in ipairs(result.data or {}) do
-      issues[#issues + 1] = translate_task(t)
-    end
-    respond_json(200, issues)
-  end,
+b:rest("get_repo_issues", function(owner, repo_name)
+  local phid = resolve_project_phid(owner, repo_name)
+  if not phid then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  local state = GetParam("state") or "open"
+  local params = {
+    ["constraints[projects][0]"] = phid,
+    ["limit"] = count,
+  }
+  -- Phabricator cursor pagination: compute after cursor for page > 1.
+  -- Each page has 'count' items; after = (page-1)*count as a numeric cursor string.
+  if page > 1 then
+    params["after"] = tostring((page - 1) * count)
+  end
+  if state == "open" then
+    params["constraints[statuses][0]"] = "open"
+  elseif state == "closed" then
+    params["constraints[statuses][0]"] = "resolved"
+    params["constraints[statuses][1]"] = "wontfix"
+    params["constraints[statuses][2]"] = "invalid"
+    params["constraints[statuses][3]"] = "spite"
+  end
+  -- state == "all": no status constraint
+  local ok, status, _, body = conduit("maniphest.search", params)
+  local result, err = conduit_result(ok, status, nil, body)
+  if not result then
+    respond_json(err or 503, {})
+    return
+  end
+  local issues = {}
+  for _, t in ipairs(result.data or {}) do
+    issues[#issues + 1] = translate_task(t)
+  end
+  respond_json(200, issues)
+end)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}
-  -- Phabricator: POST /api/maniphest.search with constraints[ids][0]=N
+-- GET /repos/{owner}/{repo}/issues/{issue_number}
+-- Phabricator: POST /api/maniphest.search with constraints[ids][0]=N
 
-  get_repo_issue = function(_owner, _repo_name, issue_number)
-    local ok, status, _, body = conduit("maniphest.search", {
-      ["constraints[ids][0]"] = issue_number,
-      ["limit"] = 1,
-    })
-    local result, err = conduit_result(ok, status, nil, body)
-    if not result then
-      respond_json(err or 503, {})
-      return
-    end
-    local t = (result.data or {})[1]
-    if not t then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    respond_json(200, translate_task(t))
-  end,
+b:rest("get_repo_issue", function(_owner, _repo_name, issue_number)
+  local ok, status, _, body = conduit("maniphest.search", {
+    ["constraints[ids][0]"] = issue_number,
+    ["limit"] = 1,
+  })
+  local result, err = conduit_result(ok, status, nil, body)
+  if not result then
+    respond_json(err or 503, {})
+    return
+  end
+  local t = (result.data or {})[1]
+  if not t then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  respond_json(200, translate_task(t))
+end)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-  -- Phabricator: POST /api/transaction.search with objectIdentifier=T{N}
-  -- Filter to comment-type transactions only.
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
+-- Phabricator: POST /api/transaction.search with objectIdentifier=T{N}
+-- Filter to comment-type transactions only.
 
-  get_issue_comments = function(_owner, _repo_name, issue_number)
-    local count = tonumber(GetParam("per_page")) or 30
-    local page = tonumber(GetParam("page")) or 1
-    local params = {
-      ["objectIdentifier"] = "T" .. issue_number,
-      ["limit"] = count,
-    }
-    if page > 1 then
-      params["after"] = tostring((page - 1) * count)
-    end
-    local ok, status, _, body = conduit("transaction.search", params)
-    local result, err = conduit_result(ok, status, nil, body)
-    if not result then
-      respond_json(err or 503, {})
-      return
-    end
-    local comments = {}
-    for _, txn in ipairs(result.data or {}) do
-      -- Only include comment transactions (type = "comment").
-      if txn.type == "comment" then
-        local comment = txn.comments and txn.comments[1]
-        local content = comment and (comment.content or {})
-        comments[#comments + 1] = {
-          id = txn.id or 0,
-          node_id = txn.phid or "",
+b:rest("get_issue_comments", function(_owner, _repo_name, issue_number)
+  local count = tonumber(GetParam("per_page")) or 30
+  local page = tonumber(GetParam("page")) or 1
+  local params = {
+    ["objectIdentifier"] = "T" .. issue_number,
+    ["limit"] = count,
+  }
+  if page > 1 then
+    params["after"] = tostring((page - 1) * count)
+  end
+  local ok, status, _, body = conduit("transaction.search", params)
+  local result, err = conduit_result(ok, status, nil, body)
+  if not result then
+    respond_json(err or 503, {})
+    return
+  end
+  local comments = {}
+  for _, txn in ipairs(result.data or {}) do
+    -- Only include comment transactions (type = "comment").
+    if txn.type == "comment" then
+      local comment = txn.comments and txn.comments[1]
+      local content = comment and (comment.content or {})
+      comments[#comments + 1] = {
+        id = txn.id or 0,
+        node_id = txn.phid or "",
+        url = "",
+        body = type(content) == "table" and (content.raw or "") or tostring(content),
+        user = {
+          login = (txn.authorPHID or ""),
+          id = 0,
+          node_id = txn.authorPHID or "",
+          avatar_url = "",
           url = "",
-          body = type(content) == "table" and (content.raw or "") or tostring(content),
-          user = {
-            login = (txn.authorPHID or ""),
-            id = 0,
-            node_id = txn.authorPHID or "",
-            avatar_url = "",
-            url = "",
-            type = "User",
-          },
-          created_at = ts(txn.dateCreated),
-          updated_at = ts(txn.dateModified),
-          html_url = "",
-        }
-      end
+          type = "User",
+        },
+        created_at = ts(txn.dateCreated),
+        updated_at = ts(txn.dateModified),
+        html_url = "",
+      }
     end
-    respond_json(200, comments)
-  end,
+  end
+  respond_json(200, comments)
+end)
 
-  -- Checks (via Harbormaster) -------------------------------------------------
+-- Checks (via Harbormaster) -------------------------------------------------
 
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- 1. Resolve commit PHID via diffusion.commit.search.
-  -- 2. List Harbormaster builds for that commit's buildable.
-  get_commit_check_runs = function(_owner, _repo_name, ref)
-    local commit_phid = resolve_commit_phid(ref)
-    if not commit_phid then
-      respond_json(200, { total_count = 0, check_runs = {} })
-      return
-    end
-    local ok, status, _, body = conduit("harbormaster.build.search", {
-      ["constraints[buildables][0]"] = commit_phid,
-      ["limit"] = 100,
-    })
-    local result, err = conduit_result(ok, status, nil, body)
-    if not result then
-      respond_json(err or 503, {})
-      return
-    end
-    local runs = {}
-    for _, b in ipairs(result.data or {}) do
-      runs[#runs + 1] = translate_harbormaster_build(b, ref)
-    end
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
-}
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- 1. Resolve commit PHID via diffusion.commit.search.
+-- 2. List Harbormaster builds for that commit's buildable.
+b:rest("get_commit_check_runs", function(_owner, _repo_name, ref)
+  local commit_phid = resolve_commit_phid(ref)
+  if not commit_phid then
+    respond_json(200, { total_count = 0, check_runs = {} })
+    return
+  end
+  local ok, status, _, body = conduit("harbormaster.build.search", {
+    ["constraints[buildables][0]"] = commit_phid,
+    ["limit"] = 100,
+  })
+  local result, err = conduit_result(ok, status, nil, body)
+  if not result then
+    respond_json(err or 503, {})
+    return
+  end
+  local runs = {}
+  for _, br in ipairs(result.data or {}) do
+    runs[#runs + 1] = translate_harbormaster_build(br, ref)
+  end
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
+
+b:build()

--- a/backends/radicle.lua
+++ b/backends/radicle.lua
@@ -91,204 +91,205 @@ local function translate_radicle_repos(repos)
   return translate_list(translate_radicle_repo, repos)
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base(), auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base(), auth()))
+end)
 
-  -- GET /repos/{owner}/{rid} — owner is ignored; repo = RID
-  get_repo = function(_, rid)
-    proxy_json(translate_radicle_repo, fetch_json(base() .. "/repos/" .. rid))
-  end,
+-- GET /repos/{owner}/{rid} — owner is ignored; repo = RID
+b:rest("get_repo", function(_, rid)
+  proxy_json(translate_radicle_repo, fetch_json(base() .. "/repos/" .. rid))
+end)
 
-  patch_repo = function(_, rid)
-    proxy_json(
-      translate_radicle_repo,
-      fetch_json(base() .. "/repos/" .. rid, "PATCH", translate_radicle_req(GetBody()))
-    )
-  end,
+b:rest("patch_repo", function(_, rid)
+  proxy_json(
+    translate_radicle_repo,
+    fetch_json(base() .. "/repos/" .. rid, "PATCH", translate_radicle_req(GetBody()))
+  )
+end)
 
-  -- Radicle has no delete endpoint
-  delete_repo = function()
-    respond_json(
-      405,
-      "Method Not Allowed",
-      { message = "Radicle does not support repository deletion" }
-    )
-  end,
+-- Radicle has no delete endpoint
+b:rest("delete_repo", function()
+  respond_json(
+    405,
+    "Method Not Allowed",
+    { message = "Radicle does not support repository deletion" }
+  )
+end)
 
-  get_user_repos = function()
-    -- Radicle: list repos seeded/hosted locally
-    proxy_json(
-      translate_radicle_repos,
-      fetch_json(append_page_params(base() .. "/repos?show=local", PAGES))
-    )
-  end,
+b:rest("get_user_repos", function()
+  -- Radicle: list repos seeded/hosted locally
+  proxy_json(
+    translate_radicle_repos,
+    fetch_json(append_page_params(base() .. "/repos?show=local", PAGES))
+  )
+end)
 
-  post_user_repos = function()
-    proxy_json_created(
-      translate_radicle_repo,
-      fetch_json(base() .. "/repos", "POST", translate_radicle_req(GetBody()))
-    )
-  end,
+b:rest("post_user_repos", function()
+  proxy_json_created(
+    translate_radicle_repo,
+    fetch_json(base() .. "/repos", "POST", translate_radicle_req(GetBody()))
+  )
+end)
 
-  get_repo_tags = function(_, rid)
-    -- Radicle returns [{ name, oid }] or [{ ref, oid }]
-    proxy_json(function(tags)
-      tags = tags or {}
-      local result = {}
-      for _, t in ipairs(tags) do
-        result[#result + 1] = {
-          name = t.name or t.ref or "",
-          commit = { sha = t.oid or t.target or "", url = "" },
-        }
-      end
-      return result
-    end, fetch_json(base() .. "/repos/" .. rid .. "/tags"))
-  end,
-
-  -- Branches ------------------------------------------------------------------
-  -- Radicle: GET /api/v1/repos/{rid}/branches → [{ name, head }]
-
-  get_repo_branches = function(_, rid)
-    proxy_json(function(branches)
-      branches = branches or {}
-      local result = {}
-      for _, b in ipairs(branches) do
-        result[#result + 1] = {
-          name = b.name or "",
-          commit = { sha = b.head or "", url = "" },
-          protected = false,
-        }
-      end
-      return result
-    end, fetch_json(base() .. "/repos/" .. rid .. "/branches"))
-  end,
-
-  get_repo_branch = function(_, rid, branch)
-    -- Fetch all branches and find the named one.
-    proxy_json(function(branches)
-      for _, b in ipairs(branches or {}) do
-        if b.name == branch then
-          return { name = b.name, commit = { sha = b.head or "", url = "" }, protected = false }
-        end
-      end
-      return {}
-    end, fetch_json(base() .. "/repos/" .. rid .. "/branches"))
-  end,
-
-  -- Commits -------------------------------------------------------------------
-  -- Radicle: GET /api/v1/repos/{rid}/commits?branch={branch}
-
-  get_repo_commits = function(_, rid)
-    local branch = GetParam("sha") or ""
-    local url = base() .. "/repos/" .. rid .. "/commits"
-    if branch ~= "" then
-      url = url .. "?branch=" .. branch
+b:rest("get_repo_tags", function(_, rid)
+  -- Radicle returns [{ name, oid }] or [{ ref, oid }]
+  proxy_json(function(tags)
+    tags = tags or {}
+    local result = {}
+    for _, t in ipairs(tags) do
+      result[#result + 1] = {
+        name = t.name or t.ref or "",
+        commit = { sha = t.oid or t.target or "", url = "" },
+      }
     end
-    proxy_json(function(commits)
-      commits = commits or {}
-      local result = {}
-      for _, c in ipairs(commits) do
-        local author = c.author or {}
-        result[#result + 1] = {
-          sha = c.id or "",
-          commit = {
-            message = c.message or "",
-            author = { name = author.name or "", email = author.email or "", date = "" },
-            committer = { name = author.name or "", email = author.email or "", date = "" },
-          },
-          author = { login = author.name or "", id = 0, avatar_url = "" },
-          committer = { login = author.name or "", id = 0, avatar_url = "" },
-        }
-      end
-      return result
-    end, fetch_json(url))
-  end,
+    return result
+  end, fetch_json(base() .. "/repos/" .. rid .. "/tags"))
+end)
 
-  get_repo_commit = function(_, rid, ref)
-    proxy_json(function(c)
-      if not c then
-        return {}
+-- Branches ------------------------------------------------------------------
+-- Radicle: GET /api/v1/repos/{rid}/branches → [{ name, head }]
+
+b:rest("get_repo_branches", function(_, rid)
+  proxy_json(function(branches)
+    branches = branches or {}
+    local result = {}
+    for _, br in ipairs(branches) do
+      result[#result + 1] = {
+        name = br.name or "",
+        commit = { sha = br.head or "", url = "" },
+        protected = false,
+      }
+    end
+    return result
+  end, fetch_json(base() .. "/repos/" .. rid .. "/branches"))
+end)
+
+b:rest("get_repo_branch", function(_, rid, branch)
+  -- Fetch all branches and find the named one.
+  proxy_json(function(branches)
+    for _, br in ipairs(branches or {}) do
+      if br.name == branch then
+        return { name = br.name, commit = { sha = br.head or "", url = "" }, protected = false }
       end
+    end
+    return {}
+  end, fetch_json(base() .. "/repos/" .. rid .. "/branches"))
+end)
+
+-- Commits -------------------------------------------------------------------
+-- Radicle: GET /api/v1/repos/{rid}/commits?branch={branch}
+
+b:rest("get_repo_commits", function(_, rid)
+  local branch = GetParam("sha") or ""
+  local url = base() .. "/repos/" .. rid .. "/commits"
+  if branch ~= "" then
+    url = url .. "?branch=" .. branch
+  end
+  proxy_json(function(commits)
+    commits = commits or {}
+    local result = {}
+    for _, c in ipairs(commits) do
       local author = c.author or {}
-      return {
+      result[#result + 1] = {
         sha = c.id or "",
         commit = {
           message = c.message or "",
           author = { name = author.name or "", email = author.email or "", date = "" },
           committer = { name = author.name or "", email = author.email or "", date = "" },
         },
+        author = { login = author.name or "", id = 0, avatar_url = "" },
+        committer = { login = author.name or "", id = 0, avatar_url = "" },
       }
-    end, fetch_json(base() .. "/repos/" .. rid .. "/commits/" .. ref))
-  end,
-
-  -- Issues -----------------------------------------------------------------------
-  -- Radicle has a decentralized issues system (rad issue) but it uses a
-  -- peer-to-peer protocol not compatible with the GitHub Issues REST API shape.
-  -- All issues, labels, milestones, and assignees endpoints fall back to the
-  -- default empty-list / 404 handlers defined in .init.lua.
-
-  -- Contents ------------------------------------------------------------------
-  -- Radicle: GET /api/v1/repos/{rid}/blob/{commit}/{path} — raw bytes
-
-  get_repo_readme = function(_, rid)
-    local ref = GetParam("ref") or "HEAD"
-    local candidates = { "README.md", "README", "readme.md", "README.rst" }
-    for _, fname in ipairs(candidates) do
-      local ok, status, _, body =
-        fetch_json(base() .. "/repos/" .. rid .. "/blob/" .. ref .. "/" .. fname)
-      if ok and status == 200 then
-        respond_json(200, {
-          type = "file",
-          name = fname,
-          path = fname,
-          sha = "",
-          size = #body,
-          encoding = "base64",
-          content = EncodeBase64(body),
-        })
-        return
-      end
     end
-    respond_json(404, { message = "Not Found" })
-  end,
+    return result
+  end, fetch_json(url))
+end)
 
-  get_repo_content = function(_, rid, path)
-    local ref = GetParam("ref") or "HEAD"
+b:rest("get_repo_commit", function(_, rid, ref)
+  proxy_json(function(c)
+    if not c then
+      return {}
+    end
+    local author = c.author or {}
+    return {
+      sha = c.id or "",
+      commit = {
+        message = c.message or "",
+        author = { name = author.name or "", email = author.email or "", date = "" },
+        committer = { name = author.name or "", email = author.email or "", date = "" },
+      },
+    }
+  end, fetch_json(base() .. "/repos/" .. rid .. "/commits/" .. ref))
+end)
+
+-- Issues -----------------------------------------------------------------------
+-- Radicle has a decentralized issues system (rad issue) but it uses a
+-- peer-to-peer protocol not compatible with the GitHub Issues REST API shape.
+-- All issues, labels, milestones, and assignees endpoints fall back to the
+-- default empty-list / 404 handlers defined in .init.lua.
+
+-- Contents ------------------------------------------------------------------
+-- Radicle: GET /api/v1/repos/{rid}/blob/{commit}/{path} — raw bytes
+
+b:rest("get_repo_readme", function(_, rid)
+  local ref = GetParam("ref") or "HEAD"
+  local candidates = { "README.md", "README", "readme.md", "README.rst" }
+  for _, fname in ipairs(candidates) do
     local ok, status, _, body =
-      fetch_json(base() .. "/repos/" .. rid .. "/blob/" .. ref .. "/" .. path)
+      fetch_json(base() .. "/repos/" .. rid .. "/blob/" .. ref .. "/" .. fname)
     if ok and status == 200 then
       respond_json(200, {
         type = "file",
-        name = path:match("[^/]+$") or path,
-        path = path,
+        name = fname,
+        path = fname,
         sha = "",
         size = #body,
         encoding = "base64",
         content = EncodeBase64(body),
       })
-    elseif ok then
-      respond_json(status, { message = "Error" })
-    else
-      respond_json(503, {})
+      return
     end
-  end,
+  end
+  respond_json(404, { message = "Not Found" })
+end)
 
-  -- Users' repos --------------------------------------------------------------
+b:rest("get_repo_content", function(_, rid, path)
+  local ref = GetParam("ref") or "HEAD"
+  local ok, status, _, body =
+    fetch_json(base() .. "/repos/" .. rid .. "/blob/" .. ref .. "/" .. path)
+  if ok and status == 200 then
+    respond_json(200, {
+      type = "file",
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = #body,
+      encoding = "base64",
+      content = EncodeBase64(body),
+    })
+  elseif ok then
+    respond_json(status, { message = "Error" })
+  else
+    respond_json(503, {})
+  end
+end)
 
-  get_users_repos = function(username)
-    -- Radicle: list repos seeded by a specific node/delegate
-    proxy_json(
-      translate_radicle_repos,
-      fetch_json(append_page_params(base() .. "/repos?show=all&delegate=" .. username, PAGES))
-    )
-  end,
+-- Users' repos --------------------------------------------------------------
 
-  get_repositories = function()
-    proxy_json(
-      translate_radicle_repos,
-      fetch_json(append_page_params(base() .. "/repos?show=all", PAGES))
-    )
-  end,
-}
+b:rest("get_users_repos", function(username)
+  -- Radicle: list repos seeded by a specific node/delegate
+  proxy_json(
+    translate_radicle_repos,
+    fetch_json(append_page_params(base() .. "/repos?show=all&delegate=" .. username, PAGES))
+  )
+end)
+
+b:rest("get_repositories", function()
+  proxy_json(
+    translate_radicle_repos,
+    fetch_json(append_page_params(base() .. "/repos?show=all", PAGES))
+  )
+end)
+
+b:build()

--- a/backends/rhodecode.lua
+++ b/backends/rhodecode.lua
@@ -1,11 +1,12 @@
 -- RhodeCode backend handler overrides.
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, config.base_url .. "/_admin/api", make_fetch_opts("bearer")))
+end)
 
-  -- Issues -----------------------------------------------------------------------
-  -- RhodeCode has no native issue tracker; it integrates with external trackers
-  -- such as JIRA. All issues, labels, milestones, and assignees endpoints fall
-  -- back to the default empty-list / 404 handlers defined in .init.lua.
-}
+-- Issues -----------------------------------------------------------------------
+-- RhodeCode has no native issue tracker; it integrates with external trackers
+-- such as JIRA. All issues, labels, milestones, and assignees endpoints fall
+-- back to the default empty-list / 404 handlers defined in .init.lua.
+
+b:build()

--- a/backends/sourceforge.lua
+++ b/backends/sourceforge.lua
@@ -2,18 +2,15 @@
 if config.base_url == "" then
   config.base_url = "https://sourceforge.net"
 end
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, config.base_url .. "/rest/p"))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, config.base_url .. "/rest/p"))
+end)
 
-  -- Issues -----------------------------------------------------------------------
-  -- SourceForge uses the Allura ticket tracker, whose REST API shape differs
-  -- significantly from GitHub Issues and is not currently mapped.
-  -- All issues, labels, milestones, and assignees endpoints fall back to the
-  -- default empty-list / 404 handlers defined in .init.lua.
-}
+-- Issues -----------------------------------------------------------------------
+-- SourceForge uses the Allura ticket tracker, whose REST API shape differs
+-- significantly from GitHub Issues and is not currently mapped.
+-- All issues, labels, milestones, and assignees endpoints fall back to the
+-- default empty-list / 404 handlers defined in .init.lua.
 
--- Code scanning: SourceForge has no native code scanning API.
--- All code scanning endpoints fall back to the default handlers in .init.lua:
--- list endpoints return 200 empty, per-resource endpoints return 501.
+b:build()

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -237,71 +237,76 @@ local function translate_srht_commit(c)
   }
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, config.base_url .. "/api/version", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, config.base_url .. "/api/version", auth()))
+end)
 
-  get_repo = proxy_handler(translate_srht_repo, function(owner, repo_name)
+b:rest(
+  "get_repo",
+  proxy_handler(translate_srht_repo, function(owner, repo_name)
     return base() .. "/~" .. owner .. "/repos/" .. repo_name
-  end),
+  end)
+)
 
-  patch_repo = function(owner, repo_name)
-    -- Sourcehut uses PUT for updates
-    proxy_json(
-      translate_srht_repo,
-      fetch_json(
-        base() .. "/~" .. owner .. "/repos/" .. repo_name,
-        "PUT",
-        translate_srht_req(GetBody())
-      )
+b:rest("patch_repo", function(owner, repo_name)
+  -- Sourcehut uses PUT for updates
+  proxy_json(
+    translate_srht_repo,
+    fetch_json(
+      base() .. "/~" .. owner .. "/repos/" .. repo_name,
+      "PUT",
+      translate_srht_req(GetBody())
     )
-  end,
+  )
+end)
 
-  delete_repo = function(owner, repo_name)
-    local url = base() .. "/~" .. owner .. "/repos/" .. repo_name
-    local dopts = auth() or {}
-    dopts.method = "DELETE"
-    proxy_204({ 200 }, pcall(Fetch, url, dopts))
-  end,
+b:rest("delete_repo", function(owner, repo_name)
+  local url = base() .. "/~" .. owner .. "/repos/" .. repo_name
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  proxy_204({ 200 }, pcall(Fetch, url, dopts))
+end)
 
-  get_user_repos = function()
-    -- Sourcehut: need to know the authenticated user. Use /api/user first.
-    local ok, status, _, ubody = fetch_json(config.base_url .. "/api/user")
-    if not ok or status ~= 200 then
-      respond_json(503, {})
-      return
-    end
-    local user = DecodeJson(ubody)
-    local canonical = user.canonical_name or ("~" .. (user.name or ""))
-    proxy_json(
-      function(data)
-        return translate_list(translate_srht_repo, data.results)
-      end,
-      -- Sourcehut uses cursor-based pagination; only limit is supported for page size
-      fetch_json(append_page_params(base() .. "/" .. canonical .. "/repos", PAGES))
-    )
-  end,
+b:rest("get_user_repos", function()
+  -- Sourcehut: need to know the authenticated user. Use /api/user first.
+  local ok, status, _, ubody = fetch_json(config.base_url .. "/api/user")
+  if not ok or status ~= 200 then
+    respond_json(503, {})
+    return
+  end
+  local user = DecodeJson(ubody)
+  local canonical = user.canonical_name or ("~" .. (user.name or ""))
+  proxy_json(
+    function(data)
+      return translate_list(translate_srht_repo, data.results)
+    end,
+    -- Sourcehut uses cursor-based pagination; only limit is supported for page size
+    fetch_json(append_page_params(base() .. "/" .. canonical .. "/repos", PAGES))
+  )
+end)
 
-  post_user_repos = function()
-    -- Sourcehut: create via POST /api/~{user}/repos — need user context
-    local ok, status, _, ubody = fetch_json(config.base_url .. "/api/user")
-    if not ok or status ~= 200 then
-      respond_json(503, {})
-      return
-    end
-    local user = DecodeJson(ubody)
-    local canonical = user.canonical_name or ("~" .. (user.name or ""))
-    proxy_json_created(
-      translate_srht_repo,
-      fetch_json(base() .. "/" .. canonical .. "/repos", "POST", translate_srht_req(GetBody()))
-    )
-  end,
+b:rest("post_user_repos", function()
+  -- Sourcehut: create via POST /api/~{user}/repos — need user context
+  local ok, status, _, ubody = fetch_json(config.base_url .. "/api/user")
+  if not ok or status ~= 200 then
+    respond_json(503, {})
+    return
+  end
+  local user = DecodeJson(ubody)
+  local canonical = user.canonical_name or ("~" .. (user.name or ""))
+  proxy_json_created(
+    translate_srht_repo,
+    fetch_json(base() .. "/" .. canonical .. "/repos", "POST", translate_srht_req(GetBody()))
+  )
+end)
 
-  -- Branches ------------------------------------------------------------------
-  -- Sourcehut: filter /refs for refs starting with "refs/heads/"
+-- Branches ------------------------------------------------------------------
+-- Sourcehut: filter /refs for refs starting with "refs/heads/"
 
-  get_repo_branches = proxy_handler(function(data)
+b:rest(
+  "get_repo_branches",
+  proxy_handler(function(data)
     local branches = {}
     for _, ref in ipairs(data.results or {}) do
       if ref.name and ref.name:match("^refs/heads/") then
@@ -311,9 +316,12 @@ app.backend_impl = {
     return branches
   end, function(owner, repo_name)
     return base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/refs"
-  end),
+  end)
+)
 
-  get_repo_branch = proxy_handler(function(data, _owner, _repo_name, branch)
+b:rest(
+  "get_repo_branch",
+  proxy_handler(function(data, _owner, _repo_name, branch)
     for _, ref in ipairs(data.results or {}) do
       if ref.name == "refs/heads/" .. branch then
         return translate_srht_branch(ref)
@@ -322,259 +330,251 @@ app.backend_impl = {
     return {}
   end, function(owner, repo_name)
     return base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/refs"
-  end),
+  end)
+)
 
-  -- Tags ----------------------------------------------------------------------
-  -- Sourcehut /refs returns { results: [...] } with name and target fields
-  -- Filter to tags only (refs starting with "refs/tags/")
+-- Tags ----------------------------------------------------------------------
+-- Sourcehut /refs returns { results: [...] } with name and target fields
+-- Filter to tags only (refs starting with "refs/tags/")
 
-  get_repo_tags = function(owner, repo_name)
-    proxy_json(function(data)
-      local tags = {}
-      for _, ref in ipairs(data.results or {}) do
-        local tag_name = ref.name and ref.name:match("^refs/tags/(.+)")
-        if tag_name then
-          tags[#tags + 1] = { name = tag_name, commit = { sha = ref.target or "", url = "" } }
-        end
-      end
-      return tags
-    end, fetch_json(base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/refs"))
-  end,
-
-  -- Commits -------------------------------------------------------------------
-  -- Sourcehut: GET /api/~{owner}/repos/{name}/log or /log/{ref}
-
-  get_repo_commits = function(owner, repo_name)
-    local ref = GetParam("sha") or ""
-    local url = base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/log"
-    if ref ~= "" then
-      url = url .. "/" .. ref
-    end
-    url = append_page_params(url, PAGES)
-    proxy_json(function(data)
-      return translate_list(translate_srht_commit, data.results)
-    end, fetch_json(url))
-  end,
-
-  get_repo_commit = function(owner, repo_name, ref)
-    -- Fetch the log at the specific ref and return first entry.
-    proxy_json(
-      function(data)
-        local c = (data.results or {})[1]
-        return translate_srht_commit(c)
-      end,
-      fetch_json(base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/log/" .. ref .. "?limit=1")
-    )
-  end,
-
-  -- Contents ------------------------------------------------------------------
-  -- Sourcehut: GET /api/~{owner}/repos/{name}/blob/{ref}/{path} — raw bytes.
-
-  get_repo_readme = function(owner, repo_name)
-    local ref = GetParam("ref") or "HEAD"
-    local candidates = { "README.md", "README", "readme.md", "README.rst" }
-    for _, fname in ipairs(candidates) do
-      local url = base()
-        .. "/~"
-        .. owner
-        .. "/repos/"
-        .. repo_name
-        .. "/blob/"
-        .. ref
-        .. "/"
-        .. fname
-      local ok, status, _, body = fetch_json(url)
-      if ok and status == 200 then
-        respond_json(200, {
-          type = "file",
-          name = fname,
-          path = fname,
-          sha = "",
-          size = #body,
-          encoding = "base64",
-          content = EncodeBase64(body),
-        })
-        return
+b:rest("get_repo_tags", function(owner, repo_name)
+  proxy_json(function(data)
+    local tags = {}
+    for _, ref in ipairs(data.results or {}) do
+      local tag_name = ref.name and ref.name:match("^refs/tags/(.+)")
+      if tag_name then
+        tags[#tags + 1] = { name = tag_name, commit = { sha = ref.target or "", url = "" } }
       end
     end
-    respond_json(404, { message = "Not Found" })
-  end,
+    return tags
+  end, fetch_json(base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/refs"))
+end)
 
-  get_repo_content = function(owner, repo_name, path)
-    local ref = GetParam("ref") or "HEAD"
-    local url = base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/blob/" .. ref .. "/" .. path
+-- Commits -------------------------------------------------------------------
+-- Sourcehut: GET /api/~{owner}/repos/{name}/log or /log/{ref}
+
+b:rest("get_repo_commits", function(owner, repo_name)
+  local ref = GetParam("sha") or ""
+  local url = base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/log"
+  if ref ~= "" then
+    url = url .. "/" .. ref
+  end
+  url = append_page_params(url, PAGES)
+  proxy_json(function(data)
+    return translate_list(translate_srht_commit, data.results)
+  end, fetch_json(url))
+end)
+
+b:rest("get_repo_commit", function(owner, repo_name, ref)
+  -- Fetch the log at the specific ref and return first entry.
+  proxy_json(
+    function(data)
+      local c = (data.results or {})[1]
+      return translate_srht_commit(c)
+    end,
+    fetch_json(base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/log/" .. ref .. "?limit=1")
+  )
+end)
+
+-- Contents ------------------------------------------------------------------
+-- Sourcehut: GET /api/~{owner}/repos/{name}/blob/{ref}/{path} — raw bytes.
+
+b:rest("get_repo_readme", function(owner, repo_name)
+  local ref = GetParam("ref") or "HEAD"
+  local candidates = { "README.md", "README", "readme.md", "README.rst" }
+  for _, fname in ipairs(candidates) do
+    local url = base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/blob/" .. ref .. "/" .. fname
     local ok, status, _, body = fetch_json(url)
     if ok and status == 200 then
       respond_json(200, {
         type = "file",
-        name = path:match("[^/]+$") or path,
-        path = path,
+        name = fname,
+        path = fname,
         sha = "",
         size = #body,
         encoding = "base64",
         content = EncodeBase64(body),
       })
-    elseif ok then
-      respond_json(status, { message = "Error" })
-    else
-      respond_json(503, {})
-    end
-  end,
-
-  -- Users' repos --------------------------------------------------------------
-
-  get_users_repos = function(username)
-    proxy_json(function(data)
-      return translate_list(translate_srht_repo, data.results)
-    end, fetch_json(append_page_params(base() .. "/~" .. username .. "/repos", PAGES)))
-  end,
-
-  -- Users ---------------------------------------------------------------------
-
-  -- GET /user
-  get_user = function()
-    proxy_json(function(u)
-      if not u then
-        return {}
-      end
-      local canonical = u.canonical_name or ""
-      local login = canonical:sub(1, 1) == "~" and canonical:sub(2) or canonical
-      return {
-        login = login,
-        id = 0,
-        node_id = "",
-        avatar_url = "",
-        html_url = config.base_url .. "/" .. canonical,
-        type = "User",
-        site_admin = false,
-        name = u.name or canonical,
-        email = u.email or "",
-        blog = u.url or "",
-      }
-    end, fetch_json(base() .. "/user"))
-  end,
-
-  -- Issues --------------------------------------------------------------------
-  -- todo.sr.ht: GET /api/~{owner}/trackers/{repo}/tickets
-
-  get_repo_issues = function(owner, repo_name)
-    local url = todo_base() .. "/~" .. owner .. "/trackers/" .. repo_name .. "/tickets"
-    url = append_page_params(url, PAGES)
-    proxy_json(function(data)
-      return translate_list(translate_srht_ticket, data.results)
-    end, fetch_json(url))
-  end,
-
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}
-  -- Cannot use proxy_json: todo.sr.ht returns a 404 body with tracker-specific
-  -- error text; we emit a clean GitHub-shaped { message = "Not Found" } instead.
-  get_repo_issue = function(owner, repo_name, issue_number)
-    local url = todo_base()
-      .. "/~"
-      .. owner
-      .. "/trackers/"
-      .. repo_name
-      .. "/tickets/"
-      .. issue_number
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
       return
     end
-    if status == 404 then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local ticket = DecodeJson(body)
-    respond_json(200, translate_srht_ticket(ticket))
-  end,
+  end
+  respond_json(404, { message = "Not Found" })
+end)
 
-  -- POST /repos/{owner}/{repo}/issues
-  post_repo_issues = function(owner, repo_name)
-    local req = DecodeJson(GetBody() or "{}")
-    local payload = EncodeJson({ title = req.title or "", description = req.body or "" })
-    proxy_json_created(
-      translate_srht_ticket,
-      fetch_json(
-        todo_base() .. "/~" .. owner .. "/trackers/" .. repo_name .. "/tickets",
-        "POST",
-        payload
-      )
+b:rest("get_repo_content", function(owner, repo_name, path)
+  local ref = GetParam("ref") or "HEAD"
+  local url = base() .. "/~" .. owner .. "/repos/" .. repo_name .. "/blob/" .. ref .. "/" .. path
+  local ok, status, _, body = fetch_json(url)
+  if ok and status == 200 then
+    respond_json(200, {
+      type = "file",
+      name = path:match("[^/]+$") or path,
+      path = path,
+      sha = "",
+      size = #body,
+      encoding = "base64",
+      content = EncodeBase64(body),
+    })
+  elseif ok then
+    respond_json(status, { message = "Error" })
+  else
+    respond_json(503, {})
+  end
+end)
+
+-- Users' repos --------------------------------------------------------------
+
+b:rest("get_users_repos", function(username)
+  proxy_json(function(data)
+    return translate_list(translate_srht_repo, data.results)
+  end, fetch_json(append_page_params(base() .. "/~" .. username .. "/repos", PAGES)))
+end)
+
+-- Users ---------------------------------------------------------------------
+
+-- GET /user
+b:rest("get_user", function()
+  proxy_json(function(u)
+    if not u then
+      return {}
+    end
+    local canonical = u.canonical_name or ""
+    local login = canonical:sub(1, 1) == "~" and canonical:sub(2) or canonical
+    return {
+      login = login,
+      id = 0,
+      node_id = "",
+      avatar_url = "",
+      html_url = config.base_url .. "/" .. canonical,
+      type = "User",
+      site_admin = false,
+      name = u.name or canonical,
+      email = u.email or "",
+      blog = u.url or "",
+    }
+  end, fetch_json(base() .. "/user"))
+end)
+
+-- Issues --------------------------------------------------------------------
+-- todo.sr.ht: GET /api/~{owner}/trackers/{repo}/tickets
+
+b:rest("get_repo_issues", function(owner, repo_name)
+  local url = todo_base() .. "/~" .. owner .. "/trackers/" .. repo_name .. "/tickets"
+  url = append_page_params(url, PAGES)
+  proxy_json(function(data)
+    return translate_list(translate_srht_ticket, data.results)
+  end, fetch_json(url))
+end)
+
+-- GET /repos/{owner}/{repo}/issues/{issue_number}
+-- Cannot use proxy_json: todo.sr.ht returns a 404 body with tracker-specific
+-- error text; we emit a clean GitHub-shaped { message = "Not Found" } instead.
+b:rest("get_repo_issue", function(owner, repo_name, issue_number)
+  local url = todo_base()
+    .. "/~"
+    .. owner
+    .. "/trackers/"
+    .. repo_name
+    .. "/tickets/"
+    .. issue_number
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status == 404 then
+    respond_json(404, { message = "Not Found" })
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local ticket = DecodeJson(body)
+  respond_json(200, translate_srht_ticket(ticket))
+end)
+
+-- POST /repos/{owner}/{repo}/issues
+b:rest("post_repo_issues", function(owner, repo_name)
+  local req = DecodeJson(GetBody() or "{}")
+  local payload = EncodeJson({ title = req.title or "", description = req.body or "" })
+  proxy_json_created(
+    translate_srht_ticket,
+    fetch_json(
+      todo_base() .. "/~" .. owner .. "/trackers/" .. repo_name .. "/tickets",
+      "POST",
+      payload
     )
-  end,
+  )
+end)
 
-  -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-  -- todo.sr.ht: GET /api/~{owner}/trackers/{repo}/tickets/{id}/events
-  -- Filter events to only those with a comment field.
-  get_issue_comments = function(owner, repo_name, issue_number)
-    local url = todo_base()
-      .. "/~"
-      .. owner
-      .. "/trackers/"
-      .. repo_name
-      .. "/tickets/"
-      .. issue_number
-      .. "/events"
-    url = append_page_params(url, PAGES)
-    proxy_json(function(data)
-      local events = data.results or {}
-      local comments = {}
-      for _, e in ipairs(events) do
-        local c = translate_srht_event_comment(e)
-        if c then
-          comments[#comments + 1] = c
-        end
+-- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
+-- todo.sr.ht: GET /api/~{owner}/trackers/{repo}/tickets/{id}/events
+-- Filter events to only those with a comment field.
+b:rest("get_issue_comments", function(owner, repo_name, issue_number)
+  local url = todo_base()
+    .. "/~"
+    .. owner
+    .. "/trackers/"
+    .. repo_name
+    .. "/tickets/"
+    .. issue_number
+    .. "/events"
+  url = append_page_params(url, PAGES)
+  proxy_json(function(data)
+    local events = data.results or {}
+    local comments = {}
+    for _, e in ipairs(events) do
+      local c = translate_srht_event_comment(e)
+      if c then
+        comments[#comments + 1] = c
       end
-      return comments
-    end, fetch_json(url))
-  end,
-
-  -- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
-  post_issue_comment = function(owner, repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}")
-    local payload = EncodeJson({ comment = req.body or "" })
-    local url = todo_base()
-      .. "/~"
-      .. owner
-      .. "/trackers/"
-      .. repo_name
-      .. "/tickets/"
-      .. issue_number
-      .. "/events"
-    proxy_json_created(function(e)
-      return translate_srht_event_comment(e) or {}
-    end, fetch_json(url, "POST", payload))
-  end,
-
-  -- Checks (via builds.sr.ht jobs) --------------------------------------------
-
-  -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-  -- Maps to builds.sr.ht GET /api/jobs filtered by the git repo tag and commit SHA.
-  -- builds.sr.ht jobs are tagged with "git.sr.ht/~owner/repo=sha" when triggered
-  -- from a git push.
-  get_commit_check_runs = function(owner, repo_name, ref)
-    -- Derive the git.sr.ht hostname from the config base URL for the tag filter.
-    local git_host = config.base_url:match("^https?://([^/]+)") or "git.sr.ht"
-    local tag = git_host .. "/~" .. owner .. "/" .. repo_name .. "=" .. ref
-    local url = builds_base() .. "/jobs?filter[tags]=" .. tag
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
-      return
     end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local data = DecodeJson(body) or {}
-    local runs = translate_list(translate_srht_job_to_check_run, data.results)
-    respond_json(200, { total_count = #runs, check_runs = runs })
-  end,
-}
+    return comments
+  end, fetch_json(url))
+end)
+
+-- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+b:rest("post_issue_comment", function(owner, repo_name, issue_number)
+  local req = DecodeJson(GetBody() or "{}")
+  local payload = EncodeJson({ comment = req.body or "" })
+  local url = todo_base()
+    .. "/~"
+    .. owner
+    .. "/trackers/"
+    .. repo_name
+    .. "/tickets/"
+    .. issue_number
+    .. "/events"
+  proxy_json_created(function(e)
+    return translate_srht_event_comment(e) or {}
+  end, fetch_json(url, "POST", payload))
+end)
+
+-- Checks (via builds.sr.ht jobs) --------------------------------------------
+
+-- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
+-- Maps to builds.sr.ht GET /api/jobs filtered by the git repo tag and commit SHA.
+-- builds.sr.ht jobs are tagged with "git.sr.ht/~owner/repo=sha" when triggered
+-- from a git push.
+b:rest("get_commit_check_runs", function(owner, repo_name, ref)
+  -- Derive the git.sr.ht hostname from the config base URL for the tag filter.
+  local git_host = config.base_url:match("^https?://([^/]+)") or "git.sr.ht"
+  local tag = git_host .. "/~" .. owner .. "/" .. repo_name .. "=" .. ref
+  local url = builds_base() .. "/jobs?filter[tags]=" .. tag
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local data = DecodeJson(body) or {}
+  local runs = translate_list(translate_srht_job_to_check_run, data.results)
+  respond_json(200, { total_count = #runs, check_runs = runs })
+end)
 
 -- Code scanning: Sourcehut has no native code scanning API.
 -- All code scanning endpoints fall back to the default handlers in .init.lua:
@@ -607,7 +607,7 @@ local function translate_srht_user_for_graphql(u)
   }
 end
 
-graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
+b:graphql("Query.repository", function(_parent, args, ctx)
   if not args.owner or not args.name then
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
@@ -617,9 +617,9 @@ graphql_resolvers["Query.repository"] = function(_parent, args, ctx)
     return nil
   end
   return graphql_translate_repo(translate_srht_repo(data))
-end
+end)
 
-graphql_resolvers["node.Repository"] = function(local_id, _ctx)
+b:graphql("node.Repository", function(local_id, _ctx)
   local owner, name = local_id:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
@@ -629,9 +629,9 @@ graphql_resolvers["node.Repository"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_repo(translate_srht_repo(data))
-end
+end)
 
-graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
+b:graphql("Query.viewer", function(_parent, _args, ctx)
   local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
   if not data then
     return nil
@@ -639,7 +639,7 @@ graphql_resolvers["Query.viewer"] = function(_parent, _args, ctx)
   local u = graphql_translate_user(translate_srht_user_for_graphql(data))
   u.isViewer = true
   return u
-end
+end)
 
 -- Repository.issues: paginated list of issues via todo.sr.ht trackers.
 -- Sourcehut pagination uses cursor-based results with a `limit` param;
@@ -668,15 +668,15 @@ local function srht_issue_connection(owner, repo_name, args, ctx)
   return graphql_issues_connection(nodes, args, nil, ctx)
 end
 
-graphql_resolvers["Repository.issues"] = function(parent, args, ctx)
+b:graphql("Repository.issues", function(parent, args, ctx)
   local owner, name = parent.nameWithOwner:match("^([^/]+)/(.+)$")
   if not owner then
     return nil
   end
   return srht_issue_connection(owner, name, args, ctx)
-end
+end)
 
-graphql_resolvers["node.Issue"] = function(local_id, _ctx)
+b:graphql("node.Issue", function(local_id, _ctx)
   local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
   if not owner then
     return nil
@@ -687,4 +687,6 @@ graphql_resolvers["node.Issue"] = function(local_id, _ctx)
     return nil
   end
   return graphql_translate_issue(translate_srht_ticket(data), owner, repo)
-end
+end)
+
+b:build()

--- a/backends/tuleap.lua
+++ b/backends/tuleap.lua
@@ -135,121 +135,122 @@ local function find_project(shortname)
   return nil
 end
 
-app.backend_impl = {
-  get_root = function()
-    proxy_health_check(pcall(Fetch, base() .. "/projects?limit=1", auth()))
-  end,
+local b = make_backend_builder()
+b:rest("get_root", function()
+  proxy_health_check(pcall(Fetch, base() .. "/projects?limit=1", auth()))
+end)
 
-  -- GET /repos/{owner}/{repo}: owner = project shortname, repo = git repo name.
-  -- Two-step: find project by shortname, then list git repos and filter by name.
-  get_repo = function(owner, repo_name)
-    local project = find_project(owner)
-    if not project then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    local ok, status, _, body = fetch_json(project_git_url(project.id))
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local repos = DecodeJson(body) or {}
-    for _, r in ipairs(repos) do
-      if r.name == repo_name then
-        respond_json(200, translate_tuleap_repo(r))
-        return
-      end
-    end
+-- GET /repos/{owner}/{repo}: owner = project shortname, repo = git repo name.
+-- Two-step: find project by shortname, then list git repos and filter by name.
+b:rest("get_repo", function(owner, repo_name)
+  local project = find_project(owner)
+  if not project then
     respond_json(404, { message = "Not Found" })
-  end,
+    return
+  end
+  local ok, status, _, body = fetch_json(project_git_url(project.id))
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local repos = DecodeJson(body) or {}
+  for _, r in ipairs(repos) do
+    if r.name == repo_name then
+      respond_json(200, translate_tuleap_repo(r))
+      return
+    end
+  end
+  respond_json(404, { message = "Not Found" })
+end)
 
-  -- GET /orgs/{org}/repos: org = project shortname; lists git repos in that project.
-  get_org_repos = function(org)
-    local project = find_project(org)
-    if not project then
-      respond_json(404, { message = "Not Found" })
-      return
-    end
-    proxy_json(function(repos)
-      local result = {}
-      for _, r in ipairs(repos or {}) do
-        result[#result + 1] = translate_tuleap_repo(r)
-      end
-      return result
-    end, fetch_json(project_git_url(project.id)))
-  end,
-
-  -- GET /users/{username}: find Tuleap user by username.
-  get_users_username = function(username)
-    local url = base() .. '/users?query={"username":"' .. username .. '"}&limit=1'
-    local ok, status, _, body = fetch_json(url)
-    if not ok then
-      respond_json(503, {})
-      return
-    end
-    if status ~= 200 then
-      respond_json(status, {})
-      return
-    end
-    local users = DecodeJson(body) or {}
-    for _, u in ipairs(users) do
-      if u.username == username then
-        respond_json(200, translate_tuleap_user(u))
-        return
-      end
-    end
+-- GET /orgs/{org}/repos: org = project shortname; lists git repos in that project.
+b:rest("get_org_repos", function(org)
+  local project = find_project(org)
+  if not project then
     respond_json(404, { message = "Not Found" })
-  end,
+    return
+  end
+  proxy_json(function(repos)
+    local result = {}
+    for _, r in ipairs(repos or {}) do
+      result[#result + 1] = translate_tuleap_repo(r)
+    end
+    return result
+  end, fetch_json(project_git_url(project.id)))
+end)
 
-  -- GET /users: list Tuleap users (search by ?q= if given).
-  get_users = function()
-    local q = GetParam("q") or ""
-    proxy_json(function(users)
-      local result = {}
-      for _, u in ipairs(users or {}) do
-        result[#result + 1] = translate_tuleap_user(u)
-      end
-      return result
-    end, fetch_json(users_url(q)))
-  end,
+-- GET /users/{username}: find Tuleap user by username.
+b:rest("get_users_username", function(username)
+  local url = base() .. '/users?query={"username":"' .. username .. '"}&limit=1'
+  local ok, status, _, body = fetch_json(url)
+  if not ok then
+    respond_json(503, {})
+    return
+  end
+  if status ~= 200 then
+    respond_json(status, {})
+    return
+  end
+  local users = DecodeJson(body) or {}
+  for _, u in ipairs(users) do
+    if u.username == username then
+      respond_json(200, translate_tuleap_user(u))
+      return
+    end
+  end
+  respond_json(404, { message = "Not Found" })
+end)
 
-  -- GET /search/repositories: search Tuleap projects by name.
-  search_repositories = function()
-    local q = GetParam("q") or ""
-    proxy_json(function(projects)
-      local items = {}
-      for _, p in ipairs(projects or {}) do
-        items[#items + 1] = {
+-- GET /users: list Tuleap users (search by ?q= if given).
+b:rest("get_users", function()
+  local q = GetParam("q") or ""
+  proxy_json(function(users)
+    local result = {}
+    for _, u in ipairs(users or {}) do
+      result[#result + 1] = translate_tuleap_user(u)
+    end
+    return result
+  end, fetch_json(users_url(q)))
+end)
+
+-- GET /search/repositories: search Tuleap projects by name.
+b:rest("search_repositories", function()
+  local q = GetParam("q") or ""
+  proxy_json(function(projects)
+    local items = {}
+    for _, p in ipairs(projects or {}) do
+      items[#items + 1] = {
+        id = p.id or 0,
+        name = p.shortname or "",
+        full_name = p.shortname or "",
+        description = p.description,
+        private = p.access ~= "public",
+        owner = {
+          login = p.shortname or "",
           id = p.id or 0,
-          name = p.shortname or "",
-          full_name = p.shortname or "",
-          description = p.description,
-          private = p.access ~= "public",
-          owner = {
-            login = p.shortname or "",
-            id = p.id or 0,
-            type = "Organization",
-          },
-          html_url = config.base_url .. "/projects/" .. (p.shortname or ""),
-        }
-      end
-      return { total_count = #items, incomplete_results = false, items = items }
-    end, fetch_json(projects_url(q)))
-  end,
+          type = "Organization",
+        },
+        html_url = config.base_url .. "/projects/" .. (p.shortname or ""),
+      }
+    end
+    return { total_count = #items, incomplete_results = false, items = items }
+  end, fetch_json(projects_url(q)))
+end)
 
-  -- GET /search/users: search Tuleap users by username.
-  search_users = function()
-    local q = GetParam("q") or ""
-    proxy_json(function(users)
-      local items = {}
-      for _, u in ipairs(users or {}) do
-        items[#items + 1] = translate_tuleap_user(u)
-      end
-      return { total_count = #items, incomplete_results = false, items = items }
-    end, fetch_json(users_url(q)))
-  end,
-}
+-- GET /search/users: search Tuleap users by username.
+b:rest("search_users", function()
+  local q = GetParam("q") or ""
+  proxy_json(function(users)
+    local items = {}
+    for _, u in ipairs(users or {}) do
+      items[#items + 1] = translate_tuleap_user(u)
+    end
+    return { total_count = #items, incomplete_results = false, items = items }
+  end, fetch_json(users_url(q)))
+end)
+
+b:build()

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -21,8 +21,7 @@ local endpoint_sections = {
     "graphql",
     {
       -- GraphQL API (https://docs.github.com/en/graphql)
-      -- graphql_handler is the fixed handler for all backends; backends populate
-      -- graphql_resolvers rather than overriding app.backend_impl.graphql_request.
+      -- graphql_handler is the fixed handler; backends register resolvers via b:graphql().
       { "POST /graphql", "graphql_request", graphql_handler },
     },
   },

--- a/internal/context.lua
+++ b/internal/context.lua
@@ -7,6 +7,9 @@
 --   config          — backend config table (same object as the global `config`)
 --   backend_impl    — handler registry set by the backend at startup
 --   allow_anonymous — auth-gate flag; true means unauthenticated requests are allowed
+--   _family_strip   — private; set by load_family_backend before loading a root
+--                     backend so the root's builder can strip alias feature gaps
+--                     declaratively in b:build(); always nil outside that window
 
 function make_app(cfg) -- luacheck: globals make_app
   return {

--- a/internal/families.lua
+++ b/internal/families.lua
@@ -8,9 +8,9 @@
 -- The table key is the root backend name (the canonical family implementation).
 -- Each alias entry declares:
 --   default_url  string — backend default when no base_url is given
---   strip        table  — Lua patterns; app.backend_impl keys matching any are
---                         cleared after inheriting from the root implementation,
---                         because those features are absent from this variant
+--   strip        table  — Lua patterns; REST handler keys matching any pattern are
+--                         excluded when the root builder calls b:build(), because
+--                         those features are absent from this alias variant
 provider_families = {
   gitea = {
     aliases = {
@@ -28,9 +28,13 @@ provider_families = {
 -- load_family_backend is global: alias backends call it to inherit a family
 -- implementation.  Looks up config.backend in provider_families[root].aliases,
 -- sets config.base_url from the alias's default_url when the user hasn't
--- supplied one, loads the root backend via dofile, then clears any app.backend_impl
--- keys whose names match the alias's strip patterns (features absent from this
--- variant).
+-- supplied one, then loads the root backend via dofile.
+--
+-- Strip patterns are declared declaratively: before loading the root backend,
+-- app._family_strip is set to the alias's strip list.  The root backend's
+-- builder reads app._family_strip in b:build() and excludes REST handler keys
+-- whose names match any pattern.  app._family_strip is cleared after dofile
+-- returns.
 function load_family_backend(root)
   local family = provider_families[root]
   assert(family, "unknown provider family: " .. root)
@@ -39,12 +43,9 @@ function load_family_backend(root)
   if config.base_url == "" then
     config.base_url = alias.default_url
   end
+  -- Declare strip patterns before loading the root backend so the builder can
+  -- apply them inside b:build() rather than mutating app.backend_impl afterward.
+  app._family_strip = alias.strip
   dofile("/zip/backends/" .. root .. ".lua")
-  for _, pattern in ipairs(alias.strip or {}) do
-    for k in pairs(app.backend_impl) do
-      if k:find(pattern) then
-        app.backend_impl[k] = nil
-      end
-    end
-  end
+  app._family_strip = nil
 end

--- a/internal/registry.lua
+++ b/internal/registry.lua
@@ -1,0 +1,83 @@
+-- Backend builder: structured alternative to directly mutating global registries.
+--
+-- make_backend_builder() returns a builder.  A backend file calls b:rest(name, fn),
+-- b:graphql(key, fn), and b:set_allow_anonymous(v) to declare its handlers and
+-- metadata, then calls b:build() to commit them to the app context.
+--
+-- This is the new registration path.  The old path (directly assigning
+-- app.backend_impl = {...} and graphql_resolvers["k"] = fn) remains supported
+-- during migration and coexists without conflict since only one backend loads
+-- per process.
+--
+-- Globals exported:
+--   make_backend_builder   — builder factory; backends call this at load time
+
+function make_backend_builder() -- luacheck: globals make_backend_builder
+  local b = {
+    _rest = {},
+    _graphql = {},
+    _anonymous = nil,
+  }
+
+  -- Register a REST handler.
+  -- name: catalog handler name (e.g. "get_repo")
+  -- fn:   handler function, called with route captures as positional args
+  -- Returns self for method chaining.
+  function b:rest(name, fn)
+    self._rest[name] = fn
+    return self
+  end
+
+  -- Register a GraphQL resolver.
+  -- key: resolver key in graphql_resolvers (e.g. "Query.viewer", "node.Repository")
+  -- fn:  resolver function (parent, args, ctx) or (local_id, ctx) for node resolvers
+  -- Returns self for method chaining.
+  function b:graphql(key, fn)
+    self._graphql[key] = fn
+    return self
+  end
+
+  -- Declare the anonymous-access policy for this backend.
+  -- v: true = allow unauthenticated requests; false = require Authorization header
+  -- When not called, app.allow_anonymous is left at its current value.
+  -- Returns self for method chaining.
+  function b:set_allow_anonymous(v)
+    self._anonymous = v
+    return self
+  end
+
+  -- Commit all registered handlers to the app context.
+  --
+  -- strip: optional array of Lua patterns; REST keys whose names match any pattern
+  --        are silently omitted from the commit.  Used by load_family_backend to
+  --        strip features absent from a family alias (e.g. gogs strips "_package").
+  --
+  -- After build() returns:
+  --   app.backend_impl[name] = fn  for each registered REST handler (unless stripped)
+  --   graphql_resolvers[key]  = fn  for each registered GraphQL resolver
+  --   app.allow_anonymous     = v   only when set_allow_anonymous was called
+  function b:build(strip)
+    for name, fn in pairs(self._rest) do
+      local skip = false
+      if strip then
+        for _, pat in ipairs(strip) do
+          if name:find(pat) then
+            skip = true
+            break
+          end
+        end
+      end
+      if not skip then
+        app.backend_impl[name] = fn
+      end
+    end
+    for key, fn in pairs(self._graphql) do
+      graphql_resolvers[key] = fn
+    end
+    if self._anonymous ~= nil then
+      app.allow_anonymous = self._anonymous
+    end
+  end
+
+  return b
+end

--- a/internal/registry.lua
+++ b/internal/registry.lua
@@ -1,13 +1,11 @@
--- Backend builder: structured alternative to directly mutating global registries.
+-- Backend builder: the required API for registering REST handlers and GraphQL resolvers.
 --
 -- make_backend_builder() returns a builder.  A backend file calls b:rest(name, fn),
 -- b:graphql(key, fn), and b:set_allow_anonymous(v) to declare its handlers and
 -- metadata, then calls b:build() to commit them to the app context.
 --
--- This is the new registration path.  The old path (directly assigning
--- app.backend_impl = {...} and graphql_resolvers["k"] = fn) remains supported
--- during migration and coexists without conflict since only one backend loads
--- per process.
+-- Direct assignment to app.backend_impl or graphql_resolvers is forbidden;
+-- make validate-builders enforces this at CI time.
 --
 -- Globals exported:
 --   make_backend_builder   — builder factory; backends call this at load time

--- a/internal/registry.lua
+++ b/internal/registry.lua
@@ -49,18 +49,23 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
   -- Commit all registered handlers to the app context.
   --
   -- strip: optional array of Lua patterns; REST keys whose names match any pattern
-  --        are silently omitted from the commit.  Used by load_family_backend to
-  --        strip features absent from a family alias (e.g. gogs strips "_package").
+  --        are silently omitted from the commit.  When omitted, b:build() falls back
+  --        to app._family_strip, which load_family_backend sets before loading the
+  --        root backend file so alias feature gaps are applied declaratively rather
+  --        than by post-hoc mutation.
   --
   -- After build() returns:
   --   app.backend_impl[name] = fn  for each registered REST handler (unless stripped)
   --   graphql_resolvers[key]  = fn  for each registered GraphQL resolver
   --   app.allow_anonymous     = v   only when set_allow_anonymous was called
   function b:build(strip)
+    -- Explicit strip arg takes precedence; fall back to the family-level strip
+    -- declared by load_family_backend before the root backend file was loaded.
+    local effective_strip = strip or app._family_strip
     for name, fn in pairs(self._rest) do
       local skip = false
-      if strip then
-        for _, pat in ipairs(strip) do
+      if effective_strip then
+        for _, pat in ipairs(effective_strip) do
           if name:find(pat) then
             skip = true
             break

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1589,12 +1589,16 @@ do
   local _saved_base_url = config.base_url
   local _saved_impl = app.backend_impl
 
-  -- Stub dofile so load_family_backend's dofile("/zip/backends/gitea.lua") is a no-op.
+  -- Stub dofile so load_family_backend's dofile("/zip/backends/gitea.lua") is a
+  -- no-op.  Also captures app._family_strip at the time of the call so tests can
+  -- verify the declarative strip declaration.
   -- luacheck: push
   -- luacheck: globals dofile
   local _real_dofile2 = dofile
+  local _strip_during_dofile
   dofile = function(path)
     if path and path:match("^/zip/backends/") then
+      _strip_during_dofile = app._family_strip
       return
     end
     return _real_dofile2(path)
@@ -1604,7 +1608,6 @@ do
   -- Happy path: sets base_url from alias default when config.base_url is empty.
   config.backend = "forgejo"
   config.base_url = ""
-  app.backend_impl = {}
   load_family_backend("gitea")
   eq(
     config.base_url,
@@ -1615,7 +1618,6 @@ do
   -- Explicit base_url is preserved (not overwritten by alias default).
   config.backend = "forgejo"
   config.base_url = "https://custom.example.com"
-  app.backend_impl = {}
   load_family_backend("gitea")
   eq(
     config.base_url,
@@ -1623,26 +1625,38 @@ do
     "load_family_backend: preserves explicit base_url"
   )
 
-  -- Strip patterns remove matching app.backend_impl keys (gogs strips _package and _actions_).
+  -- Strip patterns are declared in app._family_strip before the root backend loads,
+  -- then cleared afterward (gogs strips _package and _actions_).
   config.backend = "gogs"
   config.base_url = "https://try.gogs.io"
-  app.backend_impl = {
-    get_package_info = function() end,
-    list_actions_runs = function() end,
-    get_repo = function() end,
-  }
+  _strip_during_dofile = nil
   load_family_backend("gitea")
   ok(
+    _strip_during_dofile ~= nil,
+    "load_family_backend: app._family_strip is set during dofile for gogs"
+  )
+  ok(app._family_strip == nil, "load_family_backend: app._family_strip is cleared after dofile")
+
+  -- The builder reads app._family_strip in b:build() and excludes matching keys.
+  app.backend_impl = {}
+  app._family_strip = _strip_during_dofile -- luacheck: globals app
+  local bt = make_backend_builder()
+  bt:rest("get_package_info", function() end)
+  bt:rest("list_actions_runs", function() end)
+  bt:rest("get_repo", function() end)
+  bt:build()
+  app._family_strip = nil -- luacheck: globals app
+  ok(
     app.backend_impl["get_package_info"] == nil,
-    "load_family_backend: strips _package keys for gogs"
+    "load_family_backend: builder strips _package keys for gogs"
   )
   ok(
     app.backend_impl["list_actions_runs"] == nil,
-    "load_family_backend: strips _actions_ keys for gogs"
+    "load_family_backend: builder strips _actions_ keys for gogs"
   )
   ok(
     app.backend_impl["get_repo"] ~= nil,
-    "load_family_backend: preserves non-stripped keys for gogs"
+    "load_family_backend: builder preserves non-matching keys for gogs"
   )
 
   dofile = _real_dofile2 -- luacheck: globals dofile

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1672,6 +1672,95 @@ do
 end
 
 -- ============================================================
+-- make_backend_builder
+-- ============================================================
+
+do
+  local saved_impl = app.backend_impl
+  local saved_resolvers = graphql_resolvers -- luacheck: globals graphql_resolvers
+  local saved_anon = app.allow_anonymous
+
+  local function restore()
+    app.backend_impl = saved_impl
+    graphql_resolvers = saved_resolvers -- luacheck: globals graphql_resolvers
+    app.allow_anonymous = saved_anon
+  end
+
+  -- factory returns a builder table with the expected methods
+  local b = make_backend_builder()
+  ok(type(b) == "table", "make_backend_builder: returns a table")
+  ok(type(b.rest) == "function", "make_backend_builder: has rest method")
+  ok(type(b.graphql) == "function", "make_backend_builder: has graphql method")
+  ok(
+    type(b.set_allow_anonymous) == "function",
+    "make_backend_builder: has set_allow_anonymous method"
+  )
+  ok(type(b.build) == "function", "make_backend_builder: has build method")
+
+  -- registration methods return self for chaining
+  local b2 = make_backend_builder()
+  ok(b2:rest("get_foo", function() end) == b2, "builder:rest: returns self")
+  ok(b2:graphql("Query.foo", function() end) == b2, "builder:graphql: returns self")
+  ok(b2:set_allow_anonymous(true) == b2, "builder:set_allow_anonymous: returns self")
+
+  -- build() populates app.backend_impl and graphql_resolvers
+  app.backend_impl = {}
+  graphql_resolvers = {} -- luacheck: globals graphql_resolvers
+  app.allow_anonymous = true
+
+  local get_fn = function() end
+  local gql_fn = function() end
+  local b3 = make_backend_builder()
+  b3:rest("get_repo", get_fn)
+  b3:graphql("Query.viewer", gql_fn)
+  b3:set_allow_anonymous(false)
+  b3:build()
+
+  eq(app.backend_impl["get_repo"], get_fn, "builder:build: registers REST handler")
+  eq(graphql_resolvers["Query.viewer"], gql_fn, "builder:build: registers GraphQL resolver") -- luacheck: globals graphql_resolvers
+  eq(app.allow_anonymous, false, "builder:build: sets allow_anonymous")
+
+  -- build() without set_allow_anonymous leaves allow_anonymous unchanged
+  app.backend_impl = {}
+  app.allow_anonymous = true
+  local b4 = make_backend_builder()
+  b4:rest("get_root", function() end)
+  b4:build()
+  ok(
+    app.allow_anonymous == true,
+    "builder:build: does not change allow_anonymous when not declared"
+  )
+
+  -- build(strip) excludes REST keys matching any pattern
+  app.backend_impl = {}
+  local b5 = make_backend_builder()
+  b5:rest("get_repo", function() end)
+  b5:rest("get_package_info", function() end)
+  b5:rest("list_actions_runs", function() end)
+  b5:build({ "_package", "_actions_" })
+  ok(app.backend_impl["get_repo"] ~= nil, "builder:build(strip): keeps non-matching key")
+  ok(app.backend_impl["get_package_info"] == nil, "builder:build(strip): strips _package key")
+  ok(app.backend_impl["list_actions_runs"] == nil, "builder:build(strip): strips _actions_ key")
+
+  -- two builders are independent and do not share state
+  app.backend_impl = {}
+  local ba = make_backend_builder()
+  ba:rest("get_foo", function() end)
+  local bb = make_backend_builder()
+  bb:rest("get_bar", function() end)
+  ba:build()
+  ok(app.backend_impl["get_foo"] ~= nil, "make_backend_builder: builders are independent (a built)")
+  ok(
+    app.backend_impl["get_bar"] == nil,
+    "make_backend_builder: builders are independent (b not yet built)"
+  )
+  bb:build()
+  ok(app.backend_impl["get_bar"] ~= nil, "make_backend_builder: builders are independent (b built)")
+
+  restore()
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 


### PR DESCRIPTION
Fixes #204.

Introduces a backend builder/registry abstraction so backend files declare their REST handlers, GraphQL resolvers, and metadata through a structured API instead of directly mutating `app.backend_impl` and `graphql_resolvers` globals. All GraphQL-enabled backends (gitea, gitlab, bitbucket, bitbucket_datacenter, sourcehut, azuredevops, gitbucket, pagure) and the Gitea family aliases are already migrated; the remaining simple backends follow, after which the legacy global-mutation path is removed entirely.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (9)</summary>

- [x] Migrate remaining simple backends to builder pattern <!-- type:spec -->
- [x] Remove legacy global mutation path and enforce builder-only registration <!-- type:spec -->
- [x] Migrate bitbucket and bitbucket_datacenter to builder pattern <!-- type:spec -->
- [x] Migrate GraphQL-enabled backends to builder pattern <!-- type:spec -->
- [x] Migrate gitlab.lua to backend builder pattern <!-- type:spec -->
- [x] Migrate Gitea family aliases to builder pattern <!-- type:spec -->
- [x] Update load_family_backend for declarative builder inheritance <!-- type:spec -->
- [x] Migrate gitea.lua to backend builder pattern <!-- type:spec -->
- [x] Add backend registry module and wire into load chain and dispatch <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->