### PR TITLE
Rank 6: migrate GitLab to capability modules and thin REST/GraphQL adapters (closes #207)

### DIFF
--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -554,66 +554,192 @@ local GL_STATUS_TO_CHECK_RUN = {
   canceled = { status = "completed", conclusion = "cancelled" },
 }
 
+-- ---------------------------------------------------------------------------
+-- Repos capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_repo for all repository operations.
+-- REST handlers and GraphQL resolvers both call into this table rather than
+-- duplicating the URL construction, error mapping, and translation logic.
+-- All operations return (data, nil) on success or (nil, err) on failure.
+-- Paged list operations return (items, headers, nil) or (nil, nil, err).
+
+local repos = {}
+
+-- get: fetch a single repository.
+repos.get = function(owner, repo_name)
+  local raw, err = cap_fetch(fetch_json, base() .. "/projects/" .. project_id(owner, repo_name))
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_repo(raw), nil
+end
+
+-- update: apply a partial update (GitLab uses PUT for project updates).
+-- body: raw GitHub-format request body string (translated internally).
+repos.update = function(owner, repo_name, body)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name),
+    "PUT",
+    translate_gl_req(body)
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_repo(raw), nil
+end
+
+-- delete: permanently remove a repository.
+-- GitLab returns 202 Accepted for async deletion.
+-- Returns (true, nil) on 202 success or (nil, err) on failure.
+repos.delete = function(owner, repo_name)
+  local url = base() .. "/projects/" .. project_id(owner, repo_name)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  local ok, status = pcall(Fetch, url, dopts)
+  if not ok then
+    return nil, cap_err(0, "network error deleting " .. owner .. "/" .. repo_name)
+  end
+  if status ~= 202 and status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " deleting repository")
+  end
+  return true, nil
+end
+
+-- list_user: paginated list of repos for the authenticated user.
+repos.list_user = function()
+  local url = append_page_params(base() .. "/projects?owned=true&membership=true", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
+
+-- create_user: create a repository under the authenticated user.
+repos.create_user = function(body)
+  local raw, err = cap_fetch(fetch_json, base() .. "/projects", "POST", translate_gl_req(body))
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_repo(raw), nil
+end
+
+-- list_org: paginated list of repos for a GitLab group.
+repos.list_org = function(org)
+  local url = append_page_params(base() .. "/groups/" .. org .. "/projects", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
+
+-- create_org: create a repository inside a GitLab group (namespace).
+repos.create_org = function(org, body)
+  local gl_req = translate_gl_req(body)
+  local gl = DecodeJson(gl_req)
+  gl.namespace_id = org
+  local raw, err = cap_fetch(fetch_json, base() .. "/projects", "POST", EncodeJson(gl))
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_repo(raw), nil
+end
+
+-- list_by_user: paginated list of public repos for a specific user.
+repos.list_by_user = function(username)
+  local url = append_page_params(base() .. "/users/" .. username .. "/projects", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
+
+-- list_all: paginated list of all public projects.
+repos.list_all = function()
+  local url = append_page_params(base() .. "/projects?visibility=public", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
+
+-- get_topics: fetch project topics, returned as { names = [...] }.
+repos.get_topics = function(owner, repo_name)
+  local raw, err = cap_fetch(fetch_json, base() .. "/projects/" .. project_id(owner, repo_name))
+  if not raw then
+    return nil, err
+  end
+  return { names = raw.topics or {} }, nil
+end
+
+-- put_topics: replace project topics.
+repos.put_topics = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}")
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name),
+    "PUT",
+    EncodeJson({ topics = req.names or {} })
+  )
+  if not raw then
+    return nil, err
+  end
+  return { names = raw.topics or {} }, nil
+end
+
 local b = make_backend_builder()
 
 b:rest("get_root", function()
   proxy_health_check(pcall(Fetch, base() .. "/version", auth()))
 end)
 
-b:rest(
-  "get_repo",
-  proxy_handler(translate_gl_repo, function(owner, repo_name)
-    return base() .. "/projects/" .. project_id(owner, repo_name)
-  end)
-)
+-- GET /repos/{owner}/{repo}
+b:rest("get_repo", function(owner, repo_name)
+  local data, err = repos.get(owner, repo_name)
+  cap_rest_respond(data, err)
+end)
 
+-- PATCH /repos/{owner}/{repo}
 b:rest("patch_repo", function(owner, repo_name)
-  proxy_json(
-    translate_gl_repo,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name),
-      "PUT",
-      translate_gl_req(GetBody())
-    )
-  )
+  local data, err = repos.update(owner, repo_name, GetBody())
+  cap_rest_respond(data, err)
 end)
 
+-- DELETE /repos/{owner}/{repo}
 b:rest("delete_repo", function(owner, repo_name)
-  local url = base() .. "/projects/" .. project_id(owner, repo_name)
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  -- GitLab returns 202 Accepted for async deletion
-  proxy_204({ 202 }, pcall(Fetch, url, dopts))
+  local ok, err = repos.delete(owner, repo_name)
+  cap_rest_204(ok, err)
 end)
 
-b:rest(
-  "get_user_repos",
-  proxy_handler_paged(translate_gl_projects, function()
-    return append_page_params(base() .. "/projects?owned=true&membership=true", PAGES)
-  end)
-)
+-- GET /user/repos
+b:rest("get_user_repos", function()
+  local items, hdrs, err = repos.list_user()
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
+-- POST /user/repos
 b:rest("post_user_repos", function()
-  proxy_json_created(
-    translate_gl_repo,
-    fetch_json(base() .. "/projects", "POST", translate_gl_req(GetBody()))
-  )
+  local data, err = repos.create_user(GetBody())
+  cap_rest_created(data, err)
 end)
 
-b:rest(
-  "get_org_repos",
-  proxy_handler_paged(translate_gl_projects, function(org)
-    return append_page_params(base() .. "/groups/" .. org .. "/projects", PAGES)
-  end)
-)
+-- GET /orgs/{org}/repos
+b:rest("get_org_repos", function(org)
+  local items, hdrs, err = repos.list_org(org)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
+-- POST /orgs/{org}/repos
 b:rest("post_org_repos", function(org)
-  local gl_req = translate_gl_req(GetBody())
-  local gl = DecodeJson(gl_req)
-  gl.namespace_id = org
-  proxy_json_created(translate_gl_repo, fetch_json(base() .. "/projects", "POST", EncodeJson(gl)))
+  local data, err = repos.create_org(org, GetBody())
+  cap_rest_created(data, err)
 end)
 
+-- GET /repos/{owner}/{repo}/topics
 b:rest(
   "get_repo_topics",
   proxy_handler(function(p)
@@ -623,18 +749,10 @@ b:rest(
   end)
 )
 
+-- PUT /repos/{owner}/{repo}/topics
 b:rest("put_repo_topics", function(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
-  proxy_json(
-    function(p)
-      return { names = p.topics or {} }
-    end,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name),
-      "PUT",
-      EncodeJson({ topics = req.names or {} })
-    )
-  )
+  local data, err = repos.put_topics(owner, repo_name, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 b:rest(
@@ -1569,20 +1687,16 @@ b:rest("patch_repo_hook_config", function(owner, repo_name, hook_id)
 end)
 
 -- GET /users/{username}/repos -----------------------------------------------
-b:rest(
-  "get_users_repos",
-  proxy_handler_paged(translate_gl_projects, function(username)
-    return append_page_params(base() .. "/users/" .. username .. "/projects", PAGES)
-  end)
-)
+b:rest("get_users_repos", function(username)
+  local items, hdrs, err = repos.list_by_user(username)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- GET /repositories (all public projects) -----------------------------------
-b:rest(
-  "get_repositories",
-  proxy_handler_paged(translate_gl_projects, function()
-    return append_page_params(base() .. "/projects?visibility=public", PAGES)
-  end)
-)
+b:rest("get_repositories", function()
+  local items, hdrs, err = repos.list_all()
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- Commit comments -----------------------------------------------------------
 -- GitLab uses notes on commits: /projects/{id}/repository/commits/{sha}/comments
@@ -3984,12 +4098,11 @@ b:graphql("Query.repository", function(_parent, args, ctx)
     graphql_error(ctx, "repository requires owner and name arguments")
     return nil
   end
-  local data, _ =
-    graphql_fetch(fetch_json, base() .. "/projects/" .. project_id(args.owner, args.name))
+  local data, _ = repos.get(args.owner, args.name)
   if not data then
     return nil
   end
-  return graphql_translate_repo(translate_gl_repo(data))
+  return graphql_translate_repo(data)
 end)
 
 -- node.Repository: fetch a repository by "owner/repo" local ID.
@@ -3998,11 +4111,11 @@ b:graphql("node.Repository", function(local_id, _ctx)
   if not owner then
     return nil
   end
-  local data, _ = graphql_fetch(fetch_json, base() .. "/projects/" .. project_id(owner, repo))
+  local data, _ = repos.get(owner, repo)
   if not data then
     return nil
   end
-  return graphql_translate_repo(translate_gl_repo(data))
+  return graphql_translate_repo(data)
 end)
 
 -- node.User: fetch a user by login.
@@ -4596,4 +4709,5 @@ b:graphql("Query.search", function(_parent, args, ctx)
   }
 end)
 
+b:capability("repos", repos)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -2371,6 +2371,245 @@ pulls_cap.list_review_comments = function(owner, repo_name, pull_number)
   return result, nil
 end
 
+-- ---------------------------------------------------------------------------
+-- Releases capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for release and release asset (link) operations.
+-- GitLab identifies releases by tag_name; GitHub uses integer IDs.
+-- gl_tag_by_id and gl_find_link are helpers defined above.
+
+local releases_cap = {}
+
+-- list: paginated list of releases for a repository.
+-- Returns (items, headers, nil) or (nil, nil, err).
+releases_cap.list = function(owner, repo_name)
+  local url =
+    append_page_params(base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  local result = {}
+  for i, r in ipairs(items) do
+    result[i] = translate_gl_release(r, i)
+  end
+  return result, hdrs, nil
+end
+
+-- create: create a new release.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+releases_cap.create = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}") or {}
+  local gl_body = EncodeJson({
+    tag_name = req.tag_name,
+    name = req.name,
+    description = req.body,
+  })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases",
+    "POST",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_release(raw, 1), nil
+end
+
+-- get_latest: get the latest release.
+-- Returns (data, nil) or (nil, err).
+releases_cap.get_latest = function(owner, repo_name)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/permalink/latest"
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_release(raw, 1), nil
+end
+
+-- get_by_tag: get a release by its tag name.
+-- Returns (data, nil) or (nil, err).
+releases_cap.get_by_tag = function(owner, repo_name, tag)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_release(raw, 1), nil
+end
+
+-- get: get a release by GitHub integer release_id (resolved via gl_tag_by_id).
+-- Returns (data, nil) or (nil, err).
+releases_cap.get = function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    return nil, cap_err(404, "Not Found")
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_release(raw, tonumber(release_id)), nil
+end
+
+-- update: update a release by GitHub integer release_id.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+releases_cap.update = function(owner, repo_name, release_id, body)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    return nil, cap_err(404, "Not Found")
+  end
+  local req = DecodeJson(body or "{}") or {}
+  local gl_body = EncodeJson({ name = req.name, description = req.body })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
+    "PUT",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_release(raw, tonumber(release_id)), nil
+end
+
+-- delete: delete a release by GitHub integer release_id.
+-- Returns (true, nil) or (nil, err).
+releases_cap.delete = function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    return nil, cap_err(404, "Not Found")
+  end
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
+    "DELETE"
+  )
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "delete release failed")
+  end
+  return true, nil
+end
+
+-- list_assets: paginated list of release assets (links) by GitHub integer release_id.
+-- Returns (items, headers, nil) or (nil, nil, err).
+releases_cap.list_assets = function(owner, repo_name, release_id)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    return nil, nil, cap_err(404, "Not Found")
+  end
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag .. "/assets/links",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_link, items), hdrs, nil
+end
+
+-- create_asset: create a release asset (link) for a release by GitHub integer release_id.
+-- Returns (data, nil) or (nil, err).
+releases_cap.create_asset = function(owner, repo_name, release_id, body)
+  local tag = gl_tag_by_id(owner, repo_name, release_id)
+  if not tag then
+    return nil, cap_err(404, "Not Found")
+  end
+  local req = DecodeJson(body or "{}") or {}
+  local gl_body = EncodeJson({ name = req.name, url = req.url or "" })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag .. "/assets/links",
+    "POST",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_link(raw), nil
+end
+
+-- get_asset: get a release asset (link) by asset_id.
+-- Returns (data, nil) or (nil, err).
+releases_cap.get_asset = function(owner, repo_name, asset_id)
+  local tag = gl_find_link(owner, repo_name, asset_id)
+  if not tag then
+    return nil, cap_err(404, "Not Found")
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/releases/"
+      .. tag
+      .. "/assets/links/"
+      .. asset_id
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_link(raw), nil
+end
+
+-- update_asset: update a release asset (link) by asset_id.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+releases_cap.update_asset = function(owner, repo_name, asset_id, body)
+  local tag = gl_find_link(owner, repo_name, asset_id)
+  if not tag then
+    return nil, cap_err(404, "Not Found")
+  end
+  local req = DecodeJson(body or "{}") or {}
+  local gl_body = EncodeJson({ name = req.name })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/releases/"
+      .. tag
+      .. "/assets/links/"
+      .. asset_id,
+    "PUT",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_link(raw), nil
+end
+
+-- delete_asset: delete a release asset (link) by asset_id.
+-- Returns (true, nil) or (nil, err).
+releases_cap.delete_asset = function(owner, repo_name, asset_id)
+  local tag = gl_find_link(owner, repo_name, asset_id)
+  if not tag then
+    return nil, cap_err(404, "Not Found")
+  end
+  local ok, status = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/releases/"
+      .. tag
+      .. "/assets/links/"
+      .. asset_id,
+    "DELETE"
+  )
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "delete release asset failed")
+  end
+  return true, nil
+end
+
 local b = make_backend_builder()
 
 b:rest("get_root", function()
@@ -2641,252 +2880,64 @@ end)
 -- Releases ------------------------------------------------------------------
 -- GitLab releases use tag_name as identifier rather than an integer ID.
 
-b:rest(
-  "get_repo_releases",
-  proxy_handler_paged(function(rels)
-    local result = {}
-    for i, r in ipairs(rels or {}) do
-      result[i] = {
-        id = i,
-        tag_name = r.tag_name,
-        name = r.name,
-        body = r.description,
-        draft = false,
-        prerelease = false,
-        created_at = r.created_at,
-        published_at = r.released_at or r.created_at,
-        assets = {},
-      }
-    end
-    return result
-  end, function(owner, repo_name)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases",
-      PAGES
-    )
-  end)
-)
-
-b:rest("post_repo_releases", function(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
-  local body = EncodeJson({
-    tag_name = req.tag_name,
-    name = req.name,
-    description = req.body,
-  })
-  proxy_json_created(
-    function(r)
-      return {
-        id = 1,
-        tag_name = r.tag_name,
-        name = r.name,
-        body = r.description,
-        draft = false,
-        prerelease = false,
-        created_at = r.created_at,
-        published_at = r.released_at or r.created_at,
-        assets = {},
-      }
-    end,
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases", "POST", body)
-  )
+b:rest("get_repo_releases", function(owner, repo_name)
+  local items, hdrs, err = releases_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
-b:rest(
-  "get_repo_release_latest",
-  proxy_handler(function(r)
-    return {
-      id = 1,
-      tag_name = r.tag_name,
-      name = r.name,
-      body = r.description,
-      draft = false,
-      prerelease = false,
-      created_at = r.created_at,
-      published_at = r.released_at or r.created_at,
-      assets = {},
-    }
-  end, function(owner, repo_name)
-    return base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/permalink/latest"
-  end)
-)
+b:rest("post_repo_releases", function(owner, repo_name)
+  local data, err = releases_cap.create(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
+end)
 
-b:rest(
-  "get_repo_release_by_tag",
-  proxy_handler(function(r)
-    return {
-      id = 1,
-      tag_name = r.tag_name,
-      name = r.name,
-      body = r.description,
-      draft = false,
-      prerelease = false,
-      created_at = r.created_at,
-      published_at = r.released_at or r.created_at,
-      assets = {},
-    }
-  end, function(owner, repo_name, tag)
-    return base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag
-  end)
-)
+b:rest("get_repo_release_latest", function(owner, repo_name)
+  local data, err = releases_cap.get_latest(owner, repo_name)
+  cap_rest_respond(data, err)
+end)
+
+b:rest("get_repo_release_by_tag", function(owner, repo_name, tag)
+  local data, err = releases_cap.get_by_tag(owner, repo_name, tag)
+  cap_rest_respond(data, err)
+end)
 
 b:rest("get_repo_release", function(owner, repo_name, release_id)
-  local tag = gl_tag_by_id(owner, repo_name, release_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  proxy_json(function(r)
-    return translate_gl_release(r, tonumber(release_id))
-  end, fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag))
+  local data, err = releases_cap.get(owner, repo_name, release_id)
+  cap_rest_respond(data, err)
 end)
 
 b:rest("patch_repo_release", function(owner, repo_name, release_id)
-  local tag = gl_tag_by_id(owner, repo_name, release_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local req = DecodeJson(GetBody() or "{}")
-  local body = EncodeJson({ name = req.name, description = req.body })
-  proxy_json(
-    function(r)
-      return translate_gl_release(r, tonumber(release_id))
-    end,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
-      "PUT",
-      body
-    )
-  )
+  local data, err = releases_cap.update(owner, repo_name, release_id, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 b:rest("delete_repo_release", function(owner, repo_name, release_id)
-  local tag = gl_tag_by_id(owner, repo_name, release_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local ok, status = fetch_json(
-    base() .. "/projects/" .. project_id(owner, repo_name) .. "/releases/" .. tag,
-    "DELETE"
-  )
-  proxy_204({ 200 }, ok, status)
+  local ok, err = releases_cap.delete(owner, repo_name, release_id)
+  cap_rest_204(ok, err)
 end)
 
 b:rest("get_repo_release_assets", function(owner, repo_name, release_id)
-  local tag = gl_tag_by_id(owner, repo_name, release_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  proxy_json_paged(
-    function(links)
-      local result = {}
-      for i, l in ipairs(links or {}) do
-        result[i] = translate_gl_link(l)
-      end
-      return result
-    end,
-    PAGES,
-    fetch_json(
-      append_page_params(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/releases/"
-          .. tag
-          .. "/assets/links",
-        PAGES
-      )
-    )
-  )
+  local items, hdrs, err = releases_cap.list_assets(owner, repo_name, release_id)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 b:rest("post_repo_release_assets", function(owner, repo_name, release_id)
-  local tag = gl_tag_by_id(owner, repo_name, release_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local req = DecodeJson(GetBody() or "{}")
-  local body = EncodeJson({ name = req.name, url = req.url or "" })
-  proxy_json_created(
-    translate_gl_link,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/releases/"
-        .. tag
-        .. "/assets/links",
-      "POST",
-      body
-    )
-  )
+  local data, err = releases_cap.create_asset(owner, repo_name, release_id, GetBody())
+  cap_rest_created(data, err)
 end)
 
 b:rest("get_repo_release_asset", function(owner, repo_name, asset_id)
-  local tag = gl_find_link(owner, repo_name, asset_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  proxy_json(
-    translate_gl_link,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/releases/"
-        .. tag
-        .. "/assets/links/"
-        .. asset_id
-    )
-  )
+  local data, err = releases_cap.get_asset(owner, repo_name, asset_id)
+  cap_rest_respond(data, err)
 end)
 
 b:rest("patch_repo_release_asset", function(owner, repo_name, asset_id)
-  local tag = gl_find_link(owner, repo_name, asset_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local req = DecodeJson(GetBody() or "{}")
-  local body = EncodeJson({ name = req.name })
-  proxy_json(
-    translate_gl_link,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/releases/"
-        .. tag
-        .. "/assets/links/"
-        .. asset_id,
-      "PUT",
-      body
-    )
-  )
+  local data, err = releases_cap.update_asset(owner, repo_name, asset_id, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 b:rest("delete_repo_release_asset", function(owner, repo_name, asset_id)
-  local tag = gl_find_link(owner, repo_name, asset_id)
-  if not tag then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local ok, status = fetch_json(
-    base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/releases/"
-      .. tag
-      .. "/assets/links/"
-      .. asset_id,
-    "DELETE"
-  )
-  proxy_204({ 200 }, ok, status)
+  local ok, err = releases_cap.delete_asset(owner, repo_name, asset_id)
+  cap_rest_204(ok, err)
 end)
 
 -- Deploy keys ---------------------------------------------------------------
@@ -5396,4 +5447,5 @@ b:capability("commit_comments", commit_comments_cap)
 b:capability("collaborators", collaborators_cap)
 b:capability("forks", forks_cap)
 b:capability("pulls", pulls_cap)
+b:capability("releases", releases_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -569,6 +569,85 @@ local GL_STATUS_TO_CHECK_RUN = {
   canceled = { status = "completed", conclusion = "cancelled" },
 }
 
+-- Map a GitLab branch object to GitHub branch format.
+-- Normalises commit.id → commit.sha in place and returns the branch.
+local function translate_gl_branch(br)
+  if not br then
+    return {}
+  end
+  if br.commit then
+    br.commit.sha = br.commit.id
+  end
+  return br
+end
+
+-- Map a GitLab commit object to GitHub commit format.
+local function translate_gl_commit(c)
+  if not c then
+    return {}
+  end
+  return {
+    sha = c.id,
+    html_url = c.web_url or "",
+    commit = {
+      message = c.message,
+      author = { name = c.author_name, email = c.author_email, date = c.authored_date },
+      committer = {
+        name = c.committer_name or c.author_name,
+        email = c.committer_email or c.author_email,
+        date = c.committed_date or c.authored_date,
+      },
+    },
+    stats = c.stats,
+  }
+end
+
+-- Map a GitLab commit status object to GitHub status format.
+local function translate_gl_status(s)
+  if not s then
+    return {}
+  end
+  return {
+    id = s.id,
+    state = GL_STATUS_TO_GH[s.status] or s.status,
+    description = s.description,
+    target_url = s.target_url,
+    context = s.name,
+    created_at = s.created_at,
+    updated_at = s.updated_at,
+  }
+end
+
+-- Map a GitLab commit status object to a GitHub check run object.
+-- sha: the commit SHA to embed as head_sha (GitLab status may not include it).
+local function translate_gl_status_to_check_run(s, sha)
+  if not s then
+    return {}
+  end
+  local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
+    or { status = "completed", conclusion = "failure" }
+  return {
+    id = s.id,
+    node_id = "",
+    head_sha = sha or "",
+    name = s.name or "",
+    status = mapped.status,
+    conclusion = mapped.conclusion,
+    started_at = s.created_at,
+    completed_at = mapped.status == "completed" and s.updated_at or nil,
+    output = {
+      title = s.description or "",
+      summary = s.description or "",
+      text = "",
+      annotations_count = 0,
+      annotations_url = "",
+    },
+    url = "",
+    html_url = s.target_url or "",
+    details_url = s.target_url or "",
+  }
+end
+
 -- ---------------------------------------------------------------------------
 -- Repos capability module
 -- ---------------------------------------------------------------------------
@@ -910,6 +989,219 @@ orgs.get = function(login)
   return translate_gl_group_to_org(raw), nil
 end
 
+-- ---------------------------------------------------------------------------
+-- Branches capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_branch for all branch operations.
+-- Paged list operations return (items, headers, nil) or (nil, nil, err).
+-- Single-item operations return (data, nil) or (nil, err).
+
+local branches = {}
+
+-- list: paginated list of branches for a repository.
+branches.list = function(owner, repo_name)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/branches",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_branch, items), hdrs, nil
+end
+
+-- get: fetch a single branch by name.
+branches.get = function(owner, repo_name, branch)
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/branches/"
+    .. branch
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_branch(raw), nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Commits capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_commit for all commit operations.
+-- Paged list operations return (items, headers, nil) or (nil, nil, err).
+-- Single-item operations return (data, nil) or (nil, err).
+
+local commits = {}
+
+-- list: paginated list of commits for a repository.
+commits.list = function(owner, repo_name)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/commits",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_commit, items), hdrs, nil
+end
+
+-- get: fetch a single commit by ref (SHA, branch, or tag).
+commits.get = function(owner, repo_name, ref)
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/commits/"
+    .. ref
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_commit(raw), nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Statuses capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translation for commit statuses and check runs.
+-- GitLab has no check-run concept; both map to the GitLab commit statuses API.
+-- Paged list operations return (items, headers, nil) or (nil, nil, err).
+-- Single-item and aggregate operations return (data, nil) or (nil, err).
+
+local statuses_cap = {}
+
+-- list: paginated list of commit statuses for a ref.
+statuses_cap.list = function(owner, repo_name, ref)
+  local url = append_page_params(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/repository/commits/"
+      .. ref
+      .. "/statuses",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_status, items), hdrs, nil
+end
+
+-- get_combined: aggregate all commit statuses into a GitHub combined status.
+-- Returns ({ state, statuses, total_count }, nil) or (nil, err).
+statuses_cap.get_combined = function(owner, repo_name, ref)
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/commits/"
+    .. ref
+    .. "/statuses"
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  local state = "success"
+  local result = {}
+  for _, s in ipairs(raw) do
+    local gh_state = GL_STATUS_TO_GH[s.status] or s.status
+    if gh_state == "failure" or gh_state == "error" then
+      state = gh_state
+    end
+    if gh_state == "pending" and state == "success" then
+      state = "pending"
+    end
+    result[#result + 1] = {
+      id = s.id,
+      state = gh_state,
+      context = s.name,
+      description = s.description,
+      target_url = s.target_url,
+    }
+  end
+  return { state = state, statuses = result, total_count = #result }, nil
+end
+
+-- create: create a commit status from a GitHub-format request body.
+-- Returns the created status in GitHub format or (nil, err).
+statuses_cap.create = function(owner, repo_name, sha, body)
+  local req = DecodeJson(body or "{}")
+  local gh_to_gl =
+    { pending = "pending", success = "success", failure = "failed", error = "failed" }
+  local gl_body = EncodeJson({
+    state = gh_to_gl[req.state] or req.state,
+    name = req.context or "default",
+    description = req.description,
+    target_url = req.target_url,
+  })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
+    "POST",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_status(raw), nil
+end
+
+-- list_check_runs: fetch commit statuses shaped as GitHub check runs for a ref.
+-- Returns ({ total_count, check_runs }, nil) or (nil, err).
+statuses_cap.list_check_runs = function(owner, repo_name, ref)
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/commits/"
+    .. ref
+    .. "/statuses"
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  local runs = {}
+  for i, s in ipairs(raw) do
+    runs[i] = translate_gl_status_to_check_run(s, ref)
+  end
+  return { total_count = #runs, check_runs = runs }, nil
+end
+
+-- create_check_run: create a GitHub check run via GitLab commit status.
+-- body: raw GitHub-format request body string.
+-- Returns the created check run in GitHub format or (nil, err).
+statuses_cap.create_check_run = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}")
+  local sha = req.head_sha or ""
+  local check_status = req.status or "queued"
+  local conclusion = req.conclusion
+  local gh_conclusion_to_gl = {
+    success = "success",
+    neutral = "success",
+    skipped = "success",
+  }
+  local gl_state = check_status == "completed" and (gh_conclusion_to_gl[conclusion] or "failed")
+    or "running"
+  local gl_body = EncodeJson({
+    state = gl_state,
+    target_url = req.details_url or "",
+    description = (req.output and req.output.summary) or req.name or "",
+    name = req.name or "",
+    context = req.name or "",
+    ref = sha,
+  })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
+    "POST",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_status_to_check_run(raw, sha), nil
+end
+
 local b = make_backend_builder()
 
 b:rest("get_root", function()
@@ -1010,191 +1302,50 @@ b:rest(
 
 -- Branches ------------------------------------------------------------------
 
-b:rest(
-  "get_repo_branches",
-  proxy_handler_paged(function(branches)
-    for _, br in ipairs(branches or {}) do
-      if br.commit then
-        br.commit.sha = br.commit.id
-      end
-    end
-    return branches or {}
-  end, function(owner, repo_name)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/branches",
-      PAGES
-    )
-  end)
-)
+-- GET /repos/{owner}/{repo}/branches
+b:rest("get_repo_branches", function(owner, repo_name)
+  local items, hdrs, err = branches.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
-b:rest(
-  "get_repo_branch",
-  proxy_handler(function(br)
-    if br and br.commit then
-      br.commit.sha = br.commit.id
-    end
-    return br or {}
-  end, function(owner, repo_name, branch)
-    return base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/repository/branches/"
-      .. branch
-  end)
-)
+-- GET /repos/{owner}/{repo}/branches/{branch}
+b:rest("get_repo_branch", function(owner, repo_name, branch)
+  local data, err = branches.get(owner, repo_name, branch)
+  cap_rest_respond(data, err)
+end)
 
 -- Commits -------------------------------------------------------------------
 
-b:rest(
-  "get_repo_commits",
-  proxy_handler_paged(function(commits)
-    local result = {}
-    for _, c in ipairs(commits or {}) do
-      result[#result + 1] = {
-        sha = c.id,
-        html_url = c.web_url or "",
-        commit = {
-          message = c.message,
-          author = { name = c.author_name, email = c.author_email, date = c.authored_date },
-          committer = {
-            name = c.committer_name or c.author_name,
-            email = c.committer_email or c.author_email,
-            date = c.committed_date or c.authored_date,
-          },
-        },
-      }
-    end
-    return result
-  end, function(owner, repo_name)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/commits",
-      PAGES
-    )
-  end)
-)
+-- GET /repos/{owner}/{repo}/commits
+b:rest("get_repo_commits", function(owner, repo_name)
+  local items, hdrs, err = commits.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
-b:rest(
-  "get_repo_commit",
-  proxy_handler(function(c)
-    if not c then
-      return {}
-    end
-    return {
-      sha = c.id,
-      html_url = c.web_url or "",
-      commit = {
-        message = c.message,
-        author = { name = c.author_name, email = c.author_email, date = c.authored_date },
-        committer = {
-          name = c.committer_name or c.author_name,
-          email = c.committer_email or c.author_email,
-          date = c.committed_date or c.authored_date,
-        },
-      },
-      stats = c.stats,
-    }
-  end, function(owner, repo_name, ref)
-    return base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/commits/" .. ref
-  end)
-)
+-- GET /repos/{owner}/{repo}/commits/{ref}
+b:rest("get_repo_commit", function(owner, repo_name, ref)
+  local data, err = commits.get(owner, repo_name, ref)
+  cap_rest_respond(data, err)
+end)
 
 -- Statuses ------------------------------------------------------------------
 
--- GitLab status mapping: running→pending, failed→failure, canceled→error
+-- GET /repos/{owner}/{repo}/commits/{ref}/statuses
 b:rest("get_commit_statuses", function(owner, repo_name, ref)
-  proxy_json_paged(
-    function(statuses)
-      local result = {}
-      for _, s in ipairs(statuses or {}) do
-        result[#result + 1] = {
-          id = s.id,
-          state = GL_STATUS_TO_GH[s.status] or s.status,
-          description = s.description,
-          target_url = s.target_url,
-          context = s.name,
-          created_at = s.created_at,
-          updated_at = s.updated_at,
-        }
-      end
-      return result
-    end,
-    PAGES,
-    fetch_json(
-      append_page_params(
-        base()
-          .. "/projects/"
-          .. project_id(owner, repo_name)
-          .. "/repository/commits/"
-          .. ref
-          .. "/statuses",
-        PAGES
-      )
-    )
-  )
+  local items, hdrs, err = statuses_cap.list(owner, repo_name, ref)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
+-- GET /repos/{owner}/{repo}/commits/{ref}/status
 b:rest("get_commit_combined_status", function(owner, repo_name, ref)
-  -- GitLab has no single-object combined status; return the list as-is
-  -- and wrap in a GitHub-style combined status object.
-  proxy_json(
-    function(statuses)
-      local state = "success"
-      local result = {}
-      for _, s in ipairs(statuses or {}) do
-        local gh_state = GL_STATUS_TO_GH[s.status] or s.status
-        if gh_state == "failure" or gh_state == "error" then
-          state = gh_state
-        end
-        if gh_state == "pending" and state == "success" then
-          state = "pending"
-        end
-        result[#result + 1] = {
-          id = s.id,
-          state = gh_state,
-          context = s.name,
-          description = s.description,
-          target_url = s.target_url,
-        }
-      end
-      return { state = state, statuses = result, total_count = #result }
-    end,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/repository/commits/"
-        .. ref
-        .. "/statuses"
-    )
-  )
+  local data, err = statuses_cap.get_combined(owner, repo_name, ref)
+  cap_rest_respond(data, err)
 end)
 
+-- POST /repos/{owner}/{repo}/statuses/{sha}
 b:rest("post_commit_status", function(owner, repo_name, sha)
-  local req = DecodeJson(GetBody() or "{}")
-  local gh_to_gl =
-    { pending = "pending", success = "success", failure = "failed", error = "failed" }
-  local gl_body = EncodeJson({
-    state = gh_to_gl[req.state] or req.state,
-    name = req.context or "default",
-    description = req.description,
-    target_url = req.target_url,
-  })
-  proxy_json_created(
-    function(s)
-      return {
-        id = s.id,
-        state = GL_STATUS_TO_GH[s.status] or s.status,
-        description = s.description,
-        target_url = s.target_url,
-        context = s.name,
-      }
-    end,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
-      "POST",
-      gl_body
-    )
-  )
+  local data, err = statuses_cap.create(owner, repo_name, sha, GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- Contents ------------------------------------------------------------------
@@ -2948,9 +3099,9 @@ end)
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
 b:rest(
   "get_pull_commits",
-  proxy_handler_paged(function(commits)
+  proxy_handler_paged(function(commit_list)
     local result = {}
-    for _, c in ipairs(commits or {}) do
+    for _, c in ipairs(commit_list or {}) do
       result[#result + 1] = {
         sha = c.id,
         html_url = c.web_url or "",
@@ -3283,111 +3434,16 @@ end)
 --   canceled→ status=completed,   conclusion=cancelled
 --   other   → status=completed,   conclusion=failure
 
--- Translate a GitLab commit status object to a GitHub check run object.
--- id is taken from the GitLab status.id field (used as check_run_id).
+-- POST /repos/{owner}/{repo}/check-runs
 b:rest("post_check_runs", function(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
-  local sha = req.head_sha or ""
-  local status = req.status or "queued"
-  local conclusion = req.conclusion
-  local gh_conclusion_to_gl = {
-    success = "success",
-    neutral = "success",
-    skipped = "success",
-  }
-  local gl_state = status == "completed" and (gh_conclusion_to_gl[conclusion] or "failed")
-    or "running"
-  local gl_body = EncodeJson({
-    state = gl_state,
-    target_url = req.details_url or "",
-    description = (req.output and req.output.summary) or req.name or "",
-    name = req.name or "",
-    context = req.name or "",
-    ref = sha,
-  })
-  local function translate(s)
-    if not s then
-      return {}
-    end
-    local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
-      or { status = "completed", conclusion = "failure" }
-    return {
-      id = s.id,
-      node_id = "",
-      head_sha = sha,
-      name = s.name or "",
-      status = mapped.status,
-      conclusion = mapped.conclusion,
-      started_at = s.created_at,
-      completed_at = mapped.status == "completed" and s.updated_at or nil,
-      output = {
-        title = s.description or "",
-        summary = s.description or "",
-        text = "",
-        annotations_count = 0,
-        annotations_url = "",
-      },
-      url = "",
-      html_url = s.target_url or "",
-      details_url = s.target_url or "",
-    }
-  end
-  proxy_json_created(
-    translate,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/statuses/" .. sha,
-      "POST",
-      gl_body
-    )
-  )
+  local data, err = statuses_cap.create_check_run(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- GET /repos/{owner}/{repo}/commits/{ref}/check-runs
--- Uses GitLab commit statuses.
 b:rest("get_commit_check_runs", function(owner, repo_name, ref)
-  local ok, status, _, body = fetch_json(
-    base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/repository/commits/"
-      .. ref
-      .. "/statuses"
-  )
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local statuses = DecodeJson(body) or {}
-  local runs = {}
-  for i, s in ipairs(statuses) do
-    local mapped = GL_STATUS_TO_CHECK_RUN[s.status]
-      or { status = "completed", conclusion = "failure" }
-    runs[i] = {
-      id = s.id,
-      node_id = "",
-      head_sha = ref,
-      name = s.name or "",
-      status = mapped.status,
-      conclusion = mapped.conclusion,
-      started_at = s.created_at,
-      completed_at = mapped.status == "completed" and s.updated_at or nil,
-      output = {
-        title = s.description or "",
-        summary = s.description or "",
-        text = "",
-        annotations_count = 0,
-        annotations_url = "",
-      },
-      url = "",
-      html_url = s.target_url or "",
-      details_url = s.target_url or "",
-    }
-  end
-  respond_json(200, { total_count = #runs, check_runs = runs })
+  local data, err = statuses_cap.list_check_runs(owner, repo_name, ref)
+  cap_rest_respond(data, err)
 end)
 
 -- Check suites have no GitLab equivalent; all suite endpoints fall back to
@@ -4870,4 +4926,7 @@ end)
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)
+b:capability("branches", branches)
+b:capability("commits", commits)
+b:capability("statuses", statuses_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -377,10 +377,6 @@ local function translate_gl_mr(mr)
   }
 end
 
-local function translate_gl_mrs(mrs)
-  return translate_list(translate_gl_mr, mrs)
-end
-
 -- Map GitLab MR approvals to GitHub reviews (APPROVED state).
 -- GitLab uses an approvals object; GitHub uses an array of review objects.
 local function translate_gl_approvals_to_reviews(approvals)
@@ -2101,6 +2097,280 @@ forks_cap.create = function(owner, repo_name, body)
   return translate_gl_repo(raw), nil
 end
 
+-- ---------------------------------------------------------------------------
+-- Pulls capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for pull request (merge request) operations.
+-- GitLab uses /projects/{id}/merge_requests and related sub-resources.
+
+local pulls_cap = {}
+
+-- list: paginated list of merge requests for a repository.
+-- Returns (items, headers, nil) or (nil, nil, err).
+pulls_cap.list = function(owner, repo_name)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_mr, items), hdrs, nil
+end
+
+-- create: open a new merge request.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.create = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}") or {}
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.body then
+    gl.description = req.body
+  end
+  if req.head then
+    gl.source_branch = req.head
+  end
+  if req.base then
+    gl.target_branch = req.base
+  end
+  if req.draft ~= nil then
+    gl.draft = req.draft
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests",
+    "POST",
+    EncodeJson(gl)
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_mr(raw), nil
+end
+
+-- get: fetch a single merge request by iid.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.get = function(owner, repo_name, pull_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_mr(raw), nil
+end
+
+-- update: update a merge request.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.update = function(owner, repo_name, pull_number, body)
+  local req = DecodeJson(body or "{}") or {}
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.body then
+    gl.description = req.body
+  end
+  if req.state then
+    gl.state_event = req.state == "closed" and "close" or "reopen"
+  end
+  if req.draft ~= nil then
+    gl.draft = req.draft
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number,
+    "PUT",
+    EncodeJson(gl)
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_mr(raw), nil
+end
+
+-- list_commits: paginated list of commits for a merge request.
+-- Returns (items, headers, nil) or (nil, nil, err).
+pulls_cap.list_commits = function(owner, repo_name, pull_number)
+  local url = append_page_params(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/commits",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  local result = {}
+  for _, c in ipairs(items) do
+    result[#result + 1] = {
+      sha = c.id,
+      html_url = c.web_url or "",
+      commit = {
+        message = c.message,
+        author = { name = c.author_name, email = c.author_email, date = c.authored_date },
+        committer = {
+          name = c.committer_name or c.author_name,
+          email = c.committer_email or c.author_email,
+          date = c.committed_date or c.authored_date,
+        },
+      },
+    }
+  end
+  return result, hdrs, nil
+end
+
+-- list_files: get changed files for a merge request.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.list_files = function(owner, repo_name, pull_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/changes"
+  )
+  if not raw then
+    return nil, err
+  end
+  local result = {}
+  for _, c in ipairs((raw or {}).changes or {}) do
+    local status = "modified"
+    if c.new_file then
+      status = "added"
+    elseif c.deleted_file then
+      status = "removed"
+    elseif c.renamed_file then
+      status = "renamed"
+    end
+    result[#result + 1] = {
+      sha = "",
+      filename = c.new_path or c.old_path or "",
+      status = status,
+      additions = 0,
+      deletions = 0,
+      changes = 0,
+      patch = c.diff,
+    }
+  end
+  return result, nil
+end
+
+-- check_merged: return (true, nil) if the MR is merged, (nil, err) if not.
+-- Uses err.status == 404 to indicate "not merged".
+pulls_cap.check_merged = function(owner, repo_name, pull_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number
+  )
+  if not raw then
+    return nil, err
+  end
+  if raw.state == "merged" or raw.merged_at ~= nil then
+    return true, nil
+  end
+  return nil, cap_err(404, "Pull Request is not merged")
+end
+
+-- merge: merge a merge request.  body is raw GitHub-format JSON.
+-- Returns (true, nil) or (nil, err).
+pulls_cap.merge = function(owner, repo_name, pull_number, body)
+  local req = DecodeJson(body or "{}") or {}
+  local gl = {}
+  if req.merge_method then
+    gl.merge_method = req.merge_method
+  end
+  local ok, status = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/merge",
+    "PUT",
+    EncodeJson(gl)
+  )
+  if ok and (status == 200 or status == 201 or status == 204) then
+    return true, nil
+  end
+  return nil, cap_err(status or 0, "merge failed")
+end
+
+-- list_requested_reviewers: get reviewers assigned to a merge request.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.list_requested_reviewers = function(owner, repo_name, pull_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/reviewers"
+  )
+  if not raw then
+    return nil, err
+  end
+  local reviewer_users = {}
+  for _, u in ipairs(raw) do
+    reviewer_users[#reviewer_users + 1] = translate_gl_user(u)
+  end
+  return { users = reviewer_users, teams = {} }, nil
+end
+
+-- list_reviews: get approvals mapped to GitHub review objects.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.list_reviews = function(owner, repo_name, pull_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/merge_requests/"
+      .. pull_number
+      .. "/approvals"
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_approvals_to_reviews(raw), nil
+end
+
+-- get_review: get a single review by 1-based index id.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.get_review = function(owner, repo_name, pull_number, review_id)
+  local reviews, err = pulls_cap.list_reviews(owner, repo_name, pull_number)
+  if not reviews then
+    return nil, err
+  end
+  local rid = tonumber(review_id)
+  if rid and reviews[rid] then
+    return reviews[rid], nil
+  end
+  return nil, cap_err(404, "Not Found")
+end
+
+-- list_review_comments: get inline (position-based) MR notes.
+-- GitLab has no per-review inline comments; returns all inline MR notes.
+-- Returns (data, nil) or (nil, err).
+pulls_cap.list_review_comments = function(owner, repo_name, pull_number)
+  local result, status = fetch_gl_mr_review_comments(owner, repo_name, pull_number)
+  if not result then
+    return nil, cap_err(status or 0, "fetch review comments failed")
+  end
+  return result, nil
+end
+
 local b = make_backend_builder()
 
 b:rest("get_root", function()
@@ -3472,279 +3742,93 @@ b:rest(
 -- Pull Requests (mapped to GitLab Merge Requests) --------------------------
 
 -- GET /repos/{owner}/{repo}/pulls
-b:rest(
-  "get_repo_pulls",
-  proxy_handler_paged(translate_gl_mrs, function(o, r)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(o, r) .. "/merge_requests",
-      PAGES
-    )
-  end)
-)
+b:rest("get_repo_pulls", function(owner, repo_name)
+  local items, hdrs, err = pulls_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- POST /repos/{owner}/{repo}/pulls
 b:rest("post_repo_pulls", function(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
-  local gl = {}
-  if req.title then
-    gl.title = req.title
-  end
-  if req.body then
-    gl.description = req.body
-  end
-  if req.head then
-    gl.source_branch = req.head
-  end
-  if req.base then
-    gl.target_branch = req.base
-  end
-  if req.draft ~= nil then
-    gl.draft = req.draft
-  end
-  proxy_json_created(
-    translate_gl_mr,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests",
-      "POST",
-      EncodeJson(gl)
-    )
-  )
+  local data, err = pulls_cap.create(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}
-b:rest(
-  "get_repo_pull",
-  proxy_handler(translate_gl_mr, function(o, r, n)
-    return base() .. "/projects/" .. project_id(o, r) .. "/merge_requests/" .. n
-  end)
-)
+b:rest("get_repo_pull", function(owner, repo_name, pull_number)
+  local data, err = pulls_cap.get(owner, repo_name, pull_number)
+  cap_rest_respond(data, err)
+end)
 
 -- PATCH /repos/{owner}/{repo}/pulls/{pull_number}
 b:rest("patch_repo_pull", function(owner, repo_name, pull_number)
-  local req = DecodeJson(GetBody() or "{}")
-  local gl = {}
-  if req.title then
-    gl.title = req.title
-  end
-  if req.body then
-    gl.description = req.body
-  end
-  if req.state then
-    gl.state_event = req.state == "closed" and "close" or "reopen"
-  end
-  if req.draft ~= nil then
-    gl.draft = req.draft
-  end
-  proxy_json(
-    translate_gl_mr,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number,
-      "PUT",
-      EncodeJson(gl)
-    )
-  )
+  local data, err = pulls_cap.update(owner, repo_name, pull_number, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
-b:rest(
-  "get_pull_commits",
-  proxy_handler_paged(function(commit_list)
-    local result = {}
-    for _, c in ipairs(commit_list or {}) do
-      result[#result + 1] = {
-        sha = c.id,
-        html_url = c.web_url or "",
-        commit = {
-          message = c.message,
-          author = { name = c.author_name, email = c.author_email, date = c.authored_date },
-          committer = {
-            name = c.committer_name or c.author_name,
-            email = c.committer_email or c.author_email,
-            date = c.committed_date or c.authored_date,
-          },
-        },
-      }
-    end
-    return result
-  end, function(o, r, n)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(o, r) .. "/merge_requests/" .. n .. "/commits",
-      PAGES
-    )
-  end)
-)
+b:rest("get_pull_commits", function(owner, repo_name, pull_number)
+  local items, hdrs, err = pulls_cap.list_commits(owner, repo_name, pull_number)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/files
 -- GitLab uses /changes which wraps the diff list in a parent object.
-b:rest(
-  "get_pull_files",
-  proxy_handler(function(mr)
-    local result = {}
-    for _, c in ipairs((mr or {}).changes or {}) do
-      local status = "modified"
-      if c.new_file then
-        status = "added"
-      elseif c.deleted_file then
-        status = "removed"
-      elseif c.renamed_file then
-        status = "renamed"
-      end
-      result[#result + 1] = {
-        sha = "",
-        filename = c.new_path or c.old_path or "",
-        status = status,
-        additions = 0,
-        deletions = 0,
-        changes = 0,
-        patch = c.diff,
-      }
-    end
-    return result
-  end, function(o, r, n)
-    return base() .. "/projects/" .. project_id(o, r) .. "/merge_requests/" .. n .. "/changes"
-  end)
-)
+b:rest("get_pull_files", function(owner, repo_name, pull_number)
+  local data, err = pulls_cap.list_files(owner, repo_name, pull_number)
+  cap_rest_respond(data, err)
+end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
 -- Returns 204 if the MR is merged, 404 if not.
 b:rest("get_pull_merge", function(owner, repo_name, pull_number)
-  local ok, status, _, body = fetch_json(
-    base() .. "/projects/" .. project_id(owner, repo_name) .. "/merge_requests/" .. pull_number
-  )
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local mr = DecodeJson(body) or {}
-  if mr.state == "merged" or mr.merged_at ~= nil then
+  local ok, err = pulls_cap.check_merged(owner, repo_name, pull_number)
+  if ok then
     SetStatus(204, "No Content")
+  elseif err and err.status == 404 then
+    respond_json(404, { message = err.message })
   else
-    respond_json(404, { message = "Pull Request is not merged" })
+    cap_rest_204(nil, err)
   end
 end)
 
 -- PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
 b:rest("put_pull_merge", function(owner, repo_name, pull_number)
-  local req = DecodeJson(GetBody() or "{}")
-  local gl = {}
-  if req.merge_method then
-    gl.merge_method = req.merge_method
-  end
-  local ok, status = fetch_json(
-    base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/merge_requests/"
-      .. pull_number
-      .. "/merge",
-    "PUT",
-    EncodeJson(gl)
-  )
-  proxy_204({ 200 }, ok, status)
+  local ok, err = pulls_cap.merge(owner, repo_name, pull_number, GetBody())
+  cap_rest_204(ok, err)
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
 -- GitLab: reviewers assigned to the MR.
 b:rest("get_pull_requested_reviewers", function(owner, repo_name, pull_number)
-  local ok, status, _, body = fetch_json(
-    base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/merge_requests/"
-      .. pull_number
-      .. "/reviewers"
-  )
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local reviewers = DecodeJson(body) or {}
-  local reviewer_users = {}
-  for _, u in ipairs(reviewers) do
-    reviewer_users[#reviewer_users + 1] = translate_gl_user(u)
-  end
-  respond_json(200, { users = reviewer_users, teams = {} })
+  local data, err = pulls_cap.list_requested_reviewers(owner, repo_name, pull_number)
+  cap_rest_respond(data, err)
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
 -- GitLab: MR approvals mapped to GitHub reviews.
 b:rest("get_pull_reviews", function(owner, repo_name, pull_number)
-  local ok, status, _, body = fetch_json(
-    base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/merge_requests/"
-      .. pull_number
-      .. "/approvals"
-  )
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local approvals = DecodeJson(body) or {}
-  respond_json(200, translate_gl_approvals_to_reviews(approvals))
+  local data, err = pulls_cap.list_reviews(owner, repo_name, pull_number)
+  cap_rest_respond(data, err)
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
 b:rest("get_pull_review", function(owner, repo_name, pull_number, review_id)
-  local ok, status, _, body = fetch_json(
-    base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/merge_requests/"
-      .. pull_number
-      .. "/approvals"
-  )
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local approvals = DecodeJson(body) or {}
-  local reviews = translate_gl_approvals_to_reviews(approvals)
-  local rid = tonumber(review_id)
-  if rid and reviews[rid] then
-    respond_json(200, reviews[rid])
-  else
-    respond_json(404, { message = "Not Found" })
-  end
+  local data, err = pulls_cap.get_review(owner, repo_name, pull_number, review_id)
+  cap_rest_respond(data, err)
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
 -- GitLab has no per-review inline comments; return all inline MR notes.
 b:rest("get_pull_review_comments", function(owner, repo_name, pull_number)
-  local result, status = fetch_gl_mr_review_comments(owner, repo_name, pull_number)
-  if not result then
-    respond_json(status or 503, {})
-    return
-  end
-  respond_json(200, result)
+  local data, err = pulls_cap.list_review_comments(owner, repo_name, pull_number)
+  cap_rest_respond(data, err)
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/comments
 -- GitLab: inline (position-based) MR notes.
 b:rest("get_pull_comments", function(owner, repo_name, pull_number)
-  local result, status = fetch_gl_mr_review_comments(owner, repo_name, pull_number)
-  if not result then
-    respond_json(status or 503, {})
-    return
-  end
-  respond_json(200, result)
+  local data, err = pulls_cap.list_review_comments(owner, repo_name, pull_number)
+  cap_rest_respond(data, err)
 end)
 
 -- Search -----------------------------------------------------------------------
@@ -5311,4 +5395,5 @@ b:capability("contents", contents_cap)
 b:capability("commit_comments", commit_comments_cap)
 b:capability("collaborators", collaborators_cap)
 b:capability("forks", forks_cap)
+b:capability("pulls", pulls_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -740,14 +740,10 @@ b:rest("post_org_repos", function(org)
 end)
 
 -- GET /repos/{owner}/{repo}/topics
-b:rest(
-  "get_repo_topics",
-  proxy_handler(function(p)
-    return { names = p.topics or {} }
-  end, function(owner, repo_name)
-    return base() .. "/projects/" .. project_id(owner, repo_name)
-  end)
-)
+b:rest("get_repo_topics", function(owner, repo_name)
+  local data, err = repos.get_topics(owner, repo_name)
+  cap_rest_respond(data, err)
+end)
 
 -- PUT /repos/{owner}/{repo}/topics
 b:rest("put_repo_topics", function(owner, repo_name)

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -2942,126 +2942,200 @@ end)
 
 -- Deploy keys ---------------------------------------------------------------
 
-b:rest(
-  "get_repo_keys",
-  proxy_handler_paged(nil, function(owner, repo_name)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys",
-      PAGES
-    )
-  end)
-)
+local deploy_keys_cap = {}
 
-b:rest("post_repo_keys", function(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
-  local body = EncodeJson({
+-- list: paginated list of deploy keys for a repository.
+-- Returns (items, headers, nil) or (nil, nil, err).
+deploy_keys_cap.list = function(owner, repo_name)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys",
+    PAGES
+  )
+  return cap_fetch_paged(fetch_json, url)
+end
+
+-- create: create a deploy key.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+deploy_keys_cap.create = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}") or {}
+  local gl_body = EncodeJson({
     title = req.title,
     key = req.key,
     can_push = req.read_only == false,
   })
-  proxy_json_created(
-    nil,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys",
-      "POST",
-      body
-    )
+  return cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys",
+    "POST",
+    gl_body
   )
-end)
+end
 
-b:rest(
-  "get_repo_key",
-  proxy_handler(nil, function(owner, repo_name, key_id)
-    return base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys/" .. key_id
-  end)
-)
+-- get: get a single deploy key by key_id.
+-- Returns (data, nil) or (nil, err).
+deploy_keys_cap.get = function(owner, repo_name, key_id)
+  return cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys/" .. key_id
+  )
+end
 
-b:rest("delete_repo_key", function(owner, repo_name, key_id)
+-- delete: delete a deploy key by key_id.
+-- Returns (true, nil) or (nil, err).
+deploy_keys_cap.delete = function(owner, repo_name, key_id)
   local ok, status = fetch_json(
     base() .. "/projects/" .. project_id(owner, repo_name) .. "/deploy_keys/" .. key_id,
     "DELETE"
   )
-  proxy_204({ 200 }, ok, status)
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "delete deploy key failed")
+  end
+  return true, nil
+end
+
+b:rest("get_repo_keys", function(owner, repo_name)
+  local items, hdrs, err = deploy_keys_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+b:rest("post_repo_keys", function(owner, repo_name)
+  local data, err = deploy_keys_cap.create(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
+end)
+
+b:rest("get_repo_key", function(owner, repo_name, key_id)
+  local data, err = deploy_keys_cap.get(owner, repo_name, key_id)
+  cap_rest_respond(data, err)
+end)
+
+b:rest("delete_repo_key", function(owner, repo_name, key_id)
+  local ok, err = deploy_keys_cap.delete(owner, repo_name, key_id)
+  cap_rest_204(ok, err)
 end)
 
 -- Webhooks ------------------------------------------------------------------
 
-b:rest(
-  "get_repo_hooks",
-  proxy_handler_paged(nil, function(owner, repo_name)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks",
-      PAGES
-    )
-  end)
-)
+local webhooks_cap = {}
 
-b:rest("post_repo_hooks", function(owner, repo_name)
-  proxy_json_created(
-    nil,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks",
-      "POST",
-      GetBody()
-    )
+-- list: paginated list of webhooks for a repository.
+-- Returns (items, headers, nil) or (nil, nil, err).
+webhooks_cap.list = function(owner, repo_name)
+  local url =
+    append_page_params(base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks", PAGES)
+  return cap_fetch_paged(fetch_json, url)
+end
+
+-- create: create a webhook.  body is raw JSON passthrough.
+-- Returns (data, nil) or (nil, err).
+webhooks_cap.create = function(owner, repo_name, body)
+  return cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks",
+    "POST",
+    body
   )
-end)
+end
 
-b:rest(
-  "get_repo_hook",
-  proxy_handler(nil, function(owner, repo_name, hook_id)
-    return base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
-  end)
-)
-
--- GitLab uses PUT for hook updates
-b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
-  proxy_json(
-    nil,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id,
-      "PUT",
-      GetBody()
-    )
+-- get: get a single webhook by hook_id.
+-- Returns (data, nil) or (nil, err).
+webhooks_cap.get = function(owner, repo_name, hook_id)
+  return cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
   )
-end)
+end
 
-b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+-- update: update a webhook by hook_id.  GitLab uses PUT for hook updates.
+-- Returns (data, nil) or (nil, err).
+webhooks_cap.update = function(owner, repo_name, hook_id, body)
+  return cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id,
+    "PUT",
+    body
+  )
+end
+
+-- delete: delete a webhook by hook_id.
+-- Returns (true, nil) or (nil, err).
+webhooks_cap.delete = function(owner, repo_name, hook_id)
   local ok, status = fetch_json(
     base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id,
     "DELETE"
   )
-  proxy_204({ 200 }, ok, status)
-end)
-
-b:rest(
-  "get_repo_hook_config",
-  proxy_handler(function(h)
-    return { url = h.url }
-  end, function(owner, repo_name, hook_id)
-    return base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
-  end)
-)
-
-b:rest("patch_repo_hook_config", function(owner, repo_name, hook_id)
-  local new_cfg = DecodeJson(GetBody() or "{}")
-  local url = base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
-  local ok, status, _, body = fetch_json(url)
-  if not ok or status ~= 200 then
-    if ok then
-      respond_json(status, {})
-    else
-      respond_json(503, {})
-    end
-    return
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "delete webhook failed")
   end
-  local hook = DecodeJson(body) or {}
+  return true, nil
+end
+
+-- get_config: get the config (url only) for a webhook.
+-- Returns (data, nil) or (nil, err).
+webhooks_cap.get_config = function(owner, repo_name, hook_id)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
+  )
+  if not raw then
+    return nil, err
+  end
+  return { url = raw.url }, nil
+end
+
+-- update_config: merge new_cfg into existing hook config (url field only).
+-- Returns (data, nil) or (nil, err).
+webhooks_cap.update_config = function(owner, repo_name, hook_id, new_cfg)
+  local url = base() .. "/projects/" .. project_id(owner, repo_name) .. "/hooks/" .. hook_id
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  local hook = raw
   if new_cfg.url then
     hook.url = new_cfg.url
   end
-  proxy_json(function(h)
-    return { url = h.url }
-  end, fetch_json(url, "PUT", EncodeJson(hook)))
+  local updated, uerr = cap_fetch(fetch_json, url, "PUT", EncodeJson(hook))
+  if not updated then
+    return nil, uerr
+  end
+  return { url = updated.url }, nil
+end
+
+b:rest("get_repo_hooks", function(owner, repo_name)
+  local items, hdrs, err = webhooks_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+b:rest("post_repo_hooks", function(owner, repo_name)
+  local data, err = webhooks_cap.create(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
+end)
+
+b:rest("get_repo_hook", function(owner, repo_name, hook_id)
+  local data, err = webhooks_cap.get(owner, repo_name, hook_id)
+  cap_rest_respond(data, err)
+end)
+
+-- GitLab uses PUT for hook updates
+b:rest("patch_repo_hook", function(owner, repo_name, hook_id)
+  local data, err = webhooks_cap.update(owner, repo_name, hook_id, GetBody())
+  cap_rest_respond(data, err)
+end)
+
+b:rest("delete_repo_hook", function(owner, repo_name, hook_id)
+  local ok, err = webhooks_cap.delete(owner, repo_name, hook_id)
+  cap_rest_204(ok, err)
+end)
+
+b:rest("get_repo_hook_config", function(owner, repo_name, hook_id)
+  local data, err = webhooks_cap.get_config(owner, repo_name, hook_id)
+  cap_rest_respond(data, err)
+end)
+
+b:rest("patch_repo_hook_config", function(owner, repo_name, hook_id)
+  local new_cfg = DecodeJson(GetBody() or "{}")
+  local data, err = webhooks_cap.update_config(owner, repo_name, hook_id, new_cfg)
+  cap_rest_respond(data, err)
 end)
 
 -- GET /users/{username}/repos -----------------------------------------------
@@ -5448,4 +5522,6 @@ b:capability("collaborators", collaborators_cap)
 b:capability("forks", forks_cap)
 b:capability("pulls", pulls_cap)
 b:capability("releases", releases_cap)
+b:capability("deploy_keys", deploy_keys_cap)
+b:capability("webhooks", webhooks_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -1918,6 +1918,189 @@ commit_comments_cap.create = function(owner, repo_name, commit_sha, body)
   return raw, nil
 end
 
+-- ---------------------------------------------------------------------------
+-- Collaborators capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for project member operations.
+-- GitLab uses /projects/{id}/members/all (list) and /projects/{id}/members/{uid}.
+-- Username→UID resolution is done internally via /users?username=.
+-- Paginated list operations return (items, headers, nil) or (nil, nil, err).
+-- Single-item and 204 operations return (data, nil) or (nil, err).
+
+local collaborators_cap = {}
+
+-- translate_gl_collaborator: map a GitLab project member object to GitHub collaborator shape.
+local function translate_gl_collaborator(m)
+  if not m then
+    return {}
+  end
+  local al = m.access_level or 0
+  return {
+    login = m.username,
+    id = m.id,
+    avatar_url = m.avatar_url or "",
+    type = "User",
+    permissions = {
+      admin = al >= 50,
+      push = al >= 30,
+      pull = al >= 10,
+    },
+  }
+end
+
+-- resolve_uid: look up a GitLab user ID by username.
+-- Returns (uid, nil) or (nil, err).
+local function resolve_uid(username)
+  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
+  if not ok or status ~= 200 then
+    return nil, cap_err(status or 0, "user lookup failed")
+  end
+  local ulist = DecodeJson(ubody) or {}
+  local uid = ulist[1] and ulist[1].id
+  if not uid then
+    return nil, cap_err(404, "user not found")
+  end
+  return uid, nil
+end
+
+-- list: paginated list of project members.
+collaborators_cap.list = function(owner, repo_name)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/all",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_collaborator, items), hdrs, nil
+end
+
+-- check: return (true, nil) if username is a member, (nil, err) if not.
+collaborators_cap.check = function(owner, repo_name, username)
+  local uid, uerr = resolve_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local ok, status = pcall(
+    Fetch,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
+    auth()
+  )
+  if ok and status == 200 then
+    return true, nil
+  end
+  return nil, cap_err(404, "Not a collaborator")
+end
+
+-- put: add or update a member.  body is raw GitHub-format JSON.
+-- Returns (true, nil) on success or (nil, err).
+collaborators_cap.put = function(owner, repo_name, username, body)
+  local uid, uerr = resolve_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local req = DecodeJson(body or "{}") or {}
+  local perm = req.permission or "push"
+  local level_map = { pull = 30, push = 30, admin = 50 }
+  local gl_body = EncodeJson({ user_id = uid, access_level = level_map[perm] or 30 })
+  -- Try add first; if conflict (409), update instead.
+  local ok2, status2 = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members",
+    "POST",
+    gl_body
+  )
+  if ok2 and (status2 == 201 or status2 == 200) then
+    return true, nil
+  elseif ok2 and status2 == 409 then
+    local ok3, status3 = fetch_json(
+      base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
+      "PUT",
+      gl_body
+    )
+    if ok3 and (status3 == 200 or status3 == 201) then
+      return true, nil
+    else
+      return nil, cap_err(status3 or 0, "update member failed")
+    end
+  else
+    return nil, cap_err(status2 or 0, "add member failed")
+  end
+end
+
+-- delete: remove a member.  Returns (true, nil) or (nil, err).
+collaborators_cap.delete = function(owner, repo_name, username)
+  local uid, uerr = resolve_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local ok2, status2 = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
+    "DELETE"
+  )
+  if ok2 and (status2 == 204 or status2 == 200) then
+    return true, nil
+  end
+  return nil, cap_err(status2 or 0, "remove member failed")
+end
+
+-- get_permission: return permission level for a user.
+-- Returns (data, nil) or (nil, err).
+collaborators_cap.get_permission = function(owner, repo_name, username)
+  local uid, uerr = resolve_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid
+  )
+  if not raw then
+    return nil, err
+  end
+  local al = raw.access_level or 0
+  local perm = al >= 50 and "admin" or (al >= 30 and "write" or "read")
+  return { permission = perm, user = { login = username, id = uid } }, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Forks capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for fork operations.
+-- GitLab uses /projects/{id}/forks (list) and /projects/{id}/fork (create).
+-- Paginated list operations return (items, headers, nil) or (nil, nil, err).
+-- Create operation returns (data, nil) or (nil, err).
+
+local forks_cap = {}
+
+-- list: paginated list of forks for a repository.
+forks_cap.list = function(owner, repo_name)
+  local url =
+    append_page_params(base() .. "/projects/" .. project_id(owner, repo_name) .. "/forks", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
+
+-- create: fork a repository.  body is raw GitHub-format JSON.
+-- Returns translated repo shape or (nil, err).
+forks_cap.create = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}") or {}
+  local gl_body = req.organization and EncodeJson({ namespace = req.organization }) or "{}"
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/fork",
+    "POST",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_repo(raw), nil
+end
+
 local b = make_backend_builder()
 
 b:rest("get_root", function()
@@ -2141,152 +2324,48 @@ end)
 
 -- Collaborators -------------------------------------------------------------
 
-b:rest(
-  "get_repo_collaborators",
-  proxy_handler_paged(function(members)
-    local result = {}
-    for _, m in ipairs(members or {}) do
-      result[#result + 1] = {
-        login = m.username,
-        id = m.id,
-        avatar_url = m.avatar_url or "",
-        type = "User",
-        permissions = {
-          admin = (m.access_level or 0) >= 50,
-          push = (m.access_level or 0) >= 30,
-          pull = (m.access_level or 0) >= 10,
-        },
-      }
-    end
-    return result
-  end, function(owner, repo_name)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/all",
-      PAGES
-    )
-  end)
-)
+-- GET /repos/{owner}/{repo}/collaborators
+b:rest("get_repo_collaborators", function(owner, repo_name)
+  local items, hdrs, err = collaborators_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
+-- GET /repos/{owner}/{repo}/collaborators/{username}
 b:rest("get_repo_collaborator", function(owner, repo_name, username)
-  -- Resolve username to user ID, then check membership
-  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-  if not ok or status ~= 200 then
-    respond_json(404, {})
-    return
-  end
-  local ulist = DecodeJson(ubody) or {}
-  local uid = ulist[1] and ulist[1].id
-  if not uid then
-    respond_json(404, {})
-    return
-  end
-  local ok2, status2 = pcall(
-    Fetch,
-    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
-    auth()
-  )
-  if ok2 and status2 == 200 then
-    SetStatus(204, "No Content")
-  else
-    respond_json(404, { message = "Not a collaborator" })
-  end
+  local ok, err = collaborators_cap.check(owner, repo_name, username)
+  cap_rest_204(ok, err)
 end)
 
+-- PUT /repos/{owner}/{repo}/collaborators/{username}
 b:rest("put_repo_collaborator", function(owner, repo_name, username)
-  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-  if not ok or status ~= 200 then
-    respond_json(404, {})
-    return
-  end
-  local ulist = DecodeJson(ubody) or {}
-  local uid = ulist[1] and ulist[1].id
-  if not uid then
-    respond_json(404, {})
-    return
-  end
-  local req = DecodeJson(GetBody() or "{}")
-  local perm = req.permission or "push"
-  local level_map = { pull = 30, push = 30, admin = 50 }
-  local body = EncodeJson({ user_id = uid, access_level = level_map[perm] or 30 })
-  -- Try add first; if conflict, update
-  local ok2, status2 =
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/members", "POST", body)
-  if ok2 and (status2 == 201 or status2 == 200) then
-    SetStatus(204, "No Content")
-  elseif ok2 and status2 == 409 then
-    -- Already a member — update
-    local ok3, status3 = fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
-      "PUT",
-      body
-    )
-    if ok3 and (status3 == 200 or status3 == 201) then
-      SetStatus(204, "No Content")
-    else
-      respond_json(status3 or 503, {})
-    end
-  else
-    respond_json(status2 or 503, {})
-  end
+  local ok, err = collaborators_cap.put(owner, repo_name, username, GetBody())
+  cap_rest_204(ok, err)
 end)
 
+-- DELETE /repos/{owner}/{repo}/collaborators/{username}
 b:rest("delete_repo_collaborator", function(owner, repo_name, username)
-  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-  if not ok or status ~= 200 then
-    respond_json(404, {})
-    return
-  end
-  local ulist = DecodeJson(ubody) or {}
-  local uid = ulist[1] and ulist[1].id
-  if not uid then
-    respond_json(404, {})
-    return
-  end
-  local ok2, status2 = fetch_json(
-    base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid,
-    "DELETE"
-  )
-  proxy_204({ 200 }, ok2, status2)
+  local ok, err = collaborators_cap.delete(owner, repo_name, username)
+  cap_rest_204(ok, err)
 end)
 
+-- GET /repos/{owner}/{repo}/collaborators/{username}/permission
 b:rest("get_repo_collaborator_permission", function(owner, repo_name, username)
-  local ok, status, _, ubody = fetch_json(base() .. "/users?username=" .. username)
-  if not ok or status ~= 200 then
-    respond_json(404, {})
-    return
-  end
-  local ulist = DecodeJson(ubody) or {}
-  local uid = ulist[1] and ulist[1].id
-  if not uid then
-    respond_json(404, {})
-    return
-  end
-  proxy_json(function(m)
-    local al = m and m.access_level or 0
-    local perm = al >= 50 and "admin" or (al >= 30 and "write" or "read")
-    return { permission = perm, user = { login = username, id = uid } }
-  end, fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/members/" .. uid))
+  local data, err = collaborators_cap.get_permission(owner, repo_name, username)
+  cap_rest_respond(data, err)
 end)
 
 -- Forks ---------------------------------------------------------------------
 
-b:rest(
-  "get_repo_forks",
-  proxy_handler_paged(translate_gl_projects, function(owner, repo_name)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/forks",
-      PAGES
-    )
-  end)
-)
+-- GET /repos/{owner}/{repo}/forks
+b:rest("get_repo_forks", function(owner, repo_name)
+  local items, hdrs, err = forks_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
+-- POST /repos/{owner}/{repo}/forks
 b:rest("post_repo_forks", function(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
-  local body = req.organization and EncodeJson({ namespace = req.organization }) or "{}"
-  proxy_json_created(
-    translate_gl_repo,
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/fork", "POST", body)
-  )
+  local data, err = forks_cap.create(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- Releases ------------------------------------------------------------------
@@ -5230,4 +5309,6 @@ b:capability("milestones", milestones_cap)
 b:capability("reactions", reactions_cap)
 b:capability("contents", contents_cap)
 b:capability("commit_comments", commit_comments_cap)
+b:capability("collaborators", collaborators_cap)
+b:capability("forks", forks_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -1743,6 +1743,181 @@ reactions_cap.delete_issue = function(owner, repo_name, issue_number, reaction_i
   return true, nil
 end
 
+-- ---------------------------------------------------------------------------
+-- Contents capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for repository file operations (GitLab repository files API).
+-- Single-item operations return (data, nil) on success or (nil, err) on failure.
+-- PUT/DELETE operations proxy the raw upstream response (no GitHub translation).
+
+local contents_cap = {}
+
+-- translate_gl_file: map a GitLab file metadata object to GitHub content shape.
+local function translate_gl_file(f)
+  if not f then
+    return {}
+  end
+  return {
+    name = f.file_name,
+    path = f.file_path,
+    sha = f.blob_id,
+    size = f.size,
+    type = "file",
+    encoding = f.encoding,
+    content = f.content,
+  }
+end
+
+-- get_readme: fetch the root README.md for a repository.
+-- Returns translated file shape or (nil, err).
+contents_cap.get_readme = function(owner, repo_name)
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/files/README.md?ref=HEAD"
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_file(raw), nil
+end
+
+-- get_readme_dir: fetch a README.md inside a subdirectory.
+-- Returns translated file shape or (nil, err).
+contents_cap.get_readme_dir = function(owner, repo_name, dir)
+  local enc_path = dir:gsub("/", "%%2F") .. "%%2FREADME.md"
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/files/"
+    .. enc_path
+    .. "?ref=HEAD"
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_file(raw), nil
+end
+
+-- get: fetch a single file by path.
+-- Returns translated file shape or (nil, err).
+contents_cap.get = function(owner, repo_name, path)
+  local enc_path = path:gsub("/", "%%2F")
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/files/"
+    .. enc_path
+    .. "?ref=HEAD"
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_file(raw), nil
+end
+
+-- put: create or update a file.  body is raw GitHub-format JSON string.
+-- Returns the raw upstream response (no GitHub translation) or (nil, err).
+contents_cap.put = function(owner, repo_name, path, body)
+  local enc_path = path:gsub("/", "%%2F")
+  local req = DecodeJson(body or "{}") or {}
+  -- Check if file exists to decide create vs update.
+  local ok, status = pcall(
+    Fetch,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/repository/files/"
+      .. enc_path
+      .. "?ref="
+      .. (req.branch or "HEAD"),
+    auth()
+  )
+  local method = (ok and status == 200) and "PUT" or "POST"
+  local gl_body = EncodeJson({
+    branch = req.branch or "main",
+    content = req.content,
+    commit_message = req.message,
+    encoding = req.encoding or "base64",
+  })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
+    method,
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- delete: delete a file by path.  body is raw GitHub-format JSON string.
+-- Returns the raw upstream response or (nil, err).
+contents_cap.delete = function(owner, repo_name, path, body)
+  local enc_path = path:gsub("/", "%%2F")
+  local req = DecodeJson(body or "{}") or {}
+  local gl_body = EncodeJson({
+    branch = req.branch or "main",
+    commit_message = req.message,
+    sha = req.sha,
+  })
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
+    "DELETE",
+    gl_body
+  )
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Commit comments capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for commit comment operations.
+-- GitLab uses /projects/{id}/repository/commits/{sha}/comments.
+-- Paginated list operations return (items, headers, nil) or (nil, nil, err).
+-- Create operations return (data, nil) or (nil, err).
+
+local commit_comments_cap = {}
+
+-- list: paginated list of comments for a commit.
+commit_comments_cap.list = function(owner, repo_name, commit_sha)
+  local url = append_page_params(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/repository/commits/"
+      .. commit_sha
+      .. "/comments",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return items, hdrs, nil
+end
+
+-- create: post a new comment on a commit.  body is raw JSON string.
+-- Returns the raw upstream response or (nil, err).
+commit_comments_cap.create = function(owner, repo_name, commit_sha, body)
+  local url = base()
+    .. "/projects/"
+    .. project_id(owner, repo_name)
+    .. "/repository/commits/"
+    .. commit_sha
+    .. "/comments"
+  local raw, err = cap_fetch(fetch_json, url, "POST", body)
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
 local b = make_backend_builder()
 
 b:rest("get_root", function()
@@ -1891,133 +2066,29 @@ end)
 
 -- Contents ------------------------------------------------------------------
 
-b:rest(
-  "get_repo_readme",
-  proxy_handler(function(f)
-    if not f then
-      return {}
-    end
-    return {
-      name = f.file_name,
-      path = f.file_path,
-      sha = f.blob_id,
-      size = f.size,
-      type = "file",
-      encoding = f.encoding,
-      content = f.content,
-    }
-  end, function(owner, repo_name)
-    return base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/repository/files/README.md?ref=HEAD"
-  end)
-)
+b:rest("get_repo_readme", function(owner, repo_name)
+  local data, err = contents_cap.get_readme(owner, repo_name)
+  cap_rest_respond(data, err)
+end)
 
 b:rest("get_repo_readme_dir", function(owner, repo_name, dir)
-  local enc_path = dir:gsub("/", "%%2F") .. "%%2FREADME.md"
-  proxy_json(
-    function(f)
-      if not f then
-        return {}
-      end
-      return {
-        name = f.file_name,
-        path = f.file_path,
-        sha = f.blob_id,
-        size = f.size,
-        type = "file",
-        encoding = f.encoding,
-        content = f.content,
-      }
-    end,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/repository/files/"
-        .. enc_path
-        .. "?ref=HEAD"
-    )
-  )
+  local data, err = contents_cap.get_readme_dir(owner, repo_name, dir)
+  cap_rest_respond(data, err)
 end)
 
 b:rest("get_repo_content", function(owner, repo_name, path)
-  local enc_path = path:gsub("/", "%%2F")
-  proxy_json(
-    function(f)
-      if not f then
-        return {}
-      end
-      return {
-        name = f.file_name,
-        path = f.file_path,
-        sha = f.blob_id,
-        size = f.size,
-        type = "file",
-        encoding = f.encoding,
-        content = f.content,
-      }
-    end,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/repository/files/"
-        .. enc_path
-        .. "?ref=HEAD"
-    )
-  )
+  local data, err = contents_cap.get(owner, repo_name, path)
+  cap_rest_respond(data, err)
 end)
 
 b:rest("put_repo_content", function(owner, repo_name, path)
-  local enc_path = path:gsub("/", "%%2F")
-  local req = DecodeJson(GetBody() or "{}")
-  -- Check if file exists to decide create vs update
-  local ok, status = pcall(
-    Fetch,
-    base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/repository/files/"
-      .. enc_path
-      .. "?ref="
-      .. (req.branch or "HEAD"),
-    auth()
-  )
-  local method = (ok and status == 200) and "PUT" or "POST"
-  local gl_body = EncodeJson({
-    branch = req.branch or "main",
-    content = req.content,
-    commit_message = req.message,
-    encoding = req.encoding or "base64",
-  })
-  proxy_json(
-    nil,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
-      method,
-      gl_body
-    )
-  )
+  local data, err = contents_cap.put(owner, repo_name, path, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 b:rest("delete_repo_content", function(owner, repo_name, path)
-  local enc_path = path:gsub("/", "%%2F")
-  local req = DecodeJson(GetBody() or "{}")
-  local gl_body = EncodeJson({
-    branch = req.branch or "main",
-    commit_message = req.message,
-    sha = req.sha,
-  })
-  proxy_json(
-    nil,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/files/" .. enc_path,
-      "DELETE",
-      gl_body
-    )
-  )
+  local data, err = contents_cap.delete(owner, repo_name, path, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 b:rest("get_repo_tarball", function(owner, repo_name, ref)
@@ -2607,35 +2678,15 @@ end)
 
 -- Commit comments -----------------------------------------------------------
 -- GitLab uses notes on commits: /projects/{id}/repository/commits/{sha}/comments
-b:rest(
-  "get_commit_comments",
-  proxy_handler_paged(nil, function(owner, repo_name, commit_sha)
-    return append_page_params(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/repository/commits/"
-        .. commit_sha
-        .. "/comments",
-      PAGES
-    )
-  end)
-)
+
+b:rest("get_commit_comments", function(owner, repo_name, commit_sha)
+  local items, hdrs, err = commit_comments_cap.list(owner, repo_name, commit_sha)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 b:rest("post_commit_comment", function(owner, repo_name, commit_sha)
-  proxy_json_created(
-    nil,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/repository/commits/"
-        .. commit_sha
-        .. "/comments",
-      "POST",
-      GetBody()
-    )
-  )
+  local data, err = commit_comments_cap.create(owner, repo_name, commit_sha, GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- Users ---------------------------------------------------------------------
@@ -5177,4 +5228,6 @@ b:capability("issues", issues_cap)
 b:capability("labels", labels_cap)
 b:capability("milestones", milestones_cap)
 b:capability("reactions", reactions_cap)
+b:capability("contents", contents_cap)
+b:capability("commit_comments", commit_comments_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -93,10 +93,6 @@ local function translate_gl_req(body_str)
   return EncodeJson(gl)
 end
 
-local function translate_gl_projects(projects)
-  return translate_list(translate_gl_repo, projects)
-end
-
 -- Map a GitLab user object to GitHub format.
 local function translate_gl_user(u)
   if not u then
@@ -3267,251 +3263,586 @@ b:rest("get_users_gpg_keys", function(username)
   cap_rest_respond(data, err)
 end)
 
--- Teams — mapped to GitLab subgroups ----------------------------------------
+-- ---------------------------------------------------------------------------
+-- Teams capability module
+-- ---------------------------------------------------------------------------
+-- Teams in GitHub map to GitLab subgroups.
 -- GitHub: /orgs/{org}/teams/{team_slug}  →  GitLab: /groups/{org}%2F{slug}
+-- Legacy /teams/{team_id} API maps team_id to a GitLab group numeric ID.
 -- GitLab group members have access levels; repos are the group's projects.
 
--- GET /orgs/{org}/teams
-b:rest("get_org_teams", function(org)
-  proxy_json_paged(function(groups)
-    for i, g in ipairs(groups) do
-      groups[i] = translate_gl_team(g)
-    end
-    return groups
-  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. org .. "/subgroups", PAGES)))
-end)
+local teams_cap = {}
 
--- POST /orgs/{org}/teams
-b:rest("post_org_teams", function(org)
-  local req = DecodeJson(GetBody() or "{}")
-  local parent_ok, parent_status, _, parent_body = fetch_json(base() .. "/groups/" .. org)
-  if not parent_ok or parent_status ~= 200 then
-    respond_json(parent_ok and parent_status or 503, {})
-    return
+-- resolve_group_id: look up the numeric GitLab group ID for a slug path.
+-- path is the URL-encoded group path (e.g. "org%2Fslug").
+-- Returns (gid, nil) or (nil, err).
+local function resolve_group_id(path)
+  local ok, status, _, body = fetch_json(base() .. "/groups/" .. path)
+  if not ok or status ~= 200 then
+    return nil, cap_err(status or 0, "group lookup failed")
   end
-  local parent = DecodeJson(parent_body) or {}
-  local body = {
+  local g = DecodeJson(body) or {}
+  if not g.id then
+    return nil, cap_err(404, "group not found")
+  end
+  return g.id, nil
+end
+
+-- resolve_team_uid: look up a GitLab user ID by username for team operations.
+-- Returns (uid, nil) or (nil, err).
+local function resolve_team_uid(username)
+  local uid = gl_user_id(username)
+  if not uid then
+    return nil, cap_err(404, "user not found")
+  end
+  return uid, nil
+end
+
+-- list_org_teams: paginated list of subgroups (teams) under an org.
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_org_teams = function(org)
+  local url = append_page_params(base() .. "/groups/" .. org .. "/subgroups", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_team, items), hdrs, nil
+end
+
+-- create_org_team: create a subgroup under org.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+teams_cap.create_org_team = function(org, body)
+  local req = DecodeJson(body or "{}") or {}
+  local parent, perr = cap_fetch(fetch_json, base() .. "/groups/" .. org)
+  if not parent then
+    return nil, perr
+  end
+  local gl_body = EncodeJson({
     name = req.name,
     path = (req.name or ""):lower():gsub("[^%w%-]", "-"),
     parent_id = parent.id,
     description = req.description,
     visibility = req.privacy == "secret" and "private" or "internal",
-  }
-  proxy_json_created(translate_gl_team, fetch_json(base() .. "/groups", "POST", EncodeJson(body)))
-end)
+  })
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups", "POST", gl_body)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_team(raw), nil
+end
 
--- GET /orgs/{org}/teams/{team_slug}
-b:rest("get_org_team", function(org, slug)
-  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug))
-end)
+-- get_org_team: get a single team (subgroup) by org and slug.
+-- Returns (data, nil) or (nil, err).
+teams_cap.get_org_team = function(org, slug)
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups/" .. org .. "%2F" .. slug)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_team(raw), nil
+end
 
--- PATCH /orgs/{org}/teams/{team_slug}
-b:rest("patch_org_team", function(org, slug)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- update_org_team: update a team by org and slug.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+teams_cap.update_org_team = function(org, slug, body)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
-  local req = DecodeJson(GetBody() or "{}")
-  local upd = {}
-  if req.name then
-    upd.name = req.name
+  local req = DecodeJson(body or "{}") or {}
+  local upd = { name = req.name, description = req.description }
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups/" .. gid, "PUT", EncodeJson(upd))
+  if not raw then
+    return nil, err
   end
-  if req.description then
-    upd.description = req.description
-  end
-  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. gid, "PUT", EncodeJson(upd)))
-end)
+  return translate_gl_team(raw), nil
+end
 
--- DELETE /orgs/{org}/teams/{team_slug}
-b:rest("delete_org_team", function(org, slug)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- delete_org_team: delete a team by org and slug.
+-- Returns (true, nil) or (nil, err).
+teams_cap.delete_org_team = function(org, slug)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. gid, dopts))
-end)
+  local ok, status = fetch_json(base() .. "/groups/" .. gid, "DELETE")
+  if not ok or (status ~= 200 and status ~= 202 and status ~= 204) then
+    return nil, cap_err(status or 0, "delete team failed")
+  end
+  return true, nil
+end
 
--- GET /orgs/{org}/teams/{team_slug}/members
-b:rest("get_org_team_members", function(org, slug)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- list_org_team_members: paginated list of members for a team (by org/slug).
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_org_team_members = function(org, slug)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
-  proxy_json_paged(function(members)
-    local out = {}
-    for _, m in ipairs(members) do
-      out[#out + 1] = translate_gl_member(m)
-    end
-    return out
-  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/members", PAGES)))
-end)
+  local url = append_page_params(base() .. "/groups/" .. gid .. "/members", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_member, items), hdrs, nil
+end
 
--- GET /orgs/{org}/teams/{team_slug}/memberships/{username}
-b:rest("get_org_team_membership", function(org, slug, username)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- get_org_team_membership: get membership for a user in a team (by org/slug).
+-- Returns (data, nil) or (nil, err).
+-- data = { url, role, state }
+teams_cap.get_org_team_membership = function(org, slug, username)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
-  local uid = gl_user_id(username)
+  local uid, uerr = resolve_team_uid(username)
   if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
+    return nil, uerr
   end
-  local mok, mstatus, _, mbody = fetch_json(base() .. "/groups/" .. gid .. "/members/" .. uid)
-  if mok and mstatus == 200 then
-    local m = DecodeJson(mbody) or {}
-    local role = (m.access_level or 0) >= 50 and "maintainer" or "member"
-    respond_json(200, { url = "", role = role, state = "active" })
-  elseif mok then
-    respond_json(404, { message = "Not Found" })
-  else
-    respond_json(503, {})
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups/" .. gid .. "/members/" .. uid)
+  if not raw then
+    return nil, err
   end
-end)
+  local role = (raw.access_level or 0) >= 50 and "maintainer" or "member"
+  return { url = "", role = role, state = "active" }, nil
+end
 
--- PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
-b:rest("put_org_team_membership", function(org, slug, username)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- put_org_team_membership: add or update membership for a user in a team (by org/slug).
+-- Returns (data, nil) or (nil, err).
+teams_cap.put_org_team_membership = function(org, slug, username, body)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
-  local uid = gl_user_id(username)
+  local uid, uerr = resolve_team_uid(username)
   if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
+    return nil, uerr
   end
-  local req = DecodeJson(GetBody() or "{}")
+  local req = DecodeJson(body or "{}") or {}
   local level = req.role == "maintainer" and 50 or 30
-  local mok, mstatus = fetch_json(
+  local ok, status = fetch_json(
     base() .. "/groups/" .. gid .. "/members",
     "POST",
     EncodeJson({ user_id = uid, access_level = level })
   )
-  if mok and (mstatus == 200 or mstatus == 201) then
-    respond_json(200, { url = "", role = req.role or "member", state = "active" })
-  elseif mok then
-    respond_json(mstatus, {})
-  else
-    respond_json(503, {})
+  if not ok then
+    return nil, cap_err(0, "add member failed")
   end
-end)
+  if status ~= 200 and status ~= 201 then
+    return nil, cap_err(status, "add member failed")
+  end
+  return { url = "", role = req.role or "member", state = "active" }, nil
+end
 
--- DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
-b:rest("delete_org_team_membership", function(org, slug, username)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- delete_org_team_membership: remove a user from a team (by org/slug).
+-- Returns (true, nil) or (nil, err).
+teams_cap.delete_org_team_membership = function(org, slug, username)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
-  local uid = gl_user_id(username)
+  local uid, uerr = resolve_team_uid(username)
   if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
+    return nil, uerr
   end
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. gid .. "/members/" .. uid, dopts))
-end)
+  local ok, status = fetch_json(base() .. "/groups/" .. gid .. "/members/" .. uid, "DELETE")
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "remove member failed")
+  end
+  return true, nil
+end
 
--- GET /orgs/{org}/teams/{team_slug}/repos
-b:rest("get_org_team_repos", function(org, slug)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- list_org_team_repos: paginated list of projects for a team (by org/slug).
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_org_team_repos = function(org, slug)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
-  proxy_json_paged(
-    translate_gl_projects,
-    PAGES,
-    fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/projects", PAGES))
-  )
-end)
+  local url = append_page_params(base() .. "/groups/" .. gid .. "/projects", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
 
--- GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-b:rest("get_org_team_repo", function(org, slug, owner, repo_name)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- get_org_team_repo: check if a repo belongs to a team (by org/slug) and return it.
+-- Returns (data, nil) or (nil, err).
+teams_cap.get_org_team_repo = function(org, slug, owner, repo_name)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
   local pid = project_id(owner, repo_name)
-  -- Check if the project belongs to this subgroup
-  local pok, pstatus, _, pbody = fetch_json(base() .. "/projects/" .. pid)
-  if not pok or pstatus ~= 200 then
-    respond_json(404, { message = "Not Found" })
-    return
+  local raw, ferr = cap_fetch(fetch_json, base() .. "/projects/" .. pid)
+  if not raw then
+    return nil, ferr
   end
-  local proj = DecodeJson(pbody) or {}
-  local ns = proj.namespace or {}
+  local ns = raw.namespace or {}
   if tostring(ns.id) ~= tostring(gid) then
-    respond_json(404, { message = "Not Found" })
-    return
+    return nil, cap_err(404, "Not Found")
   end
-  respond_json(200, translate_gl_repo(proj))
-end)
+  return translate_gl_repo(raw), nil
+end
 
--- PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
-b:rest("put_org_team_repo", function(org, slug, owner, repo_name)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
+-- put_org_team_repo: share a repo with a team (by org/slug).
+-- Returns (true, nil) or (nil, err).
+teams_cap.put_org_team_repo = function(org, slug, owner, repo_name, body)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
   end
-  local gid = (DecodeJson(body) or {}).id
   local pid = project_id(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
+  local req = DecodeJson(body or "{}") or {}
   local access = req.permission == "admin" and 50 or (req.permission == "push" and 30 or 20)
-  local pok, pstatus = fetch_json(
+  local ok, status = fetch_json(
     base() .. "/projects/" .. pid .. "/share",
     "POST",
     EncodeJson({ group_id = gid, group_access = access })
   )
-  proxy_204({ 200, 201 }, pok, pstatus)
+  if not ok or (status ~= 200 and status ~= 201 and status ~= 204) then
+    return nil, cap_err(status or 0, "share project failed")
+  end
+  return true, nil
+end
+
+-- delete_org_team_repo: unshare a repo from a team (by org/slug).
+-- Returns (true, nil) or (nil, err).
+teams_cap.delete_org_team_repo = function(org, slug, owner, repo_name)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, gerr
+  end
+  local pid = project_id(owner, repo_name)
+  local ok, status = fetch_json(base() .. "/projects/" .. pid .. "/share/" .. gid, "DELETE")
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "unshare project failed")
+  end
+  return true, nil
+end
+
+-- list_org_team_children: paginated list of sub-subgroups for a team (by org/slug).
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_org_team_children = function(org, slug)
+  local gid, gerr = resolve_group_id(org .. "%2F" .. slug)
+  if not gid then
+    return nil, nil, gerr
+  end
+  local url = append_page_params(base() .. "/groups/" .. gid .. "/subgroups", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  -- Translate in-place to preserve JSON array encoding metadata from DecodeJson.
+  for i, g in ipairs(items) do
+    items[i] = translate_gl_team(g)
+  end
+  return items, hdrs, nil
+end
+
+-- list_user_teams: all groups the authenticated user belongs to.
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_user_teams = function()
+  local url = append_page_params(base() .. "/groups?min_access_level=10", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_team, items), hdrs, nil
+end
+
+-- get_team: get a team by numeric ID.
+-- Returns (data, nil) or (nil, err).
+teams_cap.get_team = function(team_id)
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups/" .. team_id)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_team(raw), nil
+end
+
+-- update_team: update a team by numeric ID.  body is raw GitHub-format JSON.
+-- Returns (data, nil) or (nil, err).
+teams_cap.update_team = function(team_id, body)
+  local req = DecodeJson(body or "{}") or {}
+  local upd = { name = req.name, description = req.description }
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups/" .. team_id, "PUT", EncodeJson(upd))
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_team(raw), nil
+end
+
+-- delete_team: delete a team by numeric ID.
+-- Returns (true, nil) or (nil, err).
+teams_cap.delete_team = function(team_id)
+  local ok, status = fetch_json(base() .. "/groups/" .. team_id, "DELETE")
+  if not ok or (status ~= 200 and status ~= 202 and status ~= 204) then
+    return nil, cap_err(status or 0, "delete team failed")
+  end
+  return true, nil
+end
+
+-- list_team_members: paginated list of members for a team by numeric ID.
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_team_members = function(team_id)
+  local url = append_page_params(base() .. "/groups/" .. team_id .. "/members", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_member, items), hdrs, nil
+end
+
+-- get_team_member: deprecated legacy — returns (true, nil) if member, (nil, err) if not.
+-- On success callers emit 204 No Content.
+teams_cap.get_team_member = function(team_id, username)
+  local uid, uerr = resolve_team_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local ok, status = pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, auth())
+  if ok and status == 200 then
+    return true, nil
+  end
+  return nil, cap_err(ok and status or 0, "Not a member")
+end
+
+-- put_team_member: deprecated legacy — add a member.
+-- Returns (true, nil) or (nil, err).
+teams_cap.put_team_member = function(team_id, username)
+  local uid, uerr = resolve_team_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local ok, status = fetch_json(
+    base() .. "/groups/" .. team_id .. "/members",
+    "POST",
+    EncodeJson({ user_id = uid, access_level = 30 })
+  )
+  if not ok or (status ~= 200 and status ~= 201) then
+    return nil, cap_err(status or 0, "add member failed")
+  end
+  return true, nil
+end
+
+-- delete_team_member: deprecated legacy — remove a member.
+-- Returns (true, nil) or (nil, err).
+teams_cap.delete_team_member = function(team_id, username)
+  local uid, uerr = resolve_team_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local ok, status = fetch_json(base() .. "/groups/" .. team_id .. "/members/" .. uid, "DELETE")
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "remove member failed")
+  end
+  return true, nil
+end
+
+-- get_team_membership: get membership for a user in a team by numeric ID.
+-- Returns (data, nil) or (nil, err).
+teams_cap.get_team_membership = function(team_id, username)
+  local uid, uerr = resolve_team_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups/" .. team_id .. "/members/" .. uid)
+  if not raw then
+    return nil, err
+  end
+  local role = (raw.access_level or 0) >= 50 and "maintainer" or "member"
+  return { url = "", role = role, state = "active" }, nil
+end
+
+-- put_team_membership: add or update membership for a user in a team by numeric ID.
+-- Returns (data, nil) or (nil, err).
+teams_cap.put_team_membership = function(team_id, username, body)
+  local uid, uerr = resolve_team_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local req = DecodeJson(body or "{}") or {}
+  local level = req.role == "maintainer" and 50 or 30
+  local ok, status = fetch_json(
+    base() .. "/groups/" .. team_id .. "/members",
+    "POST",
+    EncodeJson({ user_id = uid, access_level = level })
+  )
+  if not ok then
+    return nil, cap_err(0, "add member failed")
+  end
+  if status ~= 200 and status ~= 201 then
+    return nil, cap_err(status, "add member failed")
+  end
+  return { url = "", role = req.role or "member", state = "active" }, nil
+end
+
+-- delete_team_membership: remove a user from a team by numeric ID.
+-- Returns (true, nil) or (nil, err).
+teams_cap.delete_team_membership = function(team_id, username)
+  local uid, uerr = resolve_team_uid(username)
+  if not uid then
+    return nil, uerr
+  end
+  local ok, status = fetch_json(base() .. "/groups/" .. team_id .. "/members/" .. uid, "DELETE")
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "remove member failed")
+  end
+  return true, nil
+end
+
+-- list_team_repos: paginated list of projects for a team by numeric ID.
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_team_repos = function(team_id)
+  local url = append_page_params(base() .. "/groups/" .. team_id .. "/projects", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
+
+-- get_team_repo: check if a repo belongs to a team by numeric ID and return it.
+-- Returns (data, nil) or (nil, err).
+teams_cap.get_team_repo = function(team_id, owner, repo_name)
+  local pid = project_id(owner, repo_name)
+  local raw, ferr = cap_fetch(fetch_json, base() .. "/projects/" .. pid)
+  if not raw then
+    return nil, ferr
+  end
+  local ns = raw.namespace or {}
+  if tostring(ns.id) ~= tostring(team_id) then
+    return nil, cap_err(404, "Not Found")
+  end
+  return translate_gl_repo(raw), nil
+end
+
+-- put_team_repo: share a repo with a team by numeric ID.
+-- Returns (true, nil) or (nil, err).
+teams_cap.put_team_repo = function(team_id, owner, repo_name, body)
+  local pid = project_id(owner, repo_name)
+  local req = DecodeJson(body or "{}") or {}
+  local access = req.permission == "admin" and 50 or (req.permission == "push" and 30 or 20)
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. pid .. "/share",
+    "POST",
+    EncodeJson({ group_id = team_id, group_access = access })
+  )
+  if not ok or (status ~= 200 and status ~= 201 and status ~= 204) then
+    return nil, cap_err(status or 0, "share project failed")
+  end
+  return true, nil
+end
+
+-- delete_team_repo: unshare a repo from a team by numeric ID.
+-- Returns (true, nil) or (nil, err).
+teams_cap.delete_team_repo = function(team_id, owner, repo_name)
+  local pid = project_id(owner, repo_name)
+  local ok, status = fetch_json(base() .. "/projects/" .. pid .. "/share/" .. team_id, "DELETE")
+  if not ok or (status ~= 200 and status ~= 204) then
+    return nil, cap_err(status or 0, "unshare project failed")
+  end
+  return true, nil
+end
+
+-- list_team_children: paginated list of sub-subgroups for a team by numeric ID.
+-- Returns (items, headers, nil) or (nil, nil, err).
+teams_cap.list_team_children = function(team_id)
+  local url = append_page_params(base() .. "/groups/" .. team_id .. "/subgroups", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  -- Translate in-place to preserve JSON array encoding metadata from DecodeJson.
+  for i, g in ipairs(items) do
+    items[i] = translate_gl_team(g)
+  end
+  return items, hdrs, nil
+end
+
+-- GET /orgs/{org}/teams
+b:rest("get_org_teams", function(org)
+  local items, hdrs, err = teams_cap.list_org_teams(org)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+-- POST /orgs/{org}/teams
+b:rest("post_org_teams", function(org)
+  local data, err = teams_cap.create_org_team(org, GetBody())
+  cap_rest_created(data, err)
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}
+b:rest("get_org_team", function(org, slug)
+  local data, err = teams_cap.get_org_team(org, slug)
+  cap_rest_respond(data, err)
+end)
+
+-- PATCH /orgs/{org}/teams/{team_slug}
+b:rest("patch_org_team", function(org, slug)
+  local data, err = teams_cap.update_org_team(org, slug, GetBody())
+  cap_rest_respond(data, err)
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}
+b:rest("delete_org_team", function(org, slug)
+  local ok, err = teams_cap.delete_org_team(org, slug)
+  cap_rest_204(ok, err)
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/members
+b:rest("get_org_team_members", function(org, slug)
+  local items, hdrs, err = teams_cap.list_org_team_members(org, slug)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("get_org_team_membership", function(org, slug, username)
+  local data, err = teams_cap.get_org_team_membership(org, slug, username)
+  cap_rest_respond(data, err)
+end)
+
+-- PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("put_org_team_membership", function(org, slug, username)
+  local data, err = teams_cap.put_org_team_membership(org, slug, username, GetBody())
+  cap_rest_respond(data, err)
+end)
+
+-- DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
+b:rest("delete_org_team_membership", function(org, slug, username)
+  local ok, err = teams_cap.delete_org_team_membership(org, slug, username)
+  cap_rest_204(ok, err)
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/repos
+b:rest("get_org_team_repos", function(org, slug)
+  local items, hdrs, err = teams_cap.list_org_team_repos(org, slug)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+-- GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("get_org_team_repo", function(org, slug, owner, repo_name)
+  local data, err = teams_cap.get_org_team_repo(org, slug, owner, repo_name)
+  cap_rest_respond(data, err)
+end)
+
+-- PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+b:rest("put_org_team_repo", function(org, slug, owner, repo_name)
+  local ok, err = teams_cap.put_org_team_repo(org, slug, owner, repo_name, GetBody())
+  cap_rest_204(ok, err)
 end)
 
 -- DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
 b:rest("delete_org_team_repo", function(org, slug, owner, repo_name)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
-  end
-  local gid = (DecodeJson(body) or {}).id
-  local pid = project_id(owner, repo_name)
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. gid, dopts))
+  local ok, err = teams_cap.delete_org_team_repo(org, slug, owner, repo_name)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /orgs/{org}/teams/{team_slug}/teams — list sub-subgroups
 b:rest("get_org_team_children", function(org, slug)
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. org .. "%2F" .. slug)
-  if not ok or status ~= 200 then
-    respond_json(ok and status or 503, {})
-    return
-  end
-  local gid = (DecodeJson(body) or {}).id
-  proxy_json_paged(function(groups)
-    for i, g in ipairs(groups) do
-      groups[i] = translate_gl_team(g)
-    end
-    return groups
-  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. gid .. "/subgroups", PAGES)))
+  local items, hdrs, err = teams_cap.list_org_team_children(org, slug)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 -- Legacy team-by-id API (/teams/{team_id}) ------------------------------------
@@ -3519,207 +3850,102 @@ end)
 
 -- GET /user/teams — all groups the authenticated user belongs to
 b:rest("get_user_teams", function()
-  proxy_json_paged(function(groups)
-    for i, g in ipairs(groups) do
-      groups[i] = translate_gl_team(g)
-    end
-    return groups
-  end, PAGES, fetch_json(append_page_params(base() .. "/groups?min_access_level=10", PAGES)))
+  local items, hdrs, err = teams_cap.list_user_teams()
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 -- GET /teams/{team_id}
 b:rest("get_team", function(team_id)
-  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. team_id))
+  local data, err = teams_cap.get_team(team_id)
+  cap_rest_respond(data, err)
 end)
 
 -- PATCH /teams/{team_id}
 b:rest("patch_team", function(team_id)
-  local req = DecodeJson(GetBody() or "{}")
-  local upd = {}
-  if req.name then
-    upd.name = req.name
-  end
-  if req.description then
-    upd.description = req.description
-  end
-  proxy_json(translate_gl_team, fetch_json(base() .. "/groups/" .. team_id, "PUT", EncodeJson(upd)))
+  local data, err = teams_cap.update_team(team_id, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 -- DELETE /teams/{team_id}
 b:rest("delete_team", function(team_id)
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  proxy_204({ 202 }, pcall(Fetch, base() .. "/groups/" .. team_id, dopts))
+  local ok, err = teams_cap.delete_team(team_id)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /teams/{team_id}/members
 b:rest("get_team_members", function(team_id)
-  proxy_json_paged(function(members)
-    local out = {}
-    for _, m in ipairs(members) do
-      out[#out + 1] = translate_gl_member(m)
-    end
-    return out
-  end, PAGES, fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/members", PAGES)))
+  local items, hdrs, err = teams_cap.list_team_members(team_id)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 -- GET /teams/{team_id}/members/{username} — deprecated legacy, 204 if member
 b:rest("get_team_member", function(team_id, username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local ok, status = pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, auth())
-  if ok and status == 200 then
+  local ok, err = teams_cap.get_team_member(team_id, username)
+  if ok then
     SetStatus(204, "No Content")
-  elseif ok then
-    respond_json(404, { message = "Not Found" })
   else
-    respond_json(503, {})
+    cap_rest_204(nil, err)
   end
 end)
 
 -- PUT /teams/{team_id}/members/{username} — deprecated legacy
 b:rest("put_team_member", function(team_id, username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local ok, status = fetch_json(
-    base() .. "/groups/" .. team_id .. "/members",
-    "POST",
-    EncodeJson({ user_id = uid, access_level = 30 })
-  )
-  proxy_204({ 200, 201 }, ok, status)
+  local ok, err = teams_cap.put_team_member(team_id, username)
+  cap_rest_204(ok, err)
 end)
 
 -- DELETE /teams/{team_id}/members/{username} — deprecated legacy
 b:rest("delete_team_member", function(team_id, username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
+  local ok, err = teams_cap.delete_team_member(team_id, username)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /teams/{team_id}/memberships/{username}
 b:rest("get_team_membership", function(team_id, username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local ok, status, _, body = fetch_json(base() .. "/groups/" .. team_id .. "/members/" .. uid)
-  if ok and status == 200 then
-    local m = DecodeJson(body) or {}
-    local role = (m.access_level or 0) >= 50 and "maintainer" or "member"
-    respond_json(200, { url = "", role = role, state = "active" })
-  elseif ok then
-    respond_json(404, { message = "Not Found" })
-  else
-    respond_json(503, {})
-  end
+  local data, err = teams_cap.get_team_membership(team_id, username)
+  cap_rest_respond(data, err)
 end)
 
 -- PUT /teams/{team_id}/memberships/{username}
 b:rest("put_team_membership", function(team_id, username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local req = DecodeJson(GetBody() or "{}")
-  local level = req.role == "maintainer" and 50 or 30
-  local ok, status = fetch_json(
-    base() .. "/groups/" .. team_id .. "/members",
-    "POST",
-    EncodeJson({ user_id = uid, access_level = level })
-  )
-  if ok and (status == 200 or status == 201) then
-    respond_json(200, { url = "", role = req.role or "member", state = "active" })
-  elseif ok then
-    respond_json(status, {})
-  else
-    respond_json(503, {})
-  end
+  local data, err = teams_cap.put_team_membership(team_id, username, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 -- DELETE /teams/{team_id}/memberships/{username}
 b:rest("delete_team_membership", function(team_id, username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  proxy_204({ 200 }, pcall(Fetch, base() .. "/groups/" .. team_id .. "/members/" .. uid, dopts))
+  local ok, err = teams_cap.delete_team_membership(team_id, username)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /teams/{team_id}/repos
 b:rest("get_team_repos", function(team_id)
-  proxy_json_paged(
-    translate_gl_projects,
-    PAGES,
-    fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/projects", PAGES))
-  )
+  local items, hdrs, err = teams_cap.list_team_repos(team_id)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 -- GET /teams/{team_id}/repos/{owner}/{repo}
 b:rest("get_team_repo", function(team_id, owner, repo_name)
-  local pid = project_id(owner, repo_name)
-  local ok, status, _, body = fetch_json(base() .. "/projects/" .. pid)
-  if not ok or status ~= 200 then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local proj = DecodeJson(body) or {}
-  local ns = proj.namespace or {}
-  if tostring(ns.id) ~= tostring(team_id) then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  respond_json(200, translate_gl_repo(proj))
+  local data, err = teams_cap.get_team_repo(team_id, owner, repo_name)
+  cap_rest_respond(data, err)
 end)
 
 -- PUT /teams/{team_id}/repos/{owner}/{repo}
 b:rest("put_team_repo", function(team_id, owner, repo_name)
-  local pid = project_id(owner, repo_name)
-  local req = DecodeJson(GetBody() or "{}")
-  local access = req.permission == "admin" and 50 or (req.permission == "push" and 30 or 20)
-  local ok, status = fetch_json(
-    base() .. "/projects/" .. pid .. "/share",
-    "POST",
-    EncodeJson({ group_id = team_id, group_access = access })
-  )
-  proxy_204({ 200, 201 }, ok, status)
+  local ok, err = teams_cap.put_team_repo(team_id, owner, repo_name, GetBody())
+  cap_rest_204(ok, err)
 end)
 
 -- DELETE /teams/{team_id}/repos/{owner}/{repo}
 b:rest("delete_team_repo", function(team_id, owner, repo_name)
-  local pid = project_id(owner, repo_name)
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  proxy_204({ 200 }, pcall(Fetch, base() .. "/projects/" .. pid .. "/share/" .. team_id, dopts))
+  local ok, err = teams_cap.delete_team_repo(team_id, owner, repo_name)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /teams/{team_id}/teams — sub-subgroups
 b:rest("get_team_children", function(team_id)
-  proxy_json_paged(
-    function(groups)
-      for i, g in ipairs(groups) do
-        groups[i] = translate_gl_team(g)
-      end
-      return groups
-    end,
-    PAGES,
-    fetch_json(append_page_params(base() .. "/groups/" .. team_id .. "/subgroups", PAGES))
-  )
+  local items, hdrs, err = teams_cap.list_team_children(team_id)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 -- Issues -------------------------------------------------------------------
@@ -5524,4 +5750,5 @@ b:capability("pulls", pulls_cap)
 b:capability("releases", releases_cap)
 b:capability("deploy_keys", deploy_keys_cap)
 b:capability("webhooks", webhooks_cap)
+b:capability("teams", teams_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -4411,76 +4411,69 @@ end)
 -- Check suites have no GitLab equivalent; all suite endpoints fall back to
 -- the route_defaults stubs defined in .init.lua.
 
--- Packages (org via GitLab group packages API) --------------------------------
+-- ---------------------------------------------------------------------------
+-- Packages capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translation for GitLab group package registry operations.
+-- Maps GitLab package objects to the GitHub Packages REST shape.
+-- Paged list operations: (items, headers, nil) or (nil, nil, err).
+-- Single-item operations: (data, nil) or (nil, err).
+-- Delete operations: (true, nil) or (nil, err).
 
-b:rest("get_org_packages", function(org)
-  local pkg_type = GetParam("package_type") or ""
-  local url = base() .. "/groups/" .. org .. "/packages"
-  if pkg_type ~= "" then
-    url = url .. "?package_type=" .. pkg_type
-  end
-  url = append_page_params(url, PAGES)
-  proxy_json_paged(function(entries)
-    local pkgs = {}
-    for i, p in ipairs(entries) do
-      pkgs[i] = {
-        id = p.id,
-        name = p.name or "",
-        package_type = p.package_type or "",
-        url = "",
-        html_url = p._links and p._links.web_path or "",
-        version_count = 1,
-        visibility = "public",
-        owner = nil,
-        repository = nil,
-        created_at = p.created_at,
-        updated_at = p.created_at,
-      }
-    end
-    return pkgs
-  end, PAGES, fetch_json(url))
-end)
+local packages_cap = {}
 
-b:rest("get_org_package", function(org, pkg_type, pkg_name)
-  local url = base()
-    .. "/groups/"
-    .. org
-    .. "/packages?package_type="
-    .. pkg_type
-    .. "&package_name="
-    .. pkg_name
-    .. "&per_page=100"
-  local ok, status, _, body = fetch_json(url)
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local entries = DecodeJson(body) or {}
-  if #entries == 0 then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local p = entries[1]
-  respond_json(200, {
+-- Helper: translate a single GitLab package entry to GitHub Packages format.
+local function translate_gl_package(p, version_count)
+  return {
     id = p.id,
     name = p.name or "",
     package_type = p.package_type or "",
     url = "",
     html_url = p._links and p._links.web_path or "",
-    version_count = #entries,
+    version_count = version_count or 1,
     visibility = "public",
     owner = nil,
     repository = nil,
     created_at = p.created_at,
     updated_at = p.created_at,
-  })
-end)
+  }
+end
 
-b:rest("delete_org_package", function(org, pkg_type, pkg_name)
+-- Helper: translate a single GitLab package entry to GitHub package version format.
+local function translate_gl_package_version(p)
+  return {
+    id = p.id,
+    name = p.version or "",
+    url = "",
+    package_html_url = "",
+    html_url = p._links and p._links.web_path or "",
+    license = "",
+    description = "",
+    created_at = p.created_at,
+    updated_at = p.created_at,
+    deleted_at = nil,
+    metadata = { package_type = p.package_type or "" },
+  }
+end
+
+-- list_org: paginated list of packages for an org (GitLab group), optionally
+-- filtered by package_type.  pkg_type may be "" to list all types.
+packages_cap.list_org = function(org, pkg_type)
+  local url = base() .. "/groups/" .. org .. "/packages"
+  if pkg_type and pkg_type ~= "" then
+    url = url .. "?package_type=" .. pkg_type
+  end
+  url = append_page_params(url, PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_package, items), hdrs, nil
+end
+
+-- get_org: fetch a single package from an org by type+name.
+-- Returns (package_data, nil) or (nil, err).
+packages_cap.get_org = function(org, pkg_type, pkg_name)
   local url = base()
     .. "/groups/"
     .. org
@@ -4489,27 +4482,44 @@ b:rest("delete_org_package", function(org, pkg_type, pkg_name)
     .. "&package_name="
     .. pkg_name
     .. "&per_page=100"
-  local ok, status, _, body = fetch_json(url)
-  if not ok then
-    respond_json(503, {})
-    return
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
   end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local entries = DecodeJson(body) or {}
+  local entries = type(raw) == "table" and raw or {}
   if #entries == 0 then
-    respond_json(404, { message = "Not Found" })
-    return
+    return nil, cap_err(404, "Not Found")
+  end
+  return translate_gl_package(entries[1], #entries), nil
+end
+
+-- delete_org: delete all versions of a package from an org by type+name.
+-- Returns (true, nil) on success or (nil, err).
+packages_cap.delete_org = function(org, pkg_type, pkg_name)
+  local url = base()
+    .. "/groups/"
+    .. org
+    .. "/packages?package_type="
+    .. pkg_type
+    .. "&package_name="
+    .. pkg_name
+    .. "&per_page=100"
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
+  end
+  local entries = type(raw) == "table" and raw or {}
+  if #entries == 0 then
+    return nil, cap_err(404, "Not Found")
   end
   for _, p in ipairs(entries) do
     fetch_json(base() .. "/projects/" .. p.project_id .. "/packages/" .. p.id, "DELETE")
   end
-  set_preamble(204)
-end)
+  return true, nil
+end
 
-b:rest("get_org_package_versions", function(org, pkg_type, pkg_name)
+-- list_org_versions: paginated list of versions of a package in an org.
+packages_cap.list_org_versions = function(org, pkg_type, pkg_name)
   local url = base()
     .. "/groups/"
     .. org
@@ -4518,28 +4528,16 @@ b:rest("get_org_package_versions", function(org, pkg_type, pkg_name)
     .. "&package_name="
     .. pkg_name
   url = append_page_params(url, PAGES)
-  proxy_json_paged(function(entries)
-    local versions = {}
-    for i, p in ipairs(entries) do
-      versions[i] = {
-        id = p.id,
-        name = p.version or "",
-        url = "",
-        package_html_url = "",
-        html_url = p._links and p._links.web_path or "",
-        license = "",
-        description = "",
-        created_at = p.created_at,
-        updated_at = p.created_at,
-        deleted_at = nil,
-        metadata = { package_type = p.package_type or "" },
-      }
-    end
-    return versions
-  end, PAGES, fetch_json(url))
-end)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_package_version, items), hdrs, nil
+end
 
-b:rest("get_org_package_version", function(org, pkg_type, pkg_name, version_id)
+-- get_org_version: fetch a single package version from an org by version_id.
+-- Returns (version_data, nil) or (nil, err).
+packages_cap.get_org_version = function(org, pkg_type, pkg_name, version_id)
   local url = base()
     .. "/groups/"
     .. org
@@ -4548,38 +4546,22 @@ b:rest("get_org_package_version", function(org, pkg_type, pkg_name, version_id)
     .. "&package_name="
     .. pkg_name
     .. "&per_page=100"
-  local ok, status, _, body = fetch_json(url)
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
   end
   local vid = tonumber(version_id)
-  for _, p in ipairs(DecodeJson(body) or {}) do
+  for _, p in ipairs(type(raw) == "table" and raw or {}) do
     if p.id == vid then
-      respond_json(200, {
-        id = p.id,
-        name = p.version or "",
-        url = "",
-        package_html_url = "",
-        html_url = p._links and p._links.web_path or "",
-        license = "",
-        description = "",
-        created_at = p.created_at,
-        updated_at = p.created_at,
-        deleted_at = nil,
-        metadata = { package_type = p.package_type or "" },
-      })
-      return
+      return translate_gl_package_version(p), nil
     end
   end
-  respond_json(404, { message = "Not Found" })
-end)
+  return nil, cap_err(404, "Not Found")
+end
 
-b:rest("delete_org_package_version", function(org, pkg_type, pkg_name, version_id)
+-- delete_org_version: delete a single package version from an org by version_id.
+-- Returns (true, nil) on success or (nil, err).
+packages_cap.delete_org_version = function(org, pkg_type, pkg_name, version_id)
   local url = base()
     .. "/groups/"
     .. org
@@ -4588,33 +4570,59 @@ b:rest("delete_org_package_version", function(org, pkg_type, pkg_name, version_i
     .. "&package_name="
     .. pkg_name
     .. "&per_page=100"
-  local ok, status, _, body = fetch_json(url)
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
+  local raw, err = cap_fetch(fetch_json, url)
+  if not raw then
+    return nil, err
   end
   local vid = tonumber(version_id)
-  for _, p in ipairs(DecodeJson(body) or {}) do
+  for _, p in ipairs(type(raw) == "table" and raw or {}) do
     if p.id == vid then
       local dopts = auth() or {}
       dopts.method = "DELETE"
       local dok, dstatus =
         pcall(Fetch, base() .. "/projects/" .. p.project_id .. "/packages/" .. p.id, dopts)
-      if dok and dstatus == 204 then
-        set_preamble(204)
-      elseif dok then
-        respond_json(dstatus, {})
-      else
-        respond_json(503, {})
+      if not dok then
+        return nil, cap_err(0, "network error deleting package version " .. tostring(version_id))
       end
-      return
+      if dstatus ~= 204 then
+        return nil,
+          cap_err(dstatus, "upstream error " .. tostring(dstatus) .. " deleting package version")
+      end
+      return true, nil
     end
   end
-  respond_json(404, { message = "Not Found" })
+  return nil, cap_err(404, "Not Found")
+end
+
+b:rest("get_org_packages", function(org)
+  local pkg_type = GetParam("package_type") or ""
+  local items, hdrs, err = packages_cap.list_org(org, pkg_type)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+b:rest("get_org_package", function(org, pkg_type, pkg_name)
+  local data, err = packages_cap.get_org(org, pkg_type, pkg_name)
+  cap_rest_respond(data, err)
+end)
+
+b:rest("delete_org_package", function(org, pkg_type, pkg_name)
+  local ok, err = packages_cap.delete_org(org, pkg_type, pkg_name)
+  cap_rest_204(ok, err)
+end)
+
+b:rest("get_org_package_versions", function(org, pkg_type, pkg_name)
+  local items, hdrs, err = packages_cap.list_org_versions(org, pkg_type, pkg_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+b:rest("get_org_package_version", function(org, pkg_type, pkg_name, version_id)
+  local data, err = packages_cap.get_org_version(org, pkg_type, pkg_name, version_id)
+  cap_rest_respond(data, err)
+end)
+
+b:rest("delete_org_package_version", function(org, pkg_type, pkg_name, version_id)
+  local ok, err = packages_cap.delete_org_version(org, pkg_type, pkg_name, version_id)
+  cap_rest_204(ok, err)
 end)
 
 -- ---------------------------------------------------------------------------
@@ -4795,66 +4803,17 @@ local function translate_gl_vulnerability(v)
   }
 end
 
-local function translate_gl_vuln_list(arr)
-  local result = {}
-  for _, v in ipairs(arr) do
-    result[#result + 1] = translate_gl_vulnerability(v)
-  end
-  return result
-end
+-- ---------------------------------------------------------------------------
+-- Security capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translation for GitLab vulnerability (Dependabot) and secret
+-- detection (Secret Scanning) operations.
+-- Paged list operations: (items, headers, nil) or (nil, nil, err).
+-- Single-item operations: (data, nil) or (nil, err).
 
-b:rest("list_repo_dependabot_alerts", function(owner, repo_name)
-  proxy_json_paged(
-    translate_gl_vuln_list,
-    PAGES,
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities")
-  )
-end)
+local security_cap = {}
 
-b:rest("get_repo_dependabot_alert", function(owner, repo_name, alert_number)
-  proxy_json(
-    translate_gl_vulnerability,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
-    )
-  )
-end)
-
-b:rest("update_repo_dependabot_alert", function(_owner, _repo_name, alert_number)
-  local req = DecodeJson(GetBody() or "{}")
-  local action = GH_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
-  local gl_url = base() .. "/vulnerabilities/" .. alert_number .. "/" .. action
-  local ok, status, _, body = fetch_json(gl_url, "POST", EncodeJson({}))
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  respond_json(200, translate_gl_vulnerability(DecodeJson(body) or {}))
-end)
-
-b:rest("list_org_dependabot_alerts", function(org)
-  proxy_json_paged(
-    translate_gl_vuln_list,
-    PAGES,
-    fetch_json(base() .. "/groups/" .. org .. "/vulnerabilities")
-  )
-end)
-
--- Secret Scanning via GitLab Secret Detection ----------------------------------
---
--- GitLab Secret Detection stores findings as vulnerabilities with
--- report_type=secret_detection. Endpoint mapping:
---   GET  /repos/{owner}/{repo}/secret-scanning/alerts       → GET  /projects/:id/vulnerabilities?report_type=secret_detection
---   GET  /repos/{owner}/{repo}/secret-scanning/alerts/{n}   → GET  /projects/:id/vulnerabilities/:n
---   PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{n}  → POST /vulnerabilities/:n/dismiss|revert-to-detected|resolve
---   GET  /orgs/{org}/secret-scanning/alerts                 → GET  /groups/:org/vulnerabilities?report_type=secret_detection
---
--- Alert locations, push-protection bypasses, pattern configurations, and
--- scan history have no GitLab equivalent and fall back to defaults.
+-- Secret Scanning state/reason mappings (shared with security_cap operations).
 --
 -- GitLab dismissed_reason → GitHub resolution:
 --   false_positive   → false_positive
@@ -4921,61 +4880,166 @@ local function translate_gl_secret_alert(v)
   }
 end
 
-local function translate_gl_secret_list(arr)
-  local result = {}
-  for _, v in ipairs(arr) do
-    result[#result + 1] = translate_gl_secret_alert(v)
+-- list_repo_dependabot: paginated list of dependabot (vulnerability) alerts for a repo.
+security_cap.list_repo_dependabot = function(owner, repo_name)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
   end
-  return result
+  return translate_list(translate_gl_vulnerability, items), hdrs, nil
 end
 
-b:rest("list_repo_secret_scanning_alerts", function(owner, repo_name)
-  proxy_json_paged(
-    translate_gl_secret_list,
-    PAGES,
-    fetch_json(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/vulnerabilities?report_type=secret_detection"
-    )
+-- get_repo_dependabot: fetch a single dependabot alert by number.
+security_cap.get_repo_dependabot = function(owner, repo_name, alert_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
   )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_vulnerability(raw), nil
+end
+
+-- update_repo_dependabot: update (dismiss/reopen) a dependabot alert.
+-- body: raw GitHub-format JSON string with a "state" field.
+security_cap.update_repo_dependabot = function(_owner, _repo_name, alert_number, body)
+  local req = DecodeJson(body or "{}")
+  local action = GH_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/vulnerabilities/" .. alert_number .. "/" .. action,
+    "POST",
+    EncodeJson({})
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_vulnerability(raw), nil
+end
+
+-- list_org_dependabot: paginated list of dependabot alerts for an org (GitLab group).
+security_cap.list_org_dependabot = function(org)
+  local url = append_page_params(base() .. "/groups/" .. org .. "/vulnerabilities", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_vulnerability, items), hdrs, nil
+end
+
+-- list_repo_secret: paginated list of secret-scanning alerts for a repo.
+security_cap.list_repo_secret = function(owner, repo_name)
+  local url = append_page_params(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/vulnerabilities?report_type=secret_detection",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_secret_alert, items), hdrs, nil
+end
+
+-- list_org_secret: paginated list of secret-scanning alerts for an org.
+security_cap.list_org_secret = function(org)
+  local url = append_page_params(
+    base() .. "/groups/" .. org .. "/vulnerabilities?report_type=secret_detection",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_secret_alert, items), hdrs, nil
+end
+
+-- get_secret: fetch a single secret-scanning alert by number.
+security_cap.get_secret = function(owner, repo_name, alert_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_secret_alert(raw), nil
+end
+
+-- update_secret: update (dismiss/reopen/resolve) a secret-scanning alert.
+-- body: raw GitHub-format JSON string with a "state" field.
+security_cap.update_secret = function(_owner, _repo_name, alert_number, body)
+  local req = DecodeJson(body or "{}")
+  local action = GH_SECRET_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/vulnerabilities/" .. alert_number .. "/" .. action,
+    "POST",
+    EncodeJson({})
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_secret_alert(raw), nil
+end
+
+b:rest("list_repo_dependabot_alerts", function(owner, repo_name)
+  local items, hdrs, err = security_cap.list_repo_dependabot(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+b:rest("get_repo_dependabot_alert", function(owner, repo_name, alert_number)
+  local data, err = security_cap.get_repo_dependabot(owner, repo_name, alert_number)
+  cap_rest_respond(data, err)
+end)
+
+b:rest("update_repo_dependabot_alert", function(owner, repo_name, alert_number)
+  local data, err = security_cap.update_repo_dependabot(owner, repo_name, alert_number, GetBody())
+  cap_rest_respond(data, err)
+end)
+
+b:rest("list_org_dependabot_alerts", function(org)
+  local items, hdrs, err = security_cap.list_org_dependabot(org)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
+
+b:rest("list_repo_secret_scanning_alerts", function(owner, repo_name)
+  local items, hdrs, err = security_cap.list_repo_secret(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 b:rest("list_org_secret_scanning_alerts", function(org)
-  proxy_json_paged(
-    translate_gl_secret_list,
-    PAGES,
-    fetch_json(base() .. "/groups/" .. org .. "/vulnerabilities?report_type=secret_detection")
-  )
+  local items, hdrs, err = security_cap.list_org_secret(org)
+  cap_rest_paged(items, hdrs, err, PAGES)
 end)
 
 b:rest("get_secret_scanning_alert", function(owner, repo_name, alert_number)
-  proxy_json(
-    translate_gl_secret_alert,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/vulnerabilities/" .. alert_number
-    )
-  )
+  local data, err = security_cap.get_secret(owner, repo_name, alert_number)
+  cap_rest_respond(data, err)
 end)
 
-b:rest("update_secret_scanning_alert", function(_owner, _repo_name, alert_number)
-  local req = DecodeJson(GetBody() or "{}")
-  local action = GH_SECRET_STATE_TO_GL_ACTION[req.state or ""] or "revert-to-detected"
-  local gl_url = base() .. "/vulnerabilities/" .. alert_number .. "/" .. action
-  local ok, status, _, body = fetch_json(gl_url, "POST", EncodeJson({}))
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  respond_json(200, translate_gl_secret_alert(DecodeJson(body) or {}))
+b:rest("update_secret_scanning_alert", function(owner, repo_name, alert_number)
+  local data, err = security_cap.update_secret(owner, repo_name, alert_number, GetBody())
+  cap_rest_respond(data, err)
 end)
 
--- Gists (GitLab Snippets) ----------------------------------------------------
+-- ---------------------------------------------------------------------------
+-- Gists capability module (GitLab Snippets)
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translation for GitLab snippet operations mapped to GitHub gists.
+-- Single-item operations: (data, nil) or (nil, err).
+-- List operations: (items, nil) or (nil, err).  (Not paginated — GitLab snippet
+-- lists are small and proxy_json_list was used in the original code.)
+-- Delete operations: (true, nil) or (nil, err).
+
+local gists_cap = {}
 
 local function translate_gl_snippet_author(a)
   if not a then
@@ -5019,10 +5083,6 @@ local function translate_gl_snippet(s)
   }
 end
 
-local function translate_gl_snippets(data)
-  return translate_list(translate_gl_snippet, data)
-end
-
 local function translate_gl_snippet_note(n)
   if not n then
     return {}
@@ -5038,11 +5098,7 @@ local function translate_gl_snippet_note(n)
   }
 end
 
-local function translate_gl_snippet_notes(data)
-  return translate_list(translate_gl_snippet_note, data)
-end
-
--- Convert a GitHub gist create/update request body to GitLab snippet format.
+-- Helper: convert a GitHub gist create/update request body to GitLab snippet format.
 local function gl_snippet_req(req)
   local gl = {}
   if req.description ~= nil then
@@ -5063,86 +5119,195 @@ local function gl_snippet_req(req)
   return EncodeJson(gl)
 end
 
-local function delete_snippet(url)
-  local opts = auth() or {}
-  opts.method = "DELETE"
-  proxy_204({ 200 }, pcall(Fetch, url, opts))
+-- list: list own snippets (mapped to authenticated user's gists).
+gists_cap.list = function()
+  local raw, err = cap_fetch(fetch_json, base() .. "/snippets")
+  if not raw then
+    return nil, err
+  end
+  return translate_list(translate_gl_snippet, type(raw) == "table" and raw or {}), nil
+end
+
+-- list_public: list public snippets (mapped to public gists).
+gists_cap.list_public = function()
+  local raw, err = cap_fetch(fetch_json, base() .. "/snippets/public")
+  if not raw then
+    return nil, err
+  end
+  return translate_list(translate_gl_snippet, type(raw) == "table" and raw or {}), nil
+end
+
+-- create: create a new snippet from a GitHub gist request body.
+gists_cap.create = function(body)
+  local req = DecodeJson(body or "{}") or {}
+  local raw, err = cap_fetch(fetch_json, base() .. "/snippets", "POST", gl_snippet_req(req))
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_snippet(raw), nil
+end
+
+-- get: fetch a single snippet by ID.
+gists_cap.get = function(id)
+  local raw, err = cap_fetch(fetch_json, base() .. "/snippets/" .. id)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_snippet(raw), nil
+end
+
+-- update: update (PUT) a snippet from a GitHub gist request body.
+gists_cap.update = function(id, body)
+  local req = DecodeJson(body or "{}") or {}
+  local raw, err = cap_fetch(fetch_json, base() .. "/snippets/" .. id, "PUT", gl_snippet_req(req))
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_snippet(raw), nil
+end
+
+-- delete: delete a snippet by ID.
+-- Returns (true, nil) on 200/204 success or (nil, err) on failure.
+gists_cap.delete = function(id)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  local ok, status = pcall(Fetch, base() .. "/snippets/" .. id, dopts)
+  if not ok then
+    return nil, cap_err(0, "network error deleting snippet " .. tostring(id))
+  end
+  if status ~= 200 and status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " deleting snippet")
+  end
+  return true, nil
+end
+
+-- list_comments: list notes (comments) on a snippet.
+gists_cap.list_comments = function(id)
+  local raw, err = cap_fetch(fetch_json, base() .. "/snippets/" .. id .. "/notes")
+  if not raw then
+    return nil, err
+  end
+  return translate_list(translate_gl_snippet_note, type(raw) == "table" and raw or {}), nil
+end
+
+-- create_comment: add a note to a snippet.
+gists_cap.create_comment = function(id, body)
+  local req = DecodeJson(body or "{}") or {}
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/snippets/" .. id .. "/notes",
+    "POST",
+    EncodeJson({ body = req.body or "" })
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_snippet_note(raw), nil
+end
+
+-- get_comment: fetch a single note on a snippet.
+gists_cap.get_comment = function(id, comment_id)
+  local raw, err = cap_fetch(fetch_json, base() .. "/snippets/" .. id .. "/notes/" .. comment_id)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_snippet_note(raw), nil
+end
+
+-- update_comment: update a note on a snippet.
+gists_cap.update_comment = function(id, comment_id, body)
+  local req = DecodeJson(body or "{}") or {}
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/snippets/" .. id .. "/notes/" .. comment_id,
+    "PUT",
+    EncodeJson({ body = req.body or "" })
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_snippet_note(raw), nil
+end
+
+-- delete_comment: delete a note on a snippet.
+-- Returns (true, nil) on 200/204 success or (nil, err) on failure.
+gists_cap.delete_comment = function(id, comment_id)
+  local dopts = auth() or {}
+  dopts.method = "DELETE"
+  local ok, status = pcall(Fetch, base() .. "/snippets/" .. id .. "/notes/" .. comment_id, dopts)
+  if not ok then
+    return nil,
+      cap_err(
+        0,
+        "network error deleting snippet comment " .. tostring(id) .. "/" .. tostring(comment_id)
+      )
+  end
+  if status ~= 200 and status ~= 204 then
+    return nil,
+      cap_err(status, "upstream error " .. tostring(status) .. " deleting snippet comment")
+  end
+  return true, nil
 end
 
 b:rest("get_gists", function()
-  proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets"))
+  local data, err = gists_cap.list()
+  cap_rest_respond(data, err)
 end)
 
 b:rest("get_gists_public", function()
-  proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets/public"))
+  local data, err = gists_cap.list_public()
+  cap_rest_respond(data, err)
 end)
 
 b:rest("post_gists", function()
-  local req = DecodeJson(GetBody() or "{}") or {}
-  proxy_json_created(
-    translate_gl_snippet,
-    fetch_json(base() .. "/snippets", "POST", gl_snippet_req(req))
-  )
+  local data, err = gists_cap.create(GetBody())
+  cap_rest_created(data, err)
 end)
 
 b:rest("get_gist", function(id)
-  proxy_json(translate_gl_snippet, fetch_json(base() .. "/snippets/" .. id))
+  local data, err = gists_cap.get(id)
+  cap_rest_respond(data, err)
 end)
 
 b:rest("patch_gist", function(id)
-  local req = DecodeJson(GetBody() or "{}") or {}
-  proxy_json(
-    translate_gl_snippet,
-    fetch_json(base() .. "/snippets/" .. id, "PUT", gl_snippet_req(req))
-  )
+  local data, err = gists_cap.update(id, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 b:rest("delete_gist", function(id)
-  delete_snippet(base() .. "/snippets/" .. id)
+  local ok, err = gists_cap.delete(id)
+  cap_rest_204(ok, err)
 end)
 
 b:rest("get_gist_comments", function(id)
-  proxy_json_list(translate_gl_snippet_notes, fetch_json(base() .. "/snippets/" .. id .. "/notes"))
+  local data, err = gists_cap.list_comments(id)
+  cap_rest_respond(data, err)
 end)
 
 b:rest("post_gist_comment", function(id)
-  local req = DecodeJson(GetBody() or "{}") or {}
-  proxy_json_created(
-    translate_gl_snippet_note,
-    fetch_json(
-      base() .. "/snippets/" .. id .. "/notes",
-      "POST",
-      EncodeJson({ body = req.body or "" })
-    )
-  )
+  local data, err = gists_cap.create_comment(id, GetBody())
+  cap_rest_created(data, err)
 end)
 
 b:rest("get_gist_comment", function(id, comment_id)
-  proxy_json(
-    translate_gl_snippet_note,
-    fetch_json(base() .. "/snippets/" .. id .. "/notes/" .. comment_id)
-  )
+  local data, err = gists_cap.get_comment(id, comment_id)
+  cap_rest_respond(data, err)
 end)
 
 b:rest("patch_gist_comment", function(id, comment_id)
-  local req = DecodeJson(GetBody() or "{}") or {}
-  proxy_json(
-    translate_gl_snippet_note,
-    fetch_json(
-      base() .. "/snippets/" .. id .. "/notes/" .. comment_id,
-      "PUT",
-      EncodeJson({ body = req.body or "" })
-    )
-  )
+  local data, err = gists_cap.update_comment(id, comment_id, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 b:rest("delete_gist_comment", function(id, comment_id)
-  delete_snippet(base() .. "/snippets/" .. id .. "/notes/" .. comment_id)
+  local ok, err = gists_cap.delete_comment(id, comment_id)
+  cap_rest_204(ok, err)
 end)
 
 b:rest("get_user_gists", function(_username)
   -- GitLab doesn't expose per-user public snippet lists; approximate with own snippets.
-  proxy_json_list(translate_gl_snippets, fetch_json(base() .. "/snippets"))
+  local data, err = gists_cap.list()
+  cap_rest_respond(data, err)
 end)
 
 -- ── Reactions (GitLab award emoji) ────────────────────────────────────────────
@@ -5863,4 +6028,7 @@ b:capability("gitignore", gitignore_cap)
 b:capability("licenses", licenses_cap)
 b:capability("markdown", markdown_cap)
 b:capability("git_db", git_db_cap)
+b:capability("packages", packages_cap)
+b:capability("security", security_cap)
+b:capability("gists", gists_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -119,10 +119,6 @@ local function translate_gl_user(u)
   }
 end
 
-local function translate_gl_users(users)
-  return translate_list(translate_gl_user, users)
-end
-
 -- Proxy a GitLab search response (plain JSON array) to the GitHub search
 -- envelope {"total_count":N,"incomplete_results":false,"items":[...]}.
 -- translate_item is applied to each element of the array.
@@ -312,6 +308,25 @@ local function translate_gl_milestones(milestones)
 end
 local function translate_gl_members(members)
   return translate_list(translate_gl_member, members)
+end
+
+-- Map a GitLab group to GitHub organization REST shape.
+-- Used by orgs capability module and GraphQL resolvers.
+local function translate_gl_group_to_org(g)
+  if not g then
+    return nil
+  end
+  return {
+    login = g.path or g.full_path or "",
+    name = g.name,
+    description = g.description,
+    avatar_url = g.avatar_url or "",
+    html_url = g.web_url or "",
+    blog = "",
+    email = "",
+    location = "",
+    created_at = g.created_at,
+  }
 end
 
 -- Map a GitLab MR (merge request) object to GitHub PR format.
@@ -689,6 +704,210 @@ repos.put_topics = function(owner, repo_name, body)
     return nil, err
   end
   return { names = raw.topics or {} }, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Users capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_user for all user operations.
+-- REST handlers and GraphQL resolvers call into this table rather than
+-- duplicating URL construction, error mapping, and translation logic.
+-- User operations return (data, nil) on success or (nil, err) on failure.
+-- Email/key/GPG operations return raw upstream data with no translation.
+-- Paged list operations return (items, headers, nil) or (nil, nil, err).
+
+local users = {}
+
+-- get_authenticated: fetch the currently authenticated user.
+users.get_authenticated = function()
+  local raw, err = cap_fetch(fetch_json, base() .. "/user")
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_user(raw), nil
+end
+
+-- update_authenticated: update the authenticated user (GitLab uses PUT /user).
+users.update_authenticated = function(body)
+  local raw, err = cap_fetch(fetch_json, base() .. "/user", "PUT", body)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_user(raw), nil
+end
+
+-- by_username: fetch a single user by username (GitLab returns an array from
+-- /users?username=X; we take the first element).
+-- Returns the GitHub REST user shape or (nil, err) when no user is found.
+users.by_username = function(username)
+  local raw, err = cap_fetch(fetch_json, base() .. "/users?username=" .. username)
+  if not raw then
+    return nil, err
+  end
+  local u = type(raw) == "table" and raw[1]
+  if not u then
+    return nil, cap_err(404, "user not found: " .. username)
+  end
+  return translate_gl_user(u), nil
+end
+
+-- list_all: paginated list of all users.
+users.list_all = function()
+  local url = append_page_params(base() .. "/users", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_user, items), hdrs, nil
+end
+
+-- list_emails: list email addresses for the authenticated user.
+-- Returns raw upstream array (no translation).
+users.list_emails = function()
+  local raw, err = cap_fetch(fetch_json, base() .. "/user/emails")
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- create_email: add an email address for the authenticated user.
+users.create_email = function(body)
+  local raw, err = cap_fetch(fetch_json, base() .. "/user/emails", "POST", body)
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- list_keys: paginated list of SSH keys for the authenticated user.
+users.list_keys = function()
+  local url = append_page_params(base() .. "/user/keys", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return items, hdrs, nil
+end
+
+-- create_key: add an SSH key for the authenticated user.
+users.create_key = function(body)
+  local raw, err = cap_fetch(fetch_json, base() .. "/user/keys", "POST", body)
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- get_key: fetch a single SSH key by ID.
+users.get_key = function(key_id)
+  local raw, err = cap_fetch(fetch_json, base() .. "/user/keys/" .. key_id)
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- delete_key: delete an SSH key by ID.
+-- Returns (true, nil) on 204 success or (nil, err) on failure.
+users.delete_key = function(key_id)
+  local ok, status = fetch_json(base() .. "/user/keys/" .. key_id, "DELETE")
+  if not ok then
+    return nil, cap_err(0, "network error deleting key " .. tostring(key_id))
+  end
+  if status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " deleting key")
+  end
+  return true, nil
+end
+
+-- list_by_username_keys: list SSH keys for a specific user (by username).
+-- Returns raw upstream array (no translation).
+users.list_by_username_keys = function(username)
+  local uid = gl_user_id(username)
+  if not uid then
+    return nil, cap_err(404, "user not found: " .. username)
+  end
+  local raw, err = cap_fetch(fetch_json, base() .. "/users/" .. uid .. "/keys")
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- list_gpg_keys: paginated list of GPG keys for the authenticated user.
+users.list_gpg_keys = function()
+  local url = append_page_params(base() .. "/user/gpg_keys", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return items, hdrs, nil
+end
+
+-- create_gpg_key: add a GPG key for the authenticated user.
+users.create_gpg_key = function(body)
+  local raw, err = cap_fetch(fetch_json, base() .. "/user/gpg_keys", "POST", body)
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- get_gpg_key: fetch a single GPG key by ID.
+users.get_gpg_key = function(gpg_key_id)
+  local raw, err = cap_fetch(fetch_json, base() .. "/user/gpg_keys/" .. gpg_key_id)
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- delete_gpg_key: delete a GPG key by ID.
+-- Returns (true, nil) on 204 success or (nil, err) on failure.
+users.delete_gpg_key = function(gpg_key_id)
+  local ok, status = fetch_json(base() .. "/user/gpg_keys/" .. gpg_key_id, "DELETE")
+  if not ok then
+    return nil, cap_err(0, "network error deleting GPG key " .. tostring(gpg_key_id))
+  end
+  if status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " deleting GPG key")
+  end
+  return true, nil
+end
+
+-- list_by_username_gpg_keys: list GPG keys for a specific user (by username).
+-- Returns raw upstream array (no translation).
+users.list_by_username_gpg_keys = function(username)
+  local uid = gl_user_id(username)
+  if not uid then
+    return nil, cap_err(404, "user not found: " .. username)
+  end
+  local raw, err = cap_fetch(fetch_json, base() .. "/users/" .. uid .. "/gpg_keys")
+  if not raw then
+    return nil, err
+  end
+  return raw, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Orgs capability module
+-- ---------------------------------------------------------------------------
+-- Shared fetch + translate operations for organization (GitLab group) resources.
+-- orgs.get returns the GitHub REST-compatible org shape (translate_gl_group_to_org
+-- applied), ready for graphql_translate_org in GraphQL resolvers.
+-- Operations return (data, nil) on success or (nil, err) on failure.
+
+local orgs = {}
+
+-- get: fetch a single organization (GitLab group) by login/path.
+-- Returns the GitHub REST org shape (translate_gl_group_to_org applied).
+orgs.get = function(login)
+  local raw, err = cap_fetch(fetch_json, base() .. "/groups/" .. login)
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_group_to_org(raw), nil
 end
 
 local b = make_backend_builder()
@@ -1192,8 +1411,8 @@ b:rest("get_repo_collaborator", function(owner, repo_name, username)
     respond_json(404, {})
     return
   end
-  local users = DecodeJson(ubody) or {}
-  local uid = users[1] and users[1].id
+  local ulist = DecodeJson(ubody) or {}
+  local uid = ulist[1] and ulist[1].id
   if not uid then
     respond_json(404, {})
     return
@@ -1216,8 +1435,8 @@ b:rest("put_repo_collaborator", function(owner, repo_name, username)
     respond_json(404, {})
     return
   end
-  local users = DecodeJson(ubody) or {}
-  local uid = users[1] and users[1].id
+  local ulist = DecodeJson(ubody) or {}
+  local uid = ulist[1] and ulist[1].id
   if not uid then
     respond_json(404, {})
     return
@@ -1254,8 +1473,8 @@ b:rest("delete_repo_collaborator", function(owner, repo_name, username)
     respond_json(404, {})
     return
   end
-  local users = DecodeJson(ubody) or {}
-  local uid = users[1] and users[1].id
+  local ulist = DecodeJson(ubody) or {}
+  local uid = ulist[1] and ulist[1].id
   if not uid then
     respond_json(404, {})
     return
@@ -1273,8 +1492,8 @@ b:rest("get_repo_collaborator_permission", function(owner, repo_name, username)
     respond_json(404, {})
     return
   end
-  local users = DecodeJson(ubody) or {}
-  local uid = users[1] and users[1].id
+  local ulist = DecodeJson(ubody) or {}
+  local uid = ulist[1] and ulist[1].id
   if not uid then
     respond_json(404, {})
     return
@@ -1730,130 +1949,105 @@ end)
 -- Users ---------------------------------------------------------------------
 
 -- GET /user
-b:rest(
-  "get_user",
-  proxy_handler(translate_gl_user, function()
-    return base() .. "/user"
-  end)
-)
+b:rest("get_user", function()
+  local data, err = users.get_authenticated()
+  cap_rest_respond(data, err)
+end)
 
 -- PATCH /user
 b:rest("patch_user", function()
-  proxy_json(translate_gl_user, fetch_json(base() .. "/user", "PUT", GetBody()))
+  local data, err = users.update_authenticated(GetBody())
+  cap_rest_respond(data, err)
 end)
 
 -- GET /users/{username}
-b:rest(
-  "get_users_username",
-  proxy_handler(function(list)
-    local u = (list and list[1]) or {}
-    return translate_gl_user(u)
-  end, function(username)
-    return base() .. "/users?username=" .. username
-  end)
-)
+b:rest("get_users_username", function(username)
+  local data, err = users.by_username(username)
+  cap_rest_respond(data, err)
+end)
 
 -- GET /users
-b:rest(
-  "get_users",
-  proxy_handler_paged(translate_gl_users, function()
-    return append_page_params(base() .. "/users", PAGES)
-  end)
-)
+b:rest("get_users", function()
+  local items, hdrs, err = users.list_all()
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- Emails --------------------------------------------------------------------
 
 -- GET /user/emails
-b:rest(
-  "get_user_emails",
-  proxy_handler(nil, function()
-    return base() .. "/user/emails"
-  end)
-)
+b:rest("get_user_emails", function()
+  local data, err = users.list_emails()
+  cap_rest_respond(data, err)
+end)
 
 -- POST /user/emails
 b:rest("post_user_emails", function()
-  proxy_json_created(nil, fetch_json(base() .. "/user/emails", "POST", GetBody()))
+  local data, err = users.create_email(GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- SSH Keys ------------------------------------------------------------------
 
 -- GET /user/keys
-b:rest(
-  "get_user_keys",
-  proxy_handler_paged(nil, function()
-    return append_page_params(base() .. "/user/keys", PAGES)
-  end)
-)
+b:rest("get_user_keys", function()
+  local items, hdrs, err = users.list_keys()
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- POST /user/keys
 b:rest("post_user_keys", function()
-  proxy_json_created(nil, fetch_json(base() .. "/user/keys", "POST", GetBody()))
+  local data, err = users.create_key(GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- GET /user/keys/{key_id}
-b:rest(
-  "get_user_key",
-  proxy_handler(nil, function(key_id)
-    return base() .. "/user/keys/" .. key_id
-  end)
-)
+b:rest("get_user_key", function(key_id)
+  local data, err = users.get_key(key_id)
+  cap_rest_respond(data, err)
+end)
 
 -- DELETE /user/keys/{key_id}
 b:rest("delete_user_key", function(key_id)
-  local opts = auth() or {}
-  opts.method = "DELETE"
-  proxy_204(nil, pcall(Fetch, base() .. "/user/keys/" .. key_id, opts))
+  local ok, err = users.delete_key(key_id)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /users/{username}/keys
 b:rest("get_users_keys", function(username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  proxy_json(nil, fetch_json(base() .. "/users/" .. uid .. "/keys"))
+  local data, err = users.list_by_username_keys(username)
+  cap_rest_respond(data, err)
 end)
 
 -- GPG Keys ------------------------------------------------------------------
 
 -- GET /user/gpg_keys
-b:rest(
-  "get_user_gpg_keys",
-  proxy_handler_paged(nil, function()
-    return append_page_params(base() .. "/user/gpg_keys", PAGES)
-  end)
-)
+b:rest("get_user_gpg_keys", function()
+  local items, hdrs, err = users.list_gpg_keys()
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- POST /user/gpg_keys
 b:rest("post_user_gpg_keys", function()
-  proxy_json_created(nil, fetch_json(base() .. "/user/gpg_keys", "POST", GetBody()))
+  local data, err = users.create_gpg_key(GetBody())
+  cap_rest_created(data, err)
 end)
 
 -- GET /user/gpg_keys/{gpg_key_id}
-b:rest(
-  "get_user_gpg_key",
-  proxy_handler(nil, function(gpg_key_id)
-    return base() .. "/user/gpg_keys/" .. gpg_key_id
-  end)
-)
+b:rest("get_user_gpg_key", function(gpg_key_id)
+  local data, err = users.get_gpg_key(gpg_key_id)
+  cap_rest_respond(data, err)
+end)
 
 -- DELETE /user/gpg_keys/{gpg_key_id}
 b:rest("delete_user_gpg_key", function(gpg_key_id)
-  local opts = auth() or {}
-  opts.method = "DELETE"
-  proxy_204(nil, pcall(Fetch, base() .. "/user/gpg_keys/" .. gpg_key_id, opts))
+  local ok, err = users.delete_gpg_key(gpg_key_id)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /users/{username}/gpg_keys
 b:rest("get_users_gpg_keys", function(username)
-  local uid = gl_user_id(username)
-  if not uid then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  proxy_json(nil, fetch_json(base() .. "/users/" .. uid .. "/gpg_keys"))
+  local data, err = users.list_by_username_gpg_keys(username)
+  cap_rest_respond(data, err)
 end)
 
 -- Teams — mapped to GitLab subgroups ----------------------------------------
@@ -2873,11 +3067,11 @@ b:rest("get_pull_requested_reviewers", function(owner, repo_name, pull_number)
     return
   end
   local reviewers = DecodeJson(body) or {}
-  local users = {}
+  local reviewer_users = {}
   for _, u in ipairs(reviewers) do
-    users[#users + 1] = translate_gl_user(u)
+    reviewer_users[#reviewer_users + 1] = translate_gl_user(u)
   end
-  respond_json(200, { users = users, teams = {} })
+  respond_json(200, { users = reviewer_users, teams = {} })
 end)
 
 -- GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
@@ -4001,57 +4195,25 @@ end)
 -- GraphQL resolvers — Query root fields and node resolvers
 -- ---------------------------------------------------------------------------
 
--- Helper: translate a GitLab group (from /groups/{id}) to GitHub org REST shape
--- suitable for graphql_translate_org.
-local function translate_gl_group_to_org(g)
-  if not g then
-    return nil
-  end
-  return {
-    login = g.path or g.full_path or "",
-    name = g.name,
-    description = g.description,
-    avatar_url = g.avatar_url or "",
-    html_url = g.web_url or "",
-    blog = "",
-    email = "",
-    location = "",
-    created_at = g.created_at,
-  }
-end
-
--- Helper: fetch a GitLab user by username.
--- GitLab returns an array from /users?username=X; we take the first element.
-local function gl_fetch_user(username)
-  local data, err = graphql_fetch(fetch_json, base() .. "/users?username=" .. username)
-  if not data then
-    return nil, err
-  end
-  local u = data[1]
-  if not u then
-    return nil, "not found: user " .. username
-  end
-  return u, nil
-end
-
 -- Query.repositoryOwner: look up a User or Organization (GitLab group) by login.
 b:graphql("Query.repositoryOwner", function(_parent, args, ctx)
   if not args.login then
     graphql_error(ctx, "repositoryOwner requires a login argument")
     return nil
   end
-  local udata, _ = gl_fetch_user(args.login)
+  local udata, _ = users.by_username(args.login)
   if udata then
-    return graphql_translate_user(translate_gl_user(udata))
+    return graphql_translate_user(udata)
   end
-  local gdata, _ = graphql_fetch(fetch_json, base() .. "/groups/" .. args.login)
+  local gdata, _ = orgs.get(args.login)
   if gdata then
-    return graphql_translate_org(translate_gl_group_to_org(gdata))
+    return graphql_translate_org(gdata)
   end
   return nil
 end)
 
 -- Query.viewer: resolve the authenticated user via GET /user.
+-- Uses graphql_fetch_or_error to surface FORBIDDEN errors when unauthenticated.
 b:graphql("Query.viewer", function(_parent, _args, ctx)
   local data = graphql_fetch_or_error(fetch_json, base() .. "/user", ctx, nil)
   if not data then
@@ -4068,11 +4230,11 @@ b:graphql("Query.user", function(_parent, args, ctx)
     graphql_error(ctx, "user requires a login argument")
     return nil
   end
-  local udata, _ = gl_fetch_user(args.login)
-  if not udata then
+  local data, _ = users.by_username(args.login)
+  if not data then
     return nil
   end
-  return graphql_translate_user(translate_gl_user(udata))
+  return graphql_translate_user(data)
 end)
 
 -- Query.organization: look up a GitLab group by path.
@@ -4081,11 +4243,11 @@ b:graphql("Query.organization", function(_parent, args, ctx)
     graphql_error(ctx, "organization requires a login argument")
     return nil
   end
-  local data, _ = graphql_fetch(fetch_json, base() .. "/groups/" .. args.login)
+  local data, _ = orgs.get(args.login)
   if not data then
     return nil
   end
-  return graphql_translate_org(translate_gl_group_to_org(data))
+  return graphql_translate_org(data)
 end)
 
 -- Query.repository: look up a Repository by owner and name.
@@ -4116,20 +4278,20 @@ end)
 
 -- node.User: fetch a user by login.
 b:graphql("node.User", function(local_id, _ctx)
-  local udata, _ = gl_fetch_user(local_id)
-  if not udata then
+  local data, _ = users.by_username(local_id)
+  if not data then
     return nil
   end
-  return graphql_translate_user(translate_gl_user(udata))
+  return graphql_translate_user(data)
 end)
 
 -- node.Organization: fetch a group by path.
 b:graphql("node.Organization", function(local_id, _ctx)
-  local data, _ = graphql_fetch(fetch_json, base() .. "/groups/" .. local_id)
+  local data, _ = orgs.get(local_id)
   if not data then
     return nil
   end
-  return graphql_translate_org(translate_gl_group_to_org(data))
+  return graphql_translate_org(data)
 end)
 
 -- node.Issue: fetch an issue by "owner/repo/iid" local ID.
@@ -4706,4 +4868,6 @@ b:graphql("Query.search", function(_parent, args, ctx)
 end)
 
 b:capability("repos", repos)
+b:capability("users", users)
+b:capability("orgs", orgs)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -14,7 +14,6 @@ local PAGES = { per_page = "per_page", page = "page" }
 local _t = make_backend_transport("bearer", PAGES)
 local fetch_json = _t.fetch_json
 local proxy_handler = _t.proxy_handler
-local proxy_handler_created = _t.proxy_handler_created
 local proxy_handler_paged = _t.proxy_handler_paged
 
 local project_id = owner_repo_id
@@ -1200,6 +1199,548 @@ statuses_cap.create_check_run = function(owner, repo_name, body)
     return nil, err
   end
   return translate_gl_status_to_check_run(raw, sha), nil
+end
+
+-- GitLab award emoji → GitHub reaction content (8 supported types).
+local GL_EMOJI_TO_CONTENT = {
+  thumbsup = "+1",
+  thumbsdown = "-1",
+  laughing = "laugh",
+  confused = "confused",
+  heart = "heart",
+  tada = "hooray",
+  rocket = "rocket",
+  eyes = "eyes",
+}
+local CONTENT_TO_GL_EMOJI = {
+  ["+1"] = "thumbsup",
+  ["-1"] = "thumbsdown",
+  laugh = "laughing",
+  confused = "confused",
+  heart = "heart",
+  hooray = "tada",
+  rocket = "rocket",
+  eyes = "eyes",
+}
+
+local function translate_gl_award(a)
+  if not a then
+    return {}
+  end
+  local user = translate_gl_user(a.user or {})
+  return {
+    id = a.id,
+    node_id = "",
+    user = user,
+    content = GL_EMOJI_TO_CONTENT[a.name] or a.name,
+    created_at = a.created_at or "2020-01-01T00:00:00Z",
+  }
+end
+
+local function translate_gl_awards(awards)
+  return translate_list(translate_gl_award, awards)
+end
+
+-- ---------------------------------------------------------------------------
+-- Issues capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_issue / translate_gl_note for all issue and
+-- issue-comment operations.  REST handlers call cap_rest_* adapters.
+-- Single-item operations: (data, nil) on success, (nil, err) on failure.
+-- Paged list operations:  (items, headers, nil) or (nil, nil, err).
+
+local issues_cap = {}
+
+-- list: paginated list of issues for a repository.
+issues_cap.list = function(owner, repo_name)
+  local url =
+    append_page_params(base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_gl_issues(items), hdrs, nil
+end
+
+-- get: fetch a single issue by iid.
+issues_cap.get = function(owner, repo_name, issue_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_issue(raw), nil
+end
+
+-- create: open a new issue.  body is raw GitHub-format JSON string.
+issues_cap.create = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}")
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.body then
+    gl.description = req.body
+  end
+  if req.milestone then
+    gl.milestone_id = req.milestone
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues",
+    "POST",
+    EncodeJson(gl)
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_issue(raw), nil
+end
+
+-- update: partially update an issue.  body is raw GitHub-format JSON string.
+issues_cap.update = function(owner, repo_name, issue_number, body)
+  local req = DecodeJson(body or "{}")
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.body then
+    gl.description = req.body
+  end
+  if req.state then
+    gl.state_event = req.state == "closed" and "close" or "reopen"
+  end
+  if req.milestone then
+    gl.milestone_id = req.milestone
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+    "PUT",
+    EncodeJson(gl)
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_issue(raw), nil
+end
+
+-- list_comments: paginated list of notes (comments) on an issue.
+issues_cap.list_comments = function(owner, repo_name, issue_number)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number .. "/notes",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_gl_notes(items), hdrs, nil
+end
+
+-- create_comment: add a note (comment) to an issue.
+issues_cap.create_comment = function(owner, repo_name, issue_number, body)
+  local req = DecodeJson(body or "{}")
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number .. "/notes",
+    "POST",
+    EncodeJson({ body = req.body })
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_note(raw), nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Labels capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_label for all label operations (repo-level and
+-- per-issue label assignment/removal).
+-- Single-item operations: (data, nil) on success, (nil, err) on failure.
+-- Paged list operations:  (items, headers, nil) or (nil, nil, err).
+-- Delete operations:      (true, nil) on success, (nil, err) on failure.
+
+local labels_cap = {}
+
+-- Helper: extract GitHub-shape label list from a raw GitLab issue body (which
+-- stores labels as either strings or label objects depending on scope).
+local function issue_labels_from_raw(issue)
+  local labels = {}
+  for _, l in ipairs((issue or {}).labels or {}) do
+    if type(l) == "table" then
+      labels[#labels + 1] = translate_gl_label(l)
+    else
+      labels[#labels + 1] = {
+        id = 0,
+        node_id = "",
+        url = "",
+        name = l,
+        color = "",
+        description = "",
+        default = false,
+      }
+    end
+  end
+  return labels
+end
+
+-- list_repo: paginated list of labels for a repository.
+labels_cap.list_repo = function(owner, repo_name)
+  local url =
+    append_page_params(base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels", PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_gl_labels(items), hdrs, nil
+end
+
+-- create_repo: create a label in a repository.  body is raw GitHub-format JSON.
+labels_cap.create_repo = function(owner, repo_name, body)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels",
+    "POST",
+    body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_label(raw), nil
+end
+
+-- get_repo: fetch a single repository label by name.
+labels_cap.get_repo = function(owner, repo_name, label_name)
+  local id = gl_find_label_id(owner, repo_name, label_name)
+  if not id then
+    return nil, cap_err(404, "Label not found")
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_label(raw), nil
+end
+
+-- update_repo: update a repository label by name.  body is raw GitHub-format JSON.
+labels_cap.update_repo = function(owner, repo_name, label_name, body)
+  local id = gl_find_label_id(owner, repo_name, label_name)
+  if not id then
+    return nil, cap_err(404, "Label not found")
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id,
+    "PUT",
+    body
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_label(raw), nil
+end
+
+-- delete_repo: delete a repository label by name.
+-- Returns (true, nil) on success or (nil, err) on failure.
+labels_cap.delete_repo = function(owner, repo_name, label_name)
+  local id = gl_find_label_id(owner, repo_name, label_name)
+  if not id then
+    return nil, cap_err(404, "Label not found")
+  end
+  local ok, status =
+    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id, "DELETE")
+  if not ok then
+    return nil, cap_err(0, "network error deleting label " .. label_name)
+  end
+  if status ~= 200 and status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " deleting label")
+  end
+  return true, nil
+end
+
+-- list_issue: return the labels currently on a single issue.
+labels_cap.list_issue = function(owner, repo_name, issue_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number
+  )
+  if not raw then
+    return nil, err
+  end
+  return issue_labels_from_raw(raw), nil
+end
+
+-- set_issue: add labels to an issue (merge with existing).
+-- new_labels is an array of label name strings.
+labels_cap.set_issue = function(owner, repo_name, issue_number, new_labels)
+  -- Fetch current labels first so we can merge.
+  local existing_raw, existing_err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number
+  )
+  if not existing_raw then
+    return nil, existing_err
+  end
+  local all_labels = existing_raw.labels or {}
+  for _, name in ipairs(new_labels or {}) do
+    all_labels[#all_labels + 1] = name
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+    "PUT",
+    EncodeJson({ labels = all_labels })
+  )
+  if not raw then
+    return nil, err
+  end
+  return issue_labels_from_raw(raw), nil
+end
+
+-- replace_issue: replace all labels on an issue.
+-- label_names is an array of label name strings.
+labels_cap.replace_issue = function(owner, repo_name, issue_number, label_names)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+    "PUT",
+    EncodeJson({ labels = label_names or {} })
+  )
+  if not raw then
+    return nil, err
+  end
+  return issue_labels_from_raw(raw), nil
+end
+
+-- delete_issue_all: remove all labels from an issue.
+-- Returns (true, nil) on success or (nil, err) on failure.
+labels_cap.delete_issue_all = function(owner, repo_name, issue_number)
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+    "PUT",
+    EncodeJson({ labels = {} })
+  )
+  if not ok then
+    return nil,
+      cap_err(0, "network error removing all labels from issue " .. tostring(issue_number))
+  end
+  if status ~= 200 and status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " removing labels")
+  end
+  return true, nil
+end
+
+-- delete_issue_one: remove a single named label from an issue.
+-- Returns (true, nil) on success or (nil, err) on failure.
+labels_cap.delete_issue_one = function(owner, repo_name, issue_number, label_name)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number
+  )
+  if not raw then
+    return nil, err
+  end
+  local labels = {}
+  for _, l in ipairs(raw.labels or {}) do
+    local name = type(l) == "table" and l.name or l
+    if name ~= label_name then
+      labels[#labels + 1] = name
+    end
+  end
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
+    "PUT",
+    EncodeJson({ labels = labels })
+  )
+  if not ok then
+    return nil, cap_err(0, "network error removing label " .. label_name)
+  end
+  if status ~= 200 and status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " removing label")
+  end
+  return true, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Milestones capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_milestone for all milestone operations.
+-- Single-item operations: (data, nil) on success, (nil, err) on failure.
+-- Paged list operations:  (items, headers, nil) or (nil, nil, err).
+-- Delete operations:      (true, nil) on success, (nil, err) on failure.
+
+local milestones_cap = {}
+
+-- list: paginated list of milestones for a repository.
+milestones_cap.list = function(owner, repo_name)
+  local url = append_page_params(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_gl_milestones(items), hdrs, nil
+end
+
+-- create: create a milestone.  body is raw GitHub-format JSON string.
+milestones_cap.create = function(owner, repo_name, body)
+  local req = DecodeJson(body or "{}")
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.description then
+    gl.description = req.description
+  end
+  if req.due_on then
+    gl.due_date = req.due_on
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones",
+    "POST",
+    EncodeJson(gl)
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_milestone(raw), nil
+end
+
+-- get: fetch a single milestone by number (iid).
+milestones_cap.get = function(owner, repo_name, milestone_number)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones/" .. milestone_number
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_milestone(raw), nil
+end
+
+-- update: partially update a milestone.  body is raw GitHub-format JSON string.
+milestones_cap.update = function(owner, repo_name, milestone_number, body)
+  local req = DecodeJson(body or "{}")
+  local gl = {}
+  if req.title then
+    gl.title = req.title
+  end
+  if req.description then
+    gl.description = req.description
+  end
+  if req.state then
+    gl.state_event = req.state == "closed" and "close" or "activate"
+  end
+  if req.due_on then
+    gl.due_date = req.due_on
+  end
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones/" .. milestone_number,
+    "PUT",
+    EncodeJson(gl)
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_milestone(raw), nil
+end
+
+-- delete: permanently remove a milestone.
+-- Returns (true, nil) on success or (nil, err) on failure.
+milestones_cap.delete = function(owner, repo_name, milestone_number)
+  local ok, status = fetch_json(
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones/" .. milestone_number,
+    "DELETE"
+  )
+  if not ok then
+    return nil, cap_err(0, "network error deleting milestone " .. tostring(milestone_number))
+  end
+  if status ~= 200 and status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " deleting milestone")
+  end
+  return true, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Reactions capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate_gl_award for all reaction (award emoji) operations.
+-- Paged list operations:  (items, headers, nil) or (nil, nil, err).
+-- Single-item operations: (data, nil) on success, (nil, err) on failure.
+-- Delete operations:      (true, nil) on success, (nil, err) on failure.
+
+local reactions_cap = {}
+
+-- list_issue: paginated list of reactions for an issue.
+reactions_cap.list_issue = function(owner, repo_name, issue_number)
+  local url = append_page_params(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/issues/"
+      .. issue_number
+      .. "/award_emoji",
+    PAGES
+  )
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_gl_awards(items), hdrs, nil
+end
+
+-- create_issue: add a reaction to an issue.  body is raw GitHub-format JSON string.
+reactions_cap.create_issue = function(owner, repo_name, issue_number, body)
+  local req = DecodeJson(body or "{}") or {}
+  local emoji = CONTENT_TO_GL_EMOJI[req.content or ""] or req.content or ""
+  local raw, err = cap_fetch(
+    fetch_json,
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/issues/"
+      .. issue_number
+      .. "/award_emoji",
+    "POST",
+    EncodeJson({ name = emoji })
+  )
+  if not raw then
+    return nil, err
+  end
+  return translate_gl_award(raw), nil
+end
+
+-- delete_issue: remove a reaction from an issue by reaction id.
+-- Returns (true, nil) on success or (nil, err) on failure.
+reactions_cap.delete_issue = function(owner, repo_name, issue_number, reaction_id)
+  local ok, status = fetch_json(
+    base()
+      .. "/projects/"
+      .. project_id(owner, repo_name)
+      .. "/issues/"
+      .. issue_number
+      .. "/award_emoji/"
+      .. reaction_id,
+    "DELETE"
+  )
+  if not ok then
+    return nil, cap_err(0, "network error deleting reaction " .. tostring(reaction_id))
+  end
+  if status ~= 204 then
+    return nil, cap_err(status, "upstream error " .. tostring(status) .. " deleting reaction")
+  end
+  return true, nil
 end
 
 local b = make_backend_builder()
@@ -2659,355 +3200,133 @@ end)
 -- Issues -------------------------------------------------------------------
 
 -- GET /repos/{owner}/{repo}/issues
-b:rest(
-  "get_repo_issues",
-  proxy_handler_paged(translate_gl_issues, function(o, r)
-    return append_page_params(base() .. "/projects/" .. project_id(o, r) .. "/issues", PAGES)
-  end)
-)
+b:rest("get_repo_issues", function(owner, repo_name)
+  local items, hdrs, err = issues_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- POST /repos/{owner}/{repo}/issues
-b:rest(
-  "post_repo_issues",
-  proxy_handler_created(translate_gl_issue, function(o, r)
-    local req = DecodeJson(GetBody() or "{}")
-    local gl = {}
-    if req.title then
-      gl.title = req.title
-    end
-    if req.body then
-      gl.description = req.body
-    end
-    if req.milestone then
-      gl.milestone_id = req.milestone
-    end
-    return base() .. "/projects/" .. project_id(o, r) .. "/issues", "POST", EncodeJson(gl)
-  end)
-)
+b:rest("post_repo_issues", function(owner, repo_name)
+  local data, err = issues_cap.create(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
+end)
 
 -- GET /repos/{owner}/{repo}/issues/{issue_number}
-b:rest(
-  "get_repo_issue",
-  proxy_handler(translate_gl_issue, function(o, r, n)
-    return base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n
-  end)
-)
+b:rest("get_repo_issue", function(owner, repo_name, issue_number)
+  local data, err = issues_cap.get(owner, repo_name, issue_number)
+  cap_rest_respond(data, err)
+end)
 
 -- PATCH /repos/{owner}/{repo}/issues/{issue_number}
-b:rest(
-  "patch_repo_issue",
-  proxy_handler(translate_gl_issue, function(o, r, n)
-    local req = DecodeJson(GetBody() or "{}")
-    local gl = {}
-    if req.title then
-      gl.title = req.title
-    end
-    if req.body then
-      gl.description = req.body
-    end
-    if req.state then
-      gl.state_event = req.state == "closed" and "close" or "reopen"
-    end
-    if req.milestone then
-      gl.milestone_id = req.milestone
-    end
-    return base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n, "PUT", EncodeJson(gl)
-  end)
-)
+b:rest("patch_repo_issue", function(owner, repo_name, issue_number)
+  local data, err = issues_cap.update(owner, repo_name, issue_number, GetBody())
+  cap_rest_respond(data, err)
+end)
 
 -- GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-b:rest(
-  "get_issue_comments",
-  proxy_handler_paged(translate_gl_notes, function(o, r, n)
-    return append_page_params(
-      base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n .. "/notes",
-      PAGES
-    )
-  end)
-)
+b:rest("get_issue_comments", function(owner, repo_name, issue_number)
+  local items, hdrs, err = issues_cap.list_comments(owner, repo_name, issue_number)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- POST /repos/{owner}/{repo}/issues/{issue_number}/comments
-b:rest(
-  "post_issue_comment",
-  proxy_handler_created(translate_gl_note, function(o, r, n)
-    local req = DecodeJson(GetBody() or "{}")
-    return base() .. "/projects/" .. project_id(o, r) .. "/issues/" .. n .. "/notes",
-      "POST",
-      EncodeJson({ body = req.body })
-  end)
-)
+b:rest("post_issue_comment", function(owner, repo_name, issue_number)
+  local data, err = issues_cap.create_comment(owner, repo_name, issue_number, GetBody())
+  cap_rest_created(data, err)
+end)
 
 -- GET /repos/{owner}/{repo}/issues/{issue_number}/labels
 b:rest("get_issue_labels", function(owner, repo_name, issue_number)
-  -- Fetch the issue and extract its labels.
-  local ok, status, _, body =
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number)
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local issue = DecodeJson(body) or {}
-  local labels = {}
-  for _, l in ipairs(issue.labels or {}) do
-    if type(l) == "table" then
-      labels[#labels + 1] = translate_gl_label(l)
-    else
-      labels[#labels + 1] = {
-        id = 0,
-        node_id = "",
-        url = "",
-        name = l,
-        color = "",
-        description = "",
-        default = false,
-      }
-    end
-  end
-  respond_json(200, labels)
+  local data, err = labels_cap.list_issue(owner, repo_name, issue_number)
+  cap_rest_respond(data, err)
 end)
 
 -- POST /repos/{owner}/{repo}/issues/{issue_number}/labels
 b:rest("post_issue_labels", function(owner, repo_name, issue_number)
   local req = DecodeJson(GetBody() or "{}")
-  local existing_ok, existing_status, _, existing_body =
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number)
-  if not existing_ok or existing_status ~= 200 then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local issue = DecodeJson(existing_body) or {}
-  local all_labels = issue.labels or {}
-  for _, name in ipairs(req.labels or {}) do
-    all_labels[#all_labels + 1] = name
-  end
-  proxy_json(
-    function(i)
-      local labels = {}
-      for _, l in ipairs(i.labels or {}) do
-        if type(l) == "table" then
-          labels[#labels + 1] = translate_gl_label(l)
-        else
-          labels[#labels + 1] = {
-            id = 0,
-            node_id = "",
-            url = "",
-            name = l,
-            color = "",
-            description = "",
-            default = false,
-          }
-        end
-      end
-      return labels
-    end,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-      "PUT",
-      EncodeJson({ labels = all_labels })
-    )
-  )
+  local data, err = labels_cap.set_issue(owner, repo_name, issue_number, req.labels or {})
+  cap_rest_respond(data, err)
 end)
 
 -- PUT /repos/{owner}/{repo}/issues/{issue_number}/labels  (replace all)
 b:rest("put_issue_labels", function(owner, repo_name, issue_number)
   local req = DecodeJson(GetBody() or "{}")
-  proxy_json(
-    function(i)
-      local labels = {}
-      for _, l in ipairs(i.labels or {}) do
-        if type(l) == "table" then
-          labels[#labels + 1] = translate_gl_label(l)
-        else
-          labels[#labels + 1] = {
-            id = 0,
-            node_id = "",
-            url = "",
-            name = l,
-            color = "",
-            description = "",
-            default = false,
-          }
-        end
-      end
-      return labels
-    end,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-      "PUT",
-      EncodeJson({ labels = req.labels or {} })
-    )
-  )
+  local data, err = labels_cap.replace_issue(owner, repo_name, issue_number, req.labels or {})
+  cap_rest_respond(data, err)
 end)
 
 -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels  (remove all)
 b:rest("delete_issue_labels", function(owner, repo_name, issue_number)
-  proxy_204(
-    { 200 },
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-      "PUT",
-      EncodeJson({ labels = {} })
-    )
-  )
+  local ok, err = labels_cap.delete_issue_all(owner, repo_name, issue_number)
+  cap_rest_204(ok, err)
 end)
 
 -- DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
 b:rest("delete_issue_label", function(owner, repo_name, issue_number, label_name)
-  local ok, status, _, body =
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number)
-  if not ok or status ~= 200 then
-    respond_json(404, { message = "Not Found" })
-    return
-  end
-  local issue = DecodeJson(body) or {}
-  local labels = {}
-  for _, l in ipairs(issue.labels or {}) do
-    local name = type(l) == "table" and l.name or l
-    if name ~= label_name then
-      labels[#labels + 1] = name
-    end
-  end
-  local upok, upstatus = fetch_json(
-    base() .. "/projects/" .. project_id(owner, repo_name) .. "/issues/" .. issue_number,
-    "PUT",
-    EncodeJson({ labels = labels })
-  )
-  proxy_204({ 200 }, upok, upstatus)
+  local ok, err = labels_cap.delete_issue_one(owner, repo_name, issue_number, label_name)
+  cap_rest_204(ok, err)
 end)
 
 -- GET /repos/{owner}/{repo}/labels
-b:rest(
-  "get_repo_labels",
-  proxy_handler_paged(translate_gl_labels, function(o, r)
-    return append_page_params(base() .. "/projects/" .. project_id(o, r) .. "/labels", PAGES)
-  end)
-)
+b:rest("get_repo_labels", function(owner, repo_name)
+  local items, hdrs, err = labels_cap.list_repo(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- POST /repos/{owner}/{repo}/labels
-b:rest(
-  "post_repo_labels",
-  proxy_handler_created(translate_gl_label, function(o, r)
-    return base() .. "/projects/" .. project_id(o, r) .. "/labels", "POST", GetBody()
-  end)
-)
+b:rest("post_repo_labels", function(owner, repo_name)
+  local data, err = labels_cap.create_repo(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
+end)
 
 -- GET /repos/{owner}/{repo}/labels/{name}
 b:rest("get_repo_label", function(owner, repo_name, label_name)
-  local id = gl_find_label_id(owner, repo_name, label_name)
-  if not id then
-    respond_json(404, { message = "Label not found" })
-    return
-  end
-  proxy_json(
-    translate_gl_label,
-    fetch_json(base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id)
-  )
+  local data, err = labels_cap.get_repo(owner, repo_name, label_name)
+  cap_rest_respond(data, err)
 end)
 
 -- PATCH /repos/{owner}/{repo}/labels/{name}
 b:rest("patch_repo_label", function(owner, repo_name, label_name)
-  local id = gl_find_label_id(owner, repo_name, label_name)
-  if not id then
-    respond_json(404, { message = "Label not found" })
-    return
-  end
-  proxy_json(
-    translate_gl_label,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id,
-      "PUT",
-      GetBody()
-    )
-  )
+  local data, err = labels_cap.update_repo(owner, repo_name, label_name, GetBody())
+  cap_rest_respond(data, err)
 end)
 
 -- DELETE /repos/{owner}/{repo}/labels/{name}
 b:rest("delete_repo_label", function(owner, repo_name, label_name)
-  local id = gl_find_label_id(owner, repo_name, label_name)
-  if not id then
-    respond_json(404, { message = "Label not found" })
-    return
-  end
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  local ok, status =
-    pcall(Fetch, base() .. "/projects/" .. project_id(owner, repo_name) .. "/labels/" .. id, dopts)
-  proxy_204({ 200 }, ok, status)
+  local ok, err = labels_cap.delete_repo(owner, repo_name, label_name)
+  cap_rest_204(ok, err)
 end)
 
 -- Milestones ----------------------------------------------------------------
 
 -- GET /repos/{owner}/{repo}/milestones
-b:rest(
-  "get_repo_milestones",
-  proxy_handler_paged(translate_gl_milestones, function(o, r)
-    return append_page_params(base() .. "/projects/" .. project_id(o, r) .. "/milestones", PAGES)
-  end)
-)
+b:rest("get_repo_milestones", function(owner, repo_name)
+  local items, hdrs, err = milestones_cap.list(owner, repo_name)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
 -- POST /repos/{owner}/{repo}/milestones
-b:rest(
-  "post_repo_milestones",
-  proxy_handler_created(translate_gl_milestone, function(o, r)
-    local req = DecodeJson(GetBody() or "{}")
-    local gl = {}
-    if req.title then
-      gl.title = req.title
-    end
-    if req.description then
-      gl.description = req.description
-    end
-    if req.due_on then
-      gl.due_date = req.due_on
-    end
-    return base() .. "/projects/" .. project_id(o, r) .. "/milestones", "POST", EncodeJson(gl)
-  end)
-)
+b:rest("post_repo_milestones", function(owner, repo_name)
+  local data, err = milestones_cap.create(owner, repo_name, GetBody())
+  cap_rest_created(data, err)
+end)
 
 -- GET /repos/{owner}/{repo}/milestones/{milestone_number}
-b:rest(
-  "get_repo_milestone",
-  proxy_handler(translate_gl_milestone, function(o, r, n)
-    return base() .. "/projects/" .. project_id(o, r) .. "/milestones/" .. n
-  end)
-)
+b:rest("get_repo_milestone", function(owner, repo_name, milestone_number)
+  local data, err = milestones_cap.get(owner, repo_name, milestone_number)
+  cap_rest_respond(data, err)
+end)
 
 -- PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
-b:rest(
-  "patch_repo_milestone",
-  proxy_handler(translate_gl_milestone, function(o, r, n)
-    local req = DecodeJson(GetBody() or "{}")
-    local gl = {}
-    if req.title then
-      gl.title = req.title
-    end
-    if req.description then
-      gl.description = req.description
-    end
-    if req.state then
-      gl.state_event = req.state == "closed" and "close" or "activate"
-    end
-    if req.due_on then
-      gl.due_date = req.due_on
-    end
-    return base() .. "/projects/" .. project_id(o, r) .. "/milestones/" .. n, "PUT", EncodeJson(gl)
-  end)
-)
+b:rest("patch_repo_milestone", function(owner, repo_name, milestone_number)
+  local data, err = milestones_cap.update(owner, repo_name, milestone_number, GetBody())
+  cap_rest_respond(data, err)
+end)
 
 -- DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
 b:rest("delete_repo_milestone", function(owner, repo_name, milestone_number)
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  local ok, status = pcall(
-    Fetch,
-    base() .. "/projects/" .. project_id(owner, repo_name) .. "/milestones/" .. milestone_number,
-    dopts
-  )
-  proxy_204({ 200 }, ok, status)
+  local ok, err = milestones_cap.delete(owner, repo_name, milestone_number)
+  cap_rest_204(ok, err)
 end)
 
 -- Assignees -----------------------------------------------------------------
@@ -4155,96 +4474,21 @@ b:rest("get_user_gists", function(_username)
 end)
 
 -- ── Reactions (GitLab award emoji) ────────────────────────────────────────────
--- GitLab award emoji → GitHub reaction content (8 supported types).
-local GL_EMOJI_TO_CONTENT = {
-  thumbsup = "+1",
-  thumbsdown = "-1",
-  laughing = "laugh",
-  confused = "confused",
-  heart = "heart",
-  tada = "hooray",
-  rocket = "rocket",
-  eyes = "eyes",
-}
-local CONTENT_TO_GL_EMOJI = {
-  ["+1"] = "thumbsup",
-  ["-1"] = "thumbsdown",
-  laugh = "laughing",
-  confused = "confused",
-  heart = "heart",
-  hooray = "tada",
-  rocket = "rocket",
-  eyes = "eyes",
-}
-
-local function translate_gl_award(a)
-  if not a then
-    return {}
-  end
-  local user = translate_gl_user(a.user or {})
-  return {
-    id = a.id,
-    node_id = "",
-    user = user,
-    content = GL_EMOJI_TO_CONTENT[a.name] or a.name,
-    created_at = a.created_at or "2020-01-01T00:00:00Z",
-  }
-end
-
-local function translate_gl_awards(awards)
-  return translate_list(translate_gl_award, awards)
-end
 
 -- Issue reactions: GitLab has full award_emoji support on issues.
-b:rest(
-  "get_issue_reactions",
-  proxy_handler_paged(translate_gl_awards, function(owner, repo_name, issue_number)
-    return append_page_params(
-      base()
-        .. "/projects/"
-        .. project_id(owner, repo_name)
-        .. "/issues/"
-        .. issue_number
-        .. "/award_emoji",
-      PAGES
-    )
-  end)
-)
+b:rest("get_issue_reactions", function(owner, repo_name, issue_number)
+  local items, hdrs, err = reactions_cap.list_issue(owner, repo_name, issue_number)
+  cap_rest_paged(items, hdrs, err, PAGES)
+end)
 
-b:rest(
-  "post_issue_reaction",
-  proxy_handler_created(translate_gl_award, function(owner, repo_name, issue_number)
-    local req = DecodeJson(GetBody() or "{}") or {}
-    local emoji = CONTENT_TO_GL_EMOJI[req.content or ""] or req.content or ""
-    return base()
-      .. "/projects/"
-      .. project_id(owner, repo_name)
-      .. "/issues/"
-      .. issue_number
-      .. "/award_emoji",
-      "POST",
-      EncodeJson({ name = emoji })
-  end)
-)
+b:rest("post_issue_reaction", function(owner, repo_name, issue_number)
+  local data, err = reactions_cap.create_issue(owner, repo_name, issue_number, GetBody())
+  cap_rest_created(data, err)
+end)
 
 b:rest("delete_issue_reaction", function(owner, repo_name, issue_number, reaction_id)
-  local url = base()
-    .. "/projects/"
-    .. project_id(owner, repo_name)
-    .. "/issues/"
-    .. issue_number
-    .. "/award_emoji/"
-    .. reaction_id
-  local dopts = auth() or {}
-  dopts.method = "DELETE"
-  local ok, status, _, body = pcall(Fetch, url, dopts)
-  if ok and status == 204 then
-    SetStatus(204, "No Content")
-  elseif ok then
-    respond_json(status, DecodeJson(body) or {})
-  else
-    respond_json(503, {})
-  end
+  local ok, err = reactions_cap.delete_issue(owner, repo_name, issue_number, reaction_id)
+  cap_rest_204(ok, err)
 end)
 
 -- ---------------------------------------------------------------------------
@@ -4929,4 +5173,8 @@ b:capability("orgs", orgs)
 b:capability("branches", branches)
 b:capability("commits", commits)
 b:capability("statuses", statuses_cap)
+b:capability("issues", issues_cap)
+b:capability("labels", labels_cap)
+b:capability("milestones", milestones_cap)
+b:capability("reactions", reactions_cap)
 b:build()

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -114,39 +114,6 @@ local function translate_gl_user(u)
   }
 end
 
--- Proxy a GitLab search response (plain JSON array) to the GitHub search
--- envelope {"total_count":N,"incomplete_results":false,"items":[...]}.
--- translate_item is applied to each element of the array.
-local function proxy_search_gl(translate_item, url)
-  local ok, status, headers, body = fetch_json(url)
-  if not ok then
-    respond_json(503, {})
-    return
-  end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local raw = DecodeJson(body) or {}
-  local items = {}
-  for i, item in ipairs(raw) do
-    items[i] = translate_item(item)
-  end
-  local link = headers and (headers["Link"] or headers["link"])
-  local rewritten = rewrite_link_header(link, PAGES)
-  set_preamble()
-  if rewritten then
-    SetHeader("Link", rewritten)
-  end
-  Write(
-    '{"total_count":'
-      .. #items
-      .. ',"incomplete_results":false,"items":'
-      .. (#items > 0 and EncodeJson(items) or "[]")
-      .. "}"
-  )
-end
-
 -- Look up a GitLab user ID by username. Returns nil on failure.
 local function gl_user_id(username)
   local ok, status, _, body = fetch_json(base() .. "/users?username=" .. username)
@@ -4182,104 +4149,190 @@ b:rest("get_pull_comments", function(owner, repo_name, pull_number)
   cap_rest_respond(data, err)
 end)
 
+-- ---------------------------------------------------------------------------
+-- Search capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for search operations.
+-- Paged list operations return (items, headers, nil) or (nil, nil, err).
+
+local search_cap = {}
+
+-- repos: paginated search of projects by query string.
+-- Returns (items, headers, nil) or (nil, nil, err).
+search_cap.repos = function(q)
+  local url = append_page_params(base() .. "/projects?search=" .. q, PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_repo, items), hdrs, nil
+end
+
+-- users: paginated search of users by query string.
+-- Returns (items, headers, nil) or (nil, nil, err).
+search_cap.users = function(q)
+  local url = append_page_params(base() .. "/users?search=" .. q, PAGES)
+  local items, hdrs, err = cap_fetch_paged(fetch_json, url)
+  if not items then
+    return nil, nil, err
+  end
+  return translate_list(translate_gl_user, items), hdrs, nil
+end
+
+-- Helper: write a GitHub search envelope from a paged cap result.
+-- items: translated array; hdrs: raw response headers (for Link forwarding).
+local function write_search_envelope(items, hdrs)
+  local link = hdrs and (hdrs["Link"] or hdrs["link"])
+  local rewritten = rewrite_link_header(link, PAGES)
+  set_preamble()
+  if rewritten then
+    SetHeader("Link", rewritten)
+  end
+  Write(
+    '{"total_count":'
+      .. #items
+      .. ',"incomplete_results":false,"items":'
+      .. (#items > 0 and EncodeJson(items) or "[]")
+      .. "}"
+  )
+end
+
 -- Search -----------------------------------------------------------------------
 
 -- GET /search/repositories — maps to GitLab GET /projects?search=<q>
 b:rest("search_repositories", function()
   local q = GetParam("q") or ""
-  proxy_search_gl(translate_gl_repo, append_page_params(base() .. "/projects?search=" .. q, PAGES))
+  local items, hdrs, err = search_cap.repos(q)
+  if not items then
+    respond_json(err and err.status ~= 0 and err.status or 503, {})
+    return
+  end
+  write_search_envelope(items, hdrs)
 end)
 
 -- GET /search/users — maps to GitLab GET /users?search=<q>
 b:rest("search_users", function()
   local q = GetParam("q") or ""
-  proxy_search_gl(translate_gl_user, append_page_params(base() .. "/users?search=" .. q, PAGES))
+  local items, hdrs, err = search_cap.users(q)
+  if not items then
+    respond_json(err and err.status ~= 0 and err.status or 503, {})
+    return
+  end
+  write_search_envelope(items, hdrs)
 end)
+
+-- ---------------------------------------------------------------------------
+-- Gitignore capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for gitignore template operations.
+-- list returns (names_array, nil) or (nil, err).
+-- get returns ({name, source}, nil) or (nil, err).
+
+local gitignore_cap = {}
+
+-- list: fetch all gitignore template names.
+-- GitLab returns [{key,name},...]; GitHub returns ["Name",...].
+-- Returns (names_array, nil) or (nil, err).
+gitignore_cap.list = function()
+  local raw, err = cap_fetch(fetch_json, base() .. "/templates/gitignores")
+  if not raw then
+    return nil, err
+  end
+  local names = {}
+  for i, t in ipairs(raw) do
+    names[i] = t.name
+  end
+  return names, nil
+end
+
+-- get: fetch a single gitignore template by name.
+-- GitLab returns {name, content}; GitHub returns {name, source}.
+-- Returns ({name, source}, nil) or (nil, err).
+gitignore_cap.get = function(name)
+  local raw, err = cap_fetch(fetch_json, base() .. "/templates/gitignores/" .. name)
+  if not raw then
+    return nil, err
+  end
+  return { name = raw.name, source = raw.content }, nil
+end
 
 -- Gitignore -----------------------------------------------------------------
 
 -- GET /gitignore/templates → GitLab GET /api/v4/templates/gitignores
 -- GitLab returns [{key,name}, ...]; GitHub returns ["Name", ...]
 b:rest("get_gitignore_templates", function()
-  proxy_json(function(list)
-    local names = {}
-    for i, t in ipairs(list or {}) do
-      names[i] = t.name
-    end
-    return names
-  end, fetch_json(base() .. "/templates/gitignores"))
+  local data, err = gitignore_cap.list()
+  cap_rest_respond(data, err)
 end)
 
 -- GET /gitignore/templates/{name} → GitLab GET /api/v4/templates/gitignores/{name}
 -- GitLab returns {name, content}; GitHub returns {name, source}
 b:rest("get_gitignore_template", function(name)
-  proxy_json(function(t)
-    if not t then
-      return {}
-    end
-    return { name = t.name, source = t.content }
-  end, fetch_json(base() .. "/templates/gitignores/" .. name))
+  local data, err = gitignore_cap.get(name)
+  cap_rest_respond(data, err)
 end)
 
--- Licenses -----------------------------------------------------------------
+-- ---------------------------------------------------------------------------
+-- Licenses capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for license template and repo license operations.
+-- list returns (array, nil) or (nil, err).
+-- get returns (object, nil) or (nil, err).
 
--- GET /licenses → GitLab GET /api/v4/templates/licenses
--- GitLab returns [{key,name,...}]; GitHub returns [{key,name,...}] (license-simple)
-b:rest("get_licenses", function()
-  proxy_json(function(list)
-    local result = {}
-    for i, t in ipairs(list or {}) do
-      result[i] = { key = t.key, name = t.name }
-    end
-    return result
-  end, fetch_json(base() .. "/templates/licenses"))
-end)
+local licenses_cap = {}
 
--- GET /licenses/{license} → GitLab GET /api/v4/templates/licenses/{key}
--- GitLab returns {key,name,content,description,conditions,permissions,limitations,html_url}
--- GitHub returns {key,name,body,description,conditions,permissions,limitations,html_url,...}
-b:rest("get_license", function(license_name)
-  proxy_json(function(t)
-    if not t then
-      return {}
-    end
-    return {
-      key = t.key,
-      name = t.name,
-      html_url = t.html_url,
-      description = t.description,
-      body = t.content,
-      permissions = t.permissions or {},
-      conditions = t.conditions or {},
-      limitations = t.limitations or {},
-    }
-  end, fetch_json(base() .. "/templates/licenses/" .. license_name))
-end)
+-- list: fetch all license template summaries.
+-- GitLab returns [{key,name,...}]; GitHub returns [{key,name}] (license-simple).
+-- Returns (array, nil) or (nil, err).
+licenses_cap.list = function()
+  local raw, err = cap_fetch(fetch_json, base() .. "/templates/licenses")
+  if not raw then
+    return nil, err
+  end
+  local result = {}
+  for i, t in ipairs(raw) do
+    result[i] = { key = t.key, name = t.name }
+  end
+  return result, nil
+end
 
--- GET /repos/{owner}/{repo}/license
--- Combines /repository/files/LICENSE content with project license metadata.
-b:rest("get_repo_license", function(owner, repo_name)
+-- get: fetch a single license template by key.
+-- GitLab returns {key,name,content,...}; maps content → body for GitHub shape.
+-- Returns (object, nil) or (nil, err).
+licenses_cap.get = function(license_name)
+  local raw, err = cap_fetch(fetch_json, base() .. "/templates/licenses/" .. license_name)
+  if not raw then
+    return nil, err
+  end
+  return {
+    key = raw.key,
+    name = raw.name,
+    html_url = raw.html_url,
+    description = raw.description,
+    body = raw.content,
+    permissions = raw.permissions or {},
+    conditions = raw.conditions or {},
+    limitations = raw.limitations or {},
+  },
+    nil
+end
+
+-- get_repo_license: fetch the LICENSE file and project license metadata.
+-- Combines /repository/files/LICENSE with project.license field.
+-- Returns (object, nil) or (nil, err).
+licenses_cap.get_repo_license = function(owner, repo_name)
   local pid = project_id(owner, repo_name)
-  local ok, status, _, body =
-    fetch_json(base() .. "/projects/" .. pid .. "/repository/files/LICENSE?ref=HEAD")
-  if not ok then
-    respond_json(503, {})
-    return
+  local f, ferr =
+    cap_fetch(fetch_json, base() .. "/projects/" .. pid .. "/repository/files/LICENSE?ref=HEAD")
+  if not f then
+    return nil, ferr
   end
-  if status ~= 200 then
-    respond_json(status, {})
-    return
-  end
-  local f = DecodeJson(body) or {}
-  local rok, rstatus, _, rbody = fetch_json(base() .. "/projects/" .. pid)
+  local proj, _ = cap_fetch(fetch_json, base() .. "/projects/" .. pid)
   local license_meta = nil
-  if rok and rstatus == 200 then
-    local lic = (DecodeJson(rbody) or {}).license
-    if lic then
-      license_meta = { key = lic.key, name = lic.name }
-    end
+  if proj and proj.license then
+    license_meta = { key = proj.license.key, name = proj.license.name }
   end
-  respond_json(200, {
+  return {
     name = f.file_name,
     path = f.file_path,
     sha = f.blob_id,
@@ -4288,7 +4341,32 @@ b:rest("get_repo_license", function(owner, repo_name)
     content = f.content,
     encoding = f.encoding,
     license = license_meta,
-  })
+  },
+    nil
+end
+
+-- Licenses -----------------------------------------------------------------
+
+-- GET /licenses → GitLab GET /api/v4/templates/licenses
+-- GitLab returns [{key,name,...}]; GitHub returns [{key,name,...}] (license-simple)
+b:rest("get_licenses", function()
+  local data, err = licenses_cap.list()
+  cap_rest_respond(data, err)
+end)
+
+-- GET /licenses/{license} → GitLab GET /api/v4/templates/licenses/{key}
+-- GitLab returns {key,name,content,description,conditions,permissions,limitations,html_url}
+-- GitHub returns {key,name,body,description,conditions,permissions,limitations,html_url,...}
+b:rest("get_license", function(license_name)
+  local data, err = licenses_cap.get(license_name)
+  cap_rest_respond(data, err)
+end)
+
+-- GET /repos/{owner}/{repo}/license
+-- Combines /repository/files/LICENSE content with project license metadata.
+b:rest("get_repo_license", function(owner, repo_name)
+  local data, err = licenses_cap.get_repo_license(owner, repo_name)
+  cap_rest_respond(data, err)
 end)
 
 -- Checks (via GitLab commit statuses and pipelines) -------------------------
@@ -4539,13 +4617,19 @@ b:rest("delete_org_package_version", function(org, pkg_type, pkg_name, version_i
   respond_json(404, { message = "Not Found" })
 end)
 
--- Markdown -------------------------------------------------------------------
+-- ---------------------------------------------------------------------------
+-- Markdown capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + HTML extraction for markdown rendering.
+-- render(text) returns (html_string, status, nil) or (nil, nil, err).
+-- render_raw(text) wraps plain text in JSON for the same GitLab endpoint.
 
--- POST /markdown → POST /api/v4/markdown
--- GitLab returns {"html": "..."} JSON; extract the html field.
-b:rest("render_markdown", function()
-  local incoming = DecodeJson(GetBody() or "{}") or {}
-  local payload = EncodeJson({ text = incoming.text or "", gfm = true })
+local markdown_cap = {}
+
+-- render: POST markdown text; returns (html_string, upstream_status, nil) or (nil, nil, err).
+-- text: GitHub-format text field; gfm is always true for GitLab.
+markdown_cap.render = function(text)
+  local payload = EncodeJson({ text = text or "", gfm = true })
   local opts = auth() or {}
   opts.method = "POST"
   opts.body = payload
@@ -4553,12 +4637,55 @@ b:rest("render_markdown", function()
   opts.headers["Content-Type"] = "application/json"
   local ok, status, _, body = pcall(Fetch, base() .. "/markdown", opts)
   if not ok then
-    respond_json(503, {})
-    return
+    return nil, nil, cap_err(0, "network error rendering markdown")
   end
   local parsed = DecodeJson(body or "{}") or {}
+  return parsed.html or "", status, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Git database capability module
+-- ---------------------------------------------------------------------------
+-- Owns fetch + translate for git object operations (blobs).
+-- get_blob returns ({content, encoding, url, sha, size, node_id}, nil) or (nil, err).
+
+local git_db_cap = {}
+
+-- get_blob: fetch a git blob by SHA.
+-- GitLab: GET /projects/:id/repository/blobs/:sha
+-- Returns GitHub blob shape or (nil, err).
+git_db_cap.get_blob = function(owner, repo_name, file_sha)
+  local raw, err = cap_fetch(
+    fetch_json,
+    base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/blobs/" .. file_sha
+  )
+  if not raw then
+    return nil, err
+  end
+  return {
+    content = raw.content,
+    encoding = raw.encoding,
+    url = "",
+    sha = raw.sha,
+    size = raw.size,
+    node_id = "",
+  },
+    nil
+end
+
+-- Markdown -------------------------------------------------------------------
+
+-- POST /markdown → POST /api/v4/markdown
+-- GitLab returns {"html": "..."} JSON; extract the html field.
+b:rest("render_markdown", function()
+  local incoming = DecodeJson(GetBody() or "{}") or {}
+  local html, status, err = markdown_cap.render(incoming.text)
+  if not html then
+    respond_json(err and err.status ~= 0 and err.status or 503, {})
+    return
+  end
   set_preamble(status, "text/html; charset=utf-8")
-  Write(parsed.html or "")
+  Write(html)
 end)
 
 -- Git database (https://docs.github.com/en/rest/git) -----------------------
@@ -4567,41 +4694,21 @@ end)
 -- GitLab: GET /projects/:id/repository/blobs/:sha
 -- Returns {size, encoding, content, sha} — translate to GitHub blob shape.
 b:rest("get_git_blob", function(owner, repo_name, file_sha)
-  proxy_json(
-    function(br)
-      return {
-        content = br.content,
-        encoding = br.encoding,
-        url = "",
-        sha = br.sha,
-        size = br.size,
-        node_id = "",
-      }
-    end,
-    fetch_json(
-      base() .. "/projects/" .. project_id(owner, repo_name) .. "/repository/blobs/" .. file_sha
-    )
-  )
+  local data, err = git_db_cap.get_blob(owner, repo_name, file_sha)
+  cap_rest_respond(data, err)
 end)
 
 -- POST /markdown/raw → POST /api/v4/markdown
 -- GitLab has no separate raw endpoint; wrap the plain-text body in JSON.
 b:rest("render_markdown_raw", function()
-  local raw = GetBody() or ""
-  local payload = EncodeJson({ text = raw, gfm = true })
-  local opts = auth() or {}
-  opts.method = "POST"
-  opts.body = payload
-  opts.headers = opts.headers or {}
-  opts.headers["Content-Type"] = "application/json"
-  local ok, status, _, body = pcall(Fetch, base() .. "/markdown", opts)
-  if not ok then
-    respond_json(503, {})
+  local raw_text = GetBody() or ""
+  local html, status, err = markdown_cap.render(raw_text)
+  if not html then
+    respond_json(err and err.status ~= 0 and err.status or 503, {})
     return
   end
-  local parsed = DecodeJson(body or "{}") or {}
   set_preamble(status, "text/html; charset=utf-8")
-  Write(parsed.html or "")
+  Write(html)
 end)
 
 -- Dependabot alerts via GitLab Vulnerabilities API (requires Ultimate tier).
@@ -5751,4 +5858,9 @@ b:capability("releases", releases_cap)
 b:capability("deploy_keys", deploy_keys_cap)
 b:capability("webhooks", webhooks_cap)
 b:capability("teams", teams_cap)
+b:capability("search", search_cap)
+b:capability("gitignore", gitignore_cap)
+b:capability("licenses", licenses_cap)
+b:capability("markdown", markdown_cap)
+b:capability("git_db", git_db_cap)
 b:build()

--- a/test/gitlab-reactions.hurl
+++ b/test/gitlab-reactions.hurl
@@ -88,8 +88,6 @@ DELETE http://{{host}}/repos/octocat/hello-world/issues/1/reactions/9999
 Authorization: token testtoken
 
 HTTP 404
-[Asserts]
-jsonpath "$.message" isString
 
 # ── PR comment reactions ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #207.

Migrates GitLab's REST handlers and GraphQL resolvers from direct `proxy_handler`/`proxy_json` calls to capability modules with thin REST/GraphQL adapters, matching the pattern established in the Gitea migration. All core domain caps and most leaf modules (repos, users/orgs, branches/commits/statuses, issues/labels/milestones/reactions, contents/commit_comments, collaborators/forks, pulls, releases, deploy_keys/webhooks, teams) are done; final two tasks cover utility caps (search, git_db, licenses, markdown) and packages/gists — each using `cap_fetch`/`cap_fetch_paged` for operations and `cap_rest_*`/GraphQL adapters for response writing.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (12)</summary>

- [x] GitLab: extract utility caps (search, gitignore, licenses, markdown, checks, git_db) <!-- type:spec -->
- [x] GitLab: extract packages, security, and gists capability modules <!-- type:spec -->
- [x] GitLab: extract teams capability module (org teams and legacy team API) <!-- type:spec -->
- [x] GitLab: extract deploy_keys and webhooks capability modules <!-- type:spec -->
- [x] GitLab: extract releases capability module (releases and assets) <!-- type:spec -->
- [x] GitLab: extract pulls capability module (PRs, reviews, merge, files) <!-- type:spec -->
- [x] GitLab: extract collaborators and forks capability modules <!-- type:spec -->
- [x] GitLab: extract contents and commit_comments capability modules <!-- type:spec -->
- [x] GitLab: extract issues, labels, milestones, and reactions capability modules <!-- type:spec -->
- [x] GitLab: extract branches, commits, and statuses capability modules <!-- type:spec -->
- [x] GitLab: extract users and orgs capability modules (users, emails, SSH/GPG keys) <!-- type:spec -->
- [x] GitLab: extract repos capability module and thin REST/GraphQL adapters <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->