### PR TITLE
Rank 7: migrate family aliases and remaining backends, then delete legacy global wiring (closes #208)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -25,7 +25,6 @@ globals = {
   "OnHttpRequest",
   -- App globals defined in .init.lua, read by backends/*.lua
   "provider_families",
-  "load_family_backend",
   "config",
   "set_preamble",
   "respond_json",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ internal/
   transport.lua              — auth/fetch scaffolding: make_fetch_opts, make_proxy_handler, make_backend_transport, append_page_params
   capabilities.lua           — capability module helpers: cap_fetch, cap_fetch_paged, cap_err; REST adapters: cap_rest_respond, cap_rest_created, cap_rest_204, cap_rest_paged
   translators.lua            — shared Gitea-family translators: translate_repo, translate_user, translate_migration, owner_repo_id
-  families.lua               — provider_families table and load_family_backend
+  families.lua               — provider_families table
   defaults.lua               — default stub handlers collected in the global `defaults` table
   router.lua                 — segment-based radix trie: route_add, route_match, path_known
   catalog.lua                — endpoint_sections table; populates global `endpoints` and registers routes at load time
@@ -225,7 +225,7 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 | Concern | Authoritative source | What is derived from it |
 |---------|---------------------|------------------------|
 | Routes and default handler stubs | `endpoint_sections` in `internal/catalog.lua` | route registration, `defaults` table wire-up, compatibility matrix sections, test file discovery, `make dump-endpoints` / `validate-tests` / `validate-csv` / `site` |
-| Provider family membership | `provider_families` in `internal/families.lua` | mock building via `.make-families.mk` (auto-generated), `make validate-providers`, `load_family_backend` behavior |
+| Provider family membership | `provider_families` in `internal/families.lua` | mock building via `.make-families.mk` (auto-generated), `make validate-providers`, alias backend base URL and strip wiring |
 | Backend transport scaffold | `make_backend_transport` in `internal/transport.lua` | `fetch_json`, `proxy_json*`, `proxy_204`, `proxy_json_list`, `proxy_health_check`, pagination params — all consumed by backends via the transport object |
 | Application module layout | eleven `internal/*.lua` files, dofile'd in fixed order by `.init.lua` | the full global surface for backends; see "Internal module layout" for load order and exported globals |
 
@@ -233,7 +233,7 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 
 **Adding a standalone backend**: create `backends/<name>.lua`, add `<name>` to `BACKENDS` in the Makefile, create hurl test files, add a `site/compatibility.csv` column.
 
-**Adding a family-alias backend**: update `provider_families` in `internal/families.lua` (the single declaration), create a one-line `backends/<alias>.lua` calling `load_family_backend`, add to `BACKENDS` — no mock file needed.
+**Adding a family-alias backend**: update `provider_families` in `internal/families.lua` (the single declaration), create a `backends/<alias>.lua` that sets `config.base_url` from `provider_families` and dofiles the root backend, add to `BACKENDS` — no mock file needed.
 
 **Backend registration**: all backends must use `make_backend_builder()` / `b:rest()` / `b:graphql()` / `b:capability()` / `b:build()`. Direct assignment to `app.backend_impl` or `graphql_resolvers` is forbidden. `make validate-builders` enforces this and is wired into `make test`.
 
@@ -279,13 +279,10 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
   backends belong to the same API family. It drives backend loading, mock building, and
   the `validate-providers` check. Never encode family membership only in filesystem layout
   or Makefile variables — both are derived from this table.
-- **`load_family_backend(root)`** is the helper alias backends call instead of raw `dofile`.
-  It reads the alias's entry from `provider_families[root].aliases[config.backend]`, sets
-  `config.base_url` from `default_url` when none was supplied, declares the alias's strip
-  patterns in `app._family_strip`, then dofiles the root backend.  The root backend's
-  builder reads `app._family_strip` in `b:build()` and excludes matching REST keys — no
-  post-hoc `app.backend_impl` mutation needed.  `app._family_strip` is cleared to nil
-  after dofile returns so it doesn't affect other code.
+- **Alias backends set `config.base_url` from `provider_families` and dofile the root backend directly.**
+  The root backend reads the alias's strip patterns from `provider_families` in the final
+  `b:build(strip)` call, so feature gaps are applied declaratively rather than by post-hoc
+  `app.backend_impl` mutation.
 - **`strip` patterns are Lua patterns, not exact names.** `"_package"` matches any key
   containing `_package` (e.g. `list_packages`, `get_package`). Keep patterns tight enough
   not to accidentally strip unrelated keys.
@@ -297,7 +294,7 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 - **`make dump-families`** exports `provider_families` as JSON. Useful for debugging and
   piped into `make validate-providers`.
 - **`make validate-providers`** is wired into `make test`. It checks: root backend and mock
-  exist; each alias backend calls `load_family_backend`; no stale `test/mock-<alias>.lua`
+  exist; each alias backend dofiles the root backend; no stale `test/mock-<alias>.lua`
   files; every alias is in `BACKENDS`.
 
 ### Routing
@@ -327,7 +324,7 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 - **`app.allow_anonymous` is a boolean field on the app context** defaulting to `true`. `OnHttpRequest()` checks it on every request: if `false` and no `Authorization` header is present, confusio returns `401 { message = "This instance requires authentication." }` immediately, before routing.
 - **Only Gitea probes its backend at startup.** The Gitea backend calls `GET /api/v1/settings/api` and sets `app.allow_anonymous = (settings.require_signin_view ~= true)`. If the probe fails (network error or non-200), the default `true` is preserved and anonymous requests are allowed.
 - **All other backends leave the default `true`.** They neither probe nor set `app.allow_anonymous`, so anonymous access is always permitted regardless of the upstream's actual configuration.
-- **Gitea-family backends (forgejo, gogs, codeberg, notabug) inherit Gitea's probe** because `load_family_backend("gitea")` dofiles `backends/gitea.lua`, which includes the probe block.
+- **Gitea-family backends (forgejo, gogs, codeberg, notabug) inherit Gitea's probe** because their alias backend files dofile `backends/gitea.lua`, which includes the probe block.
 - **Test pattern**: `*-anon.hurl` files verify that unauthenticated requests succeed when the mock advertises anonymous access. The mock's `/api/v1/settings/api` route returns `{"require_signin_view": false}` to simulate an open instance. Closed-instance (401) behavior is covered by unit tests that set `app.allow_anonymous = false` directly.
 
 ### Mock server design
@@ -443,7 +440,7 @@ The eleven `internal/` modules are loaded by `.init.lua` in a fixed order. Each 
 | `transport.lua` | `append_page_params`, `make_fetch_opts`, `make_proxy_handler`, `make_backend_transport` | backends |
 | `capabilities.lua` | `cap_err`, `cap_fetch`, `cap_fetch_paged`, `cap_rest_respond`, `cap_rest_created`, `cap_rest_204`, `cap_rest_paged` | backends (capability modules) |
 | `translators.lua` | `owner_repo_id`, `translate_repo`, `translate_user`, `translate_migration` | backends |
-| `families.lua` | `provider_families`, `load_family_backend` | backends + Makefile scripts |
+| `families.lua` | `provider_families` | backends + Makefile scripts |
 | `registry.lua` | `make_backend_builder` | backends |
 | *(backend loaded here)* | calls `b:build()` to populate `app.backend_impl` and `graphql_resolvers`; Gitea sets `app.allow_anonymous` | dispatch |
 | `defaults.lua` | `defaults` (table of handler functions) | catalog |
@@ -459,7 +456,7 @@ The eleven `internal/` modules are loaded by `.init.lua` in a fixed order. Each 
 - Transport: all of `transport.lua`'s exports
 - Capabilities: all of `capabilities.lua`'s exports — `cap_fetch`, `cap_fetch_paged` for operations; `cap_rest_*` for REST handlers; `cap_err` for error construction
 - Translators: all of `translators.lua`'s exports
-- Family loading: `load_family_backend`
+- Family metadata: `provider_families`
 
 **Internal-only globals** (backends must not depend on these):
 - `defaults` — implementation detail of the catalog; not part of the backend API
@@ -497,9 +494,9 @@ The eleven `internal/` modules are loaded by `.init.lua` in a fixed order. Each 
 - **`dump-claims.lua` stubs `Fetch` to a noop** before loading each backend so that
   load-time network probes (e.g. Gitea's anonymous-access check) fail inside their `pcall`
   wrappers without making real network calls. This is necessary for `redbean.com -i` mode.
-- **Alias backends call `load_family_backend(root)`**, which internally calls
-  `dofile("/zip/backends/<root>.lua")`. The `dump-claims.lua` dofile stub must redirect
-  `/zip/backends/` → `backends/` (not block it) so alias backends load their root correctly.
+- **Alias backends dofile the root backend directly** (`dofile("/zip/backends/<root>.lua")`).
+  The `dump-claims.lua` dofile stub must redirect `/zip/backends/` → `backends/` (not block
+  it) so alias backends load their root correctly.
 
 ### Code coverage (luacov)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,17 @@ will catch any mismatch.
      },
    },
    ```
-2. Create `backends/<alias>.lua` — one line plus a comment:
+2. Create `backends/<alias>.lua` — a short file that sets the default base URL and
+   dofiles the root backend:
    ```lua
    -- MyAlias is API-compatible with Gitea v1.  Family metadata in provider_families.
-   load_family_backend("gitea")
+   if config.base_url == "" then
+     config.base_url = provider_families.gitea.aliases[config.backend].default_url
+   end
+   dofile("/zip/backends/gitea.lua")
    ```
+   The root backend (gitea.lua) reads strip patterns from `provider_families` automatically
+   at build time — no separate strip wiring needed in the alias file.
 3. Add `<alias>` to the `BACKENDS` list in the Makefile.
    No `test/mock-<alias>.lua` file is needed — `.make-families.mk` is auto-generated
    from `provider_families` and builds `mock-<alias>.com` from the root family's mock.

--- a/backends/codeberg.lua
+++ b/backends/codeberg.lua
@@ -1,3 +1,6 @@
 -- Codeberg runs Forgejo, which is API-compatible with Gitea v1.  Family metadata
 -- in provider_families.
-load_family_backend("gitea")
+if config.base_url == "" then
+  config.base_url = provider_families.gitea.aliases[config.backend].default_url
+end
+dofile("/zip/backends/gitea.lua")

--- a/backends/forgejo.lua
+++ b/backends/forgejo.lua
@@ -1,2 +1,5 @@
 -- Forgejo is API-compatible with Gitea v1.  Family metadata in provider_families.
-load_family_backend("gitea")
+if config.base_url == "" then
+  config.base_url = provider_families.gitea.aliases[config.backend].default_url
+end
+dofile("/zip/backends/gitea.lua")

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -1,6 +1,6 @@
 -- Gitea backend handler overrides.
--- Loaded by .init.lua when config.backend == "gitea", and by load_family_backend
--- for API-compatible family members (forgejo, codeberg, gogs, notabug).
+-- Loaded by .init.lua when config.backend == "gitea", and dofile'd directly by
+-- alias backends (forgejo, codeberg, gogs, notabug) that are API-compatible.
 -- Only endpoints that behave differently from the default need to be listed here.
 if config.base_url == "" then
   config.base_url = "https://gitea.com"

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7061,4 +7061,5 @@ b:capability("search", search_cap)
 b:capability("markdown", markdown_cap)
 b:capability("meta", meta_cap)
 b:set_allow_anonymous(_allow_anon)
-b:build()
+local _alias_meta = provider_families.gitea.aliases[config.backend]
+b:build(_alias_meta and _alias_meta.strip)

--- a/backends/gogs.lua
+++ b/backends/gogs.lua
@@ -1,3 +1,6 @@
 -- Gogs is API-compatible with Gitea v1.  Family metadata (including which
 -- features Gogs lacks) is declared in provider_families.
-load_family_backend("gitea")
+if config.base_url == "" then
+  config.base_url = provider_families.gitea.aliases[config.backend].default_url
+end
+dofile("/zip/backends/gitea.lua")

--- a/backends/notabug.lua
+++ b/backends/notabug.lua
@@ -1,3 +1,6 @@
 -- NotABug runs Gogs, which is API-compatible with Gitea v1.  Family metadata
 -- (including which features Gogs lacks) is declared in provider_families.
-load_family_backend("gitea")
+if config.base_url == "" then
+  config.base_url = provider_families.gitea.aliases[config.backend].default_url
+end
+dofile("/zip/backends/gitea.lua")

--- a/internal/context.lua
+++ b/internal/context.lua
@@ -12,9 +12,6 @@
 --                     Both REST handlers and GraphQL resolvers call into these
 --                     to avoid duplicating fetch + translate + error logic.
 --   allow_anonymous — auth-gate flag; true means unauthenticated requests are allowed
---   _family_strip   — private; set by load_family_backend before loading a root
---                     backend so the root's builder can strip alias feature gaps
---                     declaratively in b:build(); always nil outside that window
 
 function make_app(cfg) -- luacheck: globals make_app
   return {

--- a/internal/families.lua
+++ b/internal/families.lua
@@ -1,7 +1,6 @@
--- Provider-family metadata and family-backend loader (global).
+-- Provider-family metadata (global).
 --
 -- provider_families   — authoritative source for backend, mock, and test reuse
--- load_family_backend — called by alias backends to inherit a root family implementation
 
 -- Provider-family metadata (global: backends/<name>.lua can read at startup).
 -- Authoritative source for backend, mock, and test reuse relationships.
@@ -24,28 +23,3 @@ provider_families = {
     },
   },
 }
-
--- load_family_backend is global: alias backends call it to inherit a family
--- implementation.  Looks up config.backend in provider_families[root].aliases,
--- sets config.base_url from the alias's default_url when the user hasn't
--- supplied one, then loads the root backend via dofile.
---
--- Strip patterns are declared declaratively: before loading the root backend,
--- app._family_strip is set to the alias's strip list.  The root backend's
--- builder reads app._family_strip in b:build() and excludes REST handler keys
--- whose names match any pattern.  app._family_strip is cleared after dofile
--- returns.
-function load_family_backend(root)
-  local family = provider_families[root]
-  assert(family, "unknown provider family: " .. root)
-  local alias = family.aliases[config.backend]
-  assert(alias, config.backend .. " is not an alias in the " .. root .. " family")
-  if config.base_url == "" then
-    config.base_url = alias.default_url
-  end
-  -- Declare strip patterns before loading the root backend so the builder can
-  -- apply them inside b:build() rather than mutating app.backend_impl afterward.
-  app._family_strip = alias.strip
-  dofile("/zip/backends/" .. root .. ".lua")
-  app._family_strip = nil
-end

--- a/internal/registry.lua
+++ b/internal/registry.lua
@@ -67,10 +67,10 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
   -- Commit all registered handlers, resolvers, and capabilities to the app context.
   --
   -- strip: optional array of Lua patterns; REST keys whose names match any pattern
-  --        are silently omitted from the commit.  When omitted, b:build() falls back
-  --        to app._family_strip, which load_family_backend sets before loading the
-  --        root backend file so alias feature gaps are applied declaratively rather
-  --        than by post-hoc mutation.  Strip patterns do NOT affect capabilities.
+  --        are silently omitted from the commit.  Alias backends pass the strip list
+  --        from provider_families so that feature gaps are applied declaratively
+  --        rather than by post-hoc mutation.  Strip patterns do NOT affect
+  --        capabilities.
   --
   -- After build() returns:
   --   app.backend_impl[name]   = fn     for each registered REST handler (unless stripped)
@@ -78,13 +78,10 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
   --   app.capabilities[name]   = module for each registered capability module
   --   app.allow_anonymous      = v      only when set_allow_anonymous was called
   function b:build(strip)
-    -- Explicit strip arg takes precedence; fall back to the family-level strip
-    -- declared by load_family_backend before the root backend file was loaded.
-    local effective_strip = strip or app._family_strip
     for name, fn in pairs(self._rest) do
       local skip = false
-      if effective_strip then
-        for _, pat in ipairs(effective_strip) do
+      if strip then
+        for _, pat in ipairs(strip) do
           if name:find(pat) then
             skip = true
             break

--- a/scripts/dump-claims.lua
+++ b/scripts/dump-claims.lua
@@ -27,8 +27,8 @@ function dofile(path) -- luacheck: globals dofile
 end
 
 -- Load .init.lua (no backend — config.backend is "").  This populates all
--- internal globals: set_preamble, proxy_*, translate_*, load_family_backend,
--- defaults, route_add, endpoints, ...
+-- internal globals: set_preamble, proxy_*, translate_*, defaults, route_add,
+-- endpoints, ...
 config = { backend = "", base_url = "" } -- luacheck: globals config
 _real_dofile(".init.lua")
 

--- a/scripts/validate-providers.py
+++ b/scripts/validate-providers.py
@@ -2,7 +2,7 @@
 """Validate provider-family metadata consistency.
 
 Checks that provider_families in .init.lua agrees with:
-  - backend files (each alias calls load_family_backend)
+  - backend files (each alias dofiles the root backend)
   - mock files (no stale test/mock-<alias>.lua for aliases)
   - Makefile BACKENDS list (every alias must be present)
 
@@ -44,16 +44,17 @@ for family in families:
         errors.append(f"ERROR: missing mock for family root: test/mock-{root}.lua")
 
     for alias in aliases:
-        # Alias backend must exist and call load_family_backend.
+        # Alias backend must exist and dofile the root backend.
         backend_path = f"backends/{alias}.lua"
         if not os.path.exists(backend_path):
             errors.append(f"ERROR: missing backend for alias {alias}: {backend_path}")
         else:
             with open(backend_path) as f:
                 content = f.read()
-            if "load_family_backend" not in content:
+            if f'dofile("/zip/backends/{root}.lua")' not in content:
                 errors.append(
-                    f"ERROR: {backend_path} does not call load_family_backend"
+                    f"ERROR: {backend_path} does not dofile the root backend"
+                    f' (expected: dofile("/zip/backends/{root}.lua"))'
                 )
 
         # No stale per-alias mock lua (aliases share the root mock via the Makefile rule).

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1581,87 +1581,34 @@ OnHttpRequest()
 eq(_last_status, 501, "OnHttpRequest: GET /feeds → 501 (activity not implemented)")
 
 -- ============================================================
--- load_family_backend
+-- b:build() strip patterns (alias feature gaps)
 -- ============================================================
 
 do
-  local _saved_backend = config.backend
-  local _saved_base_url = config.base_url
   local _saved_impl = app.backend_impl
 
-  -- Stub dofile so load_family_backend's dofile("/zip/backends/gitea.lua") is a
-  -- no-op.  Also captures app._family_strip at the time of the call so tests can
-  -- verify the declarative strip declaration.
-  -- luacheck: push
-  -- luacheck: globals dofile
-  local _real_dofile2 = dofile
-  local _strip_during_dofile
-  dofile = function(path)
-    if path and path:match("^/zip/backends/") then
-      _strip_during_dofile = app._family_strip
-      return
-    end
-    return _real_dofile2(path)
-  end
-  -- luacheck: pop
-
-  -- Happy path: sets base_url from alias default when config.base_url is empty.
-  config.backend = "forgejo"
-  config.base_url = ""
-  load_family_backend("gitea")
-  eq(
-    config.base_url,
-    "https://codeberg.org",
-    "load_family_backend: sets base_url from alias default"
-  )
-
-  -- Explicit base_url is preserved (not overwritten by alias default).
-  config.backend = "forgejo"
-  config.base_url = "https://custom.example.com"
-  load_family_backend("gitea")
-  eq(
-    config.base_url,
-    "https://custom.example.com",
-    "load_family_backend: preserves explicit base_url"
-  )
-
-  -- Strip patterns are declared in app._family_strip before the root backend loads,
-  -- then cleared afterward (gogs strips _package and _actions_).
-  config.backend = "gogs"
-  config.base_url = "https://try.gogs.io"
-  _strip_during_dofile = nil
-  load_family_backend("gitea")
-  ok(
-    _strip_during_dofile ~= nil,
-    "load_family_backend: app._family_strip is set during dofile for gogs"
-  )
-  ok(app._family_strip == nil, "load_family_backend: app._family_strip is cleared after dofile")
-
-  -- The builder reads app._family_strip in b:build() and excludes matching keys.
+  -- b:build(strip) with explicit strip patterns excludes matching REST keys.
   app.backend_impl = {}
-  app._family_strip = _strip_during_dofile -- luacheck: globals app
   local bt = make_backend_builder()
   bt:rest("get_package_info", function() end)
   bt:rest("list_actions_runs", function() end)
   bt:rest("get_repo", function() end)
-  bt:build()
-  app._family_strip = nil -- luacheck: globals app
+  bt:build({ "_package", "_actions_" })
+  ok(app.backend_impl["get_package_info"] == nil, "b:build(strip): strips _package keys")
+  ok(app.backend_impl["list_actions_runs"] == nil, "b:build(strip): strips _actions_ keys")
+  ok(app.backend_impl["get_repo"] ~= nil, "b:build(strip): preserves non-matching keys")
+
+  -- b:build() without strip registers all REST keys.
+  app.backend_impl = {}
+  local bt2 = make_backend_builder()
+  bt2:rest("get_package_info", function() end)
+  bt2:rest("get_repo", function() end)
+  bt2:build()
   ok(
-    app.backend_impl["get_package_info"] == nil,
-    "load_family_backend: builder strips _package keys for gogs"
-  )
-  ok(
-    app.backend_impl["list_actions_runs"] == nil,
-    "load_family_backend: builder strips _actions_ keys for gogs"
-  )
-  ok(
-    app.backend_impl["get_repo"] ~= nil,
-    "load_family_backend: builder preserves non-matching keys for gogs"
+    app.backend_impl["get_package_info"] ~= nil,
+    "b:build(): without strip, all keys are registered"
   )
 
-  dofile = _real_dofile2 -- luacheck: globals dofile
-  config.backend = _saved_backend
-  config.base_url = _saved_base_url
   app.backend_impl = _saved_impl
 end
 


### PR DESCRIPTION
Fixes #208.

Migrates the four gitea family alias backends (codeberg, forgejo, gogs, notabug) from the legacy `load_family_backend` pattern to the direct builder pattern, then deletes the now-unused `load_family_backend` function and `app._family_strip` global wiring from the codebase.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Migrate gitea family alias backends to direct builder pattern <!-- type:spec -->
- [x] Delete load_family_backend and app._family_strip legacy wiring <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->