### PR TITLE
Architecture: replace Confusio's global runtime with an explicit app context and shared provider capabilities (closes #201)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -35,6 +35,12 @@ dofile("/zip/internal/registry.lua")
 -- Build the app context.  Backends register handlers via make_backend_builder():b:build().
 app = make_app(config)
 
+-- Wire the pre-populated graphql_resolvers table (created by graphql_executor.lua with
+-- the built-in Query.node/nodes/rateLimit entries) into app.backend.graphql so both
+-- paths reference the same registry.  Backends writing to graphql_resolvers via b:build()
+-- and the executor reading graphql_resolvers both see the same table as app.backend.graphql.
+app.backend.graphql = graphql_resolvers
+
 if config.backend ~= "" then
   assert(config.backend:match("^[%a][%w_]*$"), "invalid backend name: " .. config.backend)
   dofile("/zip/backends/" .. config.backend .. ".lua")

--- a/.init.lua
+++ b/.init.lua
@@ -35,11 +35,15 @@ dofile("/zip/internal/registry.lua")
 -- Build the app context.  Backends register handlers via make_backend_builder():b:build().
 app = make_app(config)
 
--- Wire the pre-populated graphql_resolvers table (created by graphql_executor.lua with
--- the built-in Query.node/nodes/rateLimit entries) into app.backend.graphql so both
--- paths reference the same registry.  Backends writing to graphql_resolvers via b:build()
--- and the executor reading graphql_resolvers both see the same table as app.backend.graphql.
+-- Wire graphql_resolvers into app.backend.graphql so both paths reference the same
+-- registry.  Backends writing to graphql_resolvers via b:build() and the executor
+-- reading graphql_resolvers both see the same table as app.backend.graphql.
 app.backend.graphql = graphql_resolvers
+
+-- Register the backend-independent built-in resolvers (Query.node, Query.nodes,
+-- Query.rateLimit) through the explicit composition point rather than as side effects
+-- of loading graphql_executor.lua.
+graphql_register_builtin_resolvers()
 
 if config.backend ~= "" then
   assert(config.backend:match("^[%a][%w_]*$"), "invalid backend name: " .. config.backend)

--- a/.init.lua
+++ b/.init.lua
@@ -54,3 +54,7 @@ dofile("/zip/internal/defaults.lua")
 dofile("/zip/internal/router.lua")
 dofile("/zip/internal/catalog.lua")
 dofile("/zip/internal/dispatch.lua")
+
+app.route_match = route_match
+app.path_known = path_known
+OnHttpRequest = make_dispatcher(app)

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -85,6 +85,7 @@ globals = {
   "respond_graphql",
   "graphql_error",
   "graphql_handler",
+  "graphql_register_builtin_resolvers",
   "get_client_mutation_id",
   "estimate_query_cost",
   -- GraphQL translators: internal/graphql_translators.lua

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -86,6 +86,7 @@ globals = {
   "graphql_error",
   "graphql_handler",
   "graphql_register_builtin_resolvers",
+  "make_dispatcher",
   "get_client_mutation_id",
   "estimate_query_cost",
   -- GraphQL translators: internal/graphql_translators.lua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ internal/
   defaults.lua               — default stub handlers collected in the global `defaults` table
   router.lua                 — segment-based radix trie: route_add, route_match, path_known
   catalog.lua                — endpoint_sections table; populates global `endpoints` and registers routes at load time
-  dispatch.lua               — OnHttpRequest: auth gate, route_match, handler dispatch
+  dispatch.lua               — make_dispatcher(app): factory returning the OnHttpRequest closure; auth gate, route_match, handler dispatch
 backends/                    — per-provider implementations; each uses make_backend_builder() and b:build() to register handlers
 docs/
   graphql/                   — GraphQL support design docs (README.md + 01–16 numbered documents)
@@ -149,7 +149,7 @@ When implementing a new endpoint, check the spec for:
    b:build()
    ```
    `make validate-builders` enforces that every backend calls `b:build()` and never assigns
-   directly to `app.backend_impl` or `graphql_resolvers`.
+   directly to `app.backend.rest` or `graphql_resolvers`.
 2. Add mock server as `test/mock-<newbackend>.lua` and build it in the `Makefile` (copy pattern from `mock-gitea.com`).
 3. Add a `test/test-mock-validate.sh`-equivalent for the new backend if its spec differs meaningfully.
 4. Add `<name>` to the `BACKENDS` list in the Makefile. Port numbers are assigned automatically.
@@ -254,14 +254,14 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 | New endpoint | Row in `endpoint_sections` in `internal/catalog.lua` | `make validate-tests`, `make validate-csv` |
 | New endpoint with native support | CSV row updated with `y`/`~`/`n` and matching backend handler | `make validate-claims`, `make validate-csv` |
 | New standalone backend | `backends/<name>.lua` calls `make_backend_builder()` and `b:build()` | `make validate-builders` |
-| New standalone backend | Backend file does NOT assign `app.backend_impl` or `graphql_resolvers` directly | `make validate-builders` |
+| New standalone backend | Backend file does NOT assign `app.backend.rest` or `graphql_resolvers` directly | `make validate-builders` |
 | New standalone backend | Mock + hurl tests cover at least every catalog group | `make validate-tests` |
 | New family-alias backend | Alias declared in `provider_families` in `internal/families.lua` | `make validate-providers` |
 | New family-alias backend | `backends/<alias>.lua` dofiles the root backend | `make validate-providers` |
 | New family-alias backend | Alias listed in `BACKENDS` in the Makefile | `make validate-providers` |
 | New capability module | Module registered via `b:capability()` with at least one function | `make validate-capabilities` |
 
-**Backend registration**: all backends must use `make_backend_builder()` / `b:rest()` / `b:graphql()` / `b:capability()` / `b:build()`. Direct assignment to `app.backend_impl` or `graphql_resolvers` is forbidden. `make validate-builders` enforces this and is wired into `make test`.
+**Backend registration**: all backends must use `make_backend_builder()` / `b:rest()` / `b:graphql()` / `b:capability()` / `b:build()`. Direct assignment to `app.backend.rest` or `graphql_resolvers` is forbidden. `make validate-builders` enforces this and is wired into `make test`.
 
 **Building a capability module**: use `cap_fetch` / `cap_fetch_paged` inside capability operations to own the fetch+error-mapping step. Capability operations return `(data, nil)` on success or `(nil, err)` on failure where `err = { status = N, message = string }` (status 0 = network error). REST handlers call `cap_rest_respond` / `cap_rest_paged` / `cap_rest_created` / `cap_rest_204` to write the HTTP response. GraphQL resolvers just check `if not data then return nil end` and pass data to `graphql_translate_*`.
 
@@ -308,7 +308,7 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
 - **Alias backends set `config.base_url` from `provider_families` and dofile the root backend directly.**
   The root backend reads the alias's strip patterns from `provider_families` in the final
   `b:build(strip)` call, so feature gaps are applied declaratively rather than by post-hoc
-  `app.backend_impl` mutation.
+  `app.backend.rest` mutation.
 - **`strip` patterns are Lua patterns, not exact names.** `"_package"` matches any key
   containing `_package` (e.g. `list_packages`, `get_package`). Keep patterns tight enough
   not to accidentally strip unrelated keys.
@@ -329,11 +329,11 @@ Issues #111–#117 established four authoritative seams. Future endpoint and pro
   k = path depth. Static edges are preferred over param edges at each node, so `/repos/search`
   beats `/repos/{owner}` when both are registered. Captures from `{param}` segments are passed
   as positional arguments to the handler.
-- **Startup-time handler resolution**: `app.backend_impl` is populated once by the backend file
-  via `make_backend_builder()` / `b:build()`; `internal/dispatch.lua` reads it on every request
-  via the `app` context. The backend is fixed for the program's lifetime — no per-request dispatch
-  needed. `dofile` runs in global scope so locals from any internal module are not visible to
-  backend files.
+- **Startup-time handler resolution**: `app.backend.rest` is populated once by the backend file
+  via `make_backend_builder()` / `b:build()`; the `OnHttpRequest` closure returned by
+  `make_dispatcher(app)` reads it on every request via the `app` upvalue. The backend is fixed
+  for the program's lifetime — no per-request dispatch needed. `dofile` runs in global scope so
+  locals from any internal module are not visible to backend files.
 - **`/zip/` prefix for dofile**: Redbean's `dofile` resolves paths on the real filesystem by
   default. Files inside the zip must be accessed as `dofile("/zip/backends/gitea.lua")`.
 - **`SetStatus` clears all previously-set response headers.** Any `SetHeader` call made before
@@ -421,7 +421,7 @@ end
 **Naming conventions:**
 
 - Capability table variable: plain domain name when no conflict (`repos`, `users`, `orgs`); `_cap` suffix when the name would shadow an existing variable (`issues_cap`, `pulls_cap`, `labels_cap`).
-- Register with `b:capability("domain_name", table)`. The domain name is the key in `app.capabilities` and is used for debugging / validation only — it does not affect routing.
+- Register with `b:capability("domain_name", table)`. The domain name is the key in `app.backend.capabilities` and is used for debugging / validation only — it does not affect routing.
 - Operations: `get`, `list`, `create`, `update`, `delete`, `merge` for the primary CRUD surface. Use a `list_` prefix to disambiguate sub-resource lists: `list_repo` (all comments in a repo) vs `list_issue` (comments on one issue).
 
 **`gitea_repo_connection` is intentionally NOT backed by a capability module.** It receives pre-fetched items inline from a single upstream page fetch and applies translation per item. Using `cap.get` per item would make O(n) redundant network calls. Keep `translate_gitea_*` direct for items inside connection translators.
@@ -468,14 +468,22 @@ The eleven `internal/` modules are loaded by `.init.lua` in a fixed order. Each 
 | `translators.lua` | `owner_repo_id`, `translate_repo`, `translate_user`, `translate_migration` | backends |
 | `families.lua` | `provider_families` | backends + Makefile scripts |
 | `registry.lua` | `make_backend_builder` | backends |
-| *(backend loaded here)* | calls `b:build()` to populate `app.backend_impl` and `graphql_resolvers`; Gitea sets `app.allow_anonymous` | dispatch |
+| *(backend loaded here)* | calls `b:build()` to populate `app.backend.rest` and `graphql_resolvers` (aliased to `app.backend.graphql`); Gitea sets `app.allow_anonymous` | dispatch |
 | `defaults.lua` | `defaults` (table of handler functions) | catalog |
 | `router.lua` | `route_add`, `route_match`, `path_known` | catalog, dispatch |
 | `catalog.lua` | `endpoints` (flat array); registers routes via `route_add` | dispatch, scripts |
-| `dispatch.lua` | `OnHttpRequest` | Redbean (entry point) |
+| `dispatch.lua` | `make_dispatcher` | `.init.lua` (called once at startup to install `OnHttpRequest`) |
+
+After `dispatch.lua` is loaded, `.init.lua` completes the composition:
+```lua
+app.route_match = route_match   -- bound router lookup
+app.path_known = path_known     -- bound path-existence check
+OnHttpRequest = make_dispatcher(app)  -- install Redbean entry point
+```
+`graphql_register_builtin_resolvers()` is called before the backend loads to register `Query.node`, `Query.nodes`, and `Query.rateLimit` into `graphql_resolvers`.
 
 **Global surface for backend authors** (backends can call any of these):
-- App context (write target): `app.allow_anonymous`, `app.config` — never assign `app.backend_impl` directly
+- App context (write target): `app.allow_anonymous`, `app.config` — never assign `app.backend.rest`, `app.backend.graphql`, or `app.backend.capabilities` directly
 - Builder (required): `make_backend_builder` — call `b:rest(name, fn)`, `b:graphql(key, fn)`, `b:capability(name, module)`, `b:set_allow_anonymous(v)`, then `b:build()` to commit; see `internal/registry.lua`
 - Response: `set_preamble`, `respond_json`
 - Proxy: all of `proxy.lua`'s exports
@@ -493,7 +501,7 @@ The eleven `internal/` modules are loaded by `.init.lua` in a fixed order. Each 
 
 ### Compatibility CSV and validate-claims
 
-- **`make validate-claims` cross-checks CSV claims against `app.backend_impl`** by running
+- **`make validate-claims` cross-checks CSV claims against `app.backend.rest`** by running
   `scripts/dump-claims.lua` (all backends) and piping the JSON output to
   `scripts/validate-claims.lua`. It is wired into `make test` and must pass before any push.
 - **CONFUSIO_NATIVE exemption**: five handlers (`get_meta`, `get_octocat`, `get_teapot`,
@@ -564,11 +572,11 @@ here so they stay visible without reading all 16 docs:
 
 - **`EncodeJson({data=nil})` silently drops the `data` key** — produces `{"errors":[...]}` instead of `{"data":null,"errors":[...]}`. The `respond_graphql` function works around this by using manual string concatenation: `EncodeJson(nil)` → `"null"`, so `'{"data":' .. data_json .. ...}` is assembled by hand when `data` is nil. Never pass `{data=nil}` to `EncodeJson` in the GraphQL response path.
 - **All GraphQL-facing Lua tables use camelCase keys** (GraphQL field names, e.g. `nameWithOwner`, `totalCount`, `hasNextPage`) — not the REST snake_case field names. The executor plucks fields by doing `parent[field_name]` where `field_name` is the GraphQL name from the query, so the keys must match exactly. This is an exception to the REST translator convention.
-- **`graphql_resolvers` is a global table, not part of `app.backend_impl`**. Backends populate it at load time alongside `app.backend_impl`. The executor reads it on every request. Backends never set `app.backend_impl.graphql_request`; that handler is always `graphql_handler` from `graphql_executor.lua`.
+- **`graphql_resolvers` is a global table aliased to `app.backend.graphql`**. `.init.lua` assigns `app.backend.graphql = graphql_resolvers` after creating the app context, so both names reference the same table. Backends populate it via `b:graphql(key, fn)`; the executor reads it on every request. Backends never assign a `graphql_request` key directly; that handler is always `graphql_handler` from `graphql_executor.lua`.
 - **GraphQL coverage is bounded by REST coverage** — a GraphQL resolver calls the same REST endpoint the REST handler already uses. A backend that doesn't implement a REST endpoint will return `null` for the corresponding GraphQL field, with an error entry if the field is non-null. No backend gains new REST coverage by adding GraphQL.
 - **Node IDs use path-segment encoding**: `encode_node_id("Repository", "owner/repo")` = `EncodeBase64("Repository:owner/repo")`. Path segments (not integer IDs) because REST backends universally support `GET /repos/{owner}/{repo}` but rarely `GET /repositories/{integer_id}`. Stable across restarts; the `node()` resolver constructs the same REST URL any other resolver uses.
 - **Item-level cursors** (`EncodeBase64("page:N:M")`) where N is the 1-based page number and M is the 1-based item index within the page. Each edge carries a unique cursor. `graphql_cursor_to_page` accepts both the old `page:N` format (backward compat) and the new `page:N:M` format, extracting only the page number — so all REST URL construction is unaffected. `startCursor` and `endCursor` in `pageInfo` are the first and last edge cursors respectively; they are distinct for multi-item pages.
-- **`graphql_request = true` must be added to `CONFUSIO_NATIVE`** in `scripts/validate-claims.lua` when the GraphQL catalog entry ships. Without this exemption, any `y` CSV claim for `POST /graphql` will fail `make validate-claims` (the handler is `graphql_handler`, not an `app.backend_impl` key).
+- **`graphql_request = true` must be added to `CONFUSIO_NATIVE`** in `scripts/validate-claims.lua` when the GraphQL catalog entry ships. Without this exemption, any `y` CSV claim for `POST /graphql` will fail `make validate-claims` (the handler is `graphql_handler`, not an `app.backend.rest` key).
 - **`pages.yml` passes args to `gen-matrix.py` in a different order than the Makefile** — the workflow passes `site/compatibility.csv` as the first positional arg (catalog position) while the Makefile pipes catalog via stdin with `-`. This pre-existing discrepancy exists independently of GraphQL; note it before touching either invocation.
 - **`graphql_schema_data.lua` is committed generated output**, not regenerated at build time. The `make generate-schema` target regenerates it from the vendored SDL; `make validate-schema` checks it is up to date. This mirrors how `vendor/github-rest-api-description/` handles the REST OpenAPI spec.
 

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,8 @@ validate-claims: $(REDBEAN_BIN) $(DUMP_CLAIMS_SCRIPT) $(VALIDATE_CLAIMS_SCRIPT) 
 	$(REDBEAN) $(DUMP_CLAIMS_SCRIPT) $(BACKENDS) | $(REDBEAN) $(VALIDATE_CLAIMS_SCRIPT) site/compatibility.csv
 
 validate-builders:
-	@if grep -rn 'app\.backend_impl\s*=' backends/ | grep -v '^Binary'; then \
-	  echo "ERROR: backend(s) still use direct app.backend_impl assignment; use make_backend_builder():b:build() instead" >&2; \
+	@if grep -rn 'app\.backend\.rest\s*=' backends/ | grep -v '^Binary'; then \
+	  echo "ERROR: backend(s) still use direct app.backend.rest assignment; use make_backend_builder():b:build() instead" >&2; \
 	  exit 1; \
 	fi
 	@if grep -rn 'graphql_resolvers\[' backends/ | grep -v '^Binary'; then \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,37 +1,36 @@
-# Target Architecture and Migration Invariants
+# Architecture: App Context and Backend Composition
 
-## Why this document exists
+## Status
 
-Issues #203–#208 will refactor confusio's runtime from the current global/load-order model
-to an explicit composition root with a proper backend registry and shared provider
-capability modules.  Before any file is moved or any global is deleted, this document
-records the target shape so every subsequent change can be judged against the same
-destination.
+This document was written before issues #203–#208 (merged as #211–#218) as a migration
+guide.  Issues #202–#209 are now closed; PR #221 completed the remaining gaps
+(`app.backend` nesting, `make_dispatcher` closure, `graphql_register_builtin_resolvers`
+explicit composition).  The migration is **complete**.  The "pre-migration state" section
+below is preserved for historical context.
 
-## What the current architecture looks like
+## Pre-migration state (historical)
 
-`.init.lua` runs a fixed sequence of `dofile` calls.  Each call mutates the global
-environment:
+Before #203, `.init.lua` ran a fixed sequence of `dofile` calls.  Each call mutated the
+global environment:
 
-- Core modules populate helpers (`respond_json`, `proxy_json`, `make_backend_transport`,
+- Core modules populated helpers (`respond_json`, `proxy_json`, `make_backend_transport`,
   `graphql_resolvers`, …).
-- `backend_impl = {}` and `backend_allow_anonymous = true` are initialized as globals.
-- The backend file (e.g. `backends/gitea.lua`) is `dofile`'d; it reads and mutates
-  `config.base_url`, assigns handler functions into `backend_impl`, assigns resolver
-  functions into `graphql_resolvers`, and may set `backend_allow_anonymous = false` after
-  an HTTP probe.
-- For family-alias backends, `load_family_backend(root)` `dofile`s the root backend file
-  and then iterates over `backend_impl` to delete keys matching the alias's `strip`
+- `backend_impl = {}` and `backend_allow_anonymous = true` were initialized as globals.
+- The backend file (e.g. `backends/gitea.lua`) was `dofile`'d; it read and mutated
+  `config.base_url`, assigned handler functions into `backend_impl`, assigned resolver
+  functions into `graphql_resolvers`, and may have set `backend_allow_anonymous = false`
+  after an HTTP probe.
+- For family-alias backends, `load_family_backend(root)` `dofile`'d the root backend file
+  and then iterated over `backend_impl` to delete keys matching the alias's `strip`
   patterns.
-- `dispatch.lua` defines `OnHttpRequest()` which reads `backend_allow_anonymous`,
+- `dispatch.lua` defined `OnHttpRequest()` which read `backend_allow_anonymous`,
   `backend_impl`, and the router globals on every request.
 
-Ownership is implicit.  The backend file is the only place `backend_impl` is written, but
-there is no enforcement.  Any module loaded in the right order can read or mutate any
-global.  Family alias inheritance works by running the root backend's entire side-effecting
+Ownership was implicit.  Any module loaded in the right order could read or mutate any
+global.  Family alias inheritance worked by running the root backend's entire side-effecting
 load and undoing some of it afterwards.
 
-## Target runtime objects
+## Current runtime objects
 
 ### `app` — composition root
 
@@ -45,12 +44,12 @@ per-application state lives in `app`; no other globals are written after startup
 | `config` | table | `{ backend, base_url }` — frozen after construction |
 | `backend` | table | the backend runtime object (see below) |
 | `allow_anonymous` | boolean | whether unauthenticated requests are accepted |
-| `route_match` | function | bound router lookup |
-| `path_known` | function | bound router path-existence check |
+| `route_match` | function | bound router lookup — set by `.init.lua` after loading `router.lua` |
+| `path_known` | function | bound router path-existence check — set by `.init.lua` after loading `router.lua` |
 
 **Forbidden to mutate:** any field of `app` after `.init.lua` returns.  Request handlers
-read `app`; they never write it.  `OnHttpRequest` receives `app` as a parameter (or via
-an upvalue in the closure returned by a dispatch factory) — it does not reach for a global.
+read `app`; they never write it.  `OnHttpRequest` is the closure returned by
+`make_dispatcher(app)` — it holds `app` as an upvalue and does not reach for a global.
 
 ### `backend` — backend runtime object
 
@@ -111,7 +110,7 @@ other capabilities, and return `nil, error_string` on failure.
 
 ## Startup flow
 
-The target startup sequence is explicit and linear.  No module has silent startup-time
+The startup sequence is explicit and linear.  No module has silent startup-time
 side effects on globals.
 
 ```
@@ -120,82 +119,70 @@ side effects on globals.
       — these export only functions; they do not mutate any app-level state
 3.  Load provider_families (families.lua)
       — read-only metadata table; not app state
-4.  Call backend_builder(config) → backend
-      — pure function: returns backend object, writes no globals
-5.  Assemble app = { config, backend, allow_anonymous, … }
-6.  Load defaults.lua, router.lua, catalog.lua (register routes)
-      — these use app.backend.rest to resolve handler names
-7.  Bind OnHttpRequest as a closure over app
+4.  Construct app = make_app(config)
+      — creates { config, backend={rest={},graphql={},capabilities={}}, allow_anonymous=true }
+5.  Wire graphql_resolvers alias: app.backend.graphql = graphql_resolvers
+6.  Call graphql_register_builtin_resolvers()
+      — registers Query.node, Query.nodes, Query.rateLimit into graphql_resolvers
+7.  Load backend file (e.g. backends/gitea.lua) via make_backend_builder():b:build()
+      — populates app.backend.rest, graphql_resolvers, app.backend.capabilities
+      — Gitea probes the upstream and may set app.allow_anonymous = false
+8.  Load defaults.lua, router.lua, catalog.lua (register routes)
+9.  Load dispatch.lua (exports make_dispatcher)
+10. Bind router lookups and install closure:
+      app.route_match = route_match
+      app.path_known = path_known
+      OnHttpRequest = make_dispatcher(app)
 ```
 
-Steps 1–5 happen once at process start.  Steps 6–7 complete the wiring.  After step 7 the
+Steps 1–9 happen once at process start.  Step 10 completes the wiring.  After step 10 the
 global environment is frozen for the lifetime of the process; `OnHttpRequest` reads only
-the `app` closure and the router globals.
+the `app` upvalue — no ambient globals.
 
 ## Family alias inheritance
 
-Today `load_family_backend` works by running the root backend file and then mutating the
-resulting `backend_impl` to delete unsupported keys.  The target replaces this with a
-composing builder.
+Alias backends (e.g. `codeberg`, `forgejo`, `notabug`) share an implementation with their
+root backend (e.g. `gitea`) through the following pattern:
 
-**Target model:**
+1. `provider_families` in `internal/families.lua` declares the alias and its `strip`
+   patterns and `default_url`.  This is the single authoritative source of alias metadata.
+2. `backends/<alias>.lua` sets `config.base_url` from `provider_families` (when not
+   supplied by the user) and then `dofile`s the root backend file.
+3. The root backend calls `make_backend_builder()`, registers handlers, and calls
+   `b:build(strip)` where `strip` comes from `provider_families[config.backend]`.  Keys
+   matching any strip pattern are omitted from `app.backend.rest` — feature gaps are
+   applied declaratively at build time rather than by post-hoc mutation.
+4. No global is mutated after `b:build()` returns.
 
-1. Each root backend exposes a `build(config, overrides) → backend` builder function.
-2. An alias backend calls `build_family_alias(root_name, config, strip_patterns)`:
-   - Calls `root_builder(config)` to get the root backend table.
-   - Copies it to a new table (shallow clone of `rest`, `graphql`, `capabilities`).
-   - Iterates the alias's `strip` patterns and deletes matching keys from the copy.
-   - Sets `config.base_url` from the alias's `default_url` when none was supplied.
-   - Returns the modified copy.
-3. No global is mutated.  No root backend file is `dofile`'d as a side effect.
+## Migration invariants (completed)
 
-`provider_families` in `internal/families.lua` remains the single authoritative source of
-alias metadata.  Only the loading mechanism changes.
-
-## Migration invariants
-
-These rules apply to every commit in #203–#208.  Any change that violates them is out of
-scope for the refactor and must be handled separately.
+These rules governed every commit in #203–#209.
 
 1. **No externally visible behavior changes.**  Request/response semantics, status codes,
-   header names, and JSON field names must be identical before and after each commit.  The
-   full test suite (`make -j test`) must pass at every commit.
+   header names, and JSON field names were identical before and after each commit.
 
-2. **No flag day.**  The repository must remain buildable and shippable throughout the
-   migration.  The old global path and the new explicit path may coexist during the
-   transition; backends that have not yet migrated continue to use the legacy wiring.
+2. **No flag day.**  The repository remained buildable and shippable throughout the
+   migration.
 
-3. **Migration order: Gitea → GitLab → remaining backends.**  Gitea is first because it
-   is the most complete backend and has the best test coverage.  GitLab is second because
-   it is the second largest.  Family aliases (forgejo, codeberg, gogs, notabug) migrate
-   with their root (Gitea).  Remaining standalone backends migrate together in #208.
+3. **Migration order: Gitea → GitLab → remaining backends** (#205 → #206 → #207–#208).
 
-4. **REST and GraphQL converge on the same capability layer.**  By the end of #208 there
-   must be no logic that is duplicated between a REST handler and a GraphQL resolver for
-   the same provider.  Each piece of provider-domain knowledge lives in one capability
-   function; the REST and GraphQL layers are thin adapters over it.
+4. **REST and GraphQL converge on the same capability layer.**  Each piece of
+   provider-domain knowledge lives in one capability function; REST and GraphQL layers
+   are thin adapters over it.
 
-5. **Legacy global wiring is deleted, not deprecated.**  Once all backends have migrated
-   to the new builder pattern, the globals `backend_impl`, `graphql_resolvers`, and
-   `backend_allow_anonymous` are deleted from `.init.lua` and any module that references
-   them.  There is no long-term compatibility shim.
+5. **Legacy global wiring is deleted, not deprecated.**  `backend_impl`,
+   `backend_allow_anonymous`, and `load_family_backend` are gone.  `graphql_resolvers`
+   is retained as an alias for `app.backend.graphql` (same table) to avoid breaking
+   the executor's existing reads.
 
-## Legacy seams to delete
+## Legacy seams — all eliminated
 
-These four seams are the concrete targets.  Every step in #203–#208 moves the codebase
-closer to eliminating them.  They must all be gone by the end of #208.
-
-| Seam | Where it lives today | Replaced by |
-|------|---------------------|-------------|
-| global `backend_impl` | `.init.lua` + every backend file | `app.backend.rest` |
-| global `graphql_resolvers` | `internal/graphql_executor.lua` + every backend file | `app.backend.graphql` |
-| global `backend_allow_anonymous` | `.init.lua` + gitea/gitea-family backends | `app.allow_anonymous` (set from `backend.allow_anonymous` during composition) |
-| startup by hidden load order | `.init.lua` `dofile` sequence | explicit `backend_builder(config)` call in `.init.lua` step 4 |
-
-The four seams are listed here in dependency order.  Eliminating `backend_impl` and
-`graphql_resolvers` is the core of #203–#207.  `backend_allow_anonymous` and the load-order
-seam are cleaned up as part of the Gitea migration (#205) and the composition root
-introduction (#203) respectively.
+| Seam | Replaced by | Closed by |
+|------|-------------|-----------|
+| global `backend_impl` | `app.backend.rest` | #211–#218 |
+| global `backend_allow_anonymous` | `app.allow_anonymous` | #212 |
+| startup by hidden load order | explicit `make_app` + `make_dispatcher(app)` | #212, #221 |
+| built-in resolver assignment at module load | `graphql_register_builtin_resolvers()` | #221 |
 
 ## Relationship to the GraphQL design
 

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -12,7 +12,7 @@
 -- group_name matches the test file suffix (<backend>-<group>.hurl) and the
 -- compatibility matrix sections in site/compatibility.csv.
 --
--- Backends override handlers by setting app.backend_impl.<name>. Parametric
+-- Backends override handlers by setting app.backend.rest.<name>. Parametric
 -- captures from {param} segments are passed positionally to the handler.
 -- ---------------------------------------------------------------------------
 

--- a/internal/context.lua
+++ b/internal/context.lua
@@ -5,19 +5,27 @@
 --
 -- Fields:
 --   config          — backend config table (same object as the global `config`)
---   backend_impl    — handler registry set by the backend at startup
---   capabilities    — provider capability modules; keyed by domain name (e.g.
---                     "repos", "users", "issues"); each value is a table of
---                     named operations (e.g. { get = fn, list = fn, ... }).
---                     Both REST handlers and GraphQL resolvers call into these
---                     to avoid duplicating fetch + translate + error logic.
+--   backend         — backend runtime object:
+--     backend.rest          — REST handler registry; keyed by handler name
+--                             (e.g. "get_repo"); set by b:build() via make_backend_builder
+--     backend.graphql       — GraphQL resolver registry; keyed by resolver key
+--                             (e.g. "Query.viewer", "node.Repository");
+--                             wired to the graphql_resolvers global in .init.lua
+--     backend.capabilities  — provider capability modules; keyed by domain name
+--                             (e.g. "repos", "users", "issues"); each value is a
+--                             table of named operations (e.g. { get, list, ... }).
+--                             Both REST handlers and GraphQL resolvers call into
+--                             these to avoid duplicating fetch + translate + error logic.
 --   allow_anonymous — auth-gate flag; true means unauthenticated requests are allowed
 
 function make_app(cfg) -- luacheck: globals make_app
   return {
     config = cfg,
-    backend_impl = {},
-    capabilities = {},
+    backend = {
+      rest = {},
+      graphql = {},
+      capabilities = {},
+    },
     allow_anonymous = true,
   }
 end

--- a/internal/dispatch.lua
+++ b/internal/dispatch.lua
@@ -11,7 +11,7 @@ function OnHttpRequest()
   end
   local ep, caps, default_fn = route_match(GetMethod(), GetPath())
   if ep then
-    local fn = app.backend_impl[ep] or default_fn
+    local fn = app.backend.rest[ep] or default_fn
     if fn then
       fn(table.unpack(caps))
     else

--- a/internal/dispatch.lua
+++ b/internal/dispatch.lua
@@ -1,25 +1,28 @@
 -- HTTP request dispatcher.
 --
--- Defines OnHttpRequest, the Redbean entry point for every incoming request.
+-- Exports make_dispatcher(a), a factory that returns the OnHttpRequest closure
+-- bound over the app context a.  The closure reads auth policy, backend handlers,
+-- and router lookups exclusively from a — no ambient globals at dispatch time.
 -- Requires all internal modules to be loaded first (http, proxy, router, catalog).
--- Reads auth policy and backend handlers from the app context (see internal/context.lua).
 
-function OnHttpRequest()
-  if not app.allow_anonymous and not GetHeader("Authorization") then
-    respond_json(401, { message = "This instance requires authentication." })
-    return
-  end
-  local ep, caps, default_fn = route_match(GetMethod(), GetPath())
-  if ep then
-    local fn = app.backend.rest[ep] or default_fn
-    if fn then
-      fn(table.unpack(caps))
+function make_dispatcher(a) -- luacheck: globals make_dispatcher
+  return function()
+    if not a.allow_anonymous and not GetHeader("Authorization") then
+      respond_json(401, { message = "This instance requires authentication." })
+      return
+    end
+    local ep, caps, default_fn = a.route_match(GetMethod(), GetPath())
+    if ep then
+      local fn = a.backend.rest[ep] or default_fn
+      if fn then
+        fn(table.unpack(caps))
+      else
+        respond_json(404, { message = "Not Found" })
+      end
+    elseif a.path_known(GetPath()) then
+      respond_json(405, { message = "Method Not Allowed" })
     else
       respond_json(404, { message = "Not Found" })
     end
-  elseif path_known(GetPath()) then
-    respond_json(405, { message = "Method Not Allowed" })
-  else
-    respond_json(404, { message = "Not Found" })
   end
 end

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -6,6 +6,8 @@
 --
 -- Globals exported:
 --   graphql_resolvers              — table; backends populate at load time (aliased as app.backend.graphql)
+--   graphql_register_builtin_resolvers() — registers the three backend-independent built-ins;
+--                                          called from .init.lua after app.backend.graphql is wired
 --   graphql_handler()              — HTTP handler for POST /graphql; registered in catalog
 --   respond_graphql(data, errs)    — null-safe GraphQL response writer
 --   graphql_error(ctx, ...)        — error-recording helper called by resolvers
@@ -614,8 +616,12 @@ end
 -- These resolvers live in the executor, not in backends, because they only
 -- decode the node ID and dispatch to a "node.TypeName" sub-resolver.  The
 -- sub-resolvers are backend-specific and registered by each backend file.
+--
+-- The functions are defined as locals here (so they close over private helpers
+-- like append_error) and registered via graphql_register_builtin_resolvers(),
+-- which .init.lua calls after app.backend.graphql is wired up.
 
-graphql_resolvers["Query.node"] = function(_parent, args, ctx) -- luacheck: globals graphql_resolvers
+local function builtin_node_resolver(_parent, args, ctx)
   local node_id = args.id
   if not node_id then
     append_error(ctx, "node requires an id argument")
@@ -639,7 +645,7 @@ graphql_resolvers["Query.node"] = function(_parent, args, ctx) -- luacheck: glob
   return result
 end
 
-graphql_resolvers["Query.nodes"] = function(_parent, args, ctx)
+local function builtin_nodes_resolver(_parent, args, ctx)
   local ids = args.ids
   if not ids or type(ids) ~= "table" then
     append_error(ctx, "nodes requires an ids argument")
@@ -749,7 +755,7 @@ end
 -- response so that clients polling rateLimit { cost remaining resetAt } work
 -- without errors.  ctx.rate_cost is populated by estimate_query_cost before
 -- execution runs.
-graphql_resolvers["Query.rateLimit"] = function(_parent, _args, ctx)
+local function builtin_rate_limit_resolver(_parent, _args, ctx)
   local limit = 999999
   local reset = os.time() + 3600
   return {
@@ -760,6 +766,20 @@ graphql_resolvers["Query.rateLimit"] = function(_parent, _args, ctx)
     nodeCount = 0,
     resetAt = os.date("!%Y-%m-%dT%H:%M:%SZ", reset),
   }
+end
+
+-- ---------------------------------------------------------------------------
+-- graphql_register_builtin_resolvers
+-- ---------------------------------------------------------------------------
+
+-- Register the three backend-independent built-in resolvers into graphql_resolvers.
+-- Must be called from .init.lua after app.backend.graphql = graphql_resolvers is
+-- set up, so registration goes through the same live table that b:build() writes to.
+-- This keeps module load-time side effects out of the global registry.
+function graphql_register_builtin_resolvers() -- luacheck: globals graphql_register_builtin_resolvers
+  graphql_resolvers["Query.node"] = builtin_node_resolver
+  graphql_resolvers["Query.nodes"] = builtin_nodes_resolver
+  graphql_resolvers["Query.rateLimit"] = builtin_rate_limit_resolver
 end
 
 -- ---------------------------------------------------------------------------

--- a/internal/graphql_executor.lua
+++ b/internal/graphql_executor.lua
@@ -5,7 +5,7 @@
 --           graphql_schema_* (internal/graphql_schema.lua).
 --
 -- Globals exported:
---   graphql_resolvers              — table; backends populate at load time alongside app.backend_impl
+--   graphql_resolvers              — table; backends populate at load time (aliased as app.backend.graphql)
 --   graphql_handler()              — HTTP handler for POST /graphql; registered in catalog
 --   respond_graphql(data, errs)    — null-safe GraphQL response writer
 --   graphql_error(ctx, ...)        — error-recording helper called by resolvers
@@ -17,7 +17,7 @@
 -- Resolver registry
 -- ---------------------------------------------------------------------------
 
--- Backends populate graphql_resolvers at load time alongside app.backend_impl.
+-- Backends populate graphql_resolvers at load time (aliased as app.backend.graphql in .init.lua).
 -- Keys are "TypeName.fieldName" strings (e.g. "Query.repository", "Repository.issues").
 graphql_resolvers = {} -- luacheck: globals graphql_resolvers
 
@@ -929,8 +929,8 @@ local function encode_result(result)
 end
 
 -- graphql_handler is registered in the catalog as the fixed handler for
--- POST /graphql.  Backends do NOT override this via app.backend_impl; they only
--- populate graphql_resolvers.
+-- POST /graphql.  Backends do NOT override this via app.backend.rest; they only
+-- populate graphql_resolvers (aliased as app.backend.graphql).
 function graphql_handler() -- luacheck: globals graphql_handler
   -- Step 1: decode request body.
   local raw = GetBody() or ""

--- a/internal/registry.lua
+++ b/internal/registry.lua
@@ -8,11 +8,11 @@
 --
 -- Capability modules are the shared domain layer consumed by both REST handlers and
 -- GraphQL resolvers.  Each module is a table of named operations (e.g.
--- { get = fn, list = fn, update = fn, delete = fn }).  They live in app.capabilities
+-- { get = fn, list = fn, update = fn, delete = fn }).  They live in app.backend.capabilities
 -- keyed by domain name (e.g. "repos", "users", "issues").  Strip patterns do NOT
 -- apply to capabilities — they are domain-level, not REST surface-level.
 --
--- Direct assignment to app.backend_impl or graphql_resolvers is forbidden;
+-- Direct assignment to app.backend.rest or graphql_resolvers is forbidden;
 -- make validate-builders enforces this at CI time.
 --
 -- Globals exported:
@@ -73,10 +73,10 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
   --        capabilities.
   --
   -- After build() returns:
-  --   app.backend_impl[name]   = fn     for each registered REST handler (unless stripped)
-  --   graphql_resolvers[key]   = fn     for each registered GraphQL resolver
-  --   app.capabilities[name]   = module for each registered capability module
-  --   app.allow_anonymous      = v      only when set_allow_anonymous was called
+  --   app.backend.rest[name]         = fn     for each registered REST handler (unless stripped)
+  --   graphql_resolvers[key]         = fn     for each registered GraphQL resolver
+  --   app.backend.capabilities[name] = module for each registered capability module
+  --   app.allow_anonymous            = v      only when set_allow_anonymous was called
   function b:build(strip)
     for name, fn in pairs(self._rest) do
       local skip = false
@@ -89,14 +89,14 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
         end
       end
       if not skip then
-        app.backend_impl[name] = fn
+        app.backend.rest[name] = fn
       end
     end
     for key, fn in pairs(self._graphql) do
       graphql_resolvers[key] = fn
     end
     for name, module in pairs(self._capabilities) do
-      app.capabilities[name] = module
+      app.backend.capabilities[name] = module
     end
     if self._anonymous ~= nil then
       app.allow_anonymous = self._anonymous

--- a/scripts/dump-capabilities.lua
+++ b/scripts/dump-capabilities.lua
@@ -46,14 +46,14 @@ local backend_parts = {}
 
 for _, name in ipairs(cli_backends) do
   config = { backend = name, base_url = "" } -- luacheck: globals config
-  app.backend_impl = {} -- luacheck: globals app
-  app.capabilities = {}
+  app.backend = { rest = {}, graphql = {}, capabilities = {} } -- luacheck: globals app
+  graphql_resolvers = app.backend.graphql -- luacheck: globals graphql_resolvers
   Fetch = noop_fetch -- luacheck: globals Fetch
   dofile("/zip/backends/" .. name .. ".lua")
   Fetch = _real_fetch -- luacheck: globals Fetch
 
   local domain_parts = {}
-  for domain, module in pairs(app.capabilities) do
+  for domain, module in pairs(app.backend.capabilities) do
     if type(module) ~= "table" then
       errors[#errors + 1] = name .. ": capability '" .. domain .. "' is not a table"
     else

--- a/scripts/dump-claims.lua
+++ b/scripts/dump-claims.lua
@@ -1,5 +1,5 @@
 -- Export endpoint catalog + per-backend handler sets as JSON.
--- Used by validate-claims.lua to check CSV support claims against app.backend_impl.
+-- Used by validate-claims.lua to check CSV support claims against app.backend.rest.
 --
 -- Usage: ./redbean.com -i scripts/dump-claims.lua <backend1> [backend2 ...]
 --
@@ -61,13 +61,14 @@ end
 local backend_parts = {}
 for _, name in ipairs(cli_backends) do
   config = { backend = name, base_url = "" } -- luacheck: globals config
-  app.backend_impl = {} -- luacheck: globals app
+  app.backend = { rest = {}, graphql = {}, capabilities = {} } -- luacheck: globals app
+  graphql_resolvers = app.backend.graphql -- luacheck: globals graphql_resolvers
   Fetch = noop_fetch -- luacheck: globals Fetch
   dofile("/zip/backends/" .. name .. ".lua")
   Fetch = _real_fetch -- luacheck: globals Fetch
 
   local handlers = {}
-  for k in pairs(app.backend_impl) do -- luacheck: globals app
+  for k in pairs(app.backend.rest) do -- luacheck: globals app
     handlers[#handlers + 1] = k
   end
   table.sort(handlers)

--- a/scripts/validate-claims.lua
+++ b/scripts/validate-claims.lua
@@ -1,12 +1,12 @@
--- Validate that CSV support claims agree with actual backend_impl handler presence.
+-- Validate that CSV support claims agree with actual backend REST handler presence.
 --
 -- Rules checked for each (backend, endpoint) cell in the CSV:
---   y  — backend_impl must contain a handler for this endpoint, UNLESS the handler is
+--   y  — app.backend.rest must contain a handler for this endpoint, UNLESS the handler is
 --          confusio-native (a complete response synthesized by confusio itself, not the
 --          backend API — e.g. GET /meta, GET /zen).  Confusio-native handlers return
 --          real responses for every backend and are exempted from the handler-presence
 --          requirement.
---   n  — backend_impl must NOT contain a handler for this endpoint
+--   n  — app.backend.rest must NOT contain a handler for this endpoint
 --          (backend silently implements something the CSV calls unsupported → error)
 --   ~* — not checked (partial support may or may not have a dedicated handler)
 --
@@ -23,7 +23,7 @@
 
 -- Handlers whose catalog defaults are complete confusio-synthesised responses.
 -- These work for every backend without a per-backend handler, so a y claim is
--- accurate even when backend_impl has no entry for them.
+-- accurate even when app.backend.rest has no entry for them.
 local CONFUSIO_NATIVE = {
   get_meta = true,
   get_octocat = true,
@@ -31,7 +31,7 @@ local CONFUSIO_NATIVE = {
   get_versions = true,
   get_zen = true,
   -- graphql_handler is the fixed handler for POST /graphql across all backends;
-  -- backends populate graphql_resolvers rather than backend_impl.graphql_request.
+  -- backends populate graphql_resolvers rather than app.backend.rest.graphql_request.
   graphql_request = true,
 }
 
@@ -135,7 +135,7 @@ for li = 2, #lines do
               .. provider
               .. " claims 'y' for "
               .. ep
-              .. " but backend_impl has no handler '"
+              .. " but app.backend.rest has no handler '"
               .. handler
               .. "'"
           elseif claim == "n" and has_handler then
@@ -143,7 +143,7 @@ for li = 2, #lines do
               .. provider
               .. " claims 'n' for "
               .. ep
-              .. " but backend_impl defines handler '"
+              .. " but app.backend.rest defines handler '"
               .. handler
               .. "'"
           end

--- a/test/unit-graphql.lua
+++ b/test/unit-graphql.lua
@@ -50,6 +50,11 @@ dofile("internal/graphql_translators.lua")
 
 dofile = _real_dofile -- luacheck: globals dofile
 
+-- Register the built-in resolvers (Query.node, Query.nodes, Query.rateLimit).
+-- In production this is done by .init.lua; here we call it explicitly so that
+-- tests which access these resolvers via graphql_resolvers["Query.*"] work.
+graphql_register_builtin_resolvers() -- luacheck: globals graphql_register_builtin_resolvers
+
 -- ============================================================
 -- Assertion helpers (globals so sub-files share state)
 -- ============================================================

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1585,31 +1585,31 @@ eq(_last_status, 501, "OnHttpRequest: GET /feeds → 501 (activity not implement
 -- ============================================================
 
 do
-  local _saved_impl = app.backend_impl
+  local _saved_rest = app.backend.rest
 
   -- b:build(strip) with explicit strip patterns excludes matching REST keys.
-  app.backend_impl = {}
+  app.backend.rest = {}
   local bt = make_backend_builder()
   bt:rest("get_package_info", function() end)
   bt:rest("list_actions_runs", function() end)
   bt:rest("get_repo", function() end)
   bt:build({ "_package", "_actions_" })
-  ok(app.backend_impl["get_package_info"] == nil, "b:build(strip): strips _package keys")
-  ok(app.backend_impl["list_actions_runs"] == nil, "b:build(strip): strips _actions_ keys")
-  ok(app.backend_impl["get_repo"] ~= nil, "b:build(strip): preserves non-matching keys")
+  ok(app.backend.rest["get_package_info"] == nil, "b:build(strip): strips _package keys")
+  ok(app.backend.rest["list_actions_runs"] == nil, "b:build(strip): strips _actions_ keys")
+  ok(app.backend.rest["get_repo"] ~= nil, "b:build(strip): preserves non-matching keys")
 
   -- b:build() without strip registers all REST keys.
-  app.backend_impl = {}
+  app.backend.rest = {}
   local bt2 = make_backend_builder()
   bt2:rest("get_package_info", function() end)
   bt2:rest("get_repo", function() end)
   bt2:build()
   ok(
-    app.backend_impl["get_package_info"] ~= nil,
+    app.backend.rest["get_package_info"] ~= nil,
     "b:build(): without strip, all keys are registered"
   )
 
-  app.backend_impl = _saved_impl
+  app.backend.rest = _saved_rest
 end
 
 -- ============================================================
@@ -1618,7 +1618,10 @@ end
 
 ok(type(app) == "table", "app: is a table")
 ok(app.config == config, "app.config: same object as global config")
-ok(type(app.backend_impl) == "table", "app.backend_impl: is a table")
+ok(type(app.backend) == "table", "app.backend: is a table")
+ok(type(app.backend.rest) == "table", "app.backend.rest: is a table")
+ok(type(app.backend.graphql) == "table", "app.backend.graphql: is a table")
+ok(type(app.backend.capabilities) == "table", "app.backend.capabilities: is a table")
 ok(type(app.allow_anonymous) == "boolean", "app.allow_anonymous: is a boolean")
 ok(app.allow_anonymous == true, "app.allow_anonymous: default true (no backend loaded)")
 
@@ -1627,8 +1630,10 @@ do
   local test_cfg = { backend = "test", base_url = "https://test.example.com" }
   local test_app = make_app(test_cfg)
   ok(test_app.config == test_cfg, "make_app: config is the supplied table")
-  ok(type(test_app.backend_impl) == "table", "make_app: backend_impl is a table")
-  ok(type(test_app.capabilities) == "table", "make_app: capabilities is a table")
+  ok(type(test_app.backend) == "table", "make_app: backend is a table")
+  ok(type(test_app.backend.rest) == "table", "make_app: backend.rest is a table")
+  ok(type(test_app.backend.graphql) == "table", "make_app: backend.graphql is a table")
+  ok(type(test_app.backend.capabilities) == "table", "make_app: backend.capabilities is a table")
   ok(test_app.allow_anonymous == true, "make_app: allow_anonymous defaults to true")
   ok(test_app ~= app, "make_app: returns a new independent table each call")
 end
@@ -1638,14 +1643,14 @@ end
 -- ============================================================
 
 do
-  local saved_impl = app.backend_impl
-  local saved_capabilities = app.capabilities
+  local saved_rest = app.backend.rest
+  local saved_capabilities = app.backend.capabilities
   local saved_resolvers = graphql_resolvers -- luacheck: globals graphql_resolvers
   local saved_anon = app.allow_anonymous
 
   local function restore()
-    app.backend_impl = saved_impl
-    app.capabilities = saved_capabilities
+    app.backend.rest = saved_rest
+    app.backend.capabilities = saved_capabilities
     graphql_resolvers = saved_resolvers -- luacheck: globals graphql_resolvers
     app.allow_anonymous = saved_anon
   end
@@ -1669,9 +1674,9 @@ do
   ok(b2:capability("repos", {}) == b2, "builder:capability: returns self")
   ok(b2:set_allow_anonymous(true) == b2, "builder:set_allow_anonymous: returns self")
 
-  -- build() populates app.backend_impl, graphql_resolvers, and app.capabilities
-  app.backend_impl = {}
-  app.capabilities = {}
+  -- build() populates app.backend.rest, graphql_resolvers, and app.backend.capabilities
+  app.backend.rest = {}
+  app.backend.capabilities = {}
   graphql_resolvers = {} -- luacheck: globals graphql_resolvers
   app.allow_anonymous = true
 
@@ -1685,14 +1690,14 @@ do
   b3:set_allow_anonymous(false)
   b3:build()
 
-  eq(app.backend_impl["get_repo"], get_fn, "builder:build: registers REST handler")
+  eq(app.backend.rest["get_repo"], get_fn, "builder:build: registers REST handler")
   eq(graphql_resolvers["Query.viewer"], gql_fn, "builder:build: registers GraphQL resolver") -- luacheck: globals graphql_resolvers
-  eq(app.capabilities["repos"], cap_repos, "builder:build: registers capability module")
+  eq(app.backend.capabilities["repos"], cap_repos, "builder:build: registers capability module")
   eq(app.allow_anonymous, false, "builder:build: sets allow_anonymous")
 
   -- build() without set_allow_anonymous leaves allow_anonymous unchanged
-  app.backend_impl = {}
-  app.capabilities = {}
+  app.backend.rest = {}
+  app.backend.capabilities = {}
   app.allow_anonymous = true
   local b4 = make_backend_builder()
   b4:rest("get_root", function() end)
@@ -1703,8 +1708,8 @@ do
   )
 
   -- build(strip) excludes REST keys matching any pattern but NOT capabilities
-  app.backend_impl = {}
-  app.capabilities = {}
+  app.backend.rest = {}
+  app.backend.capabilities = {}
   local cap_issues = { get = function() end }
   local b5 = make_backend_builder()
   b5:rest("get_repo", function() end)
@@ -1712,14 +1717,18 @@ do
   b5:rest("list_actions_runs", function() end)
   b5:capability("issues", cap_issues)
   b5:build({ "_package", "_actions_" })
-  ok(app.backend_impl["get_repo"] ~= nil, "builder:build(strip): keeps non-matching key")
-  ok(app.backend_impl["get_package_info"] == nil, "builder:build(strip): strips _package key")
-  ok(app.backend_impl["list_actions_runs"] == nil, "builder:build(strip): strips _actions_ key")
-  eq(app.capabilities["issues"], cap_issues, "builder:build(strip): capabilities are not stripped")
+  ok(app.backend.rest["get_repo"] ~= nil, "builder:build(strip): keeps non-matching key")
+  ok(app.backend.rest["get_package_info"] == nil, "builder:build(strip): strips _package key")
+  ok(app.backend.rest["list_actions_runs"] == nil, "builder:build(strip): strips _actions_ key")
+  eq(
+    app.backend.capabilities["issues"],
+    cap_issues,
+    "builder:build(strip): capabilities are not stripped"
+  )
 
   -- two builders are independent and do not share state
-  app.backend_impl = {}
-  app.capabilities = {}
+  app.backend.rest = {}
+  app.backend.capabilities = {}
   local ba = make_backend_builder()
   ba:rest("get_foo", function() end)
   ba:capability("repos", { get = function() end })
@@ -1727,23 +1736,23 @@ do
   bb:rest("get_bar", function() end)
   bb:capability("users", { get = function() end })
   ba:build()
-  ok(app.backend_impl["get_foo"] ~= nil, "make_backend_builder: builders are independent (a built)")
+  ok(app.backend.rest["get_foo"] ~= nil, "make_backend_builder: builders are independent (a built)")
   ok(
-    app.backend_impl["get_bar"] == nil,
+    app.backend.rest["get_bar"] == nil,
     "make_backend_builder: builders are independent (b not yet built)"
   )
   ok(
-    app.capabilities["repos"] ~= nil,
+    app.backend.capabilities["repos"] ~= nil,
     "make_backend_builder: capability builders independent (a built)"
   )
   ok(
-    app.capabilities["users"] == nil,
+    app.backend.capabilities["users"] == nil,
     "make_backend_builder: capability builders independent (b not yet built)"
   )
   bb:build()
-  ok(app.backend_impl["get_bar"] ~= nil, "make_backend_builder: builders are independent (b built)")
+  ok(app.backend.rest["get_bar"] ~= nil, "make_backend_builder: builders are independent (b built)")
   ok(
-    app.capabilities["users"] ~= nil,
+    app.backend.capabilities["users"] ~= nil,
     "make_backend_builder: capability builders independent (b built)"
   )
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1624,6 +1624,11 @@ ok(type(app.backend.graphql) == "table", "app.backend.graphql: is a table")
 ok(type(app.backend.capabilities) == "table", "app.backend.capabilities: is a table")
 ok(type(app.allow_anonymous) == "boolean", "app.allow_anonymous: is a boolean")
 ok(app.allow_anonymous == true, "app.allow_anonymous: default true (no backend loaded)")
+ok(type(app.route_match) == "function", "app.route_match: bound router lookup installed on app")
+ok(
+  type(app.path_known) == "function",
+  "app.path_known: bound path-existence check installed on app"
+)
 
 -- make_app: constructs independent context from a given config table.
 do


### PR DESCRIPTION
Fixes #201.

Replaces the remaining global runtime seams (`graphql_resolvers`, `app.backend_impl`, ambient `OnHttpRequest`) with an explicit `app.backend` composition root that nests REST handlers, GraphQL resolvers, and capability modules together. Finishes the architecture migration started in #202–#209 by moving built-in GraphQL resolvers into the registry, making dispatch a closure over `app`, and updating validation scripts, docs, and guardrails to match.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Update validation scripts for app.backend structure <!-- type:spec -->
- [x] Update architecture docs, CLAUDE.md, and guardrails for completed migration <!-- type:spec -->
- [x] Make OnHttpRequest a closure over app with bound router lookup <!-- type:spec -->
- [x] Move built-in GraphQL resolvers from global assignment into registry defaults <!-- type:spec -->
- [x] Restructure app context: nest REST, GraphQL, and capabilities under app.backend <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->