### PR TITLE
v3: Webhook — signature verification (all provider schemes) and re-signing (GitHub + confusio) (closes #224)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -18,6 +18,19 @@ end
 
 config.base_url = config.base_url:gsub("/$", "")
 
+-- CONFUSIO_WEBHOOK_SECRETS: optional JSON object mapping backend names to
+-- webhook secrets.  Used by the test harness to configure signature
+-- verification without recompiling; also useful for single-backend deployments
+-- that prefer environment-variable configuration.
+-- Example: CONFUSIO_WEBHOOK_SECRETS='{"gitea":"mysecret","gitlab":"othersecret"}'
+local ws_env = os.getenv("CONFUSIO_WEBHOOK_SECRETS")
+if ws_env and ws_env ~= "" then
+  local ok_ws, ws_parsed = pcall(DecodeJson, ws_env)
+  if ok_ws and type(ws_parsed) == "table" then
+    config.webhook_secrets = ws_parsed
+  end
+end
+
 dofile("/zip/internal/http.lua")
 dofile("/zip/internal/proxy.lua")
 dofile("/zip/internal/transport.lua")

--- a/.init.lua
+++ b/.init.lua
@@ -54,6 +54,7 @@ dofile("/zip/internal/defaults.lua")
 dofile("/zip/internal/router.lua")
 dofile("/zip/internal/catalog.lua")
 dofile("/zip/internal/dispatch.lua")
+dofile("/zip/internal/signing.lua")
 dofile("/zip/internal/webhooks.lua")
 
 app.route_match = route_match

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -89,6 +89,9 @@ globals = {
   "graphql_register_builtin_resolvers",
   "make_dispatcher",
   "make_webhook_receiver",
+  -- Outbound delivery signing: internal/signing.lua
+  "sign_github",
+  "sign_confusio",
   "get_client_mutation_id",
   "estimate_query_cost",
   -- GraphQL translators: internal/graphql_translators.lua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,7 +455,7 @@ Do **not** use `proxy_search_envelope` when:
 
 ### Internal module layout
 
-The eleven `internal/` modules are loaded by `.init.lua` in a fixed order. Each exports only globals — no `require`/`return` pattern; `dofile` runs in global scope.
+The twelve `internal/` modules are loaded by `.init.lua` in a fixed order. Each exports only globals — no `require`/`return` pattern; `dofile` runs in global scope.
 
 **Load order and exports:**
 
@@ -472,6 +472,8 @@ The eleven `internal/` modules are loaded by `.init.lua` in a fixed order. Each 
 | `defaults.lua` | `defaults` (table of handler functions) | catalog |
 | `router.lua` | `route_add`, `route_match`, `path_known` | catalog, dispatch |
 | `catalog.lua` | `endpoints` (flat array); registers routes via `route_add` | dispatch, scripts |
+| `signing.lua` | `sign_github`, `sign_confusio` | backends (outbound delivery) |
+| `webhooks.lua` | `make_webhook_receiver` | `.init.lua` (installed as `app.webhook_receiver`) |
 | `dispatch.lua` | `make_dispatcher` | `.init.lua` (called once at startup to install `OnHttpRequest`) |
 
 After `dispatch.lua` is loaded, `.init.lua` completes the composition:
@@ -618,3 +620,9 @@ here so they stay visible without reading all 16 docs:
 - **Pre-routing endpoints need catalog entries for validate-csv/validate-tests.**  `POST /webhooks/{backend}` is intercepted by `dispatch.lua` before the router runs, so the catalog's default stub is never called in production.  The entry exists purely so `validate-csv` and `validate-tests` can account for the endpoint.  Add such handler names to `CONFUSIO_NATIVE` in `scripts/validate-claims.lua` — otherwise `y` CSV claims for all backends will fail because `app.backend.rest` has no entry.
 - **`b:build(strip)` never strips webhook handlers.**  Strip patterns only apply to `app.backend.rest` keys; `app.backend.webhooks` entries registered via `b:webhook()` are always preserved regardless of the strip list passed to `b:build()`.
 - **Raw hurl bodies require backtick syntax.**  To send a body that doesn't start with `{` or `[` (e.g., `not-valid-json` for an invalid-JSON test), wrap it in backticks: `` `not-valid-json` ``.  Without backticks, hurl attempts to parse the first word as an HTTP method and fails with a parse error.
+- **Signature schemes are verified in `verify_signature(backend, secret, body[, now])`** in `internal/webhooks.lua`.  The optional `now` parameter defaults to `os.time()` and exists purely for unit testing — pass a fixed timestamp to test replay prevention without sleeping.  Production code always omits it.
+- **Outbound signing lives in `internal/signing.lua`** (`sign_github`, `sign_confusio`).  `sign_github(secret, body)` returns `(sha256_value, sha1_value)`; `sign_confusio(secret, body, timestamp)` returns the full `X-Confusio-Signature-256` header value.  Both return nil when no secret is configured (unsigned delivery).
+- **Confusio inbound HMAC basestring is `"v1:<ts>:<body>"`** — the timestamp is baked into the signed material, not just the header.  This means a replay with a fresh timestamp produces a different digest and fails even before the window check.  The outbound `sign_confusio` and inbound `verify_signature("confusio", ...)` are symmetric — they must stay in sync.
+- **Replay window is 300 seconds (±5 minutes)** enforced by `REPLAY_WINDOW_SECS` in `webhooks.lua`.  Only the confusio scheme has replay prevention; other schemes (HMAC or token) rely on TLS and network policy.
+- **`CONFUSIO_WEBHOOK_SECRETS` env var** — optional JSON object `{"backend":"secret",...}` that `.init.lua` reads at startup and stores as `config.webhook_secrets`.  Used by the test harness (`test/test-unit.sh` Phase 4) and single-backend deployments that prefer env-var config.  Absent key → empty string → trust-the-network for that backend.
+- **Phase 4 in `test/test-unit.sh`** computes HMAC test vectors at runtime with `openssl dgst` and passes them to `hurl` via `--variable` flags.  Never hard-code pre-computed HMACs in the test file — the confusio signature embeds `$(date +%s)` and would be stale by replay-window expiry if pre-computed.  The gitea/bitbucket/gitbucket vectors are stable (no timestamp), but computing all of them uniformly at runtime is simpler and safer.

--- a/internal/signing.lua
+++ b/internal/signing.lua
@@ -1,0 +1,53 @@
+-- Outbound delivery signing for GitHub-emulation and confusio-normalized shapes.
+--
+-- sign_github(secret, body)
+--   Computes the GitHub-emulation delivery signatures.
+--   Returns (sha256_value, sha1_value) — both are complete header value strings —
+--   or (nil, nil) when no secret is configured.
+--     X-Hub-Signature-256: <sha256_value>
+--     X-Hub-Signature:     <sha1_value>
+--
+-- sign_confusio(secret, body, timestamp)
+--   Computes the confusio-normalized delivery signature.
+--   timestamp is Unix epoch seconds (integer); it is folded into the HMAC
+--   basestring ("v1:<ts>:<body>") so that replaying an old delivery with a valid
+--   body but a stale timestamp produces a different digest.
+--   Returns the complete X-Confusio-Signature-256 header value string ("sha256=<hex>,
+--   v=1, ts=<ts>"), or nil when no secret is configured.
+--
+-- Globals exported:
+--   sign_github, sign_confusio
+
+local function to_hex(bytes)
+  local hex = {}
+  for i = 1, #bytes do
+    hex[i] = string.format("%02x", bytes:byte(i))
+  end
+  return table.concat(hex)
+end
+
+local function hmac_hex(alg, secret, msg)
+  return to_hex(GetCryptoHash(alg, msg, secret)) -- luacheck: globals GetCryptoHash
+end
+
+-- sign_github(secret, body) computes both GitHub-emulation delivery signatures.
+-- Consumers verify with X-Hub-Signature-256; X-Hub-Signature is legacy compat only.
+function sign_github(secret, body) -- luacheck: globals sign_github
+  if not secret or secret == "" then
+    return nil, nil
+  end
+  return "sha256=" .. hmac_hex("sha256", secret, body), "sha1=" .. hmac_hex("sha1", secret, body)
+end
+
+-- sign_confusio(secret, body, timestamp) computes the confusio-normalized delivery
+-- signature.  The HMAC basestring is "v1:<timestamp>:<body>"; the v=1 and ts=<ts>
+-- fields in the header value allow consumers to extract and verify the timestamp
+-- without a second parse pass.
+function sign_confusio(secret, body, timestamp) -- luacheck: globals sign_confusio
+  if not secret or secret == "" then
+    return nil
+  end
+  local ts = tostring(timestamp)
+  local basestring = "v1:" .. ts .. ":" .. body
+  return "sha256=" .. hmac_hex("sha256", secret, basestring) .. ", v=1, ts=" .. ts
+end

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -21,14 +21,16 @@
 -- Globals exported:
 --   make_webhook_receiver   — builder factory; called once at startup
 
--- KNOWN_BACKENDS maps path segment to true for all 24 supported backends.
+-- KNOWN_BACKENDS maps path segment to true for all recognised inbound sources.
 -- Requests with an unrecognised segment return 404.
+-- Includes the 24 forge backends plus "confusio" for cross-instance forwarding.
 local KNOWN_BACKENDS = {
   azuredevops = true,
   bitbucket = true,
   bitbucket_datacenter = true,
   codeberg = true,
   codecommit = true,
+  confusio = true,
   forgejo = true,
   gerrit = true,
   gitblit = true,
@@ -49,6 +51,11 @@ local KNOWN_BACKENDS = {
   sourcehut = true,
   tuleap = true,
 }
+
+-- REPLAY_WINDOW_SECS is the maximum age (and future skew) allowed for a
+-- confusio-normalized inbound delivery timestamp.  Requests with a timestamp
+-- outside this window are rejected to prevent replay attacks.
+local REPLAY_WINDOW_SECS = 300
 
 -- to_hex(bytes) converts raw binary bytes to a lowercase hex string.
 local function to_hex(bytes)
@@ -83,11 +90,13 @@ local function hmac_hex(alg, secret, body)
   return to_hex(GetCryptoHash(alg, body, secret)) -- luacheck: globals GetCryptoHash
 end
 
--- verify_signature(backend, secret, body) authenticates the inbound request
+-- verify_signature(backend, secret, body[, now]) authenticates the inbound request
 -- using the backend-native scheme.  Returns true on success, false on failure.
 -- When secret is nil or "" (trust-the-network mode) all requests are accepted.
 -- Rejection occurs before any JSON parsing; unverified payloads are not decoded.
-local function verify_signature(backend, secret, body)
+-- now: current Unix epoch seconds; defaults to os.time().  Exposed for testing.
+local function verify_signature(backend, secret, body, now)
+  now = now or os.time()
   -- Gitea family: X-Gitea-Signature, HMAC-SHA256, no prefix
   -- notabug uses the same Gitea-derived scheme.
   if
@@ -323,6 +332,33 @@ local function verify_signature(backend, secret, body)
     end
     return ct_equal(secret, tostring(tok))
 
+  -- Confusio-normalized: X-Confusio-Signature-256, HMAC-SHA256 with timestamp.
+  -- Header format: "sha256=<hex>, v=1, ts=<unix>"
+  -- HMAC basestring: "v1:<ts>:<body>"
+  -- Replay window: REPLAY_WINDOW_SECS (5 minutes).  Timestamps outside the window
+  -- are rejected even if the HMAC is correct, preventing capture-and-replay.
+  elseif backend == "confusio" then
+    if not secret or secret == "" then
+      return true
+    end
+    local sig_hdr = GetHeader("X-Confusio-Signature-256")
+    if not sig_hdr then
+      return false
+    end
+    local hex, ts_str = sig_hdr:match("^sha256=([0-9a-f]+), v=1, ts=(%d+)$")
+    if not hex or not ts_str then
+      return false
+    end
+    local ts = tonumber(ts_str)
+    if not ts then
+      return false
+    end
+    if math.abs(now - ts) > REPLAY_WINDOW_SECS then
+      return false
+    end
+    local basestring = "v1:" .. ts_str .. ":" .. body
+    return ct_equal(hmac_hex("sha256", secret, basestring), hex)
+
   -- CodeCommit (SNS X.509), Sourcehut (ed25519), Launchpad (OpenPGP):
   -- Complex asymmetric and platform-managed schemes not yet implemented.
   -- Trust-the-network when no secret configured; reject otherwise so operators
@@ -364,6 +400,10 @@ local function event_header(backend)
   -- Pagure: X-Pagure-Event
   elseif backend == "pagure" then
     return GetHeader("X-Pagure-Event")
+
+  -- Confusio-normalized: X-Confusio-Event
+  elseif backend == "confusio" then
+    return GetHeader("X-Confusio-Event")
 
   -- Remaining backends embed the event type in the body.
   -- The registered normaliser is responsible for extracting it.

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -62,3 +62,29 @@ run_mock_phase test/gitea-anon.hurl $MOCK_ARGS
 
 # Phase 3: Checks API (check runs + check suites via Gitea commit statuses)
 run_mock_phase test/gitea-checks.hurl $MOCK_ARGS
+
+# Phase 4: Webhook signature verification with HMAC test vectors.
+# CONFUSIO_WEBHOOK_SECRETS configures secrets; openssl computes the expected signatures
+# at runtime so the test is never tied to a hard-coded pre-computed value.
+WH_SECRET="webhooksecret"
+WH_BODY="{}"
+GITEA_SIG=$(printf '%s' "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}')
+BB_SIG="sha256=${GITEA_SIG}"
+GB_SIG="sha1=$(printf '%s' "$WH_BODY" | openssl dgst -sha1 -hmac "$WH_SECRET" | awk '{print $NF}')"
+CONFUSIO_TS=$(date +%s)
+CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
+WH_SECRETS_JSON="{\"gitea\":\"$WH_SECRET\",\"gitlab\":\"$WH_SECRET\",\"bitbucket\":\"$WH_SECRET\",\"gitbucket\":\"$WH_SECRET\",\"confusio\":\"$WH_SECRET\"}"
+wh_dir=$(mktemp -d)
+export CONFUSIO_WEBHOOK_SECRETS="$WH_SECRETS_JSON"
+start_confusio "$wh_dir"; WH_PID=$!
+trap "kill $WH_PID 2>/dev/null || true; unset CONFUSIO_WEBHOOK_SECRETS; rm -rf $wh_dir" EXIT
+$HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
+  --variable "host=localhost:$CONFUSIO_PORT" \
+  --variable "gitea_sig=$GITEA_SIG" \
+  --variable "gitlab_tok=$WH_SECRET" \
+  --variable "bb_sig=$BB_SIG" \
+  --variable "gb_sig=$GB_SIG" \
+  --variable "confusio_sig=$CONFUSIO_SIG" \
+  test/webhooks-sig.hurl
+kill $WH_PID 2>/dev/null || true; sleep 0.3
+unset CONFUSIO_WEBHOOK_SECRETS

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2575,6 +2575,67 @@ do
 end
 
 -- ============================================================
+-- sign_github / sign_confusio
+-- ============================================================
+
+do
+  -- GetCryptoHash stub returns 32 bytes of 0xaa → hex is 64 'a' chars.
+  local STUB_HEX = string.rep("aa", 32)
+  local SECRET = "mysecret"
+  local BODY = '{"action":"opened"}'
+
+  -- ── sign_github ──────────────────────────────────────────
+
+  ok(type(sign_github) == "function", "sign_github: exported as global function")
+
+  -- No secret → both return values are nil.
+  local s256, s1 = sign_github(nil, BODY)
+  ok(s256 == nil, "sign_github(nil): sha256 value is nil")
+  ok(s1 == nil, "sign_github(nil): sha1 value is nil")
+
+  s256, s1 = sign_github("", BODY)
+  ok(s256 == nil, "sign_github(''): sha256 value is nil")
+  ok(s1 == nil, "sign_github(''): sha1 value is nil")
+
+  -- With secret → returns "sha256=<hex>" and "sha1=<hex>".
+  s256, s1 = sign_github(SECRET, BODY)
+  eq(s256, "sha256=" .. STUB_HEX, "sign_github: sha256 value has correct prefix and hex")
+  eq(s1, "sha1=" .. STUB_HEX, "sign_github: sha1 value has correct prefix and hex")
+
+  -- Return values are strings (header-value ready).
+  ok(type(s256) == "string", "sign_github: sha256 return is a string")
+  ok(type(s1) == "string", "sign_github: sha1 return is a string")
+
+  -- ── sign_confusio ─────────────────────────────────────────
+
+  ok(type(sign_confusio) == "function", "sign_confusio: exported as global function")
+
+  -- No secret → returns nil.
+  ok(sign_confusio(nil, BODY, 1700000000) == nil, "sign_confusio(nil): returns nil")
+  ok(sign_confusio("", BODY, 1700000000) == nil, "sign_confusio(''): returns nil")
+
+  -- With secret → returns "sha256=<hex>, v=1, ts=<ts>".
+  local TS = 1700000000
+  local csig = sign_confusio(SECRET, BODY, TS)
+  ok(type(csig) == "string", "sign_confusio: return is a string")
+  eq(csig, "sha256=" .. STUB_HEX .. ", v=1, ts=1700000000", "sign_confusio: header value format")
+
+  -- Timestamp appears verbatim in the returned header value.
+  local ts_val = csig:match(", ts=(%d+)$")
+  eq(tonumber(ts_val), TS, "sign_confusio: ts field matches supplied timestamp")
+
+  -- Different timestamps produce different basestrings (stub ignores input, but
+  -- verify the ts field in the header value changes as expected).
+  local r1 = sign_confusio(SECRET, BODY, 1000)
+  local r2 = sign_confusio(SECRET, BODY, 9999)
+  ok(r1:match(", ts=1000$") ~= nil, "sign_confusio: ts=1000 appears in header")
+  ok(r2:match(", ts=9999$") ~= nil, "sign_confusio: ts=9999 appears in header")
+
+  -- v=1 is present in the header value.
+  ok(csig:find(", v=1,", 1, true) ~= nil, "sign_confusio: v=1 field present in header value")
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2572,6 +2572,65 @@ do
       "verify_signature " .. be .. ": secret configured (unimplemented scheme) → 401"
     )
   end
+
+  -- ── Confusio-normalized: X-Confusio-Signature-256, HMAC-SHA256 + timestamp
+  -- Header format: "sha256=<hex>, v=1, ts=<unix>"
+  -- HMAC basestring: "v1:<ts>:<body>"  Replay window: 300 seconds.
+  ok(no_secret("confusio", {}) ~= 401, "verify_signature confusio: no secret → not 401")
+
+  -- Valid: current timestamp, correct stub HMAC hex.
+  -- Using os.time() so the timestamp is within the replay window when the test runs.
+  local confusio_now = os.time()
+  local confusio_valid_hdr = "sha256=" .. STUB_HEX .. ", v=1, ts=" .. tostring(confusio_now)
+  ok(
+    with_secret("confusio", { ["X-Confusio-Signature-256"] = confusio_valid_hdr }) ~= 401,
+    "verify_signature confusio: valid X-Confusio-Signature-256 (current ts) → not 401"
+  )
+
+  -- Stale past timestamp (January 2001): outside replay window.
+  local confusio_stale_past = "sha256=" .. STUB_HEX .. ", v=1, ts=980000000"
+  eq(
+    with_secret("confusio", { ["X-Confusio-Signature-256"] = confusio_stale_past }),
+    401,
+    "verify_signature confusio: stale past timestamp → 401 (replay rejected)"
+  )
+
+  -- Stale future timestamp (year 5138): outside replay window.
+  local confusio_stale_future = "sha256=" .. STUB_HEX .. ", v=1, ts=99999999999"
+  eq(
+    with_secret("confusio", { ["X-Confusio-Signature-256"] = confusio_stale_future }),
+    401,
+    "verify_signature confusio: stale future timestamp → 401 (replay rejected)"
+  )
+
+  -- Bad HMAC (current timestamp but wrong hex): rejected even with fresh ts.
+  local confusio_bad_hmac = "sha256=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    .. ", v=1, ts="
+    .. tostring(confusio_now)
+  eq(
+    with_secret("confusio", { ["X-Confusio-Signature-256"] = confusio_bad_hmac }),
+    401,
+    "verify_signature confusio: bad HMAC hex → 401"
+  )
+
+  -- Missing header.
+  eq(with_secret("confusio", {}), 401, "verify_signature confusio: missing header → 401")
+
+  -- Malformed header: missing v=1.
+  local confusio_no_v = "sha256=" .. STUB_HEX .. ", ts=" .. tostring(confusio_now)
+  eq(
+    with_secret("confusio", { ["X-Confusio-Signature-256"] = confusio_no_v }),
+    401,
+    "verify_signature confusio: header missing v=1 → 401"
+  )
+
+  -- Malformed header: missing ts.
+  local confusio_no_ts = "sha256=" .. STUB_HEX .. ", v=1"
+  eq(
+    with_secret("confusio", { ["X-Confusio-Signature-256"] = confusio_no_ts }),
+    401,
+    "verify_signature confusio: header missing ts → 401"
+  )
 end
 
 -- ============================================================

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -91,8 +91,35 @@ end
 -- The dofile stub above silently drops the backend file load.
 arg = { "testbackend" } -- luacheck: globals arg
 
+-- Stub os.getenv to return a valid JSON string for CONFUSIO_WEBHOOK_SECRETS so
+-- that the env-var loading block in .init.lua (lines 28-30) is exercised by
+-- luacov.  Restore immediately after load and clear config.webhook_secrets so
+-- subsequent tests that rely on no secret being configured are unaffected.
+local _real_getenv = os.getenv
+os.getenv = function(k) -- luacheck: globals os
+  if k == "CONFUSIO_WEBHOOK_SECRETS" then
+    return '{"gitea":"ws_coverage_test"}'
+  end
+  return _real_getenv(k)
+end
+
 -- Load the module under test.
 _real_dofile(".init.lua")
+
+-- Verify the env-var block populated config.webhook_secrets.
+assert(
+  config.webhook_secrets ~= nil, -- luacheck: globals config
+  "CONFUSIO_WEBHOOK_SECRETS: config.webhook_secrets should be non-nil after load"
+)
+assert(
+  config.webhook_secrets.gitea == "ws_coverage_test",
+  "CONFUSIO_WEBHOOK_SECRETS: gitea secret mismatch: " .. tostring(config.webhook_secrets.gitea)
+)
+
+-- Restore os.getenv and clear the coverage-only secret so later tests see a
+-- clean config.  (config and app.config reference the same table.)
+os.getenv = _real_getenv -- luacheck: globals os
+config.webhook_secrets = nil
 
 -- Restore dofile so later tests that call it work normally.
 dofile = _real_dofile -- luacheck: globals dofile

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2202,6 +2202,379 @@ do
 end
 
 -- ============================================================
+-- verify_signature: comprehensive per-backend tests
+--
+-- Covers all 24 backends in KNOWN_BACKENDS.  For each:
+--   (a) trust-the-network (no secret configured) → not 401
+--   (b) valid credential/signature → not 401
+--   (c) bad credential/signature → 401
+--   (d) missing header/token → 401
+-- Pagure gets extra cases for its dual-header scheme.
+-- Kallithea gets extra cases for its body-embedded secret.
+-- codecommit/sourcehut/launchpad get both trust-the-network
+-- and "secret configured → always 401" cases.
+-- ============================================================
+do
+  -- GetCryptoHash stub always returns 32 bytes of 0xaa.
+  -- to_hex() converts that to 64 lowercase 'a' characters.
+  local STUB_HEX = string.rep("aa", 32)
+  local SECRET = "mysecret"
+
+  -- Call the webhook receiver for `backend` with the given extra headers and
+  -- body.  `secrets` controls app.config.webhook_secrets.
+  local function call_sig(backend, extra_headers, body, secrets)
+    local saved_config = app.config
+    app.config = {
+      backend = "testbackend",
+      base_url = "",
+      webhook_secrets = secrets or {},
+    }
+    local h = { ["Content-Type"] = "application/json" }
+    for k, v in pairs(extra_headers or {}) do
+      h[k] = v
+    end
+    reset_request({
+      method = "POST",
+      path = "/webhooks/" .. backend,
+      headers = h,
+      body = body or "{}",
+    })
+    reset_response()
+    app.webhook_receiver()
+    local status = _last_status
+    app.config = saved_config
+    return status
+  end
+
+  -- Convenience wrappers
+  local function no_secret(backend, hdrs, body)
+    return call_sig(backend, hdrs, body, {})
+  end
+  local function with_secret(backend, hdrs, body)
+    return call_sig(backend, hdrs, body, { [backend] = SECRET })
+  end
+
+  -- ── HMAC-SHA256 / no prefix: gitea family (X-Gitea-Signature)
+  for _, be in ipairs({ "gitea", "forgejo", "codeberg", "notabug" }) do
+    ok(no_secret(be, {}) ~= 401, "verify_signature " .. be .. ": no secret → not 401")
+    ok(
+      with_secret(be, { ["X-Gitea-Signature"] = STUB_HEX }) ~= 401,
+      "verify_signature " .. be .. ": valid X-Gitea-Signature → not 401"
+    )
+    eq(
+      with_secret(be, { ["X-Gitea-Signature"] = "deadbeef" }),
+      401,
+      "verify_signature " .. be .. ": bad X-Gitea-Signature → 401"
+    )
+    eq(with_secret(be, {}), 401, "verify_signature " .. be .. ": missing X-Gitea-Signature → 401")
+  end
+
+  -- ── HMAC-SHA256 / no prefix: gogs (X-Gogs-Signature)
+  ok(no_secret("gogs", {}) ~= 401, "verify_signature gogs: no secret → not 401")
+  ok(
+    with_secret("gogs", { ["X-Gogs-Signature"] = STUB_HEX }) ~= 401,
+    "verify_signature gogs: valid X-Gogs-Signature → not 401"
+  )
+  eq(
+    with_secret("gogs", { ["X-Gogs-Signature"] = "deadbeef" }),
+    401,
+    "verify_signature gogs: bad X-Gogs-Signature → 401"
+  )
+  eq(with_secret("gogs", {}), 401, "verify_signature gogs: missing X-Gogs-Signature → 401")
+
+  -- ── Verbatim shared token: gitlab (X-Gitlab-Token)
+  ok(no_secret("gitlab", {}) ~= 401, "verify_signature gitlab: no secret → not 401")
+  ok(
+    with_secret("gitlab", { ["X-Gitlab-Token"] = SECRET }) ~= 401,
+    "verify_signature gitlab: valid X-Gitlab-Token → not 401"
+  )
+  eq(
+    with_secret("gitlab", { ["X-Gitlab-Token"] = "wrongtoken" }),
+    401,
+    "verify_signature gitlab: bad X-Gitlab-Token → 401"
+  )
+  eq(with_secret("gitlab", {}), 401, "verify_signature gitlab: missing X-Gitlab-Token → 401")
+
+  -- ── HMAC-SHA256 / sha256= prefix: bitbucket + bitbucket_datacenter (X-Hub-Signature)
+  for _, be in ipairs({ "bitbucket", "bitbucket_datacenter" }) do
+    ok(no_secret(be, {}) ~= 401, "verify_signature " .. be .. ": no secret → not 401")
+    ok(
+      with_secret(be, { ["X-Hub-Signature"] = "sha256=" .. STUB_HEX }) ~= 401,
+      "verify_signature " .. be .. ": valid X-Hub-Signature sha256= → not 401"
+    )
+    eq(
+      with_secret(be, { ["X-Hub-Signature"] = "sha256=deadbeef" }),
+      401,
+      "verify_signature " .. be .. ": bad X-Hub-Signature → 401"
+    )
+    eq(with_secret(be, {}), 401, "verify_signature " .. be .. ": missing X-Hub-Signature → 401")
+  end
+
+  -- ── HMAC-SHA1 / sha1= prefix: gitbucket (X-Hub-Signature)
+  ok(no_secret("gitbucket", {}) ~= 401, "verify_signature gitbucket: no secret → not 401")
+  ok(
+    with_secret("gitbucket", { ["X-Hub-Signature"] = "sha1=" .. STUB_HEX }) ~= 401,
+    "verify_signature gitbucket: valid X-Hub-Signature sha1= → not 401"
+  )
+  eq(
+    with_secret("gitbucket", { ["X-Hub-Signature"] = "sha1=deadbeef" }),
+    401,
+    "verify_signature gitbucket: bad X-Hub-Signature → 401"
+  )
+  eq(
+    with_secret("gitbucket", {}),
+    401,
+    "verify_signature gitbucket: missing X-Hub-Signature → 401"
+  )
+
+  -- ── HMAC-SHA256 / no prefix: phabricator (X-Phabricator-Webhook-Signature)
+  ok(no_secret("phabricator", {}) ~= 401, "verify_signature phabricator: no secret → not 401")
+  ok(
+    with_secret("phabricator", { ["X-Phabricator-Webhook-Signature"] = STUB_HEX }) ~= 401,
+    "verify_signature phabricator: valid X-Phabricator-Webhook-Signature → not 401"
+  )
+  eq(
+    with_secret("phabricator", { ["X-Phabricator-Webhook-Signature"] = "deadbeef" }),
+    401,
+    "verify_signature phabricator: bad X-Phabricator-Webhook-Signature → 401"
+  )
+  eq(
+    with_secret("phabricator", {}),
+    401,
+    "verify_signature phabricator: missing X-Phabricator-Webhook-Signature → 401"
+  )
+
+  -- ── Pagure: dual-header scheme (X-Pagure-Signature-256 / X-Pagure-Signature)
+  -- Prefers SHA-256; falls back to SHA-512; both must verify when both present.
+  ok(no_secret("pagure", {}) ~= 401, "verify_signature pagure: no secret → not 401")
+  ok(
+    with_secret("pagure", { ["X-Pagure-Signature-256"] = STUB_HEX }) ~= 401,
+    "verify_signature pagure: valid sig256 only → not 401"
+  )
+  ok(
+    with_secret("pagure", { ["X-Pagure-Signature"] = STUB_HEX }) ~= 401,
+    "verify_signature pagure: valid sig512 only → not 401"
+  )
+  ok(with_secret("pagure", {
+    ["X-Pagure-Signature-256"] = STUB_HEX,
+    ["X-Pagure-Signature"] = STUB_HEX,
+  }) ~= 401, "verify_signature pagure: both sig256+sig512 valid → not 401")
+  eq(
+    with_secret("pagure", { ["X-Pagure-Signature-256"] = "bad" }),
+    401,
+    "verify_signature pagure: bad sig256 → 401"
+  )
+  eq(
+    with_secret("pagure", { ["X-Pagure-Signature"] = "bad" }),
+    401,
+    "verify_signature pagure: bad sig512 → 401"
+  )
+  eq(
+    with_secret("pagure", {
+      ["X-Pagure-Signature-256"] = STUB_HEX,
+      ["X-Pagure-Signature"] = "bad",
+    }),
+    401,
+    "verify_signature pagure: sig256 valid but sig512 bad → 401"
+  )
+  eq(with_secret("pagure", {}), 401, "verify_signature pagure: no signature headers → 401")
+
+  -- ── Verbatim shared token: harness (X-Harness-Token)
+  ok(no_secret("harness", {}) ~= 401, "verify_signature harness: no secret → not 401")
+  ok(
+    with_secret("harness", { ["X-Harness-Token"] = SECRET }) ~= 401,
+    "verify_signature harness: valid X-Harness-Token → not 401"
+  )
+  eq(
+    with_secret("harness", { ["X-Harness-Token"] = "bad" }),
+    401,
+    "verify_signature harness: bad X-Harness-Token → 401"
+  )
+  eq(with_secret("harness", {}), 401, "verify_signature harness: missing X-Harness-Token → 401")
+
+  -- ── Bearer token: onedev (Authorization: Bearer <secret>)
+  ok(no_secret("onedev", {}) ~= 401, "verify_signature onedev: no secret → not 401")
+  ok(
+    with_secret("onedev", { ["Authorization"] = "Bearer " .. SECRET }) ~= 401,
+    "verify_signature onedev: valid Bearer token → not 401"
+  )
+  ok(
+    with_secret("onedev", { ["Authorization"] = "bearer " .. SECRET }) ~= 401,
+    "verify_signature onedev: Bearer scheme is case-insensitive → not 401"
+  )
+  eq(
+    with_secret("onedev", { ["Authorization"] = "Bearer badtoken" }),
+    401,
+    "verify_signature onedev: bad Bearer token → 401"
+  )
+  eq(
+    with_secret("onedev", { ["Authorization"] = "Basic " .. SECRET }),
+    401,
+    "verify_signature onedev: non-Bearer scheme → 401"
+  )
+  eq(with_secret("onedev", {}), 401, "verify_signature onedev: missing Authorization → 401")
+
+  -- ── Verbatim Authorization header: radicle (raw token, no prefix)
+  ok(no_secret("radicle", {}) ~= 401, "verify_signature radicle: no secret → not 401")
+  ok(
+    with_secret("radicle", { ["Authorization"] = SECRET }) ~= 401,
+    "verify_signature radicle: valid Authorization → not 401"
+  )
+  eq(
+    with_secret("radicle", { ["Authorization"] = "bad" }),
+    401,
+    "verify_signature radicle: bad Authorization → 401"
+  )
+  eq(with_secret("radicle", {}), 401, "verify_signature radicle: missing Authorization → 401")
+
+  -- ── Verbatim Authorization header: gerrit (same scheme as radicle)
+  ok(no_secret("gerrit", {}) ~= 401, "verify_signature gerrit: no secret → not 401")
+  ok(
+    with_secret("gerrit", { ["Authorization"] = SECRET }) ~= 401,
+    "verify_signature gerrit: valid Authorization → not 401"
+  )
+  eq(
+    with_secret("gerrit", { ["Authorization"] = "bad" }),
+    401,
+    "verify_signature gerrit: bad Authorization → 401"
+  )
+  eq(with_secret("gerrit", {}), 401, "verify_signature gerrit: missing Authorization → 401")
+
+  -- ── Verbatim shared token: gitblit (X-Gitblit-Token)
+  ok(no_secret("gitblit", {}) ~= 401, "verify_signature gitblit: no secret → not 401")
+  ok(
+    with_secret("gitblit", { ["X-Gitblit-Token"] = SECRET }) ~= 401,
+    "verify_signature gitblit: valid X-Gitblit-Token → not 401"
+  )
+  eq(
+    with_secret("gitblit", { ["X-Gitblit-Token"] = "bad" }),
+    401,
+    "verify_signature gitblit: bad X-Gitblit-Token → 401"
+  )
+  eq(with_secret("gitblit", {}), 401, "verify_signature gitblit: missing X-Gitblit-Token → 401")
+
+  -- ── Verbatim shared token: rhodecode (X-RhodeCode-Signature)
+  ok(no_secret("rhodecode", {}) ~= 401, "verify_signature rhodecode: no secret → not 401")
+  ok(
+    with_secret("rhodecode", { ["X-RhodeCode-Signature"] = SECRET }) ~= 401,
+    "verify_signature rhodecode: valid X-RhodeCode-Signature → not 401"
+  )
+  eq(
+    with_secret("rhodecode", { ["X-RhodeCode-Signature"] = "bad" }),
+    401,
+    "verify_signature rhodecode: bad X-RhodeCode-Signature → 401"
+  )
+  eq(
+    with_secret("rhodecode", {}),
+    401,
+    "verify_signature rhodecode: missing X-RhodeCode-Signature → 401"
+  )
+
+  -- ── Verbatim shared token: sourceforge (X-Sourceforge-Webhook-Secret)
+  ok(no_secret("sourceforge", {}) ~= 401, "verify_signature sourceforge: no secret → not 401")
+  ok(
+    with_secret("sourceforge", { ["X-Sourceforge-Webhook-Secret"] = SECRET }) ~= 401,
+    "verify_signature sourceforge: valid X-Sourceforge-Webhook-Secret → not 401"
+  )
+  eq(
+    with_secret("sourceforge", { ["X-Sourceforge-Webhook-Secret"] = "bad" }),
+    401,
+    "verify_signature sourceforge: bad X-Sourceforge-Webhook-Secret → 401"
+  )
+  eq(
+    with_secret("sourceforge", {}),
+    401,
+    "verify_signature sourceforge: missing X-Sourceforge-Webhook-Secret → 401"
+  )
+
+  -- ── Verbatim shared token: tuleap (X-Tuleap-Webhook-Secret)
+  ok(no_secret("tuleap", {}) ~= 401, "verify_signature tuleap: no secret → not 401")
+  ok(
+    with_secret("tuleap", { ["X-Tuleap-Webhook-Secret"] = SECRET }) ~= 401,
+    "verify_signature tuleap: valid X-Tuleap-Webhook-Secret → not 401"
+  )
+  eq(
+    with_secret("tuleap", { ["X-Tuleap-Webhook-Secret"] = "bad" }),
+    401,
+    "verify_signature tuleap: bad X-Tuleap-Webhook-Secret → 401"
+  )
+  eq(
+    with_secret("tuleap", {}),
+    401,
+    "verify_signature tuleap: missing X-Tuleap-Webhook-Secret → 401"
+  )
+
+  -- ── Azure DevOps: Authorization: Basic <creds> (DecodeBase64 is identity stub)
+  -- SECRET = "mysecret"; DecodeBase64("mysecret") = "mysecret" (identity), so
+  -- "Basic mysecret" is the valid credential when secret = "mysecret".
+  ok(no_secret("azuredevops", {}) ~= 401, "verify_signature azuredevops: no secret → not 401")
+  ok(
+    with_secret("azuredevops", { ["Authorization"] = "Basic " .. SECRET }) ~= 401,
+    "verify_signature azuredevops: valid Basic creds → not 401"
+  )
+  ok(
+    with_secret("azuredevops", { ["Authorization"] = "basic " .. SECRET }) ~= 401,
+    "verify_signature azuredevops: Basic scheme is case-insensitive → not 401"
+  )
+  eq(
+    with_secret("azuredevops", { ["Authorization"] = "Basic badcreds" }),
+    401,
+    "verify_signature azuredevops: bad Basic creds → 401"
+  )
+  eq(
+    with_secret("azuredevops", { ["Authorization"] = "Bearer " .. SECRET }),
+    401,
+    "verify_signature azuredevops: non-Basic scheme → 401"
+  )
+  eq(
+    with_secret("azuredevops", {}),
+    401,
+    "verify_signature azuredevops: missing Authorization → 401"
+  )
+
+  -- ── Kallithea: body-embedded secret (exception to verify-before-parse rule)
+  ok(no_secret("kallithea", {}) ~= 401, "verify_signature kallithea: no secret → not 401")
+  ok(
+    with_secret("kallithea", {}, '{"secret":"' .. SECRET .. '"}') ~= 401,
+    "verify_signature kallithea: secret in root JSON field → not 401"
+  )
+  ok(
+    with_secret("kallithea", {}, '{"data":{"secret":"' .. SECRET .. '"}}') ~= 401,
+    "verify_signature kallithea: secret in data.secret JSON field → not 401"
+  )
+  eq(
+    with_secret("kallithea", {}, '{"secret":"bad"}'),
+    401,
+    "verify_signature kallithea: bad body secret → 401"
+  )
+  eq(
+    with_secret("kallithea", {}, '{"event":"push"}'),
+    401,
+    "verify_signature kallithea: no secret field in body → 401"
+  )
+  eq(
+    with_secret("kallithea", {}, "not-valid-json"),
+    401,
+    "verify_signature kallithea: invalid JSON body → 401"
+  )
+
+  -- ── Trust-the-network-only backends: codecommit, sourcehut, launchpad
+  -- These use asymmetric/platform-managed schemes not yet implemented.
+  -- No secret → accepted; any secret configured → always rejected.
+  for _, be in ipairs({ "codecommit", "sourcehut", "launchpad" }) do
+    ok(
+      no_secret(be, {}) ~= 401,
+      "verify_signature " .. be .. ": no secret (trust-the-network) → not 401"
+    )
+    eq(
+      call_sig(be, {}, nil, { [be] = SECRET }),
+      401,
+      "verify_signature " .. be .. ": secret configured (unimplemented scheme) → 401"
+    )
+  end
+end
+
+-- ============================================================
 -- Summary
 -- ============================================================
 

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -1,0 +1,132 @@
+# Webhook signature verification — integration tests with real HMAC.
+#
+# Run by Phase 4 in test-unit.sh with CONFUSIO_WEBHOOK_SECRETS configured.
+# Variables injected by the test script (computed via openssl at runtime):
+#   gitea_sig   — HMAC-SHA256("{}", secret) as hex (for X-Gitea-Signature)
+#   gitlab_tok  — the shared secret verbatim (for X-Gitlab-Token)
+#   bb_sig      — "sha256=<hex>" (for X-Hub-Signature on bitbucket)
+#   gb_sig      — "sha1=<hex>" (for X-Hub-Signature on gitbucket)
+#   confusio_sig — "sha256=<hex>, v=1, ts=<ts>" (for X-Confusio-Signature-256)
+#
+# Convention: valid credential → 422 (verification passed; no handlers registered
+#             means the request was accepted); invalid → 401.
+
+# ── gitea: X-Gitea-Signature, HMAC-SHA256, no prefix ─────────────────────────
+
+# Valid signature → passes verification (422 = accepted, no handlers)
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Signature: {{gitea_sig}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad signature → 401 signature verification failed
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Signature: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing signature header → 401
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── gitlab: X-Gitlab-Token, verbatim shared token ────────────────────────────
+
+# Valid token → passes verification (422)
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Token: {{gitlab_tok}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad token → 401
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Token: wrongtoken
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── bitbucket: X-Hub-Signature, HMAC-SHA256, sha256= prefix ──────────────────
+
+# Valid signature → passes verification (422)
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Hub-Signature: {{bb_sig}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad signature → 401
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Hub-Signature: sha256=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── gitbucket: X-Hub-Signature, HMAC-SHA1, sha1= prefix ──────────────────────
+
+# Valid signature → passes verification (422)
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-Hub-Signature: {{gb_sig}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad signature → 401
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-Hub-Signature: sha1=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── confusio: X-Confusio-Signature-256, HMAC-SHA256 with timestamp ───────────
+# HMAC basestring is "v1:<ts>:<body>"; ts embedded in header as ts=<unix>.
+
+# Valid signature with fresh timestamp → passes verification (422)
+POST http://{{host}}/webhooks/confusio
+Content-Type: application/json
+X-Confusio-Signature-256: {{confusio_sig}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Stale past timestamp (year 2001) → 401 replay rejected
+POST http://{{host}}/webhooks/confusio
+Content-Type: application/json
+X-Confusio-Signature-256: sha256=edc699fb5ca33c226f8ececeb563e81267b9199db0a45999e7960eb9f53add98, v=1, ts=980000000
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"


### PR DESCRIPTION
Fixes #224.

Adds comprehensive unit tests for all 24 inbound signature verification schemes, implements an outbound signing module supporting both GitHub (`X-Hub-Signature-256`) and confusio (`X-Confusio-Signature-256` with timestamp replay prevention) schemes, and wires up confusio as an inbound verification backend. Also adds webhook_secrets config support with hurl test fixtures for integration-level signature testing, plus unit test coverage for the env-var loading path.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [Fix CI test-coverage failure by covering CONFUSIO_WEBHOOK_SECRETS env-var loading path in unit tests](https://github.com/rhencke/confusio/pull/278#issuecomment-4275960048) <!-- type:thread -->
- [x] Add webhook_secrets config support and hurl signature test fixtures <!-- type:spec -->
- [x] Update CLAUDE.md with webhook signing conventions and lessons learned <!-- type:spec -->
- [x] Add confusio inbound verification with timestamp replay prevention <!-- type:spec -->
- [x] Implement outbound signing module with GitHub and confusio schemes <!-- type:spec -->
- [x] Add unit tests for all 24 inbound signature verification schemes <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->