### PR TITLE
v3: Webhook — event mapping: pull_request, merge_group (closes #226)

### DIFF
--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -1933,10 +1933,12 @@ end)
 -- Webhook handlers: Azure DevOps embeds the event type in payload.eventType.
 -- The dispatcher extracts it from the body (no header-based dispatch).
 --
--- Relevant event types for the issues family:
---   workitem.created   → issues / opened
---   workitem.updated   → issues / edited | closed | reopened  (derived from state diff)
---   workitem.commented → issue_comment / created
+-- Relevant event types:
+--   workitem.created          → issues / opened
+--   workitem.updated          → issues / edited | closed | reopened  (derived from state diff)
+--   workitem.commented        → issue_comment / created
+--   git.pullrequest.created   → pull_request / opened
+--   git.pullrequest.updated   → pull_request / closed | synchronize  (derived from status)
 --
 -- Payload shapes:
 --   workitem.created/workitem.updated:
@@ -1975,6 +1977,50 @@ local function ado_workitem_updated_action(resource)
     end
   end
   return "edited"
+end
+
+-- Translate an ADO pull request resource to GitHub format.
+local function translate_ado_pull(pr)
+  if not pr then
+    return {}
+  end
+  local status = pr.status or "active"
+  local is_merged = status == "completed"
+  local gh_state = status == "active" and "open" or "closed"
+  local src_ref = pr.sourceRefName and pr.sourceRefName:match("refs/heads/(.+)")
+    or (pr.sourceRefName or "")
+  local tgt_ref = pr.targetRefName and pr.targetRefName:match("refs/heads/(.+)")
+    or (pr.targetRefName or "")
+  local src_sha = (pr.lastMergeSourceCommit or {}).commitId or ""
+  local tgt_sha = (pr.lastMergeTargetCommit or {}).commitId or ""
+  return {
+    id = pr.pullRequestId or 0,
+    node_id = "",
+    number = pr.pullRequestId or 0,
+    state = gh_state,
+    locked = false,
+    title = pr.title or "",
+    body = pr.description or "",
+    user = ado_user(pr.createdBy),
+    head = { label = src_ref, ref = src_ref, sha = src_sha },
+    base = { label = tgt_ref, ref = tgt_ref, sha = tgt_sha },
+    draft = pr.isDraft or false,
+    created_at = pr.creationDate or "",
+    updated_at = pr.closedDate or pr.creationDate or "",
+    closed_at = (not is_merged and gh_state == "closed") and pr.closedDate or nil,
+    merged_at = is_merged and pr.closedDate or nil,
+    merge_commit_sha = nil,
+    merged_by = nil,
+    html_url = "",
+    url = "",
+    mergeable = status == "active" or nil,
+    comments = 0,
+    review_comments = 0,
+    commits = 0,
+    additions = 0,
+    deletions = 0,
+    changed_files = 0,
+  }
 end
 
 b:webhook("workitem.created", function(payload)
@@ -2036,6 +2082,49 @@ b:webhook("workitem.commented", function(payload)
       sender = ado_user(revised_by),
     },
     timestamp = resource.revisedDate or "",
+  })
+end)
+
+b:webhook("git.pullrequest.created", function(payload)
+  local resource = payload.resource or {}
+  return make_internal_event({
+    event = "pull_request",
+    action = "opened",
+    provider = "azuredevops",
+    raw = payload,
+    data = {
+      action = "opened",
+      number = resource.pullRequestId,
+      pull_request = translate_ado_pull(resource),
+      repository = translate_ado_repo(resource.repository),
+      sender = ado_user(resource.createdBy),
+    },
+    timestamp = payload.createdDate or "",
+  })
+end)
+
+b:webhook("git.pullrequest.updated", function(payload)
+  local resource = payload.resource or {}
+  local status = resource.status or "active"
+  local action
+  if status == "completed" or status == "abandoned" then
+    action = "closed"
+  else
+    action = "synchronize"
+  end
+  return make_internal_event({
+    event = "pull_request",
+    action = action,
+    provider = "azuredevops",
+    raw = payload,
+    data = {
+      action = action,
+      number = resource.pullRequestId,
+      pull_request = translate_ado_pull(resource),
+      repository = translate_ado_repo(resource.repository),
+      sender = ado_user(resource.createdBy),
+    },
+    timestamp = payload.createdDate or "",
   })
 end)
 

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -2518,4 +2518,45 @@ b:webhook("issue:comment_created", function(payload)
   })
 end)
 
+-- pull_request: opened, synchronize, closed.
+-- Registered for X-Event-Key: pullrequest:created, :updated, :fulfilled, :rejected.
+-- Bitbucket Cloud does not expose separate events for edited or reopen; all
+-- non-lifecycle changes (new commits, title edits, and PR reopens from DECLINED)
+-- arrive as pullrequest:updated, which confusio maps to synchronize.
+local function bb_pr_event(payload, action)
+  local raw_pr = payload.pullrequest or {}
+  return make_internal_event({
+    event = "pull_request",
+    action = action,
+    provider = "bitbucket",
+    raw = payload,
+    data = {
+      action = action,
+      number = raw_pr.id,
+      pull_request = translate_bb_pull(raw_pr),
+      repository = translate_bb_repo(payload.repository or {}),
+      sender = translate_bb_user(payload.actor or {}),
+    },
+    timestamp = raw_pr.updated_on or "",
+  })
+end
+
+b:webhook("pullrequest:created", function(payload)
+  return bb_pr_event(payload, "opened")
+end)
+
+b:webhook("pullrequest:updated", function(payload)
+  return bb_pr_event(payload, "synchronize")
+end)
+
+b:webhook("pullrequest:fulfilled", function(payload)
+  -- fulfilled = merged
+  return bb_pr_event(payload, "closed")
+end)
+
+b:webhook("pullrequest:rejected", function(payload)
+  -- rejected = declined
+  return bb_pr_event(payload, "closed")
+end)
+
 b:build()

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -1540,7 +1540,6 @@ end)
 
 b:webhook("pr:reviewer:updated", function(payload)
   local added = payload.addedReviewers or {}
-  local removed = payload.removedReviewers or {}
   local action = #added > 0 and "review_requested" or "review_request_removed"
   return bbs_pr_event(payload, action)
 end)

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -1499,7 +1499,62 @@ end)
 
 -- Webhook handlers: Bitbucket Data Center has no native issue tracker
 -- (it defers to Jira for issue management), so no issue:created /
--- issue:updated / issue:comment_created events exist.  No b:webhook
--- registrations are needed here.
+-- issue:updated / issue:comment_created events exist.
+--
+-- pull_request events are registered below using BBS-specific event keys.
+-- BBS PR webhook payloads use pullRequest (capital R) for the PR object,
+-- actor for the sender, and toRef.repository for the target repository.
+local function bbs_pr_event(payload, action)
+  local raw_pr = payload.pullRequest or {}
+  local repo = (raw_pr.toRef or {}).repository
+  return make_internal_event({
+    event = "pull_request",
+    action = action,
+    provider = "bitbucket_datacenter",
+    raw = payload,
+    data = {
+      action = action,
+      number = raw_pr.id,
+      pull_request = translate_bbs_pull(raw_pr),
+      repository = translate_bbs_repo(repo),
+      sender = translate_bbs_user(payload.actor or {}),
+    },
+    timestamp = bbs_ts(raw_pr.updatedDate) or "",
+  })
+end
+
+b:webhook("pr:opened", function(payload)
+  return bbs_pr_event(payload, "opened")
+end)
+
+b:webhook("pr:modified", function(payload)
+  -- pr:modified fires on title/description changes and when a DECLINED PR is
+  -- reopened.  Without prior-state tracking, reopen is indistinguishable from
+  -- edit; both map to "edited".
+  return bbs_pr_event(payload, "edited")
+end)
+
+b:webhook("pr:from_ref_updated", function(payload)
+  return bbs_pr_event(payload, "synchronize")
+end)
+
+b:webhook("pr:reviewer:updated", function(payload)
+  local added = payload.addedReviewers or {}
+  local removed = payload.removedReviewers or {}
+  local action = #added > 0 and "review_requested" or "review_request_removed"
+  return bbs_pr_event(payload, action)
+end)
+
+b:webhook("pr:merged", function(payload)
+  return bbs_pr_event(payload, "closed")
+end)
+
+b:webhook("pr:declined", function(payload)
+  return bbs_pr_event(payload, "closed")
+end)
+
+b:webhook("pr:deleted", function(payload)
+  return bbs_pr_event(payload, "closed")
+end)
 
 b:build()

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -2324,6 +2324,23 @@ local GB_MILESTONE_ACTIONS = {
   edited = "edited",
   opened = "opened",
 }
+local GB_PULL_REQUEST_ACTIONS = {
+  assigned = "assigned",
+  closed = "closed",
+  converted_to_draft = "converted_to_draft",
+  edited = "edited",
+  labeled = "labeled",
+  locked = "locked",
+  opened = "opened",
+  ready_for_review = "ready_for_review",
+  reopened = "reopened",
+  review_request_removed = "review_request_removed",
+  review_requested = "review_requested",
+  synchronize = "synchronize",
+  unassigned = "unassigned",
+  unlabeled = "unlabeled",
+  unlocked = "unlocked",
+}
 
 b:webhook("issues", function(payload)
   local raw_action = payload.action or ""
@@ -2407,6 +2424,33 @@ b:webhook("milestone", function(payload)
       sender = payload.sender or {},
     },
     timestamp = (payload.milestone or {}).updated_at or "",
+  })
+end)
+
+b:webhook("pull_request", function(payload)
+  local raw_action = payload.action or ""
+  local action = GB_PULL_REQUEST_ACTIONS[raw_action]
+  local data = {
+    action = action or "unknown",
+    number = payload.number,
+    pull_request = payload.pull_request or {},
+    repository = payload.repository or {},
+    sender = payload.sender or {},
+  }
+  if action == "labeled" or action == "unlabeled" then
+    data.label = payload.label
+  end
+  if action == "review_requested" or action == "review_request_removed" then
+    data.requested_reviewer = payload.requested_reviewer
+  end
+  return make_internal_event({
+    event = "pull_request",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitbucket",
+    raw = payload,
+    data = data,
+    timestamp = (payload.pull_request or {}).updated_at or "",
   })
 end)
 

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7079,6 +7079,22 @@ local MILESTONE_ACTIONS = {
   edited = "edited",
   deleted = "deleted",
 }
+local PULL_REQUEST_ACTIONS = {
+  opened = "opened",
+  closed = "closed",
+  reopened = "reopened",
+  edited = "edited",
+  synchronize = "synchronize", -- commits pushed to PR head branch
+  synchronized = "synchronize", -- older Gitea spelling
+  labeled = "labeled",
+  label_updated = "labeled", -- older Gitea spelling
+  unlabeled = "unlabeled",
+  label_cleared = "unlabeled", -- older Gitea spelling
+  assigned = "assigned",
+  unassigned = "unassigned",
+  review_requested = "review_requested",
+  review_request_removed = "review_request_removed",
+}
 
 b:webhook("issues", function(payload)
   local raw_action = payload.action or ""
@@ -7161,6 +7177,54 @@ b:webhook("milestone", function(payload)
       sender = translate_user(payload.sender or {}),
     },
     timestamp = (payload.milestone or {}).updated_at or "",
+  })
+end)
+
+b:webhook("pull_request", function(payload)
+  local raw_action = payload.action or ""
+  local action = PULL_REQUEST_ACTIONS[raw_action]
+  local raw_pr = payload.pull_request or {}
+  local pr = translate_gitea_pull(raw_pr)
+  -- Enrich with labels, assignees, and requested_reviewers from the payload
+  -- (translate_gitea_pull omits them as the REST endpoint fetches them separately).
+  local labels, assignees, requested_reviewers = {}, {}, {}
+  for _, l in ipairs(raw_pr.labels or {}) do
+    labels[#labels + 1] = translate_gitea_label(l)
+  end
+  for _, u in ipairs(raw_pr.assignees or {}) do
+    assignees[#assignees + 1] = translate_user(u)
+  end
+  for _, u in ipairs(raw_pr.requested_reviewers or {}) do
+    requested_reviewers[#requested_reviewers + 1] = translate_user(u)
+  end
+  pr.labels = labels
+  pr.assignees = assignees
+  pr.requested_reviewers = requested_reviewers
+  local data = {
+    action = action or "unknown",
+    number = payload.number,
+    pull_request = pr,
+    repository = translate_repo(payload.repository or {}),
+    sender = translate_user(payload.sender or {}),
+  }
+  -- For labeled/unlabeled, include the specific label that changed.
+  if action == "labeled" or action == "unlabeled" then
+    data.label = translate_gitea_label(payload.label)
+  end
+  -- For review_requested/review_request_removed, include the affected reviewer.
+  if action == "review_requested" or action == "review_request_removed" then
+    data.requested_reviewer = payload.requested_reviewer
+        and translate_user(payload.requested_reviewer)
+      or nil
+  end
+  return make_internal_event({
+    event = "pull_request",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = data,
+    timestamp = raw_pr.updated or "",
   })
 end)
 

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7228,6 +7228,43 @@ b:webhook("pull_request", function(payload)
   })
 end)
 
+local MERGE_GROUP_ACTIONS = {
+  checks_requested = "checks_requested",
+  destroyed = "destroyed",
+}
+
+b:webhook("merge_group", function(payload)
+  local raw_action = payload.action or ""
+  local action = MERGE_GROUP_ACTIONS[raw_action]
+  local mg = payload.merge_group or {}
+  local data = {
+    action = action or "unknown",
+    merge_group = {
+      head_sha = mg.head_sha or "",
+      head_ref = mg.head_ref or "",
+      base_sha = mg.base_sha or "",
+      base_ref = mg.base_ref or "",
+      head_commit = mg.head_commit or {},
+    },
+    repository = translate_repo(payload.repository or {}),
+    sender = translate_user(payload.sender or {}),
+  }
+  -- The `destroyed` action carries a reason indicating why the group was removed
+  -- from the queue: "merged", "invalidated", or "dequeued".
+  if raw_action == "destroyed" then
+    data.reason = payload.reason
+  end
+  return make_internal_event({
+    event = "merge_group",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = data,
+    timestamp = "",
+  })
+end)
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -6050,6 +6050,113 @@ local function translate_gl_webhook_project(p)
   }
 end
 
+-- Build a normalized pull_request table from a Merge Request Hook payload.
+-- object_attributes carries the MR data; labels, assignees, and reviewers are
+-- top-level arrays in the payload (current state, not diffs).
+local function webhook_mr_from_gl(payload)
+  local oa = payload.object_attributes or {}
+  local labels_arr, assignees_arr, reviewers_arr = {}, {}, {}
+  for _, l in ipairs(payload.labels or {}) do
+    labels_arr[#labels_arr + 1] = translate_gl_label(l)
+  end
+  for _, u in ipairs(payload.assignees or {}) do
+    assignees_arr[#assignees_arr + 1] = translate_gl_user(u)
+  end
+  for _, u in ipairs(payload.reviewers or {}) do
+    reviewers_arr[#reviewers_arr + 1] = translate_gl_user(u)
+  end
+  local diff_refs = oa.diff_refs or {}
+  local state = oa.state or "opened"
+  if state == "opened" then
+    state = "open"
+  elseif state == "merged" then
+    state = "closed"
+  end
+  return {
+    id = oa.id,
+    node_id = "",
+    number = oa.iid,
+    state = state,
+    locked = false,
+    title = oa.title,
+    body = oa.description,
+    user = translate_gl_user(payload.user),
+    head = {
+      label = oa.source_branch or "",
+      ref = oa.source_branch or "",
+      sha = diff_refs.head_sha or (oa.last_commit and oa.last_commit.id) or "",
+      repo = nil, -- source project not included for simplicity (same as REST translator)
+    },
+    base = {
+      label = oa.target_branch or "",
+      ref = oa.target_branch or "",
+      sha = diff_refs.base_sha or "",
+      repo = nil,
+    },
+    draft = oa.draft or oa.work_in_progress or false,
+    created_at = oa.created_at,
+    updated_at = oa.updated_at,
+    closed_at = oa.closed_at,
+    merged_at = oa.merged_at,
+    merge_commit_sha = oa.merge_commit_sha,
+    merged_by = oa.merged_by and translate_gl_user(oa.merged_by) or nil,
+    diff_url = oa.url and (oa.url .. ".diff") or "",
+    patch_url = oa.url and (oa.url .. ".patch") or "",
+    html_url = oa.url or "",
+    url = oa.url or "",
+    mergeable = oa.merge_status == "can_be_merged",
+    labels = labels_arr,
+    assignees = assignees_arr,
+    requested_reviewers = reviewers_arr,
+  }
+end
+
+-- Determine the GitHub pull_request action from a Merge Request Hook payload.
+-- GitLab's "update" covers many sub-events; disambiguate using the changes field.
+local function gl_mr_action(oa, changes)
+  local raw = oa.action or ""
+  if raw == "open" then
+    return "opened", nil
+  elseif raw == "close" then
+    return "closed", nil
+  elseif raw == "merge" then
+    return "closed", nil -- merged is a form of closed
+  elseif raw == "reopen" then
+    return "reopened", nil
+  elseif raw ~= "update" then
+    return "unknown", raw
+  end
+  -- Disambiguate GitLab's "update" action using the changes field (GitLab 10.2+).
+  if changes.last_commit then
+    return "synchronize", nil
+  end
+  local lc = changes.labels or {}
+  local nprev_l = #(lc.previous or {})
+  local ncurr_l = #(lc.current or {})
+  if ncurr_l > nprev_l then
+    return "labeled", nil
+  elseif ncurr_l < nprev_l then
+    return "unlabeled", nil
+  end
+  local ac = changes.assignees or {}
+  local nprev_a = #(ac.previous or {})
+  local ncurr_a = #(ac.current or {})
+  if ncurr_a > nprev_a then
+    return "assigned", nil
+  elseif ncurr_a < nprev_a then
+    return "unassigned", nil
+  end
+  local rc = changes.reviewers or {}
+  local nprev_r = #(rc.previous or {})
+  local ncurr_r = #(rc.current or {})
+  if ncurr_r > nprev_r then
+    return "review_requested", nil
+  elseif ncurr_r < nprev_r then
+    return "review_request_removed", nil
+  end
+  return "edited", nil
+end
+
 -- Build a normalized issue table from an Issues Hook payload.
 -- object_attributes has the issue data; labels and assignees are top-level.
 local function webhook_issue_from_gl(payload)
@@ -6232,6 +6339,33 @@ b:webhook("Milestone Hook", function(payload)
       repository = translate_gl_webhook_project(payload.project),
       sender = translate_gl_user(payload.user),
     },
+  })
+end)
+
+-- pull_request: opened, closed, reopened, synchronize, edited, labeled,
+-- unlabeled, assigned, unassigned, review_requested, review_request_removed.
+-- Registered for X-Gitlab-Event: Merge Request Hook.
+-- GitLab uses "merge request" terminology; confusio maps all events to the
+-- GitHub pull_request event family.
+b:webhook("Merge Request Hook", function(payload)
+  local oa = payload.object_attributes or {}
+  local changes = payload.changes or {}
+  local action, raw_action = gl_mr_action(oa, changes)
+  local data = {
+    action = action,
+    number = oa.iid,
+    pull_request = webhook_mr_from_gl(payload),
+    repository = translate_gl_webhook_project(payload.project),
+    sender = translate_gl_user(payload.user),
+  }
+  return make_internal_event({
+    event = "pull_request",
+    action = action,
+    raw_action = raw_action,
+    provider = config.backend,
+    timestamp = oa.updated_at or "",
+    raw = payload,
+    data = data,
   })
 end)
 

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -1013,14 +1013,64 @@ end)
 --   msg.comment — present only for comment events
 --
 -- Relevant X-Pagure-Event values:
---   issue.new            → issues / opened
---   issue.edit           → issues / edited
---   issue.status.change  → issues / closed | reopened  (derived from issue.status)
---   issue.comment.added  → issue_comment / created
+--   issue.new              → issues / opened
+--   issue.edit             → issues / edited
+--   issue.status.change    → issues / closed | reopened  (derived from issue.status)
+--   issue.comment.added    → issue_comment / created
+--   pull-request.new       → pull_request / opened
+--   pull-request.updated   → pull_request / synchronize
+--   pull-request.closed    → pull_request / closed  (status: Merged or Closed)
 
 -- Helper: build a GitHub-shaped user from a Pagure agent string (bare username).
 local function pagure_agent_user(agent)
   return translate_pagure_user({ name = agent or "" })
+end
+
+-- Translate a Pagure pull request to GitHub format.
+local function translate_pagure_pull(pr)
+  if not pr then
+    return {}
+  end
+  local status = pr.status or "Open"
+  local is_merged = status == "Merged"
+  local gh_state = status == "Open" and "open" or "closed"
+  local repo_from = pr.repo_from or {}
+  return {
+    id = pr.id or 0,
+    node_id = "",
+    number = pr.id or 0,
+    state = gh_state,
+    locked = false,
+    title = pr.title or "",
+    body = pr.initial_comment or "",
+    user = translate_pagure_user(pr.user),
+    head = {
+      label = (repo_from.fullname or "") .. ":" .. (pr.branch_from or ""),
+      ref = pr.branch_from or "",
+      sha = pr.commit_stop or "",
+    },
+    base = {
+      label = "" .. ":" .. (pr.branch or ""),
+      ref = pr.branch or "",
+      sha = "",
+    },
+    draft = false,
+    created_at = tostring(pr.date_created or ""),
+    updated_at = tostring(pr.last_updated or ""),
+    closed_at = (not is_merged and gh_state == "closed") and tostring(pr.last_updated or "") or nil,
+    merged_at = is_merged and tostring(pr.last_updated or "") or nil,
+    merge_commit_sha = nil,
+    merged_by = nil,
+    html_url = config.base_url .. "/" .. (pr.full_url or ""),
+    url = "",
+    mergeable = status == "Open" or nil,
+    comments = 0,
+    review_comments = 0,
+    commits = 0,
+    additions = 0,
+    deletions = 0,
+    changed_files = 0,
+  }
 end
 
 b:webhook("issue.new", function(payload)
@@ -1091,6 +1141,63 @@ b:webhook("issue.comment.added", function(payload)
       sender = pagure_agent_user(msg.agent),
     },
     timestamp = tostring((msg.comment or {}).date_created or ""),
+  })
+end)
+
+b:webhook("pull-request.new", function(payload)
+  local msg = payload.msg or {}
+  local pr = msg.pullrequest or {}
+  return make_internal_event({
+    event = "pull_request",
+    action = "opened",
+    provider = "pagure",
+    raw = payload,
+    data = {
+      action = "opened",
+      number = pr.id,
+      pull_request = translate_pagure_pull(pr),
+      repository = translate_pagure_repo(msg.project),
+      sender = pagure_agent_user(msg.agent),
+    },
+    timestamp = tostring(pr.date_created or ""),
+  })
+end)
+
+b:webhook("pull-request.updated", function(payload)
+  local msg = payload.msg or {}
+  local pr = msg.pullrequest or {}
+  return make_internal_event({
+    event = "pull_request",
+    action = "synchronize",
+    provider = "pagure",
+    raw = payload,
+    data = {
+      action = "synchronize",
+      number = pr.id,
+      pull_request = translate_pagure_pull(pr),
+      repository = translate_pagure_repo(msg.project),
+      sender = pagure_agent_user(msg.agent),
+    },
+    timestamp = tostring(pr.last_updated or ""),
+  })
+end)
+
+b:webhook("pull-request.closed", function(payload)
+  local msg = payload.msg or {}
+  local pr = msg.pullrequest or {}
+  return make_internal_event({
+    event = "pull_request",
+    action = "closed",
+    provider = "pagure",
+    raw = payload,
+    data = {
+      action = "closed",
+      number = pr.id,
+      pull_request = translate_pagure_pull(pr),
+      repository = translate_pagure_repo(msg.project),
+      sender = pagure_agent_user(msg.agent),
+    },
+    timestamp = tostring(pr.last_updated or ""),
   })
 end)
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2366,6 +2366,47 @@ Triggered when a comment is added, edited, or deleted on a pull request review d
 
 ---
 
+### `merge_group`
+
+Triggered on merge queue activity.  GitHub groups pull requests in a merge queue into
+merge groups to be tested and merged together.  This event fires when a group is created
+(checks must pass before merging) or destroyed (merged, removed from queue, or invalidated
+by an earlier entry being dequeued).
+
+No equivalent native event exists in Gitea, Forgejo, GitLab, or other self-hosted backends.
+Confusio emits `merge_group` only when the originating backend sends it; for the
+gitea-family this requires a Forgejo version with merge-queue support or a future Gitea
+release that introduces the feature.
+
+#### Merge group object fields
+
+| GitHub field | gitea-family | All others |
+|---|---|---|
+| `merge_group.head_sha` | ✓ | ✗ |
+| `merge_group.head_ref` | ✓ | ✗ |
+| `merge_group.base_sha` | ✓ | ✗ |
+| `merge_group.base_ref` | ✓ | ✗ |
+| `merge_group.head_commit` | ✓ | ✗ |
+
+#### Supported actions by backend
+
+| Action | gitea-family | All others |
+|--------|---|---|
+| `checks_requested` | ✓ | ✗ |
+| `destroyed` | ✓ | ✗ |
+
+**Notes:**
+- `checks_requested`: Fired when a merge group is formed and checks must pass before the
+  group can be merged into the base branch.
+- `destroyed`: Fired when a merge group is removed from the queue.  The top-level `reason`
+  field indicates why: `"merged"` (successfully merged), `"dequeued"` (pull request manually
+  removed from the queue), or `"invalidated"` (an earlier queue entry was dequeued, making
+  this group stale).  The `reason` field is only present for the `destroyed` action.
+- Backends not listed do not emit merge group events; confusio never generates `merge_group`
+  for those backends regardless of queue configuration.
+
+---
+
 ### `commit_comment`
 
 Triggered when a comment is created directly on a commit (not a PR or review).

--- a/test/azuredevops-webhooks.hurl
+++ b/test/azuredevops-webhooks.hurl
@@ -167,3 +167,94 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── git.pullrequest.created → pull_request / opened ──────────────────────────
+
+POST http://{{host}}/webhooks/azuredevops
+Content-Type: application/json
+{
+  "subscriptionId": "sub-1",
+  "notificationId": 6,
+  "id": "evt-6",
+  "eventType": "git.pullrequest.created",
+  "resource": {
+    "pullRequestId": 42,
+    "title": "Add feature X",
+    "description": "This PR adds feature X.",
+    "status": "active",
+    "isDraft": false,
+    "sourceRefName": "refs/heads/feature-x",
+    "targetRefName": "refs/heads/main",
+    "createdBy": {"displayName": "Alice", "uniqueName": "alice"},
+    "creationDate": "2024-01-15T12:00:00Z",
+    "lastMergeSourceCommit": {"commitId": "abc123"},
+    "lastMergeTargetCommit": {"commitId": "def456"},
+    "repository": {}
+  },
+  "createdDate": "2024-01-15T12:00:00Z"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── git.pullrequest.updated (completed) → pull_request / closed ───────────────
+
+POST http://{{host}}/webhooks/azuredevops
+Content-Type: application/json
+{
+  "subscriptionId": "sub-1",
+  "notificationId": 7,
+  "id": "evt-7",
+  "eventType": "git.pullrequest.updated",
+  "resource": {
+    "pullRequestId": 42,
+    "title": "Add feature X",
+    "description": "This PR adds feature X.",
+    "status": "completed",
+    "isDraft": false,
+    "sourceRefName": "refs/heads/feature-x",
+    "targetRefName": "refs/heads/main",
+    "createdBy": {"displayName": "Alice", "uniqueName": "alice"},
+    "creationDate": "2024-01-15T12:00:00Z",
+    "closedDate": "2024-01-15T13:00:00Z",
+    "lastMergeSourceCommit": {"commitId": "abc123"},
+    "lastMergeTargetCommit": {"commitId": "def456"},
+    "repository": {}
+  },
+  "createdDate": "2024-01-15T13:00:00Z"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── git.pullrequest.updated (push/synchronize) → pull_request / synchronize ───
+
+POST http://{{host}}/webhooks/azuredevops
+Content-Type: application/json
+{
+  "subscriptionId": "sub-1",
+  "notificationId": 8,
+  "id": "evt-8",
+  "eventType": "git.pullrequest.updated",
+  "resource": {
+    "pullRequestId": 42,
+    "title": "Add feature X",
+    "description": "This PR adds feature X.",
+    "status": "active",
+    "isDraft": false,
+    "sourceRefName": "refs/heads/feature-x",
+    "targetRefName": "refs/heads/main",
+    "createdBy": {"displayName": "Alice", "uniqueName": "alice"},
+    "creationDate": "2024-01-15T12:00:00Z",
+    "lastMergeSourceCommit": {"commitId": "bbb999"},
+    "lastMergeTargetCommit": {"commitId": "def456"},
+    "repository": {}
+  },
+  "createdDate": "2024-01-15T12:30:00Z"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/bitbucket-webhooks.hurl
+++ b/test/bitbucket-webhooks.hurl
@@ -250,3 +250,242 @@ X-Event-Key: issue:comment_created
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── pullrequest:created → pull_request / opened ──────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:created
+{
+  "actor": {
+    "nickname": "bob",
+    "display_name": "Bob",
+    "account_id": "def456",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "abc123"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T10:00:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pullrequest:updated → pull_request / synchronize ─────────────────────────
+# BB Cloud fires pullrequest:updated for sync, edit, and reopen; we map to
+# synchronize (most common case; distinguishing requires state tracking).
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:updated
+{
+  "actor": {
+    "nickname": "bob",
+    "display_name": "Bob",
+    "account_id": "def456",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "bbb222"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T10:05:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pullrequest:fulfilled → pull_request / closed (merged) ───────────────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:fulfilled
+{
+  "actor": {
+    "nickname": "alice",
+    "display_name": "Alice",
+    "account_id": "abc123",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "MERGED",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "closed_by": {
+      "nickname": "alice", "display_name": "Alice", "account_id": "abc123",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "merge_commit": {"hash": "ccc333"},
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "bbb222"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T10:10:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pullrequest:rejected → pull_request / closed (declined) ──────────────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:rejected
+{
+  "actor": {
+    "nickname": "alice",
+    "display_name": "Alice",
+    "account_id": "abc123",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "pullrequest": {
+    "id": 8,
+    "title": "Bad idea",
+    "description": "",
+    "state": "DECLINED",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "bad-idea"},
+      "commit": {"hash": "aaa111"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T09:00:00Z",
+    "updated_on": "2024-01-15T10:15:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/8"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/bitbucket_datacenter-webhooks.hurl
+++ b/test/bitbucket_datacenter-webhooks.hurl
@@ -1,0 +1,326 @@
+# Bitbucket Data Center webhook normalizer tests — run by test-unit-bitbucket_datacenter.
+#
+# BBS uses X-Event-Key header.  PR events are the primary event type supported
+# (BBS has no native issue tracker).
+# Trust-the-network mode (no CONFUSIO_WEBHOOK_SECRETS): signature headers omitted.
+
+# ── pr:opened → pull_request / opened ────────────────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: pr:opened
+{
+  "actor": {
+    "name": "bob",
+    "id": 2,
+    "slug": "bob",
+    "displayName": "Bob",
+    "emailAddress": "bob@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "pullRequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "user": {
+        "name": "bob", "id": 2, "slug": "bob",
+        "displayName": "Bob", "emailAddress": "bob@example.com",
+        "links": {"self": [{"href": ""}]}
+      },
+      "role": "AUTHOR", "approved": false, "status": "UNAPPROVED"
+    },
+    "fromRef": {
+      "id": "refs/heads/feature-branch",
+      "displayId": "feature-branch",
+      "latestCommit": "abc123",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "def456",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "reviewers": [],
+    "createdDate": 1705312800000,
+    "updatedDate": 1705312800000,
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/pull-requests/7"}]}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pr:modified → pull_request / edited ──────────────────────────────────────
+# pr:modified fires on title/description changes and reopen; maps to "edited"
+# (reopen is indistinguishable without state tracking).
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: pr:modified
+{
+  "actor": {
+    "name": "bob",
+    "id": 2,
+    "slug": "bob",
+    "displayName": "Bob",
+    "emailAddress": "bob@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "pullRequest": {
+    "id": 7,
+    "title": "Add new feature (updated title)",
+    "description": "Updated description.",
+    "state": "OPEN",
+    "author": {
+      "user": {
+        "name": "bob", "id": 2, "slug": "bob",
+        "displayName": "Bob", "emailAddress": "bob@example.com",
+        "links": {"self": [{"href": ""}]}
+      },
+      "role": "AUTHOR", "approved": false, "status": "UNAPPROVED"
+    },
+    "fromRef": {
+      "id": "refs/heads/feature-branch",
+      "displayId": "feature-branch",
+      "latestCommit": "abc123",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "def456",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "reviewers": [],
+    "createdDate": 1705312800000,
+    "updatedDate": 1705316400000,
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/pull-requests/7"}]}
+  },
+  "previousTitle": "Add new feature"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pr:from_ref_updated → pull_request / synchronize ─────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: pr:from_ref_updated
+{
+  "actor": {
+    "name": "bob",
+    "id": 2,
+    "slug": "bob",
+    "displayName": "Bob",
+    "emailAddress": "bob@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "pullRequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "user": {
+        "name": "bob", "id": 2, "slug": "bob",
+        "displayName": "Bob", "emailAddress": "bob@example.com",
+        "links": {"self": [{"href": ""}]}
+      },
+      "role": "AUTHOR", "approved": false, "status": "UNAPPROVED"
+    },
+    "fromRef": {
+      "id": "refs/heads/feature-branch",
+      "displayId": "feature-branch",
+      "latestCommit": "bbb222",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "def456",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "reviewers": [],
+    "createdDate": 1705312800000,
+    "updatedDate": 1705318000000,
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/pull-requests/7"}]}
+  },
+  "previousFromHash": "abc123"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pr:reviewer:updated (added) → pull_request / review_requested ────────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: pr:reviewer:updated
+{
+  "actor": {
+    "name": "alice",
+    "id": 1,
+    "slug": "alice",
+    "displayName": "Alice",
+    "emailAddress": "alice@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "pullRequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "user": {
+        "name": "bob", "id": 2, "slug": "bob",
+        "displayName": "Bob", "emailAddress": "bob@example.com",
+        "links": {"self": [{"href": ""}]}
+      },
+      "role": "AUTHOR", "approved": false, "status": "UNAPPROVED"
+    },
+    "fromRef": {
+      "id": "refs/heads/feature-branch",
+      "displayId": "feature-branch",
+      "latestCommit": "abc123",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "def456",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "alice", "id": 1, "slug": "alice",
+          "displayName": "Alice", "emailAddress": "alice@example.com",
+          "links": {"self": [{"href": ""}]}
+        },
+        "role": "REVIEWER", "approved": false, "status": "UNAPPROVED"
+      }
+    ],
+    "createdDate": 1705312800000,
+    "updatedDate": 1705319000000,
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/pull-requests/7"}]}
+  },
+  "addedReviewers": [
+    {
+      "name": "alice", "id": 1, "slug": "alice",
+      "displayName": "Alice", "emailAddress": "alice@example.com",
+      "links": {"self": [{"href": ""}]}
+    }
+  ],
+  "removedReviewers": []
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pr:merged → pull_request / closed ────────────────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: pr:merged
+{
+  "actor": {
+    "name": "alice",
+    "id": 1,
+    "slug": "alice",
+    "displayName": "Alice",
+    "emailAddress": "alice@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "pullRequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "MERGED",
+    "author": {
+      "user": {
+        "name": "bob", "id": 2, "slug": "bob",
+        "displayName": "Bob", "emailAddress": "bob@example.com",
+        "links": {"self": [{"href": ""}]}
+      },
+      "role": "AUTHOR", "approved": false, "status": "UNAPPROVED"
+    },
+    "fromRef": {
+      "id": "refs/heads/feature-branch",
+      "displayId": "feature-branch",
+      "latestCommit": "abc123",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "def456",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "reviewers": [],
+    "createdDate": 1705312800000,
+    "updatedDate": 1705320000000,
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/pull-requests/7"}]}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/gitbucket-webhooks.hurl
+++ b/test/gitbucket-webhooks.hurl
@@ -360,3 +360,295 @@ X-GitHub-Event: milestone
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── pull_request: opened → 200 ────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request
+{
+  "action": "opened",
+  "number": 7,
+  "pull_request": {
+    "id": 500,
+    "node_id": "",
+    "number": 7,
+    "title": "Add new feature",
+    "body": "This PR adds a new feature.",
+    "state": "open",
+    "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {
+      "login": "bob", "id": 2, "node_id": "", "avatar_url": "",
+      "url": "", "html_url": "", "type": "User"
+    },
+    "head": {
+      "ref": "feature-branch", "sha": "abc123",
+      "repo": {
+        "id": 1, "node_id": "", "name": "hello-world",
+        "full_name": "octocat/hello-world", "private": false,
+        "owner": {
+          "login": "octocat", "id": 1, "node_id": "", "avatar_url": "",
+          "url": "", "html_url": "", "type": "User"
+        },
+        "html_url": "http://localhost/octocat/hello-world",
+        "description": "", "fork": false, "url": "",
+        "clone_url": "", "homepage": "", "default_branch": "main",
+        "visibility": "public"
+      }
+    },
+    "base": {
+      "ref": "main", "sha": "def456",
+      "repo": {
+        "id": 1, "node_id": "", "name": "hello-world",
+        "full_name": "octocat/hello-world", "private": false,
+        "owner": {
+          "login": "octocat", "id": 1, "node_id": "", "avatar_url": "",
+          "url": "", "html_url": "", "type": "User"
+        },
+        "html_url": "http://localhost/octocat/hello-world",
+        "description": "", "fork": false, "url": "",
+        "clone_url": "", "homepage": "", "default_branch": "main",
+        "visibility": "public"
+      }
+    },
+    "labels": [],
+    "assignees": [],
+    "requested_reviewers": [],
+    "merged": false,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "closed_at": null
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {
+      "login": "octocat", "id": 1, "node_id": "", "avatar_url": "",
+      "url": "", "html_url": "", "type": "User"
+    },
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {
+    "login": "bob", "id": 2, "node_id": "", "avatar_url": "",
+    "url": "", "html_url": "", "type": "User"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: synchronize → 200 (commit pushed to PR branch) ─────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request
+{
+  "action": "synchronize",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": "This PR adds a new feature.",
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:05:00Z",
+    "closed_at": null
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: closed (merged) → 200 ──────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request
+{
+  "action": "closed",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": "This PR adds a new feature.",
+    "state": "closed", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": true,
+    "merged_at": "2024-01-16T09:00:00Z",
+    "merge_commit_sha": "jkl012",
+    "merged_by": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-16T09:00:00Z",
+    "closed_at": "2024-01-16T09:00:00Z"
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: labeled → 200 (with label field in data) ───────────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request
+{
+  "action": "labeled",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [{"id": 5, "node_id": "", "name": "bug", "color": "d73a4a", "url": ""}],
+    "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:02:00Z",
+    "closed_at": null
+  },
+  "label": {"id": 5, "node_id": "", "name": "bug", "color": "d73a4a", "url": ""},
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: review_requested → 200 (with requested_reviewer) ───────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request
+{
+  "action": "review_requested",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [],
+    "requested_reviewers": [
+      {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+    ],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:03:00Z",
+    "closed_at": null
+  },
+  "requested_reviewer": {
+    "login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: unknown action → 200 + X-Confusio-Raw-Action ───────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request
+{
+  "action": "auto_merged",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": null,
+    "state": "closed", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "closed_at": null
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "auto_merged"

--- a/test/gitea-webhooks.hurl
+++ b/test/gitea-webhooks.hurl
@@ -1,6 +1,6 @@
 # Gitea webhook normalizer tests — run by Phase 5 in test-unit.sh.
 #
-# Exercises the four event families registered in backends/gitea.lua.
+# Exercises the five event families registered in backends/gitea.lua.
 # Trust-the-network mode (no CONFUSIO_WEBHOOK_SECRETS): signature headers omitted.
 # All paths return 200 when a registered handler succeeds.
 
@@ -242,3 +242,248 @@ X-Gitea-Event: milestone
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── pull_request: opened → 200 ────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request
+{
+  "action": "opened",
+  "number": 7,
+  "pull_request": {
+    "id": 500,
+    "number": 7,
+    "title": "Add new feature",
+    "body": "This PR adds a new feature.",
+    "state": "open",
+    "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "http://localhost/api/v1/repos/octocat/hello-world/pulls/7",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {
+      "ref": "feature-branch",
+      "sha": "abc123",
+      "repo": {
+        "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+        "private": false, "html_url": "http://localhost/octocat/hello-world",
+        "fork": false, "default_branch": "main",
+        "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+      }
+    },
+    "base": {
+      "ref": "main",
+      "sha": "def456",
+      "repo": {
+        "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+        "private": false, "html_url": "http://localhost/octocat/hello-world",
+        "fork": false, "default_branch": "main",
+        "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+      }
+    },
+    "labels": [],
+    "assignees": [],
+    "requested_reviewers": [],
+    "merged": false,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "merged_by": null,
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:00:00Z",
+    "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: synchronize → 200 (commit pushed to PR branch) ─────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request
+{
+  "action": "synchronize",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": "This PR adds a new feature.",
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "http://localhost/api/v1/repos/octocat/hello-world/pulls/7",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:05:00Z",
+    "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: closed (merged) → 200 ──────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request
+{
+  "action": "closed",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": "This PR adds a new feature.",
+    "state": "closed", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "http://localhost/api/v1/repos/octocat/hello-world/pulls/7",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": true,
+    "merged_at": "2024-01-16T09:00:00Z",
+    "merge_commit_sha": "jkl012",
+    "merged_by": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""},
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-16T09:00:00Z",
+    "closed": "2024-01-16T09:00:00Z"
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: labeled → 200 (with label field in data) ───────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request
+{
+  "action": "labeled",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [{"id": 5, "name": "bug", "color": "#d73a4a", "url": ""}],
+    "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:02:00Z",
+    "closed": null
+  },
+  "label": {"id": 5, "name": "bug", "color": "#d73a4a", "url": ""},
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: review_requested → 200 (with requested_reviewer) ───────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request
+{
+  "action": "review_requested",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [],
+    "requested_reviewers": [{"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:03:00Z",
+    "closed": null
+  },
+  "requested_reviewer": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""},
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request: unknown action → 200 + X-Confusio-Raw-Action sidecar ───────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request
+{
+  "action": "auto_merged",
+  "number": 7,
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "closed", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "ghi789", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:00:00Z",
+    "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "auto_merged"

--- a/test/gitea-webhooks.hurl
+++ b/test/gitea-webhooks.hurl
@@ -487,3 +487,142 @@ HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
 header "X-Confusio-Raw-Action" == "auto_merged"
+
+# ── merge_group: checks_requested → 200 ───────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: merge_group
+{
+  "action": "checks_requested",
+  "merge_group": {
+    "head_sha": "abc123def456abc123def456abc123def456abc1",
+    "head_ref": "refs/heads/gh-readonly-queue/main/pr-7-abc123",
+    "base_sha": "def456abc123def456abc123def456abc123def4",
+    "base_ref": "refs/heads/main",
+    "head_commit": {
+      "id": "abc123def456abc123def456abc123def456abc1",
+      "tree_id": "1234567890abcdef1234567890abcdef12345678",
+      "message": "Add new feature (#7)",
+      "timestamp": "2024-01-15T10:00:00Z",
+      "author": {"name": "Bob", "email": "bob@example.com"},
+      "committer": {"name": "GitHub", "email": "noreply@github.com"}
+    }
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── merge_group: destroyed (reason: merged) → 200 ─────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: merge_group
+{
+  "action": "destroyed",
+  "reason": "merged",
+  "merge_group": {
+    "head_sha": "abc123def456abc123def456abc123def456abc1",
+    "head_ref": "refs/heads/gh-readonly-queue/main/pr-7-abc123",
+    "base_sha": "def456abc123def456abc123def456abc123def4",
+    "base_ref": "refs/heads/main",
+    "head_commit": {
+      "id": "abc123def456abc123def456abc123def456abc1",
+      "tree_id": "1234567890abcdef1234567890abcdef12345678",
+      "message": "Add new feature (#7)",
+      "timestamp": "2024-01-15T10:00:00Z",
+      "author": {"name": "Bob", "email": "bob@example.com"},
+      "committer": {"name": "GitHub", "email": "noreply@github.com"}
+    }
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── merge_group: destroyed (reason: dequeued) → 200 ──────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: merge_group
+{
+  "action": "destroyed",
+  "reason": "dequeued",
+  "merge_group": {
+    "head_sha": "abc123def456abc123def456abc123def456abc1",
+    "head_ref": "refs/heads/gh-readonly-queue/main/pr-7-abc123",
+    "base_sha": "def456abc123def456abc123def456abc123def4",
+    "base_ref": "refs/heads/main",
+    "head_commit": {
+      "id": "abc123def456abc123def456abc123def456abc1",
+      "tree_id": "1234567890abcdef1234567890abcdef12345678",
+      "message": "Add new feature (#7)",
+      "timestamp": "2024-01-15T10:00:00Z",
+      "author": {"name": "Bob", "email": "bob@example.com"},
+      "committer": {"name": "GitHub", "email": "noreply@github.com"}
+    }
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── merge_group: unknown action → 200 + X-Confusio-Raw-Action sidecar ─────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: merge_group
+{
+  "action": "queued",
+  "merge_group": {
+    "head_sha": "abc123def456abc123def456abc123def456abc1",
+    "head_ref": "refs/heads/gh-readonly-queue/main/pr-7-abc123",
+    "base_sha": "def456abc123def456abc123def456abc123def4",
+    "base_ref": "refs/heads/main",
+    "head_commit": {
+      "id": "abc123def456abc123def456abc123def456abc1",
+      "tree_id": "1234567890abcdef1234567890abcdef12345678",
+      "message": "Add new feature (#7)",
+      "timestamp": "2024-01-15T10:00:00Z",
+      "author": {"name": "Bob", "email": "bob@example.com"},
+      "committer": {"name": "GitHub", "email": "noreply@github.com"}
+    }
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "queued"

--- a/test/gitlab-webhooks.hurl
+++ b/test/gitlab-webhooks.hurl
@@ -1,6 +1,6 @@
 # GitLab webhook normalizer tests.
 #
-# Exercises the four event families registered in backends/gitlab.lua.
+# Exercises the five event families registered in backends/gitlab.lua.
 # Trust-the-network mode (no CONFUSIO_WEBHOOK_SECRETS): signature headers omitted.
 # All paths return 200 when a registered handler succeeds.
 
@@ -338,3 +338,284 @@ X-Gitlab-Event: Milestone Hook
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── Merge Request Hook: opened → 200 ──────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 2,
+    "name": "Bob",
+    "username": "bob",
+    "avatar_url": "",
+    "web_url": "http://localhost/bob"
+  },
+  "project": {
+    "id": 10,
+    "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20,
+    "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500,
+    "iid": 7,
+    "title": "Add new feature",
+    "description": "This MR adds a new feature.",
+    "state": "opened",
+    "action": "open",
+    "source_branch": "feature-branch",
+    "target_branch": "main",
+    "last_commit": {"id": "abc123"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "draft": false,
+    "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "closed_at": null,
+    "merged_at": null
+  },
+  "labels": [],
+  "assignees": [],
+  "reviewers": [],
+  "changes": {}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Merge Request Hook: update with new commit → synchronize ──────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 2, "name": "Bob", "username": "bob",
+    "avatar_url": "", "web_url": "http://localhost/bob"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500, "iid": 7, "title": "Add new feature",
+    "description": "This MR adds a new feature.",
+    "state": "opened", "action": "update",
+    "source_branch": "feature-branch", "target_branch": "main",
+    "last_commit": {"id": "ghi789"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "ghi789", "start_sha": "def456"},
+    "draft": false, "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:05:00Z",
+    "closed_at": null, "merged_at": null
+  },
+  "labels": [], "assignees": [], "reviewers": [],
+  "changes": {
+    "last_commit": {
+      "previous": {"id": "abc123"},
+      "current": {"id": "ghi789"}
+    }
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Merge Request Hook: merge → closed ────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500, "iid": 7, "title": "Add new feature",
+    "description": "This MR adds a new feature.",
+    "state": "merged", "action": "merge",
+    "source_branch": "feature-branch", "target_branch": "main",
+    "last_commit": {"id": "ghi789"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "ghi789", "start_sha": "def456"},
+    "draft": false, "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": "jkl012",
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-16T09:00:00Z",
+    "closed_at": "2024-01-16T09:00:00Z",
+    "merged_at": "2024-01-16T09:00:00Z"
+  },
+  "labels": [], "assignees": [], "reviewers": [],
+  "changes": {}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Merge Request Hook: update with label change → labeled ────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500, "iid": 7, "title": "Add new feature", "description": null,
+    "state": "opened", "action": "update",
+    "source_branch": "feature-branch", "target_branch": "main",
+    "last_commit": {"id": "abc123"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "draft": false, "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:02:00Z",
+    "closed_at": null, "merged_at": null
+  },
+  "labels": [{"id": 5, "title": "bug", "color": "#d73a4a", "description": ""}],
+  "assignees": [], "reviewers": [],
+  "changes": {
+    "labels": {
+      "previous": [],
+      "current": [{"id": 5, "title": "bug", "color": "#d73a4a", "description": ""}]
+    }
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Merge Request Hook: update with reviewer → review_requested ───────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500, "iid": 7, "title": "Add new feature", "description": null,
+    "state": "opened", "action": "update",
+    "source_branch": "feature-branch", "target_branch": "main",
+    "last_commit": {"id": "abc123"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "draft": false, "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:03:00Z",
+    "closed_at": null, "merged_at": null
+  },
+  "labels": [], "assignees": [],
+  "reviewers": [{"id": 3, "name": "Carol", "username": "carol", "avatar_url": "", "web_url": "http://localhost/carol"}],
+  "changes": {
+    "reviewers": {
+      "previous": [],
+      "current": [{"id": 3, "name": "Carol", "username": "carol", "avatar_url": "", "web_url": "http://localhost/carol"}]
+    }
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Merge Request Hook: unknown action → 200 + X-Confusio-Raw-Action ─────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500, "iid": 7, "title": "Add new feature", "description": null,
+    "state": "opened", "action": "approved",
+    "source_branch": "feature-branch", "target_branch": "main",
+    "last_commit": {"id": "abc123"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "draft": false, "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:04:00Z",
+    "closed_at": null, "merged_at": null
+  },
+  "labels": [], "assignees": [], "reviewers": [],
+  "changes": {}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "approved"

--- a/test/pagure-webhooks.hurl
+++ b/test/pagure-webhooks.hurl
@@ -199,3 +199,138 @@ X-Pagure-Event: issue.comment.added
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── pull-request.new → pull_request / opened ─────────────────────────────────
+
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Event: pull-request.new
+{
+  "topic": "pull-request.new",
+  "msg": {
+    "pullrequest": {
+      "id": 7,
+      "title": "Add feature X",
+      "initial_comment": "This PR adds feature X.",
+      "status": "Open",
+      "branch": "main",
+      "branch_from": "feature-x",
+      "repo_from": {
+        "id": 101,
+        "name": "hello-world",
+        "fullname": "alice/hello-world"
+      },
+      "user": {"name": "alice", "fullname": "Alice", "url_path": "user/alice", "avatar_url": ""},
+      "date_created": "1705312800",
+      "last_updated": "1705312800",
+      "commit_start": "abc123",
+      "commit_stop": "def456",
+      "full_url": "octocat/hello-world/pull-request/7"
+    },
+    "project": {
+      "id": 100,
+      "name": "hello-world",
+      "namespace": "octocat",
+      "fullname": "octocat/hello-world",
+      "url_path": "octocat/hello-world",
+      "full_url": "http://localhost/octocat/hello-world",
+      "private": false,
+      "user": {"name": "octocat", "url_path": "user/octocat"}
+    },
+    "agent": "alice"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull-request.updated → pull_request / synchronize ────────────────────────
+
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Event: pull-request.updated
+{
+  "topic": "pull-request.updated",
+  "msg": {
+    "pullrequest": {
+      "id": 7,
+      "title": "Add feature X",
+      "initial_comment": "This PR adds feature X.",
+      "status": "Open",
+      "branch": "main",
+      "branch_from": "feature-x",
+      "repo_from": {
+        "id": 101,
+        "name": "hello-world",
+        "fullname": "alice/hello-world"
+      },
+      "user": {"name": "alice", "fullname": "Alice", "url_path": "user/alice", "avatar_url": ""},
+      "date_created": "1705312800",
+      "last_updated": "1705316400",
+      "commit_start": "abc123",
+      "commit_stop": "ghi789",
+      "full_url": "octocat/hello-world/pull-request/7"
+    },
+    "project": {
+      "id": 100,
+      "name": "hello-world",
+      "namespace": "octocat",
+      "fullname": "octocat/hello-world",
+      "url_path": "octocat/hello-world",
+      "full_url": "http://localhost/octocat/hello-world",
+      "private": false,
+      "user": {"name": "octocat", "url_path": "user/octocat"}
+    },
+    "agent": "alice"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull-request.closed (merged) → pull_request / closed ─────────────────────
+
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Event: pull-request.closed
+{
+  "topic": "pull-request.closed",
+  "msg": {
+    "pullrequest": {
+      "id": 7,
+      "title": "Add feature X",
+      "initial_comment": "This PR adds feature X.",
+      "status": "Merged",
+      "branch": "main",
+      "branch_from": "feature-x",
+      "repo_from": {
+        "id": 101,
+        "name": "hello-world",
+        "fullname": "alice/hello-world"
+      },
+      "user": {"name": "alice", "fullname": "Alice", "url_path": "user/alice", "avatar_url": ""},
+      "date_created": "1705312800",
+      "last_updated": "1705320000",
+      "commit_start": "abc123",
+      "commit_stop": "def456",
+      "full_url": "octocat/hello-world/pull-request/7"
+    },
+    "project": {
+      "id": 100,
+      "name": "hello-world",
+      "namespace": "octocat",
+      "fullname": "octocat/hello-world",
+      "url_path": "octocat/hello-world",
+      "full_url": "http://localhost/octocat/hello-world",
+      "private": false,
+      "user": {"name": "octocat", "url_path": "user/octocat"}
+    },
+    "agent": "octocat"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"


### PR DESCRIPTION
Fixes #226.

Adds pull_request webhook event mapping across all backends with existing webhook support (Gitea family, GitLab, Bitbucket, Bitbucket DC, GitBucket, Pagure, AzureDevOps), translating each forge's native PR/MR events into GitHub-shaped pull_request events. Also adds merge_group event documentation and handling.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Pagure + AzureDevOps: add pull_request webhook handlers and tests <!-- type:spec -->
- [x] Add merge_group event docs, handler, and tests <!-- type:spec -->
- [x] GitBucket: add pull_request webhook handler and tests <!-- type:spec -->
- [x] Bitbucket + Bitbucket DC: add pull_request webhook handlers and tests <!-- type:spec -->
- [x] GitLab: add pull_request webhook handler and tests <!-- type:spec -->
- [x] Gitea: add pull_request webhook handler and tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->