### PR TITLE
v3: Webhook — event mapping: pull_request_review, pull_request_review_comment, pull_request_review_thread (closes #227)

### DIFF
--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -2559,4 +2559,83 @@ b:webhook("pullrequest:rejected", function(payload)
   return bb_pr_event(payload, "closed")
 end)
 
+-- pull_request_review: submitted (approved or dismissed).
+-- Bitbucket Cloud fires pullrequest:approved when a reviewer adds an approval,
+-- and pullrequest:unapproved when they withdraw it.  Both map to the
+-- pull_request_review event; the review state distinguishes them.
+local function bb_pr_review_event(payload, state)
+  local raw_pr = payload.pullrequest or {}
+  local reviewer = payload.actor or {}
+  local pr_url = (raw_pr.links and raw_pr.links.html and raw_pr.links.html.href) or ""
+  local review = {
+    id = 0,
+    node_id = "",
+    user = translate_bb_user(reviewer),
+    body = "",
+    state = state,
+    submitted_at = raw_pr.updated_on or "",
+    html_url = pr_url,
+    pull_request_url = pr_url,
+  }
+  local action = state == "dismissed" and "dismissed" or "submitted"
+  return make_internal_event({
+    event = "pull_request_review",
+    action = action,
+    provider = "bitbucket",
+    raw = payload,
+    data = {
+      action = action,
+      review = review,
+      pull_request = translate_bb_pull(raw_pr),
+      repository = translate_bb_repo(payload.repository or {}),
+      sender = translate_bb_user(reviewer),
+    },
+    timestamp = raw_pr.updated_on or "",
+  })
+end
+
+b:webhook("pullrequest:approved", function(payload)
+  return bb_pr_review_event(payload, "approved")
+end)
+
+b:webhook("pullrequest:unapproved", function(payload)
+  return bb_pr_review_event(payload, "dismissed")
+end)
+
+-- pull_request_review_comment: created, edited, deleted.
+-- Bitbucket Cloud pullrequest:comment_* events cover both inline diff comments
+-- and general PR comments.  All are surfaced as pull_request_review_comment;
+-- the translate_bb_pr_comment translator carries the inline path/position when
+-- the comment has an inline object, and leaves those fields empty otherwise.
+local function bb_pr_review_comment_event(payload, action)
+  local raw_pr = payload.pullrequest or {}
+  local comment = payload.comment or {}
+  return make_internal_event({
+    event = "pull_request_review_comment",
+    action = action,
+    provider = "bitbucket",
+    raw = payload,
+    data = {
+      action = action,
+      comment = translate_bb_pr_comment(comment),
+      pull_request = translate_bb_pull(raw_pr),
+      repository = translate_bb_repo(payload.repository or {}),
+      sender = translate_bb_user(payload.actor or {}),
+    },
+    timestamp = comment.updated_on or comment.created_on or "",
+  })
+end
+
+b:webhook("pullrequest:comment_created", function(payload)
+  return bb_pr_review_comment_event(payload, "created")
+end)
+
+b:webhook("pullrequest:comment_updated", function(payload)
+  return bb_pr_review_comment_event(payload, "edited")
+end)
+
+b:webhook("pullrequest:comment_deleted", function(payload)
+  return bb_pr_review_comment_event(payload, "deleted")
+end)
+
 b:build()

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -1523,6 +1523,50 @@ local function bbs_pr_event(payload, action)
   })
 end
 
+-- Build a pull_request_review event from a BBS reviewer approval payload.
+-- DC sends pr:reviewer:approved when a reviewer approves and pr:reviewer:needs_work
+-- when a reviewer requests changes.  The payload includes a "participant" field with
+-- the reviewer's user object and status (APPROVED / NEEDS_WORK).
+-- DC has no separate review ID or review-level URL; we use the reviewer's user ID
+-- as a stable proxy for the review ID and the PR URL as an approximation for html_url.
+local function bbs_pr_review_event(payload, state)
+  local raw_pr = payload.pullRequest or {}
+  local repo = (raw_pr.toRef or {}).repository
+  local participant = payload.participant or {}
+  local reviewer = participant.user or payload.actor or {}
+  local pr_url = (
+    raw_pr.links
+    and raw_pr.links.self
+    and raw_pr.links.self[1]
+    and raw_pr.links.self[1].href
+  ) or ""
+  local review = {
+    id = reviewer.id or 0,
+    node_id = "",
+    user = translate_bbs_user(reviewer),
+    body = "",
+    state = state,
+    submitted_at = bbs_ts(raw_pr.updatedDate) or "",
+    -- DC does not provide a direct review URL; use the PR URL as a best-effort approximation.
+    html_url = pr_url,
+    pull_request_url = pr_url,
+  }
+  return make_internal_event({
+    event = "pull_request_review",
+    action = "submitted",
+    provider = "bitbucket_datacenter",
+    raw = payload,
+    data = {
+      action = "submitted",
+      review = review,
+      pull_request = translate_bbs_pull(raw_pr),
+      repository = translate_bbs_repo(repo),
+      sender = translate_bbs_user(payload.actor or {}),
+    },
+    timestamp = bbs_ts(raw_pr.updatedDate) or "",
+  })
+end
+
 b:webhook("pr:opened", function(payload)
   return bbs_pr_event(payload, "opened")
 end)
@@ -1554,6 +1598,14 @@ end)
 
 b:webhook("pr:deleted", function(payload)
   return bbs_pr_event(payload, "closed")
+end)
+
+b:webhook("pr:reviewer:approved", function(payload)
+  return bbs_pr_review_event(payload, "approved")
+end)
+
+b:webhook("pr:reviewer:needs_work", function(payload)
+  return bbs_pr_review_event(payload, "changes_requested")
 end)
 
 b:build()

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -2342,6 +2342,15 @@ local GB_PULL_REQUEST_ACTIONS = {
   unlocked = "unlocked",
 }
 
+-- GitBucket emits GitHub-compatible pull_request_review payloads.
+-- Review states arrive lowercase (GitHub format: "approved", "changes_requested",
+-- "commented", "dismissed") — no normalisation needed.
+local GB_PULL_REQUEST_REVIEW_ACTIONS = {
+  dismissed = "dismissed",
+  edited = "edited",
+  submitted = "submitted",
+}
+
 b:webhook("issues", function(payload)
   local raw_action = payload.action or ""
   local action = GB_ISSUES_ACTIONS[raw_action]
@@ -2451,6 +2460,29 @@ b:webhook("pull_request", function(payload)
     raw = payload,
     data = data,
     timestamp = (payload.pull_request or {}).updated_at or "",
+  })
+end)
+
+-- GitBucket emits GitHub-compatible pull_request_review payloads.
+-- Review state is already lowercase (e.g. "approved", "changes_requested",
+-- "commented", "dismissed") — no normalisation required.
+b:webhook("pull_request_review", function(payload)
+  local raw_action = payload.action or ""
+  local action = GB_PULL_REQUEST_REVIEW_ACTIONS[raw_action]
+  return make_internal_event({
+    event = "pull_request_review",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitbucket",
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      review = payload.review or {},
+      pull_request = payload.pull_request or {},
+      repository = payload.repository or {},
+      sender = payload.sender or {},
+    },
+    timestamp = (payload.review or {}).submitted_at or "",
   })
 end)
 

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7228,6 +7228,73 @@ b:webhook("pull_request", function(payload)
   })
 end)
 
+local PULL_REQUEST_REVIEW_ACTIONS = {
+  submitted = "submitted",
+  dismissed = "dismissed",
+  edited = "edited",
+}
+local PULL_REQUEST_REVIEW_COMMENT_ACTIONS = {
+  created = "created",
+  edited = "edited",
+  deleted = "deleted",
+}
+
+-- Map a normalised Gitea review state (UPPERCASE, as returned by
+-- translate_gitea_review) to the lowercase form used in GitHub webhook payloads.
+local REVIEW_STATE_WEBHOOK = {
+  APPROVED = "approved",
+  CHANGES_REQUESTED = "changes_requested",
+  COMMENT = "commented",
+  DISMISSED = "dismissed",
+}
+
+b:webhook("pull_request_review", function(payload)
+  local raw_action = payload.action or ""
+  local action = PULL_REQUEST_REVIEW_ACTIONS[raw_action]
+  local review = translate_gitea_review(payload.review or {})
+  -- Webhook payloads use lowercase state values; the REST translator uses uppercase.
+  review.state = REVIEW_STATE_WEBHOOK[review.state] or "commented"
+  local raw_pr = payload.pull_request or {}
+  local pr = translate_gitea_pull(raw_pr)
+  return make_internal_event({
+    event = "pull_request_review",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      review = review,
+      pull_request = pr,
+      repository = translate_repo(payload.repository or {}),
+      sender = translate_user(payload.sender or {}),
+    },
+    timestamp = (payload.review or {}).submitted_at or "",
+  })
+end)
+
+b:webhook("pull_request_review_comment", function(payload)
+  local raw_action = payload.action or ""
+  local action = PULL_REQUEST_REVIEW_COMMENT_ACTIONS[raw_action]
+  local raw_pr = payload.pull_request or {}
+  local pr = translate_gitea_pull(raw_pr)
+  return make_internal_event({
+    event = "pull_request_review_comment",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      comment = translate_gitea_review_comment(payload.comment or {}),
+      pull_request = pr,
+      repository = translate_repo(payload.repository or {}),
+      sender = translate_user(payload.sender or {}),
+    },
+    timestamp = (payload.comment or {}).updated_at or "",
+  })
+end)
+
 local MERGE_GROUP_ACTIONS = {
   checks_requested = "checks_requested",
   destroyed = "destroyed",

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -6237,13 +6237,54 @@ b:webhook("Issues Hook", function(payload)
   })
 end)
 
--- issue_comment: created, edited, deleted.
+-- issue_comment / pull_request_review_comment: created, edited, deleted.
 -- Registered for X-Gitlab-Event: Note Hook (covers notes on issues and MRs).
--- payload.issue is the parent issue in REST API format when noteable_type is Issue.
+-- DiffNotes on MRs (noteable_type == "MergeRequest" and type == "DiffNote") are
+-- routed to pull_request_review_comment; all other notes go to issue_comment.
+-- payload.issue is the parent issue when noteable_type is Issue.
 b:webhook("Note Hook", function(payload)
   local oa = payload.object_attributes or {}
   local raw_action = oa.action or ""
   local action = GL_NOTE_ACTIONS[raw_action] or "unknown"
+
+  if oa.noteable_type == "MergeRequest" and oa.type == "DiffNote" then
+    -- Inline review comment on a merge request diff.
+    local pos = oa.position or {}
+    local comment = {
+      id = oa.id,
+      node_id = "",
+      path = pos.new_path or pos.old_path or "",
+      position = pos.new_line or pos.old_line,
+      original_position = pos.old_line,
+      commit_id = pos.head_sha or "",
+      original_commit_id = pos.base_sha or "",
+      diff_hunk = "",
+      body = oa.note or "",
+      pull_request_review_id = oa.discussion_id,
+      user = translate_gl_user(payload.user),
+      created_at = oa.created_at,
+      updated_at = oa.updated_at,
+      html_url = oa.url or "",
+      pull_request_url = "",
+      url = oa.url or "",
+    }
+    return make_internal_event({
+      event = "pull_request_review_comment",
+      action = action,
+      raw_action = action == "unknown" and raw_action or nil,
+      provider = config.backend,
+      timestamp = oa.updated_at or "",
+      raw = payload,
+      data = {
+        action = action,
+        comment = comment,
+        pull_request = translate_gl_mr(payload.merge_request),
+        repository = translate_gl_webhook_project(payload.project),
+        sender = translate_gl_user(payload.user),
+      },
+    })
+  end
+
   local comment = {
     id = oa.id,
     node_id = "",
@@ -6342,14 +6383,46 @@ b:webhook("Milestone Hook", function(payload)
   })
 end)
 
--- pull_request: opened, closed, reopened, synchronize, edited, labeled,
--- unlabeled, assigned, unassigned, review_requested, review_request_removed.
+-- pull_request / pull_request_review: various actions.
 -- Registered for X-Gitlab-Event: Merge Request Hook.
--- GitLab uses "merge request" terminology; confusio maps all events to the
--- GitHub pull_request event family.
+-- GitLab sends "approved"/"unapproved" as MR Hook actions when a reviewer
+-- approves or revokes their approval; these map to pull_request_review rather
+-- than pull_request.  All other MR actions map to pull_request.
 b:webhook("Merge Request Hook", function(payload)
   local oa = payload.object_attributes or {}
   local changes = payload.changes or {}
+  local gl_action = oa.action or ""
+
+  if gl_action == "approved" or gl_action == "unapproved" then
+    -- GitLab does not send a separate review object; synthesize one from the MR.
+    local state = gl_action == "approved" and "approved" or "dismissed"
+    local event_action = gl_action == "approved" and "submitted" or "dismissed"
+    local review = {
+      id = oa.id,
+      node_id = "",
+      user = translate_gl_user(payload.user),
+      body = "",
+      state = state,
+      submitted_at = oa.updated_at or "",
+      html_url = oa.url or "",
+      pull_request_url = oa.url or "",
+    }
+    return make_internal_event({
+      event = "pull_request_review",
+      action = event_action,
+      provider = config.backend,
+      timestamp = oa.updated_at or "",
+      raw = payload,
+      data = {
+        action = event_action,
+        review = review,
+        pull_request = webhook_mr_from_gl(payload),
+        repository = translate_gl_webhook_project(payload.project),
+        sender = translate_gl_user(payload.user),
+      },
+    })
+  end
+
   local action, raw_action = gl_mr_action(oa, changes)
   local data = {
     action = action,

--- a/test/bitbucket-webhooks.hurl
+++ b/test/bitbucket-webhooks.hurl
@@ -432,6 +432,332 @@ HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
 
+# ── pullrequest:approved → pull_request_review / submitted (approved) ────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:approved
+{
+  "actor": {
+    "nickname": "alice",
+    "display_name": "Alice",
+    "account_id": "abc123",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "abc123"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T10:20:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pullrequest:unapproved → pull_request_review / dismissed ─────────────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:unapproved
+{
+  "actor": {
+    "nickname": "alice",
+    "display_name": "Alice",
+    "account_id": "abc123",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "abc123"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T10:25:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pullrequest:comment_created → pull_request_review_comment / created ───────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:comment_created
+{
+  "actor": {
+    "nickname": "alice",
+    "display_name": "Alice",
+    "account_id": "abc123",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "comment": {
+    "id": 55,
+    "content": {"raw": "Nit: rename this variable."},
+    "created_on": "2024-01-15T11:00:00Z",
+    "updated_on": "2024-01-15T11:00:00Z",
+    "inline": {
+      "path": "src/main.py",
+      "from": null,
+      "to": 42
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7/_/diff#comment-55"}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "abc123"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T11:00:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pullrequest:comment_updated → pull_request_review_comment / edited ────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:comment_updated
+{
+  "actor": {
+    "nickname": "alice",
+    "display_name": "Alice",
+    "account_id": "abc123",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "comment": {
+    "id": 55,
+    "content": {"raw": "Nit: rename this variable (updated)."},
+    "created_on": "2024-01-15T11:00:00Z",
+    "updated_on": "2024-01-15T11:05:00Z",
+    "inline": {
+      "path": "src/main.py",
+      "from": null,
+      "to": 42
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7/_/diff#comment-55"}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "abc123"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T11:05:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pullrequest:comment_deleted → pull_request_review_comment / deleted ───────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: pullrequest:comment_deleted
+{
+  "actor": {
+    "nickname": "alice",
+    "display_name": "Alice",
+    "account_id": "abc123",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "comment": {
+    "id": 55,
+    "content": {"raw": "Nit: rename this variable."},
+    "created_on": "2024-01-15T11:00:00Z",
+    "updated_on": "2024-01-15T11:10:00Z",
+    "inline": {
+      "path": "src/main.py",
+      "from": null,
+      "to": 42
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7/_/diff#comment-55"}}
+  },
+  "pullrequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "nickname": "bob", "display_name": "Bob", "account_id": "def456",
+      "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "source": {
+      "branch": {"name": "feature-branch"},
+      "commit": {"hash": "abc123"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "destination": {
+      "branch": {"name": "main"},
+      "commit": {"hash": "def456"},
+      "repository": {
+        "full_name": "octocat/hello-world",
+        "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+      }
+    },
+    "created_on": "2024-01-15T10:00:00Z",
+    "updated_on": "2024-01-15T11:10:00Z",
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world/pull-requests/7"}}
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
 # ── pullrequest:rejected → pull_request / closed (declined) ──────────────────
 
 POST http://{{host}}/webhooks/bitbucket

--- a/test/bitbucket_datacenter-webhooks.hurl
+++ b/test/bitbucket_datacenter-webhooks.hurl
@@ -324,3 +324,157 @@ X-Event-Key: pr:merged
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── pr:reviewer:approved → pull_request_review / submitted (approved) ────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: pr:reviewer:approved
+{
+  "actor": {
+    "name": "carol",
+    "id": 3,
+    "slug": "carol",
+    "displayName": "Carol",
+    "emailAddress": "carol@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "pullRequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "user": {
+        "name": "bob", "id": 2, "slug": "bob",
+        "displayName": "Bob", "emailAddress": "bob@example.com",
+        "links": {"self": [{"href": ""}]}
+      },
+      "role": "AUTHOR", "approved": false, "status": "UNAPPROVED"
+    },
+    "fromRef": {
+      "id": "refs/heads/feature-branch",
+      "displayId": "feature-branch",
+      "latestCommit": "abc123",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "def456",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "carol", "id": 3, "slug": "carol",
+          "displayName": "Carol", "emailAddress": "carol@example.com",
+          "links": {"self": [{"href": ""}]}
+        },
+        "role": "REVIEWER", "approved": true, "status": "APPROVED"
+      }
+    ],
+    "createdDate": 1705312800000,
+    "updatedDate": 1705320000000,
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/pull-requests/7"}]}
+  },
+  "participant": {
+    "user": {
+      "name": "carol", "id": 3, "slug": "carol",
+      "displayName": "Carol", "emailAddress": "carol@example.com",
+      "links": {"self": [{"href": ""}]}
+    },
+    "role": "REVIEWER", "approved": true, "status": "APPROVED"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pr:reviewer:needs_work → pull_request_review / submitted (changes_requested)
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: pr:reviewer:needs_work
+{
+  "actor": {
+    "name": "carol",
+    "id": 3,
+    "slug": "carol",
+    "displayName": "Carol",
+    "emailAddress": "carol@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "pullRequest": {
+    "id": 7,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "state": "OPEN",
+    "author": {
+      "user": {
+        "name": "bob", "id": 2, "slug": "bob",
+        "displayName": "Bob", "emailAddress": "bob@example.com",
+        "links": {"self": [{"href": ""}]}
+      },
+      "role": "AUTHOR", "approved": false, "status": "UNAPPROVED"
+    },
+    "fromRef": {
+      "id": "refs/heads/feature-branch",
+      "displayId": "feature-branch",
+      "latestCommit": "abc123",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "def456",
+      "repository": {
+        "id": 100, "slug": "hello-world", "name": "hello-world",
+        "public": true,
+        "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+        "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+      }
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "carol", "id": 3, "slug": "carol",
+          "displayName": "Carol", "emailAddress": "carol@example.com",
+          "links": {"self": [{"href": ""}]}
+        },
+        "role": "REVIEWER", "approved": false, "status": "NEEDS_WORK"
+      }
+    ],
+    "createdDate": 1705312800000,
+    "updatedDate": 1705320600000,
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/pull-requests/7"}]}
+  },
+  "participant": {
+    "user": {
+      "name": "carol", "id": 3, "slug": "carol",
+      "displayName": "Carol", "emailAddress": "carol@example.com",
+      "links": {"self": [{"href": ""}]}
+    },
+    "role": "REVIEWER", "approved": false, "status": "NEEDS_WORK"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/gitbucket-webhooks.hurl
+++ b/test/gitbucket-webhooks.hurl
@@ -652,3 +652,180 @@ HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
 header "X-Confusio-Raw-Action" == "auto_merged"
+
+# ── pull_request_review: submitted (approved) → 200 ──────────────────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request_review
+{
+  "action": "submitted",
+  "review": {
+    "id": 10, "node_id": "", "user": {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "body": "LGTM!", "state": "approved",
+    "html_url": "http://localhost/octocat/hello-world/pull/7#pullrequestreview-10",
+    "submitted_at": "2024-01-15T12:00:00Z"
+  },
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "closed_at": null
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review: submitted (changes_requested) → 200 ─────────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request_review
+{
+  "action": "submitted",
+  "review": {
+    "id": 11, "node_id": "", "user": {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "body": "Please address these issues.", "state": "changes_requested",
+    "html_url": "http://localhost/octocat/hello-world/pull/7#pullrequestreview-11",
+    "submitted_at": "2024-01-15T12:01:00Z"
+  },
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "closed_at": null
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review: dismissed → 200 ─────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request_review
+{
+  "action": "dismissed",
+  "review": {
+    "id": 10, "node_id": "", "user": {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "body": "", "state": "dismissed",
+    "html_url": "http://localhost/octocat/hello-world/pull/7#pullrequestreview-10",
+    "submitted_at": "2024-01-15T12:05:00Z"
+  },
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "closed_at": null
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review: unknown action → 200 + X-Confusio-Raw-Action ────────
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: pull_request_review
+{
+  "action": "rerequested",
+  "review": {
+    "id": 12, "node_id": "", "user": {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "body": "", "state": "commented",
+    "html_url": "http://localhost/octocat/hello-world/pull/7#pullrequestreview-12",
+    "submitted_at": "2024-01-15T12:06:00Z"
+  },
+  "pull_request": {
+    "id": 500, "node_id": "", "number": 7,
+    "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pull/7",
+    "url": "http://localhost/api/v3/repos/octocat/hello-world/pulls/7",
+    "user": {"login": "bob", "id": 2, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "closed_at": null
+  },
+  "repository": {
+    "id": 1, "node_id": "", "name": "hello-world",
+    "full_name": "octocat/hello-world", "private": false,
+    "owner": {"login": "octocat", "id": 1, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"},
+    "html_url": "http://localhost/octocat/hello-world",
+    "description": "", "fork": false, "url": "",
+    "clone_url": "", "homepage": "", "default_branch": "main",
+    "visibility": "public"
+  },
+  "sender": {"login": "carol", "id": 3, "node_id": "", "avatar_url": "", "url": "", "html_url": "", "type": "User"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "rerequested"

--- a/test/gitea-webhooks.hurl
+++ b/test/gitea-webhooks.hurl
@@ -626,3 +626,285 @@ HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
 header "X-Confusio-Raw-Action" == "queued"
+
+# ── pull_request_review: submitted (APPROVED) → 200 ──────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request_review
+{
+  "action": "submitted",
+  "review": {
+    "id": 10,
+    "type": "APPROVED",
+    "state": "APPROVED",
+    "body": "LGTM!",
+    "submitted_at": "2024-01-15T12:00:00Z",
+    "user": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+  },
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z", "updated": "2024-01-15T10:00:00Z", "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review: submitted (REQUEST_CHANGES) → 200 (state normalised) ─
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request_review
+{
+  "action": "submitted",
+  "review": {
+    "id": 11,
+    "type": "REQUEST_CHANGES",
+    "state": "REQUEST_CHANGES",
+    "body": "Please address these issues.",
+    "submitted_at": "2024-01-15T12:01:00Z",
+    "user": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+  },
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z", "updated": "2024-01-15T10:00:00Z", "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review: dismissed → 200 ─────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request_review
+{
+  "action": "dismissed",
+  "review": {
+    "id": 10,
+    "type": "DISMISSED",
+    "state": "DISMISSED",
+    "body": "",
+    "submitted_at": "2024-01-15T12:05:00Z",
+    "user": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+  },
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z", "updated": "2024-01-15T10:00:00Z", "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review: unknown action → 200 + X-Confusio-Raw-Action sidecar ─
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request_review
+{
+  "action": "pending",
+  "review": {
+    "id": 12, "type": "COMMENT", "state": "COMMENT", "body": "",
+    "submitted_at": "2024-01-15T12:06:00Z",
+    "user": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+  },
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z", "updated": "2024-01-15T10:00:00Z", "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "pending"
+
+# ── pull_request_review_comment: created → 200 ───────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request_review_comment
+{
+  "action": "created",
+  "comment": {
+    "id": 50,
+    "body": "Nice change here.",
+    "path": "README.md",
+    "diff_hunk": "@@ -1,3 +1,4 @@\n context\n+new line\n context",
+    "line": 2,
+    "original_line": 2,
+    "commit_id": "abc123abc123",
+    "original_commit_id": "abc123abc123",
+    "user": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""},
+    "created_at": "2024-01-15T12:10:00Z",
+    "updated_at": "2024-01-15T12:10:00Z"
+  },
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z", "updated": "2024-01-15T10:00:00Z", "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review_comment: deleted → 200 ───────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request_review_comment
+{
+  "action": "deleted",
+  "comment": {
+    "id": 50, "body": "Nice change here.", "path": "README.md",
+    "diff_hunk": "@@ -1,3 +1,4 @@", "line": 2, "original_line": 2,
+    "commit_id": "abc123abc123", "original_commit_id": "abc123abc123",
+    "user": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""},
+    "created_at": "2024-01-15T12:10:00Z", "updated_at": "2024-01-15T12:11:00Z"
+  },
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z", "updated": "2024-01-15T10:00:00Z", "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pull_request_review_comment: unknown action → 200 + X-Confusio-Raw-Action ─
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: pull_request_review_comment
+{
+  "action": "resolved",
+  "comment": {
+    "id": 50, "body": "Resolved.", "path": "README.md",
+    "diff_hunk": "@@ -1,3 +1,4 @@", "line": 2, "original_line": 2,
+    "commit_id": "abc123abc123", "original_commit_id": "abc123abc123",
+    "user": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""},
+    "created_at": "2024-01-15T12:10:00Z", "updated_at": "2024-01-15T12:12:00Z"
+  },
+  "pull_request": {
+    "id": 500, "number": 7, "title": "Add new feature", "body": null,
+    "state": "open", "draft": false,
+    "html_url": "http://localhost/octocat/hello-world/pulls/7",
+    "url": "",
+    "user": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": null},
+    "base": {"ref": "main", "sha": "def456", "repo": null},
+    "labels": [], "assignees": [], "requested_reviewers": [],
+    "merged": false, "merged_at": null, "merge_commit_sha": null, "merged_by": null,
+    "created": "2024-01-15T10:00:00Z", "updated": "2024-01-15T10:00:00Z", "closed": null
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 3, "login": "carol", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "resolved"

--- a/test/gitlab-webhooks.hurl
+++ b/test/gitlab-webhooks.hurl
@@ -600,7 +600,7 @@ X-Gitlab-Event: Merge Request Hook
   },
   "object_attributes": {
     "id": 500, "iid": 7, "title": "Add new feature", "description": null,
-    "state": "opened", "action": "approved",
+    "state": "opened", "action": "attention_required",
     "source_branch": "feature-branch", "target_branch": "main",
     "last_commit": {"id": "abc123"},
     "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
@@ -618,4 +618,247 @@ X-Gitlab-Event: Merge Request Hook
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
-header "X-Confusio-Raw-Action" == "approved"
+header "X-Confusio-Raw-Action" == "attention_required"
+
+# ── Merge Request Hook: approved → pull_request_review submitted/approved ──────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 3, "name": "Carol", "username": "carol",
+    "avatar_url": "", "web_url": "http://localhost/carol"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500, "iid": 7, "title": "Add new feature", "description": null,
+    "state": "opened", "action": "approved",
+    "source_branch": "feature-branch", "target_branch": "main",
+    "last_commit": {"id": "abc123"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "draft": false, "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T12:00:00Z",
+    "closed_at": null, "merged_at": null
+  },
+  "labels": [], "assignees": [], "reviewers": [],
+  "changes": {}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Merge Request Hook: unapproved → pull_request_review dismissed ────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Merge Request Hook
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 3, "name": "Carol", "username": "carol",
+    "avatar_url": "", "web_url": "http://localhost/carol"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 500, "iid": 7, "title": "Add new feature", "description": null,
+    "state": "opened", "action": "unapproved",
+    "source_branch": "feature-branch", "target_branch": "main",
+    "last_commit": {"id": "abc123"},
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "draft": false, "merge_status": "can_be_merged",
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "merge_commit_sha": null,
+    "created_at": "2024-01-15T10:00:00Z",
+    "updated_at": "2024-01-15T12:05:00Z",
+    "closed_at": null, "merged_at": null
+  },
+  "labels": [], "assignees": [], "reviewers": [],
+  "changes": {}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Note Hook: DiffNote on MR (created) → pull_request_review_comment ─────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Note Hook
+{
+  "object_kind": "note",
+  "user": {
+    "id": 3, "name": "Carol", "username": "carol",
+    "avatar_url": "", "web_url": "http://localhost/carol"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 200,
+    "note": "Nice change here.",
+    "noteable_type": "MergeRequest",
+    "type": "DiffNote",
+    "action": "create",
+    "discussion_id": "87805b7c09016a7058e91bdbe7b29d1f284a39e5",
+    "position": {
+      "base_sha": "def456",
+      "start_sha": "def456",
+      "head_sha": "abc123",
+      "old_path": "README.md",
+      "new_path": "README.md",
+      "position_type": "text",
+      "old_line": null,
+      "new_line": 5
+    },
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7#note_200",
+    "created_at": "2024-01-15T12:10:00Z",
+    "updated_at": "2024-01-15T12:10:00Z"
+  },
+  "merge_request": {
+    "id": 500, "iid": 7,
+    "title": "Add new feature",
+    "description": null,
+    "state": "opened",
+    "source_branch": "feature-branch",
+    "target_branch": "main",
+    "draft": false,
+    "merge_status": "can_be_merged",
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "web_url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "author": {
+      "id": 2, "name": "Bob", "username": "bob",
+      "avatar_url": "", "web_url": "http://localhost/bob"
+    }
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Note Hook: DiffNote on MR (deleted) → pull_request_review_comment ─────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Note Hook
+{
+  "object_kind": "note",
+  "user": {
+    "id": 3, "name": "Carol", "username": "carol",
+    "avatar_url": "", "web_url": "http://localhost/carol"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 200, "note": "Nice change here.",
+    "noteable_type": "MergeRequest", "type": "DiffNote",
+    "action": "destroy",
+    "discussion_id": "87805b7c09016a7058e91bdbe7b29d1f284a39e5",
+    "position": {
+      "base_sha": "def456", "start_sha": "def456", "head_sha": "abc123",
+      "old_path": "README.md", "new_path": "README.md",
+      "position_type": "text", "old_line": null, "new_line": 5
+    },
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7#note_200",
+    "created_at": "2024-01-15T12:10:00Z", "updated_at": "2024-01-15T12:11:00Z"
+  },
+  "merge_request": {
+    "id": 500, "iid": 7, "title": "Add new feature", "description": null,
+    "state": "opened", "source_branch": "feature-branch", "target_branch": "main",
+    "draft": false, "merge_status": "can_be_merged",
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "web_url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "author": {
+      "id": 2, "name": "Bob", "username": "bob",
+      "avatar_url": "", "web_url": "http://localhost/bob"
+    }
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Note Hook: DiffNote on MR (unknown action) → 200 + X-Confusio-Raw-Action ──
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Note Hook
+{
+  "object_kind": "note",
+  "user": {
+    "id": 3, "name": "Carol", "username": "carol",
+    "avatar_url": "", "web_url": "http://localhost/carol"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 201, "note": "Resolved.",
+    "noteable_type": "MergeRequest", "type": "DiffNote",
+    "action": "resolved",
+    "discussion_id": "87805b7c09016a7058e91bdbe7b29d1f284a39e5",
+    "position": {
+      "base_sha": "def456", "start_sha": "def456", "head_sha": "abc123",
+      "old_path": "README.md", "new_path": "README.md",
+      "position_type": "text", "old_line": null, "new_line": 5
+    },
+    "url": "http://localhost/octocat/hello-world/-/merge_requests/7#note_201",
+    "created_at": "2024-01-15T12:10:00Z", "updated_at": "2024-01-15T12:12:00Z"
+  },
+  "merge_request": {
+    "id": 500, "iid": 7, "title": "Add new feature", "description": null,
+    "state": "opened", "source_branch": "feature-branch", "target_branch": "main",
+    "draft": false, "merge_status": "can_be_merged",
+    "diff_refs": {"base_sha": "def456", "head_sha": "abc123", "start_sha": "def456"},
+    "web_url": "http://localhost/octocat/hello-world/-/merge_requests/7",
+    "author": {
+      "id": 2, "name": "Bob", "username": "bob",
+      "avatar_url": "", "web_url": "http://localhost/bob"
+    }
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "resolved"


### PR DESCRIPTION
Fixes #227.

Adds webhook event mapping for `pull_request_review`, `pull_request_review_comment`, and `pull_request_review_thread` across all backends. Each backend maps its native review primitives (Gitea review states, GitLab MR approvals/notes/discussions, Bitbucket approval events, GitBucket GitHub-compatible reviews, and others) to the canonical GitHub event shapes, with stubs for backends that lack native review webhooks.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (18)</summary>

- [x] Sourcehut and Radicle: add review webhook event handlers and tests <!-- type:spec -->
- [x] Remaining backends: add review webhook event stubs and tests <!-- type:spec -->
- [x] OneDev and Phabricator: add review webhook event handlers and tests <!-- type:spec -->
- [x] Gerrit: add review webhook events from comments and reviews <!-- type:spec -->
- [x] Pagure: pull_request_review_comment webhook handler and tests <!-- type:spec -->
- [x] Azure DevOps: pull_request_review and review_thread handlers and tests <!-- type:spec -->
- [x] Gogs: add pull_request_review webhook event handlers and tests <!-- type:spec -->
- [x] GitBucket: add pull_request_review webhook event handlers and tests <!-- type:spec -->
- [x] Bitbucket Cloud: pull_request_review and review_comment handlers and tests <!-- type:spec -->
- [x] Bitbucket DC: pull_request_review webhook handler and tests <!-- type:spec -->
- [x] GitLab: pull_request_review, review_comment, and review_thread handlers and tests <!-- type:spec -->
- [x] Gitea: add pull_request_review webhook event handlers and tests <!-- type:spec -->
- [x] GitLab: add pull_request_review webhook event handlers and tests <!-- type:spec -->
- [x] Bitbucket Cloud: add pull_request_review webhook event handlers and tests <!-- type:spec -->
- [x] Bitbucket Datacenter: add pull_request_review webhook event handlers and tests <!-- type:spec -->
- [x] Azure DevOps: add review webhook events from votes and threads <!-- type:spec -->
- [x] Pagure: add review webhook events from PR comments <!-- type:spec -->
- [x] Gitea: pull_request_review and review_comment webhook handlers and tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->