### PR TITLE
v3: Webhook — event mapping: check_run / check_suite / workflow_run / workflow_job / workflow_dispatch / status (closes #228)

### DIFF
--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -2177,4 +2177,74 @@ b:webhook("git.pullrequest.reviewervote", function(payload)
   })
 end)
 
+-- build.complete: fires when a Classic or YAML pipeline build finishes.
+-- Maps to GitHub workflow_run / completed.  The ADO result field
+-- (succeeded/failed/canceled/partiallySucceeded) determines the conclusion.
+-- There is no in-progress build event in ADO webhooks, so only "completed"
+-- actions are produced here.
+local ADO_BUILD_RESULT_TO_CONCLUSION = {
+  succeeded = "success",
+  failed = "failure",
+  canceled = "cancelled",
+  partiallySucceeded = "failure",
+}
+
+b:webhook("build.complete", function(payload)
+  local resource = payload.resource or {}
+  local definition = resource.definition or {}
+  local result = resource.result or ""
+  local conclusion = ADO_BUILD_RESULT_TO_CONCLUSION[result] or "failure"
+  -- Extract short branch name from "refs/heads/..." if present.
+  local source_branch = resource.sourceBranch or ""
+  local head_branch = source_branch:match("refs/heads/(.+)") or source_branch
+  -- Prefer the browser-accessible URL from _links.web over the API URL.
+  local web_href = ((resource._links or {}).web or {}).href or resource.url or ""
+  local workflow_run = {
+    id = resource.id,
+    name = definition.name or "",
+    head_branch = head_branch,
+    head_sha = resource.sourceVersion or "",
+    run_number = resource.id,
+    event = "push",
+    display_title = resource.buildNumber or "",
+    status = "completed",
+    conclusion = conclusion,
+    workflow_id = definition.id or 0,
+    url = web_href,
+    html_url = web_href,
+    pull_requests = {},
+    created_at = resource.queueTime or "",
+    updated_at = resource.finishTime or resource.startTime or "",
+    run_attempt = 1,
+    referenced_workflows = {},
+    actor = ado_user(resource.requestedBy or resource.requestedFor),
+    triggering_actor = ado_user(resource.requestedFor or resource.requestedBy),
+  }
+  local workflow = {
+    id = definition.id or 0,
+    name = definition.name or "",
+    path = "",
+    state = "active",
+    url = "",
+    html_url = "",
+    badge_url = "",
+    created_at = "",
+    updated_at = "",
+  }
+  return make_internal_event({
+    event = "workflow_run",
+    action = "completed",
+    provider = "azuredevops",
+    raw = payload,
+    data = {
+      action = "completed",
+      workflow_run = workflow_run,
+      workflow = workflow,
+      repository = translate_ado_repo(resource.repository),
+      sender = ado_user(resource.requestedBy or resource.requestedFor),
+    },
+    timestamp = resource.finishTime or resource.startTime or "",
+  })
+end)
+
 b:build()

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -2604,4 +2604,50 @@ b:webhook("pullrequest:unapproved", function(payload)
   return bb_review_event(payload, "dismissed", "DISMISSED")
 end)
 
+-- Commit status events: repo:commit_status_created, repo:commit_status_updated.
+-- Bitbucket Cloud emits these when an external CI system posts a build result
+-- against a commit.  Both event types carry the same payload shape and map to
+-- the GitHub status event.  The translated state (success/failure/pending/error)
+-- is promoted to the action slot so consumers can filter by state without
+-- inspecting the payload body.
+-- The commit SHA is embedded in the links.commit.href URL; extract it from there.
+local function bb_commit_status_event(payload)
+  local cs = payload.commit_status or {}
+  local state = bb_state_to_github(cs.state or "")
+  local commit_href = ((cs.links or {}).commit or {}).href or ""
+  local sha = commit_href:match("/commit/([0-9a-fA-F]+)$") or ""
+  local repo = payload.repository or {}
+  local data = {
+    id = 0,
+    sha = sha,
+    name = repo.full_name or repo.slug or "",
+    target_url = cs.url,
+    context = cs.key or "",
+    description = cs.description or "",
+    state = state,
+    commit = nil,
+    branches = {},
+    created_at = cs.created_on or "",
+    updated_at = cs.updated_on or "",
+    repository = translate_bb_repo(repo),
+    sender = translate_bb_user(payload.actor or {}),
+  }
+  return make_internal_event({
+    event = "status",
+    action = state,
+    provider = "bitbucket",
+    raw = payload,
+    data = data,
+    timestamp = cs.updated_on or cs.created_on or "",
+  })
+end
+
+b:webhook("repo:commit_status_created", function(payload)
+  return bb_commit_status_event(payload)
+end)
+
+b:webhook("repo:commit_status_updated", function(payload)
+  return bb_commit_status_event(payload)
+end)
+
 b:build()

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -1603,4 +1603,57 @@ b:webhook("pr:reviewer:needs_work", function(payload)
   return bbs_review_event(payload, "CHANGES_REQUESTED")
 end)
 
+-- Build status events: build:status_created, build:status_updated.
+-- Bitbucket Data Center emits these when an external CI system posts a build
+-- result against a commit.  Both events carry the same payload shape and map
+-- to the GitHub status event.  The translated state is promoted to the action
+-- slot for consumer-side filtering without payload inspection.
+-- DC uses camelCase field names and epoch-millisecond timestamps (bbs_ts).
+-- The commit SHA is the top-level commit.id field (unlike Bitbucket Cloud,
+-- where it must be extracted from a link href).
+local BBS_BUILD_STATE_TO_GITHUB = {
+  INPROGRESS = "pending",
+  SUCCESSFUL = "success",
+  FAILED = "failure",
+  STOPPED = "error",
+}
+local function bbs_build_status_event(payload)
+  local bs = payload.buildStatus or {}
+  local commit = payload.commit or {}
+  local state = BBS_BUILD_STATE_TO_GITHUB[bs.state or ""] or "error"
+  local sha = commit.id or ""
+  local repo = payload.repository or {}
+  local data = {
+    id = 0,
+    sha = sha,
+    name = repo.slug or "",
+    target_url = bs.url,
+    context = bs.key or "",
+    description = bs.description or "",
+    state = state,
+    commit = nil,
+    branches = {},
+    created_at = bbs_ts(bs.createdDate) or "",
+    updated_at = bbs_ts(bs.updatedDate) or "",
+    repository = translate_bbs_repo(repo),
+    sender = translate_bbs_user(payload.actor or {}),
+  }
+  return make_internal_event({
+    event = "status",
+    action = state,
+    provider = "bitbucket_datacenter",
+    raw = payload,
+    data = data,
+    timestamp = bbs_ts(bs.updatedDate) or bbs_ts(bs.createdDate) or "",
+  })
+end
+
+b:webhook("build:status_created", function(payload)
+  return bbs_build_status_event(payload)
+end)
+
+b:webhook("build:status_updated", function(payload)
+  return bbs_build_status_event(payload)
+end)
+
 b:build()

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7331,6 +7331,166 @@ b:webhook("pull_request_review_comment", function(payload)
   })
 end)
 
+-- workflow_run actions mirror GitHub's naming exactly — Gitea Actions follows
+-- the GitHub Actions webhook contract.
+local WORKFLOW_RUN_ACTIONS = {
+  requested = "requested",
+  in_progress = "in_progress",
+  completed = "completed",
+}
+
+b:webhook("workflow_run", function(payload)
+  local raw_action = payload.action or ""
+  local action = WORKFLOW_RUN_ACTIONS[raw_action]
+  local raw_run = payload.workflow_run or {}
+  local raw_workflow = payload.workflow or {}
+  -- Gitea's workflow_run payload mirrors GitHub's shape; normalise fields that
+  -- may be absent and apply translate_user for actor objects.
+  local workflow_run = {
+    id = raw_run.id,
+    name = raw_run.name or "",
+    head_branch = raw_run.head_branch or "",
+    head_sha = raw_run.head_sha or "",
+    run_number = raw_run.run_number,
+    event = raw_run.event or "",
+    display_title = raw_run.display_title or raw_run.name or "",
+    status = raw_run.status or "",
+    conclusion = raw_run.conclusion,
+    workflow_id = raw_run.workflow_id,
+    url = raw_run.url or "",
+    html_url = raw_run.html_url or "",
+    pull_requests = raw_run.pull_requests or {},
+    created_at = raw_run.created_at or "",
+    updated_at = raw_run.updated_at or "",
+    run_attempt = raw_run.run_attempt or 1,
+    referenced_workflows = raw_run.referenced_workflows or {},
+    actor = translate_user(raw_run.actor or {}),
+    triggering_actor = translate_user(raw_run.triggering_actor or raw_run.actor or {}),
+  }
+  local workflow = {
+    id = raw_workflow.id,
+    name = raw_workflow.name or "",
+    path = raw_workflow.path or "",
+    state = raw_workflow.state or "active",
+    url = raw_workflow.url or "",
+    html_url = raw_workflow.html_url or "",
+    badge_url = raw_workflow.badge_url or "",
+    created_at = raw_workflow.created_at or "",
+    updated_at = raw_workflow.updated_at or "",
+  }
+  return make_internal_event({
+    event = "workflow_run",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      workflow_run = workflow_run,
+      workflow = workflow,
+      repository = translate_repo(payload.repository or {}),
+      sender = translate_user(payload.sender or {}),
+    },
+    timestamp = raw_run.updated_at or raw_run.created_at or "",
+  })
+end)
+
+-- workflow_job actions also mirror GitHub's naming.
+local WORKFLOW_JOB_ACTIONS = {
+  queued = "queued",
+  in_progress = "in_progress",
+  completed = "completed",
+  waiting = "waiting",
+}
+
+b:webhook("workflow_job", function(payload)
+  local raw_action = payload.action or ""
+  local action = WORKFLOW_JOB_ACTIONS[raw_action]
+  local raw_job = payload.workflow_job or {}
+  local workflow_job = {
+    id = raw_job.id,
+    run_id = raw_job.run_id,
+    run_url = raw_job.run_url or "",
+    run_attempt = raw_job.run_attempt or 1,
+    name = raw_job.name or "",
+    head_sha = raw_job.head_sha or "",
+    url = raw_job.url or "",
+    html_url = raw_job.html_url or "",
+    status = raw_job.status or "",
+    conclusion = raw_job.conclusion,
+    started_at = raw_job.started_at,
+    completed_at = raw_job.completed_at,
+    steps = raw_job.steps or {},
+    labels = raw_job.labels or {},
+    runner_id = raw_job.runner_id,
+    runner_name = raw_job.runner_name or "",
+  }
+  return make_internal_event({
+    event = "workflow_job",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      workflow_job = workflow_job,
+      repository = translate_repo(payload.repository or {}),
+      sender = translate_user(payload.sender or {}),
+    },
+    timestamp = raw_job.completed_at or raw_job.started_at or "",
+  })
+end)
+
+-- status: commit status update.  Gitea sends no action field; the state
+-- (pending/success/failure/error) is used as the action value so consumers can
+-- filter by state without inspecting the data payload.
+-- Gitea branch objects use commit.id; normalise to commit.sha for GitHub shape.
+local function translate_gitea_status_branch(br)
+  if not br then
+    return {}
+  end
+  local commit = br.commit or {}
+  return {
+    name = br.name or "",
+    commit = {
+      sha = commit.sha or commit.id or "",
+      url = commit.url or "",
+    },
+    protected = br.protected or false,
+  }
+end
+
+b:webhook("status", function(payload)
+  local state = payload.state or "pending"
+  local branches = {}
+  for _, br in ipairs(payload.branches or {}) do
+    branches[#branches + 1] = translate_gitea_status_branch(br)
+  end
+  local data = {
+    id = payload.id,
+    sha = payload.sha or "",
+    name = (payload.repository or {}).full_name or "",
+    target_url = payload.target_url,
+    context = payload.context or "",
+    description = payload.description or "",
+    state = state,
+    commit = payload.commit,
+    branches = branches,
+    created_at = payload.created_at or "",
+    updated_at = payload.updated_at or "",
+    repository = translate_repo(payload.repository or {}),
+    sender = translate_user(payload.sender or {}),
+  }
+  return make_internal_event({
+    event = "status",
+    action = state,
+    provider = "gitea",
+    raw = payload,
+    data = data,
+    timestamp = payload.updated_at or payload.created_at or "",
+  })
+end)
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7462,9 +7462,9 @@ end
 
 b:webhook("status", function(payload)
   local state = payload.state or "pending"
-  local branches = {}
+  local branch_list = {}
   for _, br in ipairs(payload.branches or {}) do
-    branches[#branches + 1] = translate_gitea_status_branch(br)
+    branch_list[#branch_list + 1] = translate_gitea_status_branch(br)
   end
   local data = {
     id = payload.id,
@@ -7475,7 +7475,7 @@ b:webhook("status", function(payload)
     description = payload.description or "",
     state = state,
     commit = payload.commit,
-    branches = branches,
+    branches = branch_list,
     created_at = payload.created_at or "",
     updated_at = payload.updated_at or "",
     repository = translate_repo(payload.repository or {}),

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -6404,6 +6404,193 @@ b:webhook("Merge Request Hook", function(payload)
   })
 end)
 
+-- Pipeline Hook: maps GitLab pipeline lifecycle events to workflow_run.
+-- GitLab uses a status field rather than an action field; the status drives
+-- the canonical GitHub action.  Terminal statuses (success/failed/canceled/
+-- skipped) become "completed"; running becomes "in_progress"; everything else
+-- (created/pending/manual/scheduled/waiting_for_resource/preparing) → "requested".
+local GL_PIPELINE_STATUS_TO_ACTION = {
+  created = "requested",
+  waiting_for_resource = "requested",
+  preparing = "in_progress",
+  pending = "requested",
+  running = "in_progress",
+  success = "completed",
+  failed = "completed",
+  canceled = "completed",
+  cancelled = "completed", -- defensive alternate spelling
+  skipped = "completed",
+  manual = "requested",
+  scheduled = "requested",
+}
+local GL_PIPELINE_CONCLUSION = {
+  success = "success",
+  failed = "failure",
+  canceled = "cancelled",
+  cancelled = "cancelled",
+  skipped = "skipped",
+}
+
+b:webhook("Pipeline Hook", function(payload)
+  local oa = payload.object_attributes or {}
+  local gl_status = oa.status or ""
+  local action = GL_PIPELINE_STATUS_TO_ACTION[gl_status]
+  local conclusion = (action == "completed") and (GL_PIPELINE_CONCLUSION[gl_status] or "failure")
+    or nil
+  -- Map action to GitHub workflow_run.status vocabulary.
+  local gh_status = (action == "in_progress") and "in_progress"
+    or (action == "completed") and "completed"
+    or "queued"
+  local pipeline_url = oa.url or ""
+  local commit = payload.commit or {}
+  local workflow_run = {
+    id = oa.id,
+    name = "Pipeline",
+    head_branch = oa.ref or "",
+    head_sha = oa.sha or "",
+    run_number = oa.iid or oa.id,
+    event = oa.source or "push",
+    display_title = commit.title or commit.message or "",
+    status = gh_status,
+    conclusion = conclusion,
+    workflow_id = 0,
+    url = pipeline_url,
+    html_url = pipeline_url,
+    pull_requests = {},
+    created_at = oa.created_at or "",
+    updated_at = oa.finished_at or oa.updated_at or oa.started_at or "",
+    run_attempt = 1,
+    referenced_workflows = {},
+    actor = translate_gl_user(payload.user),
+    triggering_actor = translate_gl_user(payload.user),
+  }
+  local workflow = {
+    id = 0,
+    name = "Pipeline",
+    path = ".gitlab-ci.yml",
+    state = "active",
+    url = "",
+    html_url = "",
+    badge_url = "",
+    created_at = "",
+    updated_at = "",
+  }
+  return make_internal_event({
+    event = "workflow_run",
+    action = action or "unknown",
+    raw_action = action and nil or gl_status,
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      workflow_run = workflow_run,
+      workflow = workflow,
+      repository = translate_gl_webhook_project(payload.project),
+      sender = translate_gl_user(payload.user),
+    },
+    timestamp = oa.finished_at or oa.updated_at or oa.started_at or "",
+  })
+end)
+
+-- Job Hook: maps GitLab job lifecycle events to workflow_job.
+-- Fields are top-level (build_id, build_name, build_status, …) rather than
+-- nested under object_attributes.  Repository info is a lightweight object;
+-- owner is extracted from project_name ("Group / Project" format).
+local GL_JOB_STATUS_TO_ACTION = {
+  created = "queued",
+  pending = "queued",
+  manual = "queued",
+  scheduled = "queued",
+  waiting_for_resource = "waiting",
+  preparing = "in_progress",
+  running = "in_progress",
+  success = "completed",
+  failed = "completed",
+  canceled = "completed",
+  cancelled = "completed", -- defensive alternate spelling
+  skipped = "completed",
+}
+local GL_JOB_CONCLUSION = {
+  success = "success",
+  failed = "failure",
+  canceled = "cancelled",
+  cancelled = "cancelled",
+  skipped = "skipped",
+}
+
+b:webhook("Job Hook", function(payload)
+  local raw_status = payload.build_status or ""
+  local action = GL_JOB_STATUS_TO_ACTION[raw_status]
+  local conclusion = (action == "completed") and (GL_JOB_CONCLUSION[raw_status] or "failure") or nil
+  local gh_status = (action == "in_progress") and "in_progress"
+    or (action == "waiting") and "waiting"
+    or (action == "completed") and "completed"
+    or "queued"
+  local runner = payload.runner or {}
+  -- Build a repository object from the limited fields available in Job Hook.
+  -- project_name is "Group / Project"; split to extract owner_login.
+  local repo_info = payload.repository or {}
+  local repo_name = repo_info.name or ""
+  local repo_homepage = repo_info.homepage or ""
+  local pname = payload.project_name or ""
+  local sep = pname:find(" / ", 1, true)
+  local owner_login = sep and pname:sub(1, sep - 1):gsub("%s+$", "") or ""
+  local full_name = owner_login ~= "" and (owner_login .. "/" .. repo_name) or repo_name
+  local repository = {
+    id = payload.project_id,
+    node_id = "",
+    name = repo_name,
+    full_name = full_name,
+    private = false, -- not available in Job Hook
+    owner = {
+      login = owner_login,
+      id = 0,
+      node_id = "",
+      avatar_url = "",
+      url = "",
+      html_url = "",
+      type = "User",
+    },
+    html_url = repo_homepage,
+    description = repo_info.description or "",
+    fork = false,
+    url = repo_homepage,
+    default_branch = "",
+  }
+  local workflow_job = {
+    id = payload.build_id,
+    run_id = payload.pipeline_id,
+    run_url = "",
+    run_attempt = 1,
+    name = payload.build_name or "",
+    head_sha = payload.sha or "",
+    url = "",
+    html_url = "",
+    status = gh_status,
+    conclusion = conclusion,
+    started_at = payload.build_started_at,
+    completed_at = payload.build_finished_at,
+    steps = {},
+    labels = runner.tags or {},
+    runner_id = runner.id,
+    runner_name = runner.description or "",
+  }
+  return make_internal_event({
+    event = "workflow_job",
+    action = action or "unknown",
+    raw_action = action and nil or raw_status,
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      workflow_job = workflow_job,
+      repository = repository,
+      sender = translate_gl_user(payload.user),
+    },
+    timestamp = payload.build_finished_at or payload.build_started_at or "",
+  })
+end)
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -690,4 +690,225 @@ b:rest("patch_user", function()
   end, fetch_json(base() .. "/user", "PATCH", GetBody()))
 end)
 
+-- Webhook handlers: Harness CI pipeline execution events -------------------
+--
+-- Harness CI embeds the event type in payload.eventType (no event-type
+-- header).  Pipeline execution events map to GitHub workflow_run; stage
+-- execution events map to workflow_job.
+--
+-- Pipeline event types:
+--   pipeline_execution_started → workflow_run / in_progress
+--   pipeline_execution_success → workflow_run / completed / success
+--   pipeline_execution_failed  → workflow_run / completed / failure
+--   pipeline_execution_aborted → workflow_run / completed / cancelled
+--
+-- Stage event types:
+--   stage_execution_started → workflow_job / in_progress
+--   stage_execution_success → workflow_job / completed / success
+--   stage_execution_failed  → workflow_job / completed / failure
+--   stage_execution_aborted → workflow_job / completed / cancelled
+--
+-- Harness timestamps are epoch milliseconds; convert to ISO 8601 for GitHub.
+
+local function harness_ts(ms)
+  if not ms or ms == 0 then
+    return nil
+  end
+  return os.date("!%Y-%m-%dT%H:%M:%SZ", math.floor(ms / 1000))
+end
+
+local function harness_webhook_sender(payload)
+  local tb = payload.triggeredBy or {}
+  return {
+    login = tb.name or tb.email or "",
+    id = 0,
+    node_id = "",
+    avatar_url = "",
+    url = "",
+    html_url = "",
+    type = "User",
+    site_admin = false,
+  }
+end
+
+local function harness_webhook_repo(payload)
+  local ci = (payload.moduleInfo or {}).ci or {}
+  local owner = payload.orgIdentifier or payload.projectIdentifier or ""
+  local name = ci.repoName or ""
+  return {
+    id = 0,
+    node_id = "",
+    name = name,
+    full_name = owner ~= "" and (owner .. "/" .. name) or name,
+    private = true,
+    owner = {
+      login = owner,
+      id = 0,
+      node_id = "",
+      avatar_url = "",
+      url = "",
+      html_url = "",
+      type = "Organization",
+    },
+    html_url = "",
+    description = nil,
+    fork = false,
+    url = "",
+    clone_url = "",
+    homepage = "",
+    size = 0,
+    stargazers_count = 0,
+    watchers_count = 0,
+    language = nil,
+    has_issues = false,
+    has_wiki = false,
+    forks_count = 0,
+    archived = false,
+    disabled = false,
+    open_issues_count = 0,
+    default_branch = "main",
+    visibility = "private",
+    forks = 0,
+    open_issues = 0,
+    watchers = 0,
+    created_at = nil,
+    updated_at = nil,
+    pushed_at = nil,
+  }
+end
+
+-- harness_pipeline_event builds a workflow_run internal event.
+-- gh_action: "in_progress" | "completed"
+-- gh_status: "in_progress" | "completed"
+-- gh_conclusion: "success" | "failure" | "cancelled" | nil
+local function harness_pipeline_event(payload, gh_action, gh_status, gh_conclusion)
+  local ci = (payload.moduleInfo or {}).ci or {}
+  local sender = harness_webhook_sender(payload)
+  local start_iso = harness_ts(payload.startTs)
+  local end_iso = harness_ts(payload.endTs)
+  local workflow_run = {
+    id = 0,
+    node_id = "",
+    name = payload.pipelineIdentifier or "",
+    head_branch = ci.branch or "",
+    head_sha = ci.commitSha or ci.sha or "",
+    run_number = payload.runSequence or 0,
+    event = "push",
+    display_title = payload.pipelineIdentifier or "",
+    status = gh_status,
+    conclusion = gh_conclusion,
+    workflow_id = 0,
+    url = "",
+    html_url = "",
+    pull_requests = {},
+    created_at = start_iso or "",
+    updated_at = end_iso or start_iso or "",
+    run_attempt = 1,
+    referenced_workflows = {},
+    actor = sender,
+    triggering_actor = sender,
+  }
+  local workflow = {
+    id = 0,
+    name = payload.pipelineIdentifier or "",
+    path = "",
+    state = "active",
+    url = "",
+    html_url = "",
+    badge_url = "",
+    created_at = "",
+    updated_at = "",
+  }
+  return make_internal_event({
+    event = "workflow_run",
+    action = gh_action,
+    provider = "harness",
+    raw = payload,
+    data = {
+      action = gh_action,
+      workflow_run = workflow_run,
+      workflow = workflow,
+      repository = harness_webhook_repo(payload),
+      sender = sender,
+    },
+    timestamp = end_iso or start_iso or "",
+  })
+end
+
+-- harness_stage_event builds a workflow_job internal event.
+local function harness_stage_event(payload, gh_action, gh_status, gh_conclusion)
+  local sender = harness_webhook_sender(payload)
+  local start_iso = harness_ts(payload.startTs)
+  local end_iso = harness_ts(payload.endTs)
+  local job = {
+    id = 0,
+    run_id = 0,
+    run_url = "",
+    run_attempt = 1,
+    node_id = "",
+    head_sha = "",
+    url = "",
+    html_url = "",
+    status = gh_status,
+    conclusion = gh_conclusion,
+    started_at = start_iso or "",
+    completed_at = gh_status == "completed" and (end_iso or start_iso) or nil,
+    name = payload.stageName or payload.stageIdentifier or "",
+    steps = {},
+    check_run_url = "",
+    labels = {},
+    runner_id = nil,
+    runner_name = nil,
+    runner_group_id = nil,
+    runner_group_name = nil,
+    workflow_name = payload.pipelineIdentifier or "",
+    head_branch = "",
+  }
+  return make_internal_event({
+    event = "workflow_job",
+    action = gh_action,
+    provider = "harness",
+    raw = payload,
+    data = {
+      action = gh_action,
+      workflow_job = job,
+      repository = harness_webhook_repo(payload),
+      sender = sender,
+    },
+    timestamp = end_iso or start_iso or "",
+  })
+end
+
+b:webhook("pipeline_execution_started", function(payload)
+  return harness_pipeline_event(payload, "in_progress", "in_progress", nil)
+end)
+
+b:webhook("pipeline_execution_success", function(payload)
+  return harness_pipeline_event(payload, "completed", "completed", "success")
+end)
+
+b:webhook("pipeline_execution_failed", function(payload)
+  return harness_pipeline_event(payload, "completed", "completed", "failure")
+end)
+
+b:webhook("pipeline_execution_aborted", function(payload)
+  return harness_pipeline_event(payload, "completed", "completed", "cancelled")
+end)
+
+b:webhook("stage_execution_started", function(payload)
+  return harness_stage_event(payload, "in_progress", "in_progress", nil)
+end)
+
+b:webhook("stage_execution_success", function(payload)
+  return harness_stage_event(payload, "completed", "completed", "success")
+end)
+
+b:webhook("stage_execution_failed", function(payload)
+  return harness_stage_event(payload, "completed", "completed", "failure")
+end)
+
+b:webhook("stage_execution_aborted", function(payload)
+  return harness_stage_event(payload, "completed", "completed", "cancelled")
+end)
+
 b:build()

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,6 +1,6 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
 POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
-POST /webhooks/{backend},y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y,y
+POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~no CI events,~no CI events,y,y,y,y,~no CI events,~no CI events,y,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n

--- a/test/azuredevops-webhooks.hurl
+++ b/test/azuredevops-webhooks.hurl
@@ -381,3 +381,108 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── build.complete (succeeded) → workflow_run / completed / success ───────────
+
+POST http://{{host}}/webhooks/azuredevops
+Content-Type: application/json
+{
+  "subscriptionId": "sub-1",
+  "notificationId": 20,
+  "id": "evt-20",
+  "eventType": "build.complete",
+  "resource": {
+    "id": 1001,
+    "buildNumber": "20240115.1",
+    "status": "completed",
+    "result": "succeeded",
+    "queueTime": "2024-01-15T10:00:00Z",
+    "startTime": "2024-01-15T10:01:00Z",
+    "finishTime": "2024-01-15T10:05:00Z",
+    "url": "https://dev.azure.com/org/project/_apis/build/builds/1001",
+    "_links": {
+      "web": {"href": "https://dev.azure.com/org/project/_build/results?buildId=1001"}
+    },
+    "definition": {"id": 1, "name": "CI Pipeline"},
+    "sourceBranch": "refs/heads/main",
+    "sourceVersion": "abc123def456abc123def456abc123def456abc123",
+    "requestedBy": {"displayName": "The Octocat", "uniqueName": "octocat"},
+    "requestedFor": {"displayName": "The Octocat", "uniqueName": "octocat"},
+    "repository": {}
+  },
+  "createdDate": "2024-01-15T10:05:00Z"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── build.complete (failed) → workflow_run / completed / failure ───────────────
+
+POST http://{{host}}/webhooks/azuredevops
+Content-Type: application/json
+{
+  "subscriptionId": "sub-1",
+  "notificationId": 21,
+  "id": "evt-21",
+  "eventType": "build.complete",
+  "resource": {
+    "id": 1002,
+    "buildNumber": "20240115.2",
+    "status": "completed",
+    "result": "failed",
+    "queueTime": "2024-01-15T11:00:00Z",
+    "startTime": "2024-01-15T11:01:00Z",
+    "finishTime": "2024-01-15T11:04:00Z",
+    "url": "https://dev.azure.com/org/project/_apis/build/builds/1002",
+    "_links": {
+      "web": {"href": "https://dev.azure.com/org/project/_build/results?buildId=1002"}
+    },
+    "definition": {"id": 1, "name": "CI Pipeline"},
+    "sourceBranch": "refs/heads/feature",
+    "sourceVersion": "deadbeefdeadbeef",
+    "requestedBy": {"displayName": "Bob", "uniqueName": "bob"},
+    "requestedFor": {"displayName": "Bob", "uniqueName": "bob"},
+    "repository": {}
+  },
+  "createdDate": "2024-01-15T11:04:00Z"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── build.complete (canceled) → workflow_run / completed / cancelled ───────────
+
+POST http://{{host}}/webhooks/azuredevops
+Content-Type: application/json
+{
+  "subscriptionId": "sub-1",
+  "notificationId": 22,
+  "id": "evt-22",
+  "eventType": "build.complete",
+  "resource": {
+    "id": 1003,
+    "buildNumber": "20240115.3",
+    "status": "completed",
+    "result": "canceled",
+    "queueTime": "2024-01-15T12:00:00Z",
+    "startTime": "2024-01-15T12:01:00Z",
+    "finishTime": "2024-01-15T12:02:00Z",
+    "url": "https://dev.azure.com/org/project/_apis/build/builds/1003",
+    "_links": {
+      "web": {"href": "https://dev.azure.com/org/project/_build/results?buildId=1003"}
+    },
+    "definition": {"id": 2, "name": "Deploy Pipeline"},
+    "sourceBranch": "refs/heads/main",
+    "sourceVersion": "cafebabecafebabe",
+    "requestedBy": {"displayName": "Alice", "uniqueName": "alice"},
+    "requestedFor": {"displayName": "Alice", "uniqueName": "alice"},
+    "repository": {}
+  },
+  "createdDate": "2024-01-15T12:02:00Z"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/bitbucket-webhooks.hurl
+++ b/test/bitbucket-webhooks.hurl
@@ -623,3 +623,135 @@ X-Event-Key: pullrequest:unapproved
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── repo:commit_status_created → status / success ────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: repo:commit_status_created
+{
+  "actor": {
+    "nickname": "octocat",
+    "display_name": "The Octocat",
+    "account_id": "xyz789",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "commit_status": {
+    "state": "SUCCESSFUL",
+    "key": "ci/build",
+    "description": "Build passed",
+    "url": "https://ci.example.com/builds/42",
+    "name": "My CI",
+    "created_on": "2024-01-15T10:05:00+00:00",
+    "updated_on": "2024-01-15T10:05:00+00:00",
+    "links": {
+      "commit": {
+        "href": "https://api.bitbucket.org/2.0/repositories/octocat/hello-world/commit/abc123def456"
+      },
+      "self": {"href": "https://api.bitbucket.org/2.0/repositories/octocat/hello-world/commit/abc123def456/statuses/build/ci-build"}
+    }
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── repo:commit_status_updated → status / pending ─────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: repo:commit_status_updated
+{
+  "actor": {
+    "nickname": "bob",
+    "display_name": "Bob",
+    "account_id": "def456",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "commit_status": {
+    "state": "INPROGRESS",
+    "key": "ci/test",
+    "description": "Running tests...",
+    "url": "https://ci.example.com/builds/43",
+    "name": "My CI",
+    "created_on": "2024-01-15T11:00:00+00:00",
+    "updated_on": "2024-01-15T11:01:00+00:00",
+    "links": {
+      "commit": {
+        "href": "https://api.bitbucket.org/2.0/repositories/octocat/hello-world/commit/deadbeef"
+      },
+      "self": {"href": ""}
+    }
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── repo:commit_status_updated → status / failure ─────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket
+Content-Type: application/json
+X-Event-Key: repo:commit_status_updated
+{
+  "actor": {
+    "nickname": "octocat",
+    "display_name": "The Octocat",
+    "account_id": "xyz789",
+    "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+  },
+  "commit_status": {
+    "state": "FAILED",
+    "key": "ci/build",
+    "description": "Build failed",
+    "url": "https://ci.example.com/builds/44",
+    "name": "My CI",
+    "created_on": "2024-01-15T12:00:00+00:00",
+    "updated_on": "2024-01-15T12:05:00+00:00",
+    "links": {
+      "commit": {
+        "href": "https://api.bitbucket.org/2.0/repositories/octocat/hello-world/commit/cafebabe"
+      },
+      "self": {"href": ""}
+    }
+  },
+  "repository": {
+    "full_name": "octocat/hello-world",
+    "name": "hello-world",
+    "slug": "hello-world",
+    "is_private": false,
+    "owner": {
+      "nickname": "octocat", "display_name": "The Octocat", "account_id": "xyz789",
+      "type": "user", "links": {"avatar": {"href": ""}, "html": {"href": ""}}
+    },
+    "links": {"html": {"href": "https://bitbucket.org/octocat/hello-world"}}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/bitbucket_datacenter-webhooks.hurl
+++ b/test/bitbucket_datacenter-webhooks.hurl
@@ -490,3 +490,126 @@ X-Event-Key: pr:reviewer:needs_work
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── build:status_created → status / success ───────────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: build:status_created
+{
+  "actor": {
+    "name": "octocat", "id": 1, "slug": "octocat",
+    "displayName": "The Octocat", "emailAddress": "octocat@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "buildStatus": {
+    "state": "SUCCESSFUL",
+    "key": "ci/build",
+    "name": "My CI Build",
+    "description": "Build passed",
+    "url": "https://ci.example.com/builds/42",
+    "createdDate": 1705320000000,
+    "updatedDate": 1705320300000
+  },
+  "commit": {
+    "id": "abc123def456abc123def456abc123def456abc123",
+    "displayId": "abc123d",
+    "message": "Update readme",
+    "author": {
+      "name": "The Octocat", "emailAddress": "octocat@example.com"
+    },
+    "authorTimestamp": 1705319900000
+  },
+  "repository": {
+    "id": 100, "slug": "hello-world", "name": "hello-world",
+    "public": true,
+    "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── build:status_updated → status / pending ───────────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: build:status_updated
+{
+  "actor": {
+    "name": "bob", "id": 2, "slug": "bob",
+    "displayName": "Bob", "emailAddress": "bob@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "buildStatus": {
+    "state": "INPROGRESS",
+    "key": "ci/test",
+    "name": "My CI Tests",
+    "description": "Running tests...",
+    "url": "https://ci.example.com/builds/43",
+    "createdDate": 1705323600000,
+    "updatedDate": 1705323660000
+  },
+  "commit": {
+    "id": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "displayId": "deadbee",
+    "message": "Add feature",
+    "author": {
+      "name": "Bob", "emailAddress": "bob@example.com"
+    },
+    "authorTimestamp": 1705323500000
+  },
+  "repository": {
+    "id": 100, "slug": "hello-world", "name": "hello-world",
+    "public": true,
+    "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── build:status_updated → status / failure ───────────────────────────────────
+
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Event-Key: build:status_updated
+{
+  "actor": {
+    "name": "octocat", "id": 1, "slug": "octocat",
+    "displayName": "The Octocat", "emailAddress": "octocat@example.com",
+    "links": {"self": [{"href": ""}]}
+  },
+  "buildStatus": {
+    "state": "FAILED",
+    "key": "ci/build",
+    "name": "My CI Build",
+    "description": "Build failed: compilation error",
+    "url": "https://ci.example.com/builds/44",
+    "createdDate": 1705327200000,
+    "updatedDate": 1705327500000
+  },
+  "commit": {
+    "id": "cafebabecafebabecafebabecafebabecafebabe",
+    "displayId": "cafebab",
+    "message": "Fix compile error",
+    "author": {
+      "name": "The Octocat", "emailAddress": "octocat@example.com"
+    },
+    "authorTimestamp": 1705327100000
+  },
+  "repository": {
+    "id": 100, "slug": "hello-world", "name": "hello-world",
+    "public": true,
+    "project": {"id": 10, "key": "OCTOCAT", "name": "Octocat", "type": "NORMAL"},
+    "links": {"self": [{"href": "http://localhost/projects/OCTOCAT/repos/hello-world/browse"}]}
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/gitea-webhooks.hurl
+++ b/test/gitea-webhooks.hurl
@@ -832,3 +832,306 @@ HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
 header "X-Confusio-Raw-Action" == "converted_to_draft"
+
+# ── workflow_run: completed → 200 ────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: workflow_run
+{
+  "action": "completed",
+  "workflow_run": {
+    "id": 1001, "name": "CI", "head_branch": "main", "head_sha": "abc123def456",
+    "run_number": 42, "event": "push", "display_title": "Update readme",
+    "status": "completed", "conclusion": "success", "workflow_id": 1,
+    "url": "http://localhost/octocat/hello-world/actions/runs/1001",
+    "html_url": "http://localhost/octocat/hello-world/actions/runs/1001",
+    "pull_requests": [], "run_attempt": 1, "referenced_workflows": [],
+    "created_at": "2024-01-15T10:00:00Z", "updated_at": "2024-01-15T10:05:00Z",
+    "actor": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""},
+    "triggering_actor": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "workflow": {
+    "id": 1, "name": "CI", "path": ".gitea/workflows/ci.yml", "state": "active",
+    "url": "http://localhost/octocat/hello-world/actions/workflows/ci.yml",
+    "html_url": "http://localhost/octocat/hello-world/actions/workflows/ci.yml",
+    "badge_url": "", "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── workflow_run: requested → 200 ────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: workflow_run
+{
+  "action": "requested",
+  "workflow_run": {
+    "id": 1002, "name": "CI", "head_branch": "feature", "head_sha": "deadbeef",
+    "run_number": 43, "event": "push", "display_title": "Add feature",
+    "status": "queued", "conclusion": null, "workflow_id": 1,
+    "url": "http://localhost/octocat/hello-world/actions/runs/1002",
+    "html_url": "http://localhost/octocat/hello-world/actions/runs/1002",
+    "pull_requests": [], "run_attempt": 1, "referenced_workflows": [],
+    "created_at": "2024-01-15T11:00:00Z", "updated_at": "2024-01-15T11:00:00Z",
+    "actor": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""},
+    "triggering_actor": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+  },
+  "workflow": {
+    "id": 1, "name": "CI", "path": ".gitea/workflows/ci.yml", "state": "active",
+    "url": "", "html_url": "", "badge_url": "",
+    "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── workflow_run: unknown action → 200 + X-Confusio-Raw-Action sidecar ───────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: workflow_run
+{
+  "action": "cancelled",
+  "workflow_run": {
+    "id": 1003, "name": "CI", "head_branch": "main", "head_sha": "abc123",
+    "run_number": 44, "event": "push", "display_title": "Hotfix",
+    "status": "completed", "conclusion": "cancelled", "workflow_id": 1,
+    "url": "", "html_url": "", "pull_requests": [], "run_attempt": 1,
+    "referenced_workflows": [],
+    "created_at": "2024-01-15T12:00:00Z", "updated_at": "2024-01-15T12:01:00Z",
+    "actor": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""},
+    "triggering_actor": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "workflow": {
+    "id": 1, "name": "CI", "path": ".gitea/workflows/ci.yml", "state": "active",
+    "url": "", "html_url": "", "badge_url": "",
+    "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "cancelled"
+
+# ── workflow_job: completed → 200 ─────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: workflow_job
+{
+  "action": "completed",
+  "workflow_job": {
+    "id": 2001, "run_id": 1001, "run_attempt": 1,
+    "run_url": "http://localhost/octocat/hello-world/actions/runs/1001",
+    "name": "build", "head_sha": "abc123def456",
+    "url": "http://localhost/octocat/hello-world/actions/runs/1001/jobs/2001",
+    "html_url": "http://localhost/octocat/hello-world/actions/runs/1001/jobs/2001",
+    "status": "completed", "conclusion": "success",
+    "started_at": "2024-01-15T10:01:00Z", "completed_at": "2024-01-15T10:04:00Z",
+    "steps": [
+      {
+        "name": "Set up job", "status": "completed", "conclusion": "success",
+        "number": 1,
+        "started_at": "2024-01-15T10:01:00Z", "completed_at": "2024-01-15T10:02:00Z"
+      }
+    ],
+    "labels": ["ubuntu-latest"], "runner_id": 1, "runner_name": "runner-1"
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── workflow_job: queued → 200 ────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: workflow_job
+{
+  "action": "queued",
+  "workflow_job": {
+    "id": 2002, "run_id": 1002, "run_attempt": 1,
+    "run_url": "http://localhost/octocat/hello-world/actions/runs/1002",
+    "name": "test", "head_sha": "deadbeef",
+    "url": "", "html_url": "",
+    "status": "queued", "conclusion": null,
+    "started_at": null, "completed_at": null,
+    "steps": [], "labels": [], "runner_id": null, "runner_name": ""
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── workflow_job: unknown action → 200 + X-Confusio-Raw-Action sidecar ────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: workflow_job
+{
+  "action": "skipped",
+  "workflow_job": {
+    "id": 2003, "run_id": 1003, "run_attempt": 1,
+    "run_url": "", "name": "lint", "head_sha": "abc123",
+    "url": "", "html_url": "",
+    "status": "completed", "conclusion": "skipped",
+    "started_at": null, "completed_at": null,
+    "steps": [], "labels": [], "runner_id": null, "runner_name": ""
+  },
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "skipped"
+
+# ── status: success → 200 ─────────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: status
+{
+  "id": 501,
+  "sha": "abc123def456abc123def456abc123def456abc123",
+  "state": "success",
+  "target_url": "https://ci.example.com/builds/99",
+  "context": "ci/build",
+  "description": "Build passed",
+  "branches": [
+    {
+      "name": "main",
+      "commit": {"id": "abc123def456abc123def456abc123def456abc123", "url": ""},
+      "protected": false
+    }
+  ],
+  "commit": {"id": "abc123def456abc123def456abc123def456abc123", "message": "Update readme"},
+  "created_at": "2024-01-15T10:05:00Z",
+  "updated_at": "2024-01-15T10:05:00Z",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── status: pending → 200 ─────────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: status
+{
+  "id": 502,
+  "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  "state": "pending",
+  "target_url": null,
+  "context": "ci/test",
+  "description": "Running tests...",
+  "branches": [
+    {
+      "name": "feature",
+      "commit": {"id": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "url": ""},
+      "protected": false
+    }
+  ],
+  "commit": {"id": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "message": "Add feature"},
+  "created_at": "2024-01-15T11:00:00Z",
+  "updated_at": "2024-01-15T11:00:00Z",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── status: failure → 200 ─────────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: status
+{
+  "id": 503,
+  "sha": "cafebabecafebabecafebabecafebabecafebabe",
+  "state": "failure",
+  "target_url": "https://ci.example.com/builds/101",
+  "context": "ci/build",
+  "description": "Build failed",
+  "branches": [],
+  "commit": null,
+  "created_at": "2024-01-15T12:00:00Z",
+  "updated_at": "2024-01-15T12:01:00Z",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/gitlab-webhooks.hurl
+++ b/test/gitlab-webhooks.hurl
@@ -701,3 +701,389 @@ HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
 header "X-Confusio-Raw-Action" == "approval_rules_updated"
+
+# ── Pipeline Hook: completed/success → 200 ────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Pipeline Hook
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 31, "iid": 10,
+    "ref": "main", "tag": false,
+    "sha": "abc123def456abc123def456abc123def456abc123",
+    "before_sha": "def456",
+    "source": "push",
+    "status": "success",
+    "detailed_status": "passed",
+    "stages": ["build", "test"],
+    "created_at": "2024-01-15T10:00:00Z",
+    "started_at": "2024-01-15T10:01:00Z",
+    "finished_at": "2024-01-15T10:05:00Z",
+    "updated_at": "2024-01-15T10:05:00Z",
+    "duration": 240, "queued_duration": 10,
+    "variables": [],
+    "url": "http://localhost/octocat/hello-world/-/pipelines/31"
+  },
+  "merge_request": null,
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "commit": {
+    "id": "abc123def456abc123def456abc123def456abc123",
+    "message": "Update readme\n", "title": "Update readme",
+    "timestamp": "2024-01-15T09:59:00Z",
+    "url": "http://localhost/octocat/hello-world/-/commit/abc123def456",
+    "author": {"name": "The Octocat", "email": "octocat@example.com"}
+  },
+  "source_pipeline": null
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Pipeline Hook: running → 200 ──────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Pipeline Hook
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 32, "iid": 11,
+    "ref": "feature", "tag": false,
+    "sha": "deadbeefdeadbeef",
+    "before_sha": "000000",
+    "source": "push",
+    "status": "running",
+    "detailed_status": "running",
+    "stages": ["build"],
+    "created_at": "2024-01-15T11:00:00Z",
+    "started_at": "2024-01-15T11:01:00Z",
+    "finished_at": null,
+    "updated_at": "2024-01-15T11:01:00Z",
+    "duration": null, "queued_duration": 5,
+    "variables": [],
+    "url": "http://localhost/octocat/hello-world/-/pipelines/32"
+  },
+  "merge_request": null,
+  "user": {
+    "id": 2, "name": "Bob", "username": "bob",
+    "avatar_url": "", "web_url": "http://localhost/bob"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "commit": {
+    "id": "deadbeefdeadbeef", "message": "Add feature", "title": "Add feature",
+    "timestamp": "2024-01-15T10:59:00Z",
+    "url": "", "author": {"name": "Bob", "email": "bob@example.com"}
+  },
+  "source_pipeline": null
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Pipeline Hook: pending → 200 ──────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Pipeline Hook
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 33, "iid": 12,
+    "ref": "main", "tag": false,
+    "sha": "cafebabe",
+    "before_sha": "000000",
+    "source": "web",
+    "status": "pending",
+    "detailed_status": "pending",
+    "stages": ["build"],
+    "created_at": "2024-01-15T12:00:00Z",
+    "started_at": null,
+    "finished_at": null,
+    "updated_at": "2024-01-15T12:00:00Z",
+    "duration": null, "queued_duration": null,
+    "variables": [],
+    "url": "http://localhost/octocat/hello-world/-/pipelines/33"
+  },
+  "merge_request": null,
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "commit": {
+    "id": "cafebabe", "message": "Manual trigger", "title": "Manual trigger",
+    "timestamp": "2024-01-15T11:59:00Z",
+    "url": "", "author": {"name": "The Octocat", "email": "octocat@example.com"}
+  },
+  "source_pipeline": null
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Pipeline Hook: unknown status → 200 + X-Confusio-Raw-Action ───────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Pipeline Hook
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 34, "iid": 13,
+    "ref": "main", "tag": false,
+    "sha": "abc123",
+    "before_sha": "000000",
+    "source": "push",
+    "status": "blocked",
+    "detailed_status": "blocked",
+    "stages": [],
+    "created_at": "2024-01-15T13:00:00Z",
+    "started_at": null, "finished_at": null,
+    "updated_at": "2024-01-15T13:00:00Z",
+    "duration": null, "queued_duration": null,
+    "variables": [],
+    "url": "http://localhost/octocat/hello-world/-/pipelines/34"
+  },
+  "merge_request": null,
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "project": {
+    "id": 10, "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20, "default_branch": "main"
+  },
+  "commit": {
+    "id": "abc123", "message": "Blocked run", "title": "Blocked run",
+    "timestamp": "2024-01-15T12:59:00Z",
+    "url": "", "author": {"name": "The Octocat", "email": "octocat@example.com"}
+  },
+  "source_pipeline": null
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "blocked"
+
+# ── Job Hook: completed/success → 200 ────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Job Hook
+{
+  "object_kind": "build",
+  "ref": "main", "tag": false,
+  "before_sha": "def456",
+  "sha": "abc123def456abc123def456abc123def456abc123",
+  "build_id": 456, "build_name": "build-job", "build_stage": "build",
+  "build_status": "success",
+  "build_allow_failure": false,
+  "build_created_at": "2024-01-15T10:01:00Z",
+  "build_started_at": "2024-01-15T10:02:00Z",
+  "build_finished_at": "2024-01-15T10:04:00Z",
+  "build_duration": 120.5, "build_queued_duration": 5.2,
+  "build_failure_reason": null,
+  "pipeline_id": 31,
+  "runner": {
+    "id": 1, "description": "runner-1",
+    "runner_type": "instance_type", "tags": ["ubuntu-latest"]
+  },
+  "project_id": 10,
+  "project_name": "The Octocat / hello-world",
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "commit": {
+    "id": 31, "sha": "abc123def456abc123def456abc123def456abc123",
+    "message": "Update readme", "author_name": "The Octocat",
+    "author_email": "octocat@example.com",
+    "status": "success", "duration": 240,
+    "started_at": "2024-01-15T10:01:00Z",
+    "finished_at": "2024-01-15T10:05:00Z"
+  },
+  "repository": {
+    "name": "hello-world",
+    "url": "git@localhost:octocat/hello-world.git",
+    "description": "",
+    "homepage": "http://localhost/octocat/hello-world"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Job Hook: running → 200 ───────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Job Hook
+{
+  "object_kind": "build",
+  "ref": "feature", "tag": false,
+  "before_sha": "000000",
+  "sha": "deadbeef",
+  "build_id": 457, "build_name": "test-job", "build_stage": "test",
+  "build_status": "running",
+  "build_allow_failure": false,
+  "build_created_at": "2024-01-15T11:01:00Z",
+  "build_started_at": "2024-01-15T11:02:00Z",
+  "build_finished_at": null,
+  "build_duration": null, "build_queued_duration": 3.0,
+  "build_failure_reason": null,
+  "pipeline_id": 32,
+  "runner": {
+    "id": 2, "description": "runner-2",
+    "runner_type": "instance_type", "tags": []
+  },
+  "project_id": 10,
+  "project_name": "The Octocat / hello-world",
+  "user": {
+    "id": 2, "name": "Bob", "username": "bob",
+    "avatar_url": "", "web_url": "http://localhost/bob"
+  },
+  "commit": {
+    "id": 32, "sha": "deadbeef",
+    "message": "Add feature", "author_name": "Bob",
+    "author_email": "bob@example.com",
+    "status": "running", "duration": null,
+    "started_at": "2024-01-15T11:01:00Z", "finished_at": null
+  },
+  "repository": {
+    "name": "hello-world",
+    "url": "git@localhost:octocat/hello-world.git",
+    "description": "",
+    "homepage": "http://localhost/octocat/hello-world"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Job Hook: pending → 200 ───────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Job Hook
+{
+  "object_kind": "build",
+  "ref": "main", "tag": false,
+  "before_sha": "000000",
+  "sha": "cafebabe",
+  "build_id": 458, "build_name": "deploy-job", "build_stage": "deploy",
+  "build_status": "pending",
+  "build_allow_failure": false,
+  "build_created_at": "2024-01-15T12:01:00Z",
+  "build_started_at": null,
+  "build_finished_at": null,
+  "build_duration": null, "build_queued_duration": null,
+  "build_failure_reason": null,
+  "pipeline_id": 33,
+  "runner": null,
+  "project_id": 10,
+  "project_name": "The Octocat / hello-world",
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "commit": {
+    "id": 33, "sha": "cafebabe",
+    "message": "Deploy", "author_name": "The Octocat",
+    "author_email": "octocat@example.com",
+    "status": "pending", "duration": null,
+    "started_at": null, "finished_at": null
+  },
+  "repository": {
+    "name": "hello-world",
+    "url": "git@localhost:octocat/hello-world.git",
+    "description": "",
+    "homepage": "http://localhost/octocat/hello-world"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── Job Hook: unknown status → 200 + X-Confusio-Raw-Action ───────────────────
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Job Hook
+{
+  "object_kind": "build",
+  "ref": "main", "tag": false,
+  "before_sha": "000000",
+  "sha": "abc123",
+  "build_id": 459, "build_name": "lint-job", "build_stage": "lint",
+  "build_status": "stale",
+  "build_allow_failure": true,
+  "build_created_at": "2024-01-15T13:01:00Z",
+  "build_started_at": null,
+  "build_finished_at": null,
+  "build_duration": null, "build_queued_duration": null,
+  "build_failure_reason": null,
+  "pipeline_id": 34,
+  "runner": null,
+  "project_id": 10,
+  "project_name": "The Octocat / hello-world",
+  "user": {
+    "id": 1, "name": "The Octocat", "username": "octocat",
+    "avatar_url": "", "web_url": "http://localhost/octocat"
+  },
+  "commit": {
+    "id": 34, "sha": "abc123",
+    "message": "Lint check", "author_name": "The Octocat",
+    "author_email": "octocat@example.com",
+    "status": "stale", "duration": null,
+    "started_at": null, "finished_at": null
+  },
+  "repository": {
+    "name": "hello-world",
+    "url": "git@localhost:octocat/hello-world.git",
+    "description": "",
+    "homepage": "http://localhost/octocat/hello-world"
+  }
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "stale"

--- a/test/harness-webhooks.hurl
+++ b/test/harness-webhooks.hurl
@@ -1,0 +1,192 @@
+# Harness CI webhook normalizer tests — run by test-unit-harness.
+#
+# Harness CI embeds eventType in the JSON body (no event-type header).
+# Trust-the-network mode (no CONFUSIO_WEBHOOK_SECRETS): X-Harness-Token omitted.
+# Pipeline execution events → workflow_run.
+# Stage execution events    → workflow_job.
+
+# ── pipeline_execution_started → workflow_run / in_progress ──────────────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "pipeline_execution_started",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "CI_Pipeline",
+  "planExecutionId": "exec-abc123",
+  "runSequence": 1,
+  "status": "Running",
+  "startTs": 1705316400000,
+  "triggerType": "WEBHOOK",
+  "triggeredBy": {"name": "Alice", "email": "alice@example.com"},
+  "moduleInfo": {"ci": {"branch": "main", "repoName": "hello-world", "commitSha": "abc123def456"}}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pipeline_execution_success → workflow_run / completed / success ───────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "pipeline_execution_success",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "CI_Pipeline",
+  "planExecutionId": "exec-abc123",
+  "runSequence": 1,
+  "status": "Success",
+  "startTs": 1705316400000,
+  "endTs": 1705316700000,
+  "triggerType": "WEBHOOK",
+  "triggeredBy": {"name": "Alice", "email": "alice@example.com"},
+  "moduleInfo": {"ci": {"branch": "main", "repoName": "hello-world", "commitSha": "abc123def456"}}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pipeline_execution_failed → workflow_run / completed / failure ────────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "pipeline_execution_failed",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "CI_Pipeline",
+  "planExecutionId": "exec-def456",
+  "runSequence": 2,
+  "status": "Failed",
+  "startTs": 1705320000000,
+  "endTs": 1705320180000,
+  "triggerType": "WEBHOOK",
+  "triggeredBy": {"name": "Bob", "email": "bob@example.com"},
+  "moduleInfo": {"ci": {"branch": "feature", "repoName": "hello-world", "commitSha": "deadbeef"}}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── pipeline_execution_aborted → workflow_run / completed / cancelled ─────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "pipeline_execution_aborted",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "Deploy_Pipeline",
+  "planExecutionId": "exec-ghi789",
+  "runSequence": 3,
+  "status": "Aborted",
+  "startTs": 1705323600000,
+  "endTs": 1705323660000,
+  "triggerType": "MANUAL",
+  "triggeredBy": {"name": "Alice", "email": "alice@example.com"},
+  "moduleInfo": {"ci": {"branch": "main", "repoName": "hello-world"}}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── stage_execution_started → workflow_job / in_progress ─────────────────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "stage_execution_started",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "CI_Pipeline",
+  "stageIdentifier": "build_stage",
+  "stageName": "Build",
+  "planExecutionId": "exec-abc123",
+  "status": "Running",
+  "startTs": 1705316410000,
+  "triggeredBy": {"name": "Alice", "email": "alice@example.com"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── stage_execution_success → workflow_job / completed / success ──────────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "stage_execution_success",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "CI_Pipeline",
+  "stageIdentifier": "build_stage",
+  "stageName": "Build",
+  "planExecutionId": "exec-abc123",
+  "status": "Success",
+  "startTs": 1705316410000,
+  "endTs": 1705316680000,
+  "triggeredBy": {"name": "Alice", "email": "alice@example.com"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── stage_execution_failed → workflow_job / completed / failure ───────────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "stage_execution_failed",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "CI_Pipeline",
+  "stageIdentifier": "test_stage",
+  "stageName": "Test",
+  "planExecutionId": "exec-def456",
+  "status": "Failed",
+  "startTs": 1705320010000,
+  "endTs": 1705320170000,
+  "triggeredBy": {"name": "Bob", "email": "bob@example.com"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── stage_execution_aborted → workflow_job / completed / cancelled ────────────
+
+POST http://{{host}}/webhooks/harness
+Content-Type: application/json
+{
+  "eventType": "stage_execution_aborted",
+  "accountId": "accountId",
+  "orgIdentifier": "myOrg",
+  "projectIdentifier": "myProject",
+  "pipelineIdentifier": "Deploy_Pipeline",
+  "stageIdentifier": "deploy_stage",
+  "stageName": "Deploy",
+  "planExecutionId": "exec-ghi789",
+  "status": "Aborted",
+  "startTs": 1705323610000,
+  "endTs": 1705323650000,
+  "triggeredBy": {"name": "Alice", "email": "alice@example.com"}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"


### PR DESCRIPTION
Fixes #228.

Adds CI webhook event mapping for workflow_run, workflow_job, and status across all backends with a CI surface — Gitea, GitLab, Bitbucket Cloud, Bitbucket Datacenter, Azure DevOps, and Harness. Each backend's native pipeline/build/status events are translated into GitHub-shaped webhook payloads, with hurl test fixtures per backend × action and compatibility CSV updated to reflect coverage.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] Harness: CI webhook event handlers (pipeline events) <!-- type:spec -->
- [x] Update compatibility CSV for CI webhook event coverage <!-- type:spec -->
- [x] Azure DevOps: CI webhook event handlers (build/pipeline events) <!-- type:spec -->
- [x] Bitbucket Datacenter: CI webhook event handlers (build_status events) <!-- type:spec -->
- [x] Bitbucket Cloud: CI webhook event handlers (commit_status events) <!-- type:spec -->
- [x] GitLab: CI webhook event handlers (Pipeline Hook, Job Hook) <!-- type:spec -->
- [x] Gitea: CI webhook event handlers (workflow_run, workflow_job, status) <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->