### PR TITLE
v3: Webhook — compatibility matrix rows for every (backend, event, action) (closes #232)

### DIFF
--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -2845,3 +2845,106 @@ for _, section in ipairs(endpoint_sections) do
     route_add(e[1], e[2], e[3])
   end
 end
+
+-- ---------------------------------------------------------------------------
+-- Webhook event compatibility entries.
+--
+-- These entries drive the per-(event, action) rows in the compatibility matrix.
+-- They are informational only: NOT HTTP routes, NOT registered with route_add.
+-- The "method" field uses the pseudo-verb "webhook" and the "path" field is
+-- "event/action", giving CSV keys like "webhook issues/opened".
+--
+-- Authoritative source: the fixture filenames under test/fixtures/webhooks/gitea/
+-- (gitea is the most complete backend; all 48 pairs are covered there).
+-- Other backends support subsets; their CSV values are filled in site/compatibility.csv.
+--
+-- e.is_webhook_event = true marks these as non-routable informational entries so
+-- that validate-tests.py can skip them (they have no hurl test files of their own).
+-- ---------------------------------------------------------------------------
+local webhook_event_sections = {
+  {
+    "webhook-events",
+    {
+      -- issues
+      { "webhook issues/opened", "wh_issues_opened" },
+      { "webhook issues/closed", "wh_issues_closed" },
+      { "webhook issues/edited", "wh_issues_edited" },
+      { "webhook issues/reopened", "wh_issues_reopened" },
+      { "webhook issues/labeled", "wh_issues_labeled" },
+      { "webhook issues/unlabeled", "wh_issues_unlabeled" },
+      { "webhook issues/assigned", "wh_issues_assigned" },
+      { "webhook issues/unassigned", "wh_issues_unassigned" },
+
+      -- issue_comment
+      { "webhook issue_comment/created", "wh_issue_comment_created" },
+      { "webhook issue_comment/edited", "wh_issue_comment_edited" },
+      { "webhook issue_comment/deleted", "wh_issue_comment_deleted" },
+
+      -- label
+      { "webhook label/created", "wh_label_created" },
+      { "webhook label/edited", "wh_label_edited" },
+      { "webhook label/deleted", "wh_label_deleted" },
+
+      -- merge_group
+      { "webhook merge_group/checks_requested", "wh_merge_group_checks_requested" },
+      { "webhook merge_group/destroyed", "wh_merge_group_destroyed" },
+
+      -- milestone
+      { "webhook milestone/created", "wh_milestone_created" },
+      { "webhook milestone/closed", "wh_milestone_closed" },
+      { "webhook milestone/opened", "wh_milestone_opened" },
+      { "webhook milestone/edited", "wh_milestone_edited" },
+      { "webhook milestone/deleted", "wh_milestone_deleted" },
+      { "webhook milestone/reopened", "wh_milestone_reopened" },
+
+      -- pull_request
+      { "webhook pull_request/opened", "wh_pull_request_opened" },
+      { "webhook pull_request/closed", "wh_pull_request_closed" },
+      { "webhook pull_request/reopened", "wh_pull_request_reopened" },
+      { "webhook pull_request/edited", "wh_pull_request_edited" },
+      { "webhook pull_request/synchronize", "wh_pull_request_synchronize" },
+      { "webhook pull_request/labeled", "wh_pull_request_labeled" },
+      { "webhook pull_request/unlabeled", "wh_pull_request_unlabeled" },
+      { "webhook pull_request/assigned", "wh_pull_request_assigned" },
+      { "webhook pull_request/unassigned", "wh_pull_request_unassigned" },
+      { "webhook pull_request/review_requested", "wh_pull_request_review_requested" },
+      { "webhook pull_request/review_request_removed", "wh_pull_request_review_request_removed" },
+
+      -- pull_request_review
+      { "webhook pull_request_review/submitted", "wh_pull_request_review_submitted" },
+      { "webhook pull_request_review/edited", "wh_pull_request_review_edited" },
+      { "webhook pull_request_review/dismissed", "wh_pull_request_review_dismissed" },
+
+      -- pull_request_review_comment
+      { "webhook pull_request_review_comment/created", "wh_pull_request_review_comment_created" },
+      { "webhook pull_request_review_comment/edited", "wh_pull_request_review_comment_edited" },
+      { "webhook pull_request_review_comment/deleted", "wh_pull_request_review_comment_deleted" },
+
+      -- status
+      { "webhook status/pending", "wh_status_pending" },
+      { "webhook status/success", "wh_status_success" },
+      { "webhook status/failure", "wh_status_failure" },
+
+      -- workflow_run
+      { "webhook workflow_run/requested", "wh_workflow_run_requested" },
+      { "webhook workflow_run/in_progress", "wh_workflow_run_in_progress" },
+      { "webhook workflow_run/completed", "wh_workflow_run_completed" },
+
+      -- workflow_job
+      { "webhook workflow_job/queued", "wh_workflow_job_queued" },
+      { "webhook workflow_job/in_progress", "wh_workflow_job_in_progress" },
+      { "webhook workflow_job/completed", "wh_workflow_job_completed" },
+      { "webhook workflow_job/waiting", "wh_workflow_job_waiting" },
+    },
+  },
+}
+
+for _, section in ipairs(webhook_event_sections) do
+  local g = section[1]
+  for _, e in ipairs(section[2]) do
+    e.group = g
+    e.is_webhook_event = true
+    endpoints[#endpoints + 1] = e
+    -- No route_add: these are compatibility matrix rows, not HTTP endpoints.
+  end
+end

--- a/scripts/dump-claims.lua
+++ b/scripts/dump-claims.lua
@@ -47,6 +47,8 @@ for i, e in ipairs(endpoints) do -- luacheck: globals endpoints
     .. EncodeJson(e.group)
     .. ',"has_default":'
     .. (e[3] ~= nil and "true" or "false")
+    .. ',"is_webhook_event":'
+    .. (e.is_webhook_event and "true" or "false")
     .. "}"
 end
 

--- a/scripts/dump-claims.lua
+++ b/scripts/dump-claims.lua
@@ -79,10 +79,24 @@ for _, name in ipairs(cli_backends) do
   for i, h in ipairs(handlers) do
     handler_parts[i] = EncodeJson(h)
   end
+
+  local wh_events = {}
+  for event in pairs(app.backend.webhooks) do -- luacheck: globals app
+    wh_events[#wh_events + 1] = event
+  end
+  table.sort(wh_events)
+
+  local wh_parts = {}
+  for i, ev in ipairs(wh_events) do
+    wh_parts[i] = EncodeJson(ev)
+  end
+
   backend_parts[#backend_parts + 1] = EncodeJson(name)
-    .. ":["
+    .. ':{"rest":['
     .. table.concat(handler_parts, ",")
-    .. "]"
+    .. '],"webhooks":['
+    .. table.concat(wh_parts, ",")
+    .. "]}"
 end
 
 io.write('{"endpoints":[\n')

--- a/scripts/dump-endpoints.lua
+++ b/scripts/dump-endpoints.lua
@@ -34,6 +34,8 @@ for i, e in ipairs(endpoints) do -- luacheck: globals endpoints
     .. EncodeJson(e.group)
     .. ',"has_default":'
     .. (e[3] ~= nil and "true" or "false")
+    .. ',"is_webhook_event":'
+    .. (e.is_webhook_event and "true" or "false")
     .. "}"
 end
 io.write("[\n" .. table.concat(parts, ",\n") .. "\n]\n")

--- a/scripts/gen-matrix.py
+++ b/scripts/gen-matrix.py
@@ -10,10 +10,15 @@ Usage:
   output   path to write result        (default: stdout)
 
 The template must contain the marker <!-- COMPAT_MATRIX --> where the
-generated <table> element will be inserted.
+generated REST endpoint <table> element will be inserted, and the marker
+<!-- WEBHOOK_MATRIX --> where the webhook events <table> will be inserted.
 
 The catalog JSON is produced by: ./redbean.com -i scripts/dump-endpoints.lua
-Each entry has: method, path, handler, group, has_default.
+Each entry has: method, path, handler, group, has_default, is_webhook_event.
+
+Entries with is_webhook_event=true use method "webhook" and path "event/action"
+(e.g. "webhook issues/opened").  They are rendered in a separate table keyed
+by event type (the segment before "/"), with the action as the row label.
 
 The CSV contains support values (y/n/~) keyed by "METHOD /path". Section
 headers are derived from the catalog group names; the CSV has no section rows.
@@ -84,6 +89,22 @@ GROUP_NAMES = {
     "git":                  "Git Database",
 }
 
+# Human-readable names for webhook event types (the segment before "/" in the path).
+WEBHOOK_EVENT_NAMES = {
+    "issues":                       "Issues",
+    "issue_comment":                "Issue Comments",
+    "label":                        "Labels",
+    "merge_group":                  "Merge Group",
+    "milestone":                    "Milestones",
+    "pull_request":                 "Pull Requests",
+    "pull_request_review":          "PR Reviews",
+    "pull_request_review_comment":  "PR Review Comments",
+    "push":                         "Push",
+    "status":                       "Commit Status",
+    "workflow_run":                 "Workflow Run",
+    "workflow_job":                 "Workflow Job",
+}
+
 
 def make_cell(val):
     val = val.strip()
@@ -99,6 +120,7 @@ def make_cell(val):
 
 
 def generate_table(catalog, support, providers):
+    """Generate the REST endpoint compatibility table (non-webhook entries)."""
     num_cols = len(providers) + 1  # +1 for the endpoint column
 
     # thead
@@ -111,6 +133,8 @@ def generate_table(catalog, support, providers):
     tbody_rows = []
     current_group = None
     for entry in catalog:
+        if entry.get("is_webhook_event"):
+            continue
         group = entry["group"]
         if group != current_group:
             section = GROUP_NAMES.get(group, group)
@@ -121,6 +145,54 @@ def generate_table(catalog, support, providers):
         endpoint = entry["method"] + " " + entry["path"]
         row = support.get(endpoint, {})
         cells = [f'<td class="ep">{endpoint}</td>']
+        for p in providers:
+            val = row.get(p, "n")
+            cells.append(make_cell(val))
+        tbody_rows.append("        <tr>" + "".join(cells) + "</tr>")
+
+    tbody = "      <tbody>\n" + "\n".join(tbody_rows) + "\n      </tbody>"
+    return f"    <table>\n{thead}\n{tbody}\n    </table>"
+
+
+def generate_webhook_table(catalog, support, providers):
+    """Generate the webhook event compatibility table.
+
+    Rows come from catalog entries with is_webhook_event=true.  Their path is
+    "event/action" (e.g. "issues/opened").  Section headers group by the event
+    type (before "/"); the row label shows only the action (after "/").
+
+    The CSV key for each entry is "webhook event/action" (method + " " + path).
+    """
+    num_cols = len(providers) + 1  # +1 for the action column
+
+    # thead
+    header_cells = ["<th>Action</th>"]
+    for p in providers:
+        header_cells.append(f"<th>{PROVIDER_NAMES.get(p, p)}</th>")
+    thead = "      <thead>\n        <tr>" + "".join(header_cells) + "</tr>\n      </thead>"
+
+    tbody_rows = []
+    current_event = None
+    for entry in catalog:
+        if not entry.get("is_webhook_event"):
+            continue
+        path = entry["path"]  # e.g. "issues/opened"
+        if "/" in path:
+            event, action = path.split("/", 1)
+        else:
+            event, action = path, ""
+
+        if event != current_event:
+            section = WEBHOOK_EVENT_NAMES.get(event, event)
+            tbody_rows.append(
+                f'        <tr><td colspan="{num_cols}" class="section-hdr">{section}</td></tr>'
+            )
+            current_event = event
+
+        csv_key = entry["method"] + " " + path  # e.g. "webhook issues/opened"
+        row = support.get(csv_key, {})
+        label = action if action else path
+        cells = [f'<td class="ep">{label}</td>']
         for p in providers:
             val = row.get(p, "n")
             cells.append(make_cell(val))
@@ -150,9 +222,12 @@ def main():
         for row in reader:
             support[row["endpoint"]] = {p: row.get(p, "n") for p in providers}
 
-    table_html = generate_table(catalog, support, providers)
+    rest_table_html    = generate_table(catalog, support, providers)
+    webhook_table_html = generate_webhook_table(catalog, support, providers)
+
     template = template_path.read_text()
-    output = template.replace("<!-- COMPAT_MATRIX -->", table_html, 1)
+    output = template.replace("<!-- COMPAT_MATRIX -->", rest_table_html, 1)
+    output = output.replace("<!-- WEBHOOK_MATRIX -->", webhook_table_html, 1)
 
     if output_path:
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/validate-claims.lua
+++ b/scripts/validate-claims.lua
@@ -43,7 +43,7 @@ local csv_path = (arg and arg[1]) or "site/compatibility.csv" -- luacheck: globa
 -- Read dump-claims JSON from stdin.
 local data = DecodeJson(io.read("*a"))
 local endpoints = data.endpoints
-local backends = data.backends
+local backends = data.backends -- backends[name] = { rest = [...], webhooks = [...] }
 
 -- Parse a single CSV line into fields, handling RFC 4180 quoting.
 local function parse_csv_line(line)
@@ -102,20 +102,38 @@ for _, h in ipairs(headers) do
   end
 end
 
--- Build a lookup from "METHOD /path" → handler name.
-local handler_for = {}
+-- Build a lookup from "METHOD /path" → { handler, is_webhook_event, webhook_event }.
+-- For webhook event rows, webhook_event is the event type extracted from the path
+-- (e.g. "issues" from "issues/opened") — this is the key in app.backend.webhooks.
+local ep_info = {}
 for _, e in ipairs(endpoints) do
-  handler_for[e.method .. " " .. e.path] = e.handler
+  local key = e.method .. " " .. e.path
+  local webhook_event = nil
+  if e.is_webhook_event then
+    -- path is "event/action" (e.g. "issues/opened"); extract event type
+    webhook_event = e.path:match("^([^/]+)/")
+  end
+  ep_info[key] =
+    { handler = e.handler, is_webhook_event = e.is_webhook_event, webhook_event = webhook_event }
 end
 
--- Build a set of handlers per provider for O(1) lookup.
+-- Build O(1) lookup sets per provider.
+-- impl_set[name][handler]      true if app.backend.rest has this handler
+-- wh_set[name][event]          true if app.backend.webhooks has this event handler
 local impl_set = {}
-for name, handlers in pairs(backends) do
-  local s = {}
-  for _, h in ipairs(handlers) do
-    s[h] = true
+local wh_set = {}
+for name, info in pairs(backends) do
+  local rs = {}
+  for _, h in ipairs(info.rest or {}) do
+    rs[h] = true
   end
-  impl_set[name] = s
+  impl_set[name] = rs
+
+  local ws = {}
+  for _, ev in ipairs(info.webhooks or {}) do
+    ws[ev] = true
+  end
+  wh_set[name] = ws
 end
 
 local errors = {}
@@ -127,28 +145,56 @@ for li = 2, #lines do
       row[h] = fields[fi] or ""
     end
     local ep = row.endpoint
-    local handler = handler_for[ep]
-    if handler then
+    local info = ep_info[ep]
+    if info then
       for _, provider in ipairs(csv_providers) do
         if backends[provider] then
           local claim = row[provider] or "n"
-          local has_handler = impl_set[provider][handler] == true
-          if claim == "y" and not has_handler and not CONFUSIO_NATIVE[handler] then
-            errors[#errors + 1] = "ERROR: "
-              .. provider
-              .. " claims 'y' for "
-              .. ep
-              .. " but app.backend.rest has no handler '"
-              .. handler
-              .. "'"
-          elseif claim == "n" and has_handler then
-            errors[#errors + 1] = "ERROR: "
-              .. provider
-              .. " claims 'n' for "
-              .. ep
-              .. " but app.backend.rest defines handler '"
-              .. handler
-              .. "'"
+          if info.is_webhook_event then
+            -- Webhook event rows: validate against app.backend.webhooks[event_type].
+            -- A 'y' claim requires the backend to have a webhook handler for this event type.
+            -- A 'n' claim requires the backend NOT to have one.
+            -- '~*' claims are not validated (partial/best-effort support).
+            local event_type = info.webhook_event
+            local has_wh = event_type ~= nil and wh_set[provider][event_type] == true
+            if claim == "y" and not has_wh then
+              errors[#errors + 1] = "ERROR: "
+                .. provider
+                .. " claims 'y' for "
+                .. ep
+                .. " but app.backend.webhooks has no handler for event '"
+                .. (event_type or "?")
+                .. "'"
+            elseif claim == "n" and has_wh then
+              errors[#errors + 1] = "ERROR: "
+                .. provider
+                .. " claims 'n' for "
+                .. ep
+                .. " but app.backend.webhooks defines a handler for event '"
+                .. (event_type or "?")
+                .. "'"
+            end
+          else
+            -- REST endpoint rows: validate against app.backend.rest[handler].
+            local handler = info.handler
+            local has_handler = impl_set[provider][handler] == true
+            if claim == "y" and not has_handler and not CONFUSIO_NATIVE[handler] then
+              errors[#errors + 1] = "ERROR: "
+                .. provider
+                .. " claims 'y' for "
+                .. ep
+                .. " but app.backend.rest has no handler '"
+                .. handler
+                .. "'"
+            elseif claim == "n" and has_handler then
+              errors[#errors + 1] = "ERROR: "
+                .. provider
+                .. " claims 'n' for "
+                .. ep
+                .. " but app.backend.rest defines handler '"
+                .. handler
+                .. "'"
+            end
           end
         end
       end

--- a/scripts/validate-claims.lua
+++ b/scripts/validate-claims.lua
@@ -117,11 +117,32 @@ for _, e in ipairs(endpoints) do
     { handler = e.handler, is_webhook_event = e.is_webhook_event, webhook_event = webhook_event }
 end
 
+-- The canonical set of GitHub-style webhook event type names used as keys in
+-- app.backend.webhooks for Gitea-family and GitBucket backends.  Backends that
+-- use native forge event names (e.g. "Issues Hook", "workitem.created",
+-- "pr:opened", "pipeline_execution_started") instead of these names cannot be
+-- validated at the event-type level — only at the "has any handlers" level.
+local GITHUB_EVENT_TYPES = {
+  issues = true,
+  issue_comment = true,
+  label = true,
+  merge_group = true,
+  milestone = true,
+  pull_request = true,
+  pull_request_review = true,
+  pull_request_review_comment = true,
+  status = true,
+  workflow_run = true,
+  workflow_job = true,
+}
+
 -- Build O(1) lookup sets per provider.
 -- impl_set[name][handler]      true if app.backend.rest has this handler
 -- wh_set[name][event]          true if app.backend.webhooks has this event handler
+-- wh_github_named[name]        true if all webhook keys are GitHub-style event names
 local impl_set = {}
 local wh_set = {}
+local wh_github_named = {}
 for name, info in pairs(backends) do
   local rs = {}
   for _, h in ipairs(info.rest or {}) do
@@ -130,10 +151,15 @@ for name, info in pairs(backends) do
   impl_set[name] = rs
 
   local ws = {}
+  local github_named = true
   for _, ev in ipairs(info.webhooks or {}) do
     ws[ev] = true
+    if not GITHUB_EVENT_TYPES[ev] then
+      github_named = false
+    end
   end
   wh_set[name] = ws
+  wh_github_named[name] = github_named
 end
 
 local errors = {}
@@ -151,28 +177,49 @@ for li = 2, #lines do
         if backends[provider] then
           local claim = row[provider] or "n"
           if info.is_webhook_event then
-            -- Webhook event rows: validate against app.backend.webhooks[event_type].
-            -- A 'y' claim requires the backend to have a webhook handler for this event type.
-            -- A 'n' claim requires the backend NOT to have one.
-            -- '~*' claims are not validated (partial/best-effort support).
+            -- Webhook event rows.  '~*' claims are never validated.
+            --
+            -- Two validation regimes based on whether the backend uses GitHub-style
+            -- event type names (e.g. "issues", "pull_request") or native forge names
+            -- (e.g. "Issues Hook", "workitem.created", "pr:opened").
+            --
+            -- GitHub-named backends (Gitea family, GitBucket): validate at event-type
+            -- level — 'y' requires app.backend.webhooks[event_type] to be registered;
+            -- 'n' requires it to be absent.
+            --
+            -- Native-named backends (GitLab, Azure DevOps, Bitbucket, Harness, …):
+            -- cannot validate at event-type level because their webhook keys don't
+            -- correspond to GitHub event names.  Only flag an error when 'y' is
+            -- claimed but the backend has zero webhook handlers at all.
             local event_type = info.webhook_event
-            local has_wh = event_type ~= nil and wh_set[provider][event_type] == true
-            if claim == "y" and not has_wh then
-              errors[#errors + 1] = "ERROR: "
-                .. provider
-                .. " claims 'y' for "
-                .. ep
-                .. " but app.backend.webhooks has no handler for event '"
-                .. (event_type or "?")
-                .. "'"
-            elseif claim == "n" and has_wh then
-              errors[#errors + 1] = "ERROR: "
-                .. provider
-                .. " claims 'n' for "
-                .. ep
-                .. " but app.backend.webhooks defines a handler for event '"
-                .. (event_type or "?")
-                .. "'"
+            if wh_github_named[provider] then
+              local has_wh = event_type ~= nil and wh_set[provider][event_type] == true
+              if claim == "y" and not has_wh then
+                errors[#errors + 1] = "ERROR: "
+                  .. provider
+                  .. " claims 'y' for "
+                  .. ep
+                  .. " but app.backend.webhooks has no handler for event '"
+                  .. (event_type or "?")
+                  .. "'"
+              elseif claim == "n" and has_wh then
+                errors[#errors + 1] = "ERROR: "
+                  .. provider
+                  .. " claims 'n' for "
+                  .. ep
+                  .. " but app.backend.webhooks defines a handler for event '"
+                  .. (event_type or "?")
+                  .. "'"
+              end
+            else
+              -- Native-named backend: only disallow 'y' when there are no handlers at all.
+              if claim == "y" and next(wh_set[provider]) == nil then
+                errors[#errors + 1] = "ERROR: "
+                  .. provider
+                  .. " claims 'y' for "
+                  .. ep
+                  .. " but app.backend.webhooks has no handlers"
+              end
             end
           else
             -- REST endpoint rows: validate against app.backend.rest[handler].

--- a/scripts/validate-tests.py
+++ b/scripts/validate-tests.py
@@ -16,7 +16,10 @@ import os
 import sys
 
 catalog = json.load(sys.stdin)
-groups = list(dict.fromkeys(e["group"] for e in catalog))
+# Skip groups whose entries are informational-only webhook event rows — they are not
+# HTTP endpoints and have no hurl test files.  The existing *-webhooks.hurl files
+# cover the event delivery pipeline; per-(event,action) rows need no separate tests.
+groups = list(dict.fromkeys(e["group"] for e in catalog if not e.get("is_webhook_event")))
 backends = sys.argv[1:]
 
 gaps = []

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -463,3 +463,52 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
+webhook issues/opened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook issues/closed,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook issues/edited,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook issues/reopened,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook issues/labeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook issues/unlabeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook issues/assigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook issues/unassigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook issue_comment/created,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook issue_comment/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook issue_comment/deleted,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook label/created,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook label/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook label/deleted,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook merge_group/checks_requested,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook merge_group/destroyed,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook milestone/created,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook milestone/closed,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook milestone/opened,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook milestone/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook milestone/deleted,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook milestone/reopened,~reopen emits opened,n,n,~reopen emits opened,n,~reopen emits opened,n,n,~reopen emits opened,~reopen emits opened,n,~reopen emits opened,n,n,n,~reopen emits opened,n,n,n,n,n,n,n,n
+webhook pull_request/opened,y,y,y,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook pull_request/closed,y,y,y,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook pull_request/reopened,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/edited,n,y,y,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/synchronize,y,y,y,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook pull_request/labeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/unlabeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/assigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/unassigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/review_requested,n,n,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/review_request_removed,n,n,y,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request_review/submitted,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request_review/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request_review/dismissed,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request_review_comment/created,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request_review_comment/edited,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request_review_comment/deleted,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook status/pending,n,y,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook status/success,n,y,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook status/failure,n,y,y,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook workflow_run/requested,n,n,n,y,n,y,n,n,n,y,y,y,y,n,n,y,n,n,n,n,n,n,n,n
+webhook workflow_run/in_progress,n,n,n,y,n,y,n,n,n,y,y,y,y,n,n,y,n,n,n,n,n,n,n,n
+webhook workflow_run/completed,y,n,n,y,n,y,n,n,n,y,y,y,y,n,n,y,n,n,n,n,n,n,n,n
+webhook workflow_job/queued,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook workflow_job/in_progress,n,n,n,y,n,y,n,n,n,y,y,y,y,n,n,y,n,n,n,n,n,n,n,n
+webhook workflow_job/completed,n,n,n,y,n,y,n,n,n,y,y,y,y,n,n,y,n,n,n,n,n,n,n,n
+webhook workflow_job/waiting,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/site/index.html
+++ b/site/index.html
@@ -227,6 +227,21 @@
   </p>
 </section>
 
+<section>
+  <h2>Webhook Events</h2>
+  <p style="margin-bottom:0.75rem; color:var(--text-muted); font-size:0.85rem;">
+    Inbound webhook events that confusio translates to the GitHub webhook shape.
+    One row per (event, action) pair.
+  </p>
+  <div class="table-wrap">
+<!-- WEBHOOK_MATRIX -->
+  </div>
+  <p class="table-scroll-hint">Scroll to see all providers &#x2192;</p>
+  <p style="margin-top:0.75rem; color:var(--text-muted); font-size:0.85rem;">
+    &#x2705; Supported &middot; &#x26A0;&#xFE0F; Partial &middot; &#x274C; Not emitted by this provider
+  </p>
+</section>
+
 <footer>
   Built with <a href="https://redbean.dev">Redbean</a>.
   <a href="https://github.com/rhencke/confusio">Source on GitHub</a>.


### PR DESCRIPTION
Fixes #232.

Extends the compatibility matrix to show one row per webhook (event, action) pair instead of a single blanket "webhooks" row. Adds catalog entries for every canonical event/action, renders them as a separate "Webhook Events" table on the site, extends validation scripts to handle informational webhook event claims, and fills the CSV with honest y/n per backend based on actual translator and fixture coverage.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Extend validation scripts for webhook event claims <!-- type:spec -->
- [x] Wire test coverage for webhook events catalog group <!-- type:spec -->
- [x] Add webhook event compatibility rows to CSV <!-- type:spec -->
- [x] Add webhook event catalog entries to internal/catalog.lua <!-- type:spec -->
- [x] Extend gen-matrix.py to render webhook events section <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->