### PR TITLE
v3: Webhook — event mapping: deployment family (deployment, deployment_status, deployment_review, deployment_protection_rule) (closes #236)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ test/fixtures/webhooks/gitlab/workflow_run-in_progress.json
 test/fixtures/webhooks/gitlab/workflow_run-completed.json
 test/fixtures/webhooks/gitlab/workflow_job-in_progress.json
 test/fixtures/webhooks/gitlab/workflow_job-completed.json
+test/fixtures/webhooks/gitlab/deployment_status-created-failed.json
 test/fixtures/webhooks/bitbucket/issues-closed.json
 test/fixtures/webhooks/bitbucket/issues-edited.json
 test/fixtures/webhooks/bitbucket/issues-reopened.json

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -6875,6 +6875,102 @@ b:webhook("Tag Push Hook", function(payload)
   })
 end)
 
+-- GL_DEPLOYMENT_STATE: map GitLab deployment status to GitHub deployment_status state.
+local GL_DEPLOYMENT_STATE = {
+  running = "in_progress",
+  success = "success",
+  failed = "failure",
+  canceled = "inactive",
+  cancelled = "inactive", -- defensive alternate spelling
+  blocked = "waiting",
+}
+
+-- translate_gl_webhook_deployment: build a GitHub-shaped deployment object from a
+-- GitLab Deployment Hook payload.  Used in both deployment and deployment_status events.
+local function translate_gl_webhook_deployment(payload)
+  return {
+    id = payload.deployment_id or 0,
+    node_id = "",
+    sha = payload.short_sha or "",
+    ref = payload.ref or "",
+    task = "deploy",
+    environment = payload.environment or "",
+    original_environment = "",
+    description = nil,
+    payload = {},
+    creator = translate_gl_user(payload.user),
+    created_at = payload.status_changed_at or "",
+    updated_at = payload.status_changed_at or "",
+    statuses_url = "",
+    repository_url = "",
+    production_environment = false,
+    transient_environment = false,
+  }
+end
+
+-- Deployment Hook: maps GitLab deployment lifecycle events to GitHub deployment
+-- and deployment_status events.  GitLab fires one event per status transition.
+--
+-- Mapping:
+--   running                           → deployment (created) — deployment initiated
+--   success / failed / canceled / blocked → deployment_status (created) — status update
+b:webhook("Deployment Hook", function(payload)
+  local gl_status = payload.status or ""
+  local project = payload.project or {}
+  local repository = translate_gl_webhook_project(project)
+  local sender = translate_gl_user(payload.user)
+  local deployment = translate_gl_webhook_deployment(payload)
+  local timestamp = payload.status_changed_at or ""
+
+  if gl_status == "running" then
+    -- Emit GitHub deployment (created) event for the initial deployment trigger.
+    return make_internal_event({
+      event = "deployment",
+      action = "created",
+      provider = config.backend,
+      raw = payload,
+      data = {
+        action = "created",
+        deployment = deployment,
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = timestamp,
+    })
+  end
+
+  -- All other status transitions map to deployment_status (created).
+  local state = GL_DEPLOYMENT_STATE[gl_status] or "error"
+  local deployment_status = {
+    id = 0,
+    node_id = "",
+    state = state,
+    description = "",
+    environment = payload.environment or "",
+    environment_url = "",
+    log_url = payload.deployable_url or "",
+    target_url = "",
+    deployment_url = "",
+    creator = sender,
+    created_at = timestamp,
+    updated_at = timestamp,
+  }
+  return make_internal_event({
+    event = "deployment_status",
+    action = "created",
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = "created",
+      deployment_status = deployment_status,
+      deployment = deployment,
+      repository = repository,
+      sender = sender,
+    },
+    timestamp = timestamp,
+  })
+end)
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -913,6 +913,10 @@ action availability.
 | `label` | Label lifecycle | `created`, `edited`, `deleted` |
 | `commit_comment` | Comment on a commit | `created` |
 | `status` | Commit status update | _(no action field — status is a single event)_ |
+| `deployment` | Deployment created | `created` |
+| `deployment_status` | Deployment status updated | `created` |
+| `deployment_review` | Deployment awaiting or receiving review | `approved`, `rejected`, `requested` |
+| `deployment_protection_rule` | Deployment protection rule triggered | `requested` |
 | `ping` | Sent on webhook registration | _(no action field)_ |
 
 Events not in this table are not currently emitted by confusio in GitHub-emulation
@@ -1112,6 +1116,120 @@ When `action` is `"closed"` and `pull_request.merged` is `true`, the PR was merg
   "sender":     { ... }
 }
 ```
+
+#### `deployment`
+
+```json
+{
+  "action": "created",
+  "deployment": {
+    "id":                     1,
+    "sha":                    "<commit sha>",
+    "ref":                    "main",
+    "task":                   "deploy",
+    "environment":            "production",
+    "original_environment":   "staging",
+    "description":            "<string or null>",
+    "payload":                {},
+    "creator":                { ... },
+    "created_at":             "<iso8601>",
+    "updated_at":             "<iso8601>",
+    "statuses_url":           "<url>",
+    "repository_url":         "<url>",
+    "production_environment": true,
+    "transient_environment":  false
+  },
+  "workflow":     { ... },
+  "workflow_run": { ... },
+  "repository":   { ... },
+  "sender":       { ... }
+}
+```
+
+`task` is typically `"deploy"`.  `environment` is a free-form string naming the target
+(e.g. `"production"`, `"staging"`).  `original_environment` is the environment that was
+configured before any promotion.  `payload` is an arbitrary JSON object provided by the
+creator.  `production_environment` and `transient_environment` are booleans set by the
+creator at deployment time.  `workflow` and `workflow_run` are present when the deployment
+was triggered by a GitHub Actions workflow and are `null` otherwise.
+
+#### `deployment_status`
+
+```json
+{
+  "action": "created",
+  "deployment_status": {
+    "id":               2,
+    "state":            "success",
+    "description":      "<string or null>",
+    "environment":      "production",
+    "environment_url":  "<url or null>",
+    "log_url":          "<url or null>",
+    "target_url":       "<url or null>",
+    "deployment_url":   "<url>",
+    "created_at":       "<iso8601>",
+    "updated_at":       "<iso8601>",
+    "creator":          { ... }
+  },
+  "deployment":   { ... },
+  "repository":   { ... },
+  "sender":       { ... }
+}
+```
+
+`state` values: `"error"`, `"failure"`, `"inactive"`, `"pending"`, `"success"`,
+`"queued"`, `"in_progress"`, `"waiting"`.  `deployment` is the full deployment object
+(same shape as in the `deployment` event body).  `environment_url` is a URL for the
+live environment, if set.  `log_url` is a direct link to the deployment log.
+
+#### `deployment_review`
+
+```json
+{
+  "action":       "approved",
+  "approver":     { "login": "<string>", "id": 0 },
+  "comment":      "<string or null>",
+  "since":        "<iso8601>",
+  "environment":  "production",
+  "reviewers":    [
+    {
+      "type":     "User",
+      "reviewer": { "login": "<string>", "id": 0 }
+    }
+  ],
+  "workflow_run": { ... },
+  "repository":   { ... },
+  "sender":       { ... }
+}
+```
+
+Fired when a deployment pending a required review is approved or rejected, or when a
+review is first requested.  `approver` is present on `approved` and `rejected` actions.
+`reviewers` is the list of users or teams that can review the deployment.  `since` is the
+ISO 8601 timestamp from which the review request has been pending.
+
+#### `deployment_protection_rule`
+
+```json
+{
+  "action":                  "requested",
+  "environment":             "production",
+  "event":                   "pull_request",
+  "sha":                     "<commit sha>",
+  "ref":                     "main",
+  "deployment_callback_url": "<url>",
+  "deployment":              { ... },
+  "pull_requests":           [ { ... } ],
+  "repository":              { ... },
+  "sender":                  { ... }
+}
+```
+
+Fired when a deployment protection rule is triggered for an environment.  `event` is the
+GitHub event that triggered the deployment (e.g. `"pull_request"`, `"push"`).
+`deployment_callback_url` is the URL that an integration must POST to in order to approve
+or reject the deployment.  `deployment` is the full deployment object; `pull_requests`
+is the list of pull requests that triggered this deployment (may be empty).
 
 #### `ping`
 
@@ -2708,6 +2826,174 @@ Triggered when a repository label is created, edited, or deleted.
 
 ---
 
+### `deployment`
+
+Triggered when a deployment is created.  Deployment events represent the initiation of a
+deployment to a named environment — distinct from the status updates that follow.
+
+#### Deployment object fields
+
+| GitHub field | github | gitlab | All others |
+|---|---|---|---|
+| `deployment.id` | ✓ | ✓ | ✗ |
+| `deployment.sha` | ✓ | ~ | ✗ |
+| `deployment.ref` | ✓ | ✓ | ✗ |
+| `deployment.task` | ✓ | ✗ | ✗ |
+| `deployment.environment` | ✓ | ✓ | ✗ |
+| `deployment.original_environment` | ✓ | ✗ | ✗ |
+| `deployment.description` | ✓ | ✗ | ✗ |
+| `deployment.payload` | ✓ | ✗ | ✗ |
+| `deployment.creator` | ✓ | ✓ | ✗ |
+| `deployment.created_at` | ✓ | ~ | ✗ |
+| `deployment.updated_at` | ✓ | ~ | ✗ |
+| `deployment.statuses_url` | ✓ | ✗ | ✗ |
+| `deployment.repository_url` | ✓ | ✗ | ✗ |
+| `deployment.production_environment` | ✓ | ✗ | ✗ |
+| `deployment.transient_environment` | ✓ | ✗ | ✗ |
+
+#### Supported actions
+
+| Action | github | gitlab |
+|--------|--------|--------|
+| `created` | ✓ | ✓ |
+
+**Notes:**
+- **GitLab**: GitLab fires a single "Deployment events" webhook per status transition.
+  Confusio emits a synthetic `deployment` (`created`) event when a GitLab deployment first
+  enters the `running` state.  The deployment object is reconstructed from the GitLab
+  payload: `id` is `deployment_id`, `ref` and `environment` map directly, `creator` is
+  the GitLab `user` object.
+- `deployment.sha`: GitLab provides only a short SHA (`short_sha`); confusio emits it as-is.
+  Full SHAs are not available without a back-fetch.
+- `deployment.created_at` / `updated_at`: GitLab provides `status_changed_at`; confusio
+  uses it for both timestamps.
+- `deployment.task`: GitLab has no task concept; confusio emits `"deploy"` as a stub.
+- `deployment.payload`: GitLab has no custom payload; confusio emits `{}`.
+- `deployment.original_environment`, `production_environment`, `transient_environment`:
+  GitLab does not expose these; confusio emits stubs (`""`, `false`, `false`).
+- `deployment.statuses_url`, `repository_url`: GitLab does not provide these URLs;
+  confusio emits `""`.
+- `workflow` / `workflow_run`: present in GitHub pass-through when the deployment was
+  triggered by GitHub Actions; always `null` in confusio-translated output.
+- Backends not listed (Gitea-family, Bitbucket, Azure DevOps, etc.) do not emit
+  deployment lifecycle events.  Gitea explicitly has no deployment webhook equivalent.
+
+---
+
+### `deployment_status`
+
+Triggered when the status of a deployment changes.
+
+#### Deployment status object fields
+
+| GitHub field | github | gitlab | All others |
+|---|---|---|---|
+| `deployment_status.id` | ✓ | ✗ | ✗ |
+| `deployment_status.state` | ✓ | ~ | ✗ |
+| `deployment_status.description` | ✓ | ✗ | ✗ |
+| `deployment_status.environment` | ✓ | ✓ | ✗ |
+| `deployment_status.environment_url` | ✓ | ✗ | ✗ |
+| `deployment_status.log_url` | ✓ | ~ | ✗ |
+| `deployment_status.target_url` | ✓ | ✗ | ✗ |
+| `deployment_status.deployment_url` | ✓ | ✗ | ✗ |
+| `deployment_status.creator` | ✓ | ✓ | ✗ |
+| `deployment_status.created_at` | ✓ | ~ | ✗ |
+| `deployment_status.updated_at` | ✓ | ~ | ✗ |
+| `deployment` (full object) | ✓ | ~ | ✗ |
+
+#### Supported actions
+
+| Action | github | gitlab |
+|--------|--------|--------|
+| `created` | ✓ | ✓ |
+
+**`state` mapping from GitLab:**
+
+| GitLab `status` | GitHub `state` |
+|----------------|----------------|
+| `running` | `in_progress` |
+| `success` | `success` |
+| `failed` | `failure` |
+| `canceled` | `inactive` |
+| `blocked` | `waiting` |
+
+**Notes:**
+- **GitLab**: GitLab fires "Deployment events" webhooks for every status transition.
+  Confusio emits a `deployment_status` (`created`) event for each GitLab deployment
+  event regardless of direction.  The `deployment` object embedded in the body is the
+  same reconstructed deployment object as in the `deployment` event.
+- `deployment_status.id`: GitLab does not expose a separate status ID; confusio emits `0`.
+- `deployment_status.state`: Mapped from GitLab's `status` field using the table above.
+- `deployment_status.log_url`: GitLab's `deployable_url` (a link to the CI job) is used.
+- `deployment_status.target_url`, `environment_url`, `deployment_url`: GitLab does not
+  provide these separately; confusio emits `""`.
+- `deployment_status.description`: GitLab has no free-form description; confusio emits `""`.
+- `created_at` / `updated_at`: GitLab provides `status_changed_at`; confusio uses it for
+  both timestamps.
+- `deployment` (embedded): reconstructed from GitLab fields — same fidelity as the
+  `deployment` event object (see `deployment` section Notes above).
+- Backends not listed do not emit deployment status events.
+
+---
+
+### `deployment_review`
+
+Triggered when a deployment pending a required review is approved, rejected, or first
+requested.  This event is specific to GitHub's environment protection rules.
+
+| GitHub field | github | All others |
+|---|---|---|
+| `approver` | ✓ | — |
+| `comment` | ✓ | — |
+| `since` | ✓ | — |
+| `environment` | ✓ | — |
+| `reviewers` | ✓ | — |
+| `workflow_run` | ✓ | — |
+
+#### Supported actions
+
+| Action | github | All others |
+|--------|--------|------------|
+| `approved` | ✓ | — |
+| `rejected` | ✓ | — |
+| `requested` | ✓ | — |
+
+**Notes:**
+- `deployment_review` is a GitHub Actions-specific event with no cross-forge equivalent.
+  No non-GitHub backend emits review-gated deployment events; confusio marks all
+  non-GitHub backends as `—` (not applicable).
+- When the originating backend is GitHub, the event passes through verbatim.
+
+---
+
+### `deployment_protection_rule`
+
+Triggered when a configured deployment protection rule is evaluated.  This event is
+specific to GitHub's custom deployment protection integrations.
+
+| GitHub field | github | All others |
+|---|---|---|
+| `environment` | ✓ | — |
+| `event` | ✓ | — |
+| `sha` | ✓ | — |
+| `ref` | ✓ | — |
+| `deployment_callback_url` | ✓ | — |
+| `deployment` | ✓ | — |
+| `pull_requests` | ✓ | — |
+
+#### Supported actions
+
+| Action | github | All others |
+|--------|--------|------------|
+| `requested` | ✓ | — |
+
+**Notes:**
+- `deployment_protection_rule` is a GitHub-specific integration mechanism with no
+  cross-forge equivalent.  Confusio marks all non-GitHub backends as `—` (not applicable).
+- When the originating backend is GitHub, the event passes through verbatim.
+
+---
+
 ### `ping`
 
 The `ping` event is synthetic.  It is emitted by confusio itself — not translated from an
@@ -2752,8 +3038,15 @@ surfaced via the `status` event (see above).
 | `check_suite` | ✓ pass-through | ✗ |
 | `workflow_run` | ✓ pass-through | ✗ |
 | `workflow_job` | ✓ pass-through | ✗ |
-| `deployment` | ✓ pass-through | ✗ |
-| `deployment_status` | ✓ pass-through | ✗ |
+| `deployment_review` | ✓ pass-through | ✗ |
+| `deployment_protection_rule` | ✓ pass-through | ✗ |
+
+`deployment_review` and `deployment_protection_rule` are GitHub Actions-specific events tied
+to GitHub's required-reviewer enforcement model.  No other forge has an equivalent concept.
+
+The `deployment` and `deployment_status` events have cross-forge mapping targets and are
+documented as full event families below (see [`deployment`](#deployment-1) and
+[`deployment_status`](#deployment_status-1)).
 
 For cross-forge CI/CD signal in confusio-normalized shape the `status` event provides a
 consistent envelope regardless of backend.  Future work may add a `pipeline_run` event

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -2947,6 +2947,20 @@ local webhook_event_sections = {
       { "webhook workflow_job/in_progress", "wh_workflow_job_in_progress" },
       { "webhook workflow_job/completed", "wh_workflow_job_completed" },
       { "webhook workflow_job/waiting", "wh_workflow_job_waiting" },
+
+      -- deployment
+      { "webhook deployment/created", "wh_deployment_created" },
+
+      -- deployment_status
+      { "webhook deployment_status/created", "wh_deployment_status_created" },
+
+      -- deployment_review
+      { "webhook deployment_review/approved", "wh_deployment_review_approved" },
+      { "webhook deployment_review/rejected", "wh_deployment_review_rejected" },
+      { "webhook deployment_review/requested", "wh_deployment_review_requested" },
+
+      -- deployment_protection_rule
+      { "webhook deployment_protection_rule/requested", "wh_deployment_protection_rule_requested" },
     },
   },
 }

--- a/scripts/gen-webhook-fixtures.sh
+++ b/scripts/gen-webhook-fixtures.sh
@@ -119,6 +119,7 @@ bitbucket_datacenter|status-created-success.json|status-updated-pending.json|.bu
 gerrit|comment-added-approved.json|comment-added-changes_requested.json|.change.updated = "2024-01-15T11:30:00Z" | .comment = "This needs more work. -2" | .approvals[0].value = "-2"
 harness|pipeline_execution_started.json|pipeline_execution_success.json|.eventType = "pipeline_execution_success" | .endTs = 1705313400000
 harness|stage_execution_started.json|stage_execution_success.json|.eventType = "stage_execution_success" | .endTs = 1705313300000
+gitlab|deployment_status-created-success.json|deployment_status-created-failed.json|.status = "failed" | .status_changed_at = "2024-01-15T16:06:00Z"
 VARIANTS
 
 # ---------------------------------------------------------------------------

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -516,3 +516,9 @@ webhook workflow_job/queued,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook workflow_job/in_progress,n,n,n,y,n,y,n,n,n,y,y,y,y,n,n,y,n,n,n,n,n,n,n,n
 webhook workflow_job/completed,n,n,n,y,n,y,n,n,n,y,y,y,y,n,n,y,n,n,n,n,n,n,n,n
 webhook workflow_job/waiting,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook deployment/created,n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook deployment_status/created,n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook deployment_review/approved,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook deployment_review/rejected,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook deployment_review/requested,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook deployment_protection_rule/requested,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/gitlab/deployment-created.json
+++ b/test/fixtures/webhooks/gitlab/deployment-created.json
@@ -1,0 +1,30 @@
+{
+  "object_kind": "deployment",
+  "status": "running",
+  "status_changed_at": "2024-01-15T16:00:00Z",
+  "deployment_id": 15,
+  "deployable_id": 796,
+  "deployable_url": "http://localhost/octocat/hello-world/-/jobs/796",
+  "environment": "production",
+  "project": {
+    "id": 10,
+    "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20,
+    "default_branch": "main"
+  },
+  "short_sha": "2b6127f",
+  "user": {
+    "id": 1,
+    "name": "The Octocat",
+    "username": "octocat",
+    "avatar_url": ""
+  },
+  "user_url": "http://localhost/octocat",
+  "commit_url": "http://localhost/octocat/hello-world/-/commit/2b6127f",
+  "commit_title": "Fix bug",
+  "ref": "main"
+}

--- a/test/fixtures/webhooks/gitlab/deployment_status-created-success.json
+++ b/test/fixtures/webhooks/gitlab/deployment_status-created-success.json
@@ -1,0 +1,30 @@
+{
+  "object_kind": "deployment",
+  "status": "success",
+  "status_changed_at": "2024-01-15T16:05:00Z",
+  "deployment_id": 15,
+  "deployable_id": 796,
+  "deployable_url": "http://localhost/octocat/hello-world/-/jobs/796",
+  "environment": "production",
+  "project": {
+    "id": 10,
+    "name": "hello-world",
+    "path_with_namespace": "octocat/hello-world",
+    "web_url": "http://localhost/octocat/hello-world",
+    "git_ssh_url": "git@localhost:octocat/hello-world.git",
+    "git_http_url": "http://localhost/octocat/hello-world.git",
+    "visibility_level": 20,
+    "default_branch": "main"
+  },
+  "short_sha": "2b6127f",
+  "user": {
+    "id": 1,
+    "name": "The Octocat",
+    "username": "octocat",
+    "avatar_url": ""
+  },
+  "user_url": "http://localhost/octocat",
+  "commit_url": "http://localhost/octocat/hello-world/-/commit/2b6127f",
+  "commit_title": "Fix bug",
+  "ref": "main"
+}

--- a/test/webhook-delivery-gitlab-confusio-shape.hurl
+++ b/test/webhook-delivery-gitlab-confusio-shape.hurl
@@ -175,3 +175,27 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+
+# ── deployment: created — confusio shape ─────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Deployment Hook
+file,fixtures/webhooks/gitlab/deployment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "deployment"
+jsonpath "$[0].confusio_source" == "gitlab"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""

--- a/test/webhook-delivery-gitlab.hurl
+++ b/test/webhook-delivery-gitlab.hurl
@@ -866,3 +866,69 @@ jsonpath "$" count == 1
 jsonpath "$[0].github_event" == "release"
 jsonpath "$[0].github_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
+
+# ── deployment: created (running) ─────────────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Deployment Hook
+file,fixtures/webhooks/gitlab/deployment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "deployment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+
+# ── deployment_status: created (success) ──────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Deployment Hook
+file,fixtures/webhooks/gitlab/deployment_status-created-success.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "deployment_status"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+
+# ── deployment_status: created (failed) ───────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitlab
+Content-Type: application/json
+X-Gitlab-Event: Deployment Hook
+file,fixtures/webhooks/gitlab/deployment_status-created-failed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "deployment_status"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"


### PR DESCRIPTION
Fixes #236.

Maps the deployment webhook event family (deployment, deployment_status, deployment_review, deployment_protection_rule) across all backends with analogous source events. Adds canonical GitHub shapes, per-backend translators and fixtures, delivery tests, and honest compatibility matrix entries.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add deployment event translators and fixtures for supported backends <!-- type:spec -->
- [x] Update compatibility matrix and delivery tests for deployment family <!-- type:spec -->
- [x] Document deployment family event shapes and field mappings in webhooks.md <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->