### PR TITLE
v3: Webhook — event mapping: star / watch / sponsorship (closes #240)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ test/fixtures/webhooks/gitea/release-edited.json
 test/fixtures/webhooks/gitea/release-deleted.json
 test/fixtures/webhooks/gitea/release-prereleased.json
 test/fixtures/webhooks/gitea/member-removed.json
+test/fixtures/webhooks/gitea/star-deleted.json
 test/fixtures/webhooks/gitea/deploy_key-deleted.json
 test/fixtures/webhooks/gitea/gollum-edited.json
 test/fixtures/webhooks/gitea/repository-deleted.json

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7796,6 +7796,30 @@ b:webhook("collaborator", function(payload)
   })
 end)
 
+-- star: a user starred or unstarred this repository.
+-- Gitea sends X-Gitea-Event: star with action "created" (starred) or "deleted"
+-- (unstarred).  Maps directly to GitHub's star event.
+local STAR_ACTIONS = { created = "created", deleted = "deleted" }
+b:webhook("star", function(payload)
+  local raw_action = payload.action or ""
+  local action = STAR_ACTIONS[raw_action]
+  local data = {
+    action = action or "unknown",
+    starred_at = payload.starred_at or "",
+    repository = translate_repo(payload.repository or {}),
+    sender = translate_user(payload.sender or {}),
+  }
+  return make_internal_event({
+    event = "star",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = data,
+    timestamp = payload.starred_at or "",
+  })
+end)
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -7820,6 +7820,29 @@ b:webhook("star", function(payload)
   })
 end)
 
+-- watch: a user started watching (subscribing to) this repository.
+-- Gitea sends X-Gitea-Event: watch with action "started".  GitHub's watch
+-- event also only has "started".
+local WATCH_ACTIONS = { started = "started" }
+b:webhook("watch", function(payload)
+  local raw_action = payload.action or ""
+  local action = WATCH_ACTIONS[raw_action]
+  local data = {
+    action = action or "unknown",
+    repository = translate_repo(payload.repository or {}),
+    sender = translate_user(payload.sender or {}),
+  }
+  return make_internal_event({
+    event = "watch",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "gitea",
+    raw = payload,
+    data = data,
+    timestamp = "",
+  })
+end)
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -925,6 +925,9 @@ action availability.
 | `deployment_review` | Deployment awaiting or receiving review | `approved`, `rejected`, `requested` |
 | `deployment_protection_rule` | Deployment protection rule triggered | `requested` |
 | `ping` | Sent on webhook registration | _(no action field)_ |
+| `star` | Repository starred or unstarred | `created`, `deleted` |
+| `watch` | User started watching repository | `started` |
+| `sponsorship` | GitHub Sponsors lifecycle | `created`, `cancelled`, `edited`, `tier_changed`, `pending_cancellation`, `pending_tier_change` |
 
 Events not in this table are not currently emitted by confusio in GitHub-emulation
 shape.  Backends that produce event types with no GitHub equivalent are dropped or
@@ -3358,6 +3361,81 @@ regardless of the originating backend.
   GitBucket).  Those inbound pings are consumed by confusio during webhook registration
   confirmation but are not forwarded to targets — confusio emits exactly one synthetic
   `ping` per registration regardless.
+
+---
+
+### `star`
+
+Triggered when a user stars or removes a star from a repository.
+
+| GitHub field | github | gitea-family | All others |
+|---|---|---|---|
+| `action` | ✓ | ✓ | — |
+| `starred_at` | ✓ | ✓ | — |
+| `repository` | ✓ | ✓ | — |
+| `sender` | ✓ | ✓ | — |
+
+#### Supported actions
+
+| Action | github | gitea-family |
+|--------|--------|-------------|
+| `created` | ✓ | ✓ |
+| `deleted` | ✓ | ✓ |
+
+**Notes:**
+- `starred_at`: Gitea emits an ISO 8601 timestamp for the `created` action and `null` for
+  `deleted`.  GitHub behaves identically.
+- The gitea-family includes Gitea 1.20+, Forgejo, and Codeberg.  Gogs and NotaBug share the
+  handler code but do not emit star webhook events; no delivery will occur for those backends.
+- Backends not listed do not emit star lifecycle events.
+
+---
+
+### `watch`
+
+Triggered when a user starts watching (subscribing to) a repository.  GitHub only defines the
+`started` action — there is no GitHub webhook for unwatching a repository.
+
+| GitHub field | github | gitea-family | All others |
+|---|---|---|---|
+| `action` | ✓ | ✓ | — |
+| `repository` | ✓ | ✓ | — |
+| `sender` | ✓ | ✓ | — |
+
+#### Supported actions
+
+| Action | github | gitea-family |
+|--------|--------|-------------|
+| `started` | ✓ | ✓ |
+
+**Notes:**
+- The gitea-family includes Gitea, Forgejo, and Codeberg.
+- Backends not listed do not emit watch lifecycle events.
+
+---
+
+### `sponsorship`
+
+GitHub Sponsors lifecycle events.  These events are only available on GitHub.com and require
+a webhook registered on a sponsored account — they cannot be created on any self-hosted forge.
+Confusio does not emit these events for any backend.
+
+| GitHub field | github | All others |
+|---|---|---|
+| `action` | ✓ | — |
+| `sponsorship` | ✓ | — |
+| `sender` | ✓ | — |
+
+#### Supported actions
+
+| Action | github | All others |
+|--------|--------|-----------|
+| `created` | ✓ | — |
+| `cancelled` | ✓ | — |
+| `edited` | ✓ | — |
+| `tier_changed` | ✓ | — |
+| `pending_cancellation` | ✓ | — |
+| `pending_tier_change` | ✓ | — |
 
 ---
 

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -3065,6 +3065,9 @@ local webhook_event_sections = {
       -- star
       { "webhook star/created", "wh_star_created" },
       { "webhook star/deleted", "wh_star_deleted" },
+
+      -- watch
+      { "webhook watch/started", "wh_watch_started" },
     },
   },
 }

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -3068,6 +3068,14 @@ local webhook_event_sections = {
 
       -- watch
       { "webhook watch/started", "wh_watch_started" },
+
+      -- sponsorship (GitHub.com-only; no self-hosted forge equivalent)
+      { "webhook sponsorship/cancelled", "wh_sponsorship_cancelled" },
+      { "webhook sponsorship/created", "wh_sponsorship_created" },
+      { "webhook sponsorship/edited", "wh_sponsorship_edited" },
+      { "webhook sponsorship/pending_cancellation", "wh_sponsorship_pending_cancellation" },
+      { "webhook sponsorship/pending_tier_change", "wh_sponsorship_pending_tier_change" },
+      { "webhook sponsorship/tier_changed", "wh_sponsorship_tier_changed" },
     },
   },
 }

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -3061,6 +3061,10 @@ local webhook_event_sections = {
 
       -- security_and_analysis
       { "webhook security_and_analysis/changed", "wh_security_and_analysis_changed" },
+
+      -- star
+      { "webhook star/created", "wh_star_created" },
+      { "webhook star/deleted", "wh_star_deleted" },
     },
   },
 }

--- a/scripts/gen-webhook-fixtures.sh
+++ b/scripts/gen-webhook-fixtures.sh
@@ -79,6 +79,7 @@ gitea|pull_request_review_comment-created.json|pull_request_review_comment-edite
 gitea|workflow_run-requested.json|workflow_run-in_progress.json|.action = "in_progress" | .workflow_run.status = "in_progress" | .workflow_run.updated_at = "2024-01-15T11:01:00Z"
 gitea|release-published.json|release-edited.json|.action = "edited" | .release.name = "Release 1.0.0 (updated)" | .release.body = "Updated notes"
 gitea|release-published.json|release-deleted.json|.action = "deleted"
+gitea|star-created.json|star-deleted.json|.action = "deleted" | .starred_at = null
 gitea|deploy_key-created.json|deploy_key-deleted.json|.action = "deleted"
 gitea|member-added.json|member-removed.json|.action = "deleted"
 gitea|gollum-created.json|gollum-edited.json|.pages[0].action = "edited"

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -575,3 +575,9 @@ webhook security_and_analysis/changed,n,n,n,n,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,
 webhook star/created,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook star/deleted,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook watch/started,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook sponsorship/cancelled,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook sponsorship/created,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook sponsorship/edited,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook sponsorship/pending_cancellation,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook sponsorship/pending_tier_change,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook sponsorship/tier_changed,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -572,3 +572,5 @@ webhook repository_vulnerability_alert/dismiss,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n
 webhook repository_vulnerability_alert/reopen,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook repository_vulnerability_alert/resolve,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook security_and_analysis/changed,n,n,n,n,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook star/created,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook star/deleted,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -574,3 +574,4 @@ webhook repository_vulnerability_alert/resolve,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n
 webhook security_and_analysis/changed,n,n,n,n,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook star/created,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook star/deleted,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook watch/started,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/gitea/star-created.json
+++ b/test/fixtures/webhooks/gitea/star-created.json
@@ -1,0 +1,11 @@
+{
+  "action": "created",
+  "starred_at": "2024-01-15T10:00:00Z",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main", "description": "My first repo",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": "http://localhost/octocat"}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": "http://localhost/bob"}
+}

--- a/test/fixtures/webhooks/gitea/watch-started.json
+++ b/test/fixtures/webhooks/gitea/watch-started.json
@@ -1,0 +1,25 @@
+{
+  "action": "started",
+  "repository": {
+    "id": 100,
+    "name": "hello-world",
+    "full_name": "octocat/hello-world",
+    "private": false,
+    "html_url": "http://localhost/octocat/hello-world",
+    "fork": false,
+    "default_branch": "main",
+    "description": "My first repo",
+    "owner": {
+      "id": 1,
+      "login": "octocat",
+      "avatar_url": "",
+      "html_url": "http://localhost/octocat"
+    }
+  },
+  "sender": {
+    "id": 2,
+    "login": "bob",
+    "avatar_url": "",
+    "html_url": "http://localhost/bob"
+  }
+}

--- a/test/gitea-webhooks.hurl
+++ b/test/gitea-webhooks.hurl
@@ -1444,3 +1444,66 @@ X-Gitea-Event: security_and_analysis
 HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
+
+# ── star: created → 200 ───────────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: star
+{
+  "action": "created",
+  "starred_at": "2024-01-15T10:00:00Z",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── star: deleted → 200 ───────────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: star
+{
+  "action": "deleted",
+  "starred_at": null,
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── star: unknown action → 200 + X-Confusio-Raw-Action sidecar ───────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: star
+{
+  "action": "bookmarked",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "bookmarked"

--- a/test/gitea-webhooks.hurl
+++ b/test/gitea-webhooks.hurl
@@ -1507,3 +1507,44 @@ HTTP 200
 [Asserts]
 jsonpath "$.message" == "accepted"
 header "X-Confusio-Raw-Action" == "bookmarked"
+
+# ── watch: started → 200 ──────────────────────────────────────────────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: watch
+{
+  "action": "started",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+# ── watch: unknown action → 200 + X-Confusio-Raw-Action sidecar ──────────────
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: watch
+{
+  "action": "stopped",
+  "repository": {
+    "id": 100, "name": "hello-world", "full_name": "octocat/hello-world",
+    "private": false, "html_url": "http://localhost/octocat/hello-world",
+    "fork": false, "default_branch": "main",
+    "owner": {"id": 1, "login": "octocat", "avatar_url": "", "html_url": ""}
+  },
+  "sender": {"id": 2, "login": "bob", "avatar_url": "", "html_url": ""}
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+header "X-Confusio-Raw-Action" == "stopped"

--- a/test/webhook-delivery-gitea.hurl
+++ b/test/webhook-delivery-gitea.hurl
@@ -1482,3 +1482,25 @@ jsonpath "$" count == 1
 jsonpath "$[0].github_event" == "star"
 jsonpath "$[0].github_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
+
+# ── watch: started ────────────────────────────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: watch
+file,fixtures/webhooks/gitea/watch-started.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "watch"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"

--- a/test/webhook-delivery-gitea.hurl
+++ b/test/webhook-delivery-gitea.hurl
@@ -1438,3 +1438,47 @@ jsonpath "$" count == 1
 jsonpath "$[0].github_event" == "member"
 jsonpath "$[0].github_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
+
+# ── star: created ─────────────────────────────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: star
+file,fixtures/webhooks/gitea/star-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "star"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+
+# ── star: deleted ─────────────────────────────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitea
+Content-Type: application/json
+X-Gitea-Event: star
+file,fixtures/webhooks/gitea/star-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "star"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"


### PR DESCRIPTION
Fixes #240.

Adds webhook event mapping for star (created/deleted), watch (started), and sponsorship (created/edited/cancelled/pending_cancellation/pending_tier_change/tier_changed) across all backends with analogous source events. Each event family gets handlers, fixtures, inbound+outbound hurl tests, and compatibility CSV rows, followed by a docs/webhooks.md update documenting the per-backend mapping tables.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add star webhook event mapping across backends <!-- type:spec -->
- [x] Add watch webhook event mapping across backends <!-- type:spec -->
- [x] Add sponsorship webhook event mapping across backends <!-- type:spec -->
- [x] Update docs/webhooks.md mapping tables for star, watch, sponsorship <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->