### PR TITLE
v3: Webhook — normalized event model translators (Option 1) (closes #246)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -98,6 +98,8 @@ globals = {
   "make_webhook_receiver",
   -- Webhook event mapping: internal/webhook_event.lua
   "make_internal_event",
+  "normalized_webhook_event_type",
+  "make_normalized_webhook_envelope",
   -- UUID and timestamp utilities: internal/util.lua
   "make_uuid",
   "iso8601",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -681,8 +681,8 @@ When a webhook event arrives from a forge backend, confusio can forward it to a 
 
 | Module | Role |
 |--------|------|
-| `internal/fanout.lua` | In-memory target registry; `fanout_register_target`, `fanout_dispatch`, `fanout_body` |
-| `internal/deliver.lua` | Outbound HTTP delivery: `deliver_fire(target, backend, event_type, payload)` |
+| `internal/fanout.lua` | In-memory target registry; `fanout_register_target`, `fanout_dispatch`, `fanout_body`; routes `confusio` shape through normalized webhook translators |
+| `internal/deliver.lua` | Outbound HTTP delivery: `deliver_fire(target, backend, event_type, payload[, internal_event, translators])` |
 | `internal/signing.lua` | HMAC signing for outbound deliveries using the backend's native scheme |
 
 **Configuration:**
@@ -692,6 +692,6 @@ When a webhook event arrives from a forge backend, confusio can forward it to a 
 - **`webhook_target_secret_file=/path`** — path to a 0600-permission file containing the HMAC signing secret for the outbound target.
 - **`webhook_secret_file_BACKEND=/path`** provides per-backend inbound signing secrets (see above).
 
-**Dispatch flow:** After the webhook receiver validates an inbound event, `fanout_dispatch(backend, event_type, payload)` fires `deliver_fire` for each registered target whose event subscription matches.  `deliver_fire` makes one HTTP POST with optional HMAC signing and logs the outcome (HTTP status or error message) at `kLogWarn` on failure or `kLogVerbose` on success.  Returns `(ok, http_status_or_nil, error_or_nil)`.  The caller does not inspect the return values — the result is purely for log visibility.
+**Dispatch flow:** After the webhook receiver validates an inbound event, `fanout_dispatch(backend, event_type, payload, internal_event, app.backend.webhook_translators)` fires `deliver_fire` for each registered target whose event subscription matches.  The default `github` shape forwards the raw payload; `confusio` shape uses `app.backend.webhook_translators[event_type]` when present and falls back to `make_normalized_webhook_envelope`.  `deliver_fire` makes one HTTP POST with optional HMAC signing and logs the outcome (HTTP status or error message) at `kLogWarn` on failure or `kLogVerbose` on success.  Returns `(ok, http_status_or_nil, error_or_nil)`.  The caller does not inspect the return values — the result is purely for log visibility.
 
 - **Outbound signing mirrors the active backend's inbound scheme.** The `sign_for_backend` function in `internal/signing.lua` maps backend names to their native signature headers using the same schemes documented in `verify_signature` in `internal/webhooks.lua`.  The two must stay in sync when new backends are added.

--- a/backends/azuredevops.lua
+++ b/backends/azuredevops.lua
@@ -2368,4 +2368,54 @@ b:webhook("build.complete", function(payload)
   })
 end)
 
+local ADO_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
+local ADO_NORMALIZED_WEBHOOK_EVENTS = {
+  "issues",
+  "issue_comment",
+  "pull_request",
+  "pull_request_review",
+  "workflow_run",
+  "push",
+  "create",
+  "delete",
+  "repository",
+}
+
+local function ado_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_ado_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        ADO_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or ado_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(ADO_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_ado_normalized_webhook)
+end
+
 b:build()

--- a/backends/bitbucket.lua
+++ b/backends/bitbucket.lua
@@ -2793,4 +2793,56 @@ b:webhook("repo:fork", function(payload)
   })
 end)
 
+local BB_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  fork = true,
+  push = true,
+}
+
+local BB_NORMALIZED_WEBHOOK_EVENTS = {
+  "issues",
+  "issue_comment",
+  "pull_request",
+  "pull_request_review",
+  "status",
+  "push",
+  "create",
+  "delete",
+  "repository",
+  "fork",
+}
+
+local function bb_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_bb_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        BB_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or bb_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(BB_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_bb_normalized_webhook)
+end
+
 b:build()

--- a/backends/bitbucket_datacenter.lua
+++ b/backends/bitbucket_datacenter.lua
@@ -1799,4 +1799,52 @@ b:webhook("repo:modified", function(payload)
   })
 end)
 
+local BBS_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
+local BBS_NORMALIZED_WEBHOOK_EVENTS = {
+  "pull_request",
+  "pull_request_review",
+  "status",
+  "push",
+  "create",
+  "delete",
+  "repository",
+}
+
+local function bbs_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_bbs_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        BBS_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or bbs_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(BBS_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_bbs_normalized_webhook)
+end
+
 b:build()

--- a/backends/gerrit.lua
+++ b/backends/gerrit.lua
@@ -471,4 +471,36 @@ b:webhook("comment-added", function(payload)
   })
 end)
 
+local GERRIT_NORMALIZED_WEBHOOK_EVENTS = {
+  "pull_request_review",
+}
+
+local function gerrit_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_gerrit_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or normalized_webhook_event_type(internal_event.event, internal_event.action),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or gerrit_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(GERRIT_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_gerrit_normalized_webhook)
+end
+
 b:build()

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -3402,4 +3402,92 @@ b:webhook("custom_property_values", function(payload)
   })
 end)
 
+local GB_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  fork = true,
+  gollum = true,
+  page_build = true,
+  ping = true,
+  public = true,
+  push = true,
+  team_add = true,
+}
+
+local GB_NORMALIZED_WEBHOOK_EVENTS = {
+  "issues",
+  "issue_comment",
+  "label",
+  "milestone",
+  "pull_request",
+  "pull_request_review",
+  "push",
+  "create",
+  "delete",
+  "release",
+  "fork",
+  "deploy_key",
+  "gollum",
+  "repository",
+  "public",
+  "code_scanning_alert",
+  "dependabot_alert",
+  "secret_scanning_alert",
+  "secret_scanning_alert_location",
+  "security_advisory",
+  "repository_advisory",
+  "member",
+  "organization",
+  "membership",
+  "team",
+  "team_add",
+  "project",
+  "project_card",
+  "project_column",
+  "projects_v2",
+  "projects_v2_item",
+  "discussion",
+  "discussion_comment",
+  "projects_v2_status_update",
+  "package",
+  "registry_package",
+  "ping",
+  "meta",
+  "page_build",
+  "custom_property",
+  "custom_property_values",
+}
+
+local function gitbucket_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_gitbucket_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        GB_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or gitbucket_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(GB_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_gitbucket_normalized_webhook)
+end
+
 b:build()

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -8051,6 +8051,77 @@ b:webhook("ping", function(payload)
   })
 end)
 
+local GITEA_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  fork = true,
+  gollum = true,
+  ping = true,
+  push = true,
+}
+
+local GITEA_NORMALIZED_WEBHOOK_EVENTS = {
+  "issues",
+  "issue_comment",
+  "discussion",
+  "discussion_comment",
+  "label",
+  "milestone",
+  "pull_request",
+  "merge_group",
+  "pull_request_review",
+  "pull_request_review_comment",
+  "workflow_run",
+  "workflow_job",
+  "status",
+  "push",
+  "create",
+  "delete",
+  "release",
+  "fork",
+  "repository",
+  "deploy_key",
+  "gollum",
+  "security_and_analysis",
+  "member",
+  "star",
+  "watch",
+  "package",
+  "ping",
+}
+
+local function normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_gitea_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        GITEA_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(GITEA_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_gitea_normalized_webhook)
+end
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -7309,6 +7309,67 @@ b:webhook("Member Hook", function(payload)
   })
 end)
 
+local GL_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  gollum = true,
+  push = true,
+}
+
+local GL_NORMALIZED_WEBHOOK_EVENTS = {
+  "issues",
+  "issue_comment",
+  "label",
+  "milestone",
+  "release",
+  "pull_request",
+  "pull_request_review",
+  "workflow_run",
+  "workflow_job",
+  "create",
+  "delete",
+  "push",
+  "deployment",
+  "deployment_status",
+  "repository",
+  "organization",
+  "membership",
+  "gollum",
+  "member",
+}
+
+local function gitlab_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_gitlab_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        GL_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or gitlab_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(GL_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_gitlab_normalized_webhook)
+end
+
 b:capability("repos", repos)
 b:capability("users", users)
 b:capability("orgs", orgs)

--- a/backends/harness.lua
+++ b/backends/harness.lua
@@ -911,4 +911,37 @@ b:webhook("stage_execution_aborted", function(payload)
   return harness_stage_event(payload, "completed", "completed", "cancelled")
 end)
 
+local HARNESS_NORMALIZED_WEBHOOK_EVENTS = {
+  "workflow_run",
+  "workflow_job",
+}
+
+local function harness_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_harness_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or normalized_webhook_event_type(internal_event.event, internal_event.action),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or harness_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(HARNESS_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_harness_normalized_webhook)
+end
+
 b:build()

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -1308,4 +1308,53 @@ b:webhook("project.forked", function(payload)
   })
 end)
 
+local PAGURE_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  fork = true,
+  push = true,
+}
+
+local PAGURE_NORMALIZED_WEBHOOK_EVENTS = {
+  "issues",
+  "issue_comment",
+  "pull_request",
+  "push",
+  "create",
+  "delete",
+  "fork",
+}
+
+local function pagure_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_pagure_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        PAGURE_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or pagure_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(PAGURE_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_pagure_normalized_webhook)
+end
+
 b:build()

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -30,23 +30,25 @@ selects per-target which shape to emit.
   requests are rejected before any payload parsing occurs.
 - **Multi-target fan-out** — A single inbound event can be delivered to multiple
   consumers, each with independent shape selection and event-type filtering.
-- **Durable at-least-once delivery** — Events survive process restarts; failed
-  deliveries are retried with exponential backoff.
+- **Fire-and-record delivery** — Matching targets are POSTed synchronously during the
+  inbound request.  Delivery outcomes are logged, but no retry or persistence layer is
+  currently implemented.
 
 ### Non-Goals
 
 - **Webhook registration** — Confusio does not create or delete webhooks on forges.
   Forge administrators register the confusio receiver URL manually in forge settings.
   There is no API for managing forge-side webhook subscriptions.
-- **Exactly-once delivery** — The outbox guarantees at-least-once.  Consumers must
-  be idempotent with respect to duplicate deliveries.
-- **Synchronous passthrough** — Ingest is decoupled from delivery.  The inbound HTTP
-  response (`200` / `202`) is returned before all targets have been notified.
+- **Exactly-once delivery** — Consumers should still treat webhook delivery as
+  potentially duplicate, especially when the originating forge retries an inbound
+  request.
+- **Durable replay** — Confusio currently logs delivery outcomes but does not persist
+  an outbox, retry failed targets, or expose a replay API.
 - **Full GitHub webhook management API** — Ping events, webhook secret rotation
   endpoints, and GitHub's `/repos/{owner}/{repo}/hooks` REST surface are out of
   scope.  Confusio is a receiver, not a webhook management proxy.
-- **Event deduplication across replays** — Replay re-delivers events from the outbox
-  in order.  Deduplication (e.g., idempotency keys) is the consumer's responsibility.
+- **Event deduplication** — Deduplication (e.g., idempotency keys) is the consumer's
+  responsibility.
 
 ## Architecture
 
@@ -54,12 +56,12 @@ selects per-target which shape to emit.
 Forge                          Confusio                          Consumer(s)
 ─────                          ────────                          ─────────────
 Gitea   ──▶ /webhooks/gitea  ─┐
-Forgejo ──▶ /webhooks/forgejo ─┤  verify  normalize  write        ┌─▶ target A  (GitHub shape)
-GitLab  ──▶ /webhooks/gitlab  ─┼──▶ sig ──▶  both  ──▶ outbox ───├─▶ target B  (confusio shape)
-GitHub  ──▶ /webhooks/github  ─┤          shapes    fan-out       └─▶ target C  (filtered subset)
-...     ──▶ ...               ─┘          stored    (async)
+Forgejo ──▶ /webhooks/forgejo ─┤  verify  normalize  choose       ┌─▶ target A  (GitHub shape)
+GitLab  ──▶ /webhooks/gitlab  ─┼──▶ sig ──▶ event ──▶ shape ─────├─▶ target B  (confusio shape)
+GitHub  ──▶ /webhooks/github  ─┤                  fan-out         └─▶ target C  (filtered subset)
+...     ──▶ ...               ─┘                  (sync)
 
-Operator ──▶ /webhooks/targets ──▶ target registry  (admin: create / update / delete)
+Operator ──▶ SCRIPTARGS webhook_target=... ──▶ static target registry
 ```
 
 ### Processing stages
@@ -75,23 +77,15 @@ Operator ──▶ /webhooks/targets ──▶ target registry  (admin: create /
    representation.  This is the canonical intermediate form; both output shapes are
    derived from it.
 
-4. **Translate** — The internal event is converted into **both** output shapes
-   simultaneously and the results are stored in the outbox event record:
-   - `github_payload`: GitHub emulation applies field-level mappings to produce a
-     byte-compatible GitHub webhook payload.  See
-     [GitHub-Emulation Contract](#github-emulation-contract).
-   - `confusio_payload`: Confusio normalized wraps the internal event in the confusio
+4. **Translate** — Delivery shape is selected per target:
+   - `github`: GitHub emulation re-encodes the provider-compatible webhook payload.
+     See [GitHub-Emulation Contract](#github-emulation-contract).
+   - `confusio`: Confusio normalized wraps the internal event in the normalized
      envelope.  See [Normalized Confusio Event Model](#normalized-confusio-event-model).
 
-   Pre-translating both shapes at ingest means retries and replays re-send the original
-   payload without re-processing the forge request.  Per-target shape selection happens
-   at delivery time by reading the appropriate stored variant.
-
-5. **Dispatch** — The translated payloads are placed in the durable outbox and delivered
-   asynchronously to all matching targets, each receiving the shape and applying the
-   filter configured on its registration.  Filters, retries, and replay are described in
-   [Delivery Semantics](#delivery-semantics) and
-   [Multi-Target Dispatch and Configuration](#multi-target-dispatch-and-configuration).
+5. **Dispatch** — The translated payload is delivered synchronously to all matching
+   configured targets.  Delivery is fire-and-record: each matching target receives one
+   POST attempt, the outcome is logged, and the inbound request then receives `200 OK`.
 
 ### Backend-agnostic internal model
 
@@ -1919,7 +1913,8 @@ schema works regardless of whether the originating forge is Gitea, GitLab, or So
 ### Design goals
 
 - **Stable across forge versions** — field names and structure do not change when a
-  forge adds or renames its native fields.  Forge-specific details live in `raw`.
+  forge adds or renames its native fields.  Backend-specific details remain inside
+  the event-family payload.
 - **Consistent with the internal event model** — the envelope is a thin wrapper around
   the internal representation defined in [Backend-agnostic internal model](#backend-agnostic-internal-model).
 - **Orthogonal to the GitHub-emulation shape** — no GitHub-specific legacy (e.g.
@@ -1934,36 +1929,36 @@ Confusio sends the following HTTP headers with every confusio-normalized deliver
 | Header | Value | Notes |
 |--------|-------|-------|
 | `X-Confusio-Event` | confusio event family name (e.g. `issues`, `push`) | Always present |
-| `X-Confusio-Action` | action within the event family (e.g. `opened`) | Present when the event has an action; absent for action-less events |
 | `X-Confusio-Delivery` | UUID v4, unique per delivery attempt | Always present |
-| `X-Confusio-Provider` | originating backend identifier (e.g. `gitea`, `gitlab`) | Always present |
-| `X-Confusio-Signature-256` | `sha256=<lowercase hex>` | HMAC-SHA256 of body using target's secret; omitted if no secret configured |
+| `X-Confusio-Source` | originating backend identifier (e.g. `gitea`, `gitlab`) | Always present |
+| Provider-native signature header(s) | Backend-specific | Present when the outbound target has a secret; produced by the same signing helper used for GitHub-emulation deliveries |
 | `Content-Type` | `application/json` | Always `application/json` |
-| `User-Agent` | `Confusio-Hookshot/<version>` | Same as GitHub-emulation deliveries |
+| `User-Agent` | `confusio/1.0` | Same as GitHub-emulation deliveries |
 
-**Signature computation:** `X-Confusio-Signature-256` is computed over the raw
-delivery body bytes using the consumer target's configured secret.  The format
-`sha256=<hex>` mirrors the GitHub `X-Hub-Signature-256` convention so consumers can
-reuse the same HMAC verification code path.
+**Signature computation:** Outbound signing is selected from the source backend, not
+from the delivery shape.  For example, a `gitea` source signs with `X-Gitea-Signature`,
+`gitlab` signs with `X-Gitlab-Token`, and `gitbucket` signs with `X-Hub-Signature`
+using the GitBucket SHA-1 format.  If no target secret is configured, no signature
+header is emitted.
 
-**Action-less events:** `push`, `create`, `delete`, `fork`, `status`, and `ping` carry
-no action field — the event type alone identifies the operation.  For these,
-`X-Confusio-Action` is omitted from the delivery headers.
+**Action handling:** The action is represented in the JSON body through the dotted
+`type` field, not as a separate header.  Action-less events such as `push`, `create`,
+`delete`, and `fork` use the event family name alone as `type`.
 
 ### Namespace
 
-All confusio event family names are lower-snake-case strings in the `confusio.`
-namespace when used in subscription filters and configuration, but the header value
-carries only the short name without the prefix:
+Confusio uses two related names for each normalized delivery:
 
-```
-X-Confusio-Event: issues       ← short name in header
-subscription filter: confusio.issues   ← full name in config
-```
+- The **event family** is the internal canonical key and the value of
+  `X-Confusio-Event`, such as `issues`, `issue_comment`, `pull_request`, or `push`.
+- The body **type** is the stable dotted event namespace, such as `issue.opened`,
+  `issue.comment.created`, `pull_request.opened`, or `push`.
 
-The canonical event family names match the GitHub event name set defined in
-[Supported event names](#supported-event-names).  This alignment means the same event
-taxonomy is used across both output shapes, simplifying mixed deployments.
+The event-family names match the GitHub event name set defined in
+[Supported event names](#supported-event-names).  The dotted type is derived by
+mapping the family to a normalized base name and appending the action when one exists.
+For example, `issues` maps to `issue`, `issue_comment` maps to `issue.comment`, and
+`pull_request_review` maps to `pull_request.review`.
 
 ### Envelope schema
 
@@ -1971,51 +1966,50 @@ Every confusio-normalized delivery body follows this structure:
 
 ```json
 {
-  "confusio": "1.0",
   "id":        "<uuid>",
-  "event":     "<event-family>",
-  "action":    "<action or null>",
-  "provider":  "<backend>",
-  "timestamp": "<iso8601>",
-  "data":      { ... },
-  "raw":       { ... }
+  "type":      "<normalized dotted type>",
+  "occurred_at": "<iso8601>",
+  "actor":     { ... },
+  "repository": { ... },
+  "payload":   { ... }
 }
 ```
 
-| Field | Type | R/O | Description |
-|-------|------|-----|-------------|
-| `confusio` | string | R | Envelope schema version; currently `"1.0"` |
-| `id` | string (UUID v4) | R | Unique delivery ID; same value as `X-Confusio-Delivery` header |
-| `event` | string | R | Event family name (e.g. `"issues"`, `"push"`) |
-| `action` | string or null | R | Action within the event family; `null` for action-less events |
-| `provider` | string | R | Originating backend (e.g. `"gitea"`, `"gitlab"`) |
-| `timestamp` | string (ISO 8601) | R | Event timestamp — forge-supplied if available, otherwise confusio ingest time |
-| `data` | object | R | Normalized field bag; schema is event-family-specific (see below) |
-| `raw` | object | R | Original decoded payload from the forge, unmodified |
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID v4) | Unique outbound delivery ID; same value as `X-Confusio-Delivery` |
+| `type` | string | Dotted normalized event type, for example `issue.opened` or `workflow.run.completed` |
+| `occurred_at` | string | Event timestamp from the forge when available, otherwise the current confusio time |
+| `actor` | object | Actor that triggered the event; usually from normalized `sender` data |
+| `repository` | object | Repository associated with the event, or `{}` when the event has none |
+| `payload` | object | Event-family-specific normalized payload |
 
-The `confusio` version field allows consumers to guard against future schema changes:
+The delivery source and event family are intentionally kept in headers rather than
+duplicated in the body.  Consumers that route only by event family can use
+`X-Confusio-Event`; consumers that need action-level routing should use `body.type`.
 
-```json
-if (body.confusio !== "1.0") { /* handle unknown version */ }
-```
+### The `payload` object
 
-### The `data` object
+The `payload` object contains the normalized event payload.  Its schema is
+event-family-specific and generally mirrors the provider-agnostic `data` bag produced
+by the inbound webhook normalizer.  Backend translators remove envelope-level fields
+such as `sender` and `repository` from the payload when those values are already
+promoted to `actor` and `repository`.
 
-The `data` object contains the normalized event payload.  Its schema mirrors the
-GitHub-emulation output shape with the following differences:
+Common examples:
 
-- **No GitHub-specific IDs** — integer IDs that are meaningful only to GitHub are
-  replaced with the forge's native identifier.  Both `id` (forge-native) and
-  `number` (human-visible reference) are included where available.
-- **No `node_id`** — GitHub's GraphQL node ID is not present; confusio does not
-  synthesize a GraphQL node ID for the confusio-normalized shape.
-- **`source_url` instead of `html_url`** — the forge's own web URL for the resource
-  (issue page, PR page, etc.) is in `source_url`.  This makes it clear the URL points
-  to the originating forge, not to GitHub.
-- **Timestamps always ISO 8601** — all timestamp fields use ISO 8601 format in UTC.
-  Fields that are absent from the forge response are `null`, not omitted.
+| Event family | Example `type` | Payload fields |
+|--------------|----------------|----------------|
+| `issues` | `issue.opened` | `issue`, plus event-specific fields when available |
+| `issue_comment` | `issue.comment.created` | `issue`, `comment` |
+| `pull_request` | `pull_request.opened` | `pull_request` |
+| `pull_request_review` | `pull_request.review.submitted` | `pull_request`, `review` |
+| `workflow_run` | `workflow.run.completed` | `workflow_run` |
+| `workflow_job` | `workflow.job.completed` | `workflow_job` |
+| `push` | `push` | `ref`, `before`, `after`, `commits`, `head_commit`, and related push fields |
 
-The `data` object for each event family is documented in [Field-Level Mapping Tables](#field-level-mapping-tables).
+The field-level source coverage is documented in
+[Field-Level Mapping Tables](#field-level-mapping-tables).
 
 ### Concrete delivery example
 
@@ -2026,17 +2020,16 @@ POST /hooks/confusio-normalized HTTP/1.1
 Host: consumer.example.com
 Content-Type: application/json
 X-Confusio-Event: issues
-X-Confusio-Action: opened
 X-Confusio-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
-X-Confusio-Provider: gitea
-X-Confusio-Signature-256: sha256=a3b9f12c8d7e4f01bc6234567890abcd1234ef567890abcd1234ef567890abcd
-User-Agent: Confusio-Hookshot/1.0
-Content-Length: 712
+X-Confusio-Source: gitea
+X-Gitea-Signature: a3b9f12c8d7e4f01bc6234567890abcd1234ef567890abcd1234ef567890abcd
+User-Agent: confusio/1.0
+Content-Length: 431
 
 { ... envelope body ... }
 ```
 
-A delivery for an action-less event (no `X-Confusio-Action` header):
+A delivery for an action-less event:
 
 ```http
 POST /hooks/confusio-normalized HTTP/1.1
@@ -2044,9 +2037,9 @@ Host: consumer.example.com
 Content-Type: application/json
 X-Confusio-Event: push
 X-Confusio-Delivery: 83e4273f-dd89-22f4-92bc-5d0478ed1069
-X-Confusio-Provider: gitlab
-X-Confusio-Signature-256: sha256=b4c0g23d9e8f5g12cd7345678901bcde2345fg678901bcde2345fg678901bcde
-User-Agent: Confusio-Hookshot/1.0
+X-Confusio-Source: gitlab
+X-Gitlab-Token: <target-secret>
+User-Agent: confusio/1.0
 Content-Length: 891
 
 { ... envelope body ... }
@@ -2058,104 +2051,106 @@ A `issues:opened` event originating from Gitea:
 
 ```json
 {
-  "confusio":  "1.0",
-  "id":        "72d3162e-cc78-11e3-81ab-4c9367dc0958",
-  "event":     "issues",
-  "action":    "opened",
-  "provider":  "gitea",
-  "timestamp": "2024-01-15T10:00:00Z",
-  "data": {
-    "issue": {
-      "id":         1,
-      "number":     42,
-      "title":      "Found a bug",
-      "body":       "Something broke.",
-      "state":      "open",
-      "source_url": "https://gitea.com/alice/myrepo/issues/42",
-      "author": {
-        "id":         1,
-        "login":      "alice",
-        "source_url": "https://gitea.com/alice"
-      },
-      "labels":     [],
-      "assignees":  [],
-      "milestone":  null,
-      "created_at": "2024-01-15T10:00:00Z",
-      "updated_at": "2024-01-15T10:00:00Z",
-      "closed_at":  null
-    },
-    "repository": {
-      "id":           100,
-      "name":         "myrepo",
-      "full_name":    "alice/myrepo",
-      "private":      false,
-      "source_url":   "https://gitea.com/alice/myrepo",
-      "description":  null,
-      "fork":         false,
-      "default_branch": "main",
-      "owner": {
-        "id":    1,
-        "login": "alice"
-      },
-      "created_at": "2023-01-01T00:00:00Z",
-      "updated_at": "2024-01-15T10:00:00Z",
-      "pushed_at":  "2024-01-15T10:00:00Z"
-    },
-    "sender": {
-      "id":         1,
-      "login":      "alice",
-      "source_url": "https://gitea.com/alice"
-    }
+  "id": "72d3162e-cc78-11e3-81ab-4c9367dc0958",
+  "type": "issue.opened",
+  "occurred_at": "2024-01-15T10:00:00Z",
+  "actor": {
+    "id": 1,
+    "login": "alice",
+    "source_url": "https://gitea.com/alice"
   },
-  "raw": {
-    "action": "opened",
+  "repository": {
+    "id": 100,
+    "name": "myrepo",
+    "full_name": "alice/myrepo",
+    "private": false,
+    "source_url": "https://gitea.com/alice/myrepo",
+    "description": null,
+    "fork": false,
+    "default_branch": "main",
+    "owner": {
+      "id": 1,
+      "login": "alice"
+    },
+    "created_at": "2023-01-01T00:00:00Z",
+    "updated_at": "2024-01-15T10:00:00Z",
+    "pushed_at": "2024-01-15T10:00:00Z"
+  },
+  "payload": {
     "issue": {
       "id": 1,
       "number": 42,
-      "title": "Found a bug"
+      "title": "Found a bug",
+      "body": "Something broke.",
+      "state": "open",
+      "source_url": "https://gitea.com/alice/myrepo/issues/42",
+      "author": {
+        "id": 1,
+        "login": "alice",
+        "source_url": "https://gitea.com/alice"
+      },
+      "labels": [],
+      "assignees": [],
+      "milestone": null,
+      "created_at": "2024-01-15T10:00:00Z",
+      "updated_at": "2024-01-15T10:00:00Z",
+      "closed_at": null
     }
   }
 }
 ```
 
-The `raw` object truncated for readability; it contains the complete original forge payload.
+### Translator contract
 
-### `X-Confusio-Signature-256` verification
+Backend files register confusio-shape translators with
+`b:webhook_translator(event, fn)`.  The event key is the internal event family name.
+The function is called as:
 
-Consumer verification follows the same pattern as GitHub's `X-Hub-Signature-256`:
-
-```
-secret        = configured consumer target secret (UTF-8 bytes)
-body          = raw delivery body bytes
-expected      = "sha256=" ++ HMAC-SHA256(secret, body) as lowercase hex
-received      = value of X-Confusio-Signature-256
-
-accept if constant_time_equal(expected, received)
+```lua
+translator(internal_event, fields) -> envelope_table
 ```
 
-Verification command (for testing):
-```sh
-printf '<body>' | openssl dgst -sha256 -hmac '<secret>'
-# prepend "sha256=" to the output and compare to X-Confusio-Signature-256
-```
+`internal_event` is the table returned by the backend's inbound webhook normalizer.
+`fields` carries delivery-time overrides, currently including the outbound delivery
+`id`.  Translators should call `make_normalized_webhook_envelope(internal_event,
+fields)` and override only the fields whose source data needs backend-specific
+handling.
 
-### Version negotiation
+The shared envelope helper applies these defaults:
 
-The `confusio` field in the envelope is the envelope schema version.  Confusio
-increments this on breaking changes.  The current version is `"1.0"`.
+| Envelope field | Default source |
+|----------------|----------------|
+| `id` | `fields.id`, otherwise a generated UUID |
+| `type` | `normalized_webhook_event_type(internal_event.event, internal_event.action)` |
+| `occurred_at` | `fields.occurred_at`, then `internal_event.timestamp`, then current confusio time |
+| `actor` | `fields.actor`, then `data.actor`, `data.sender`, `raw.sender`, then `{}` |
+| `repository` | `fields.repository`, then `data.repository`, `raw.repository`, then `{}` |
+| `payload` | `fields.payload`, then `data.payload`, then the full `data` bag |
 
-| Version | Status | Notes |
-|---------|--------|-------|
-| `1.0` | Current | Initial release |
+Provider translators normally use the helper but remove envelope-level values from
+`payload` so `actor` and `repository` are not duplicated.  They may also normalize
+action-less events by forcing an empty action when deriving `type`.
 
-Additive changes (new optional fields in `data`) do not increment the version.
-Breaking changes (renamed/removed fields, changed types) increment the minor or major
-version string.  Consumers should treat unknown fields as ignorable.
+### Fallback behavior
 
-### Actor schema in `data`
+If no backend translator is registered for an event, or the registered translator does
+not return a table, confusio falls back to `make_normalized_webhook_envelope` with the
+internal event.  This means a target configured with `webhook_target_shape=confusio`
+still receives a valid envelope even while a backend has partial translator coverage.
 
-User/actor objects inside `data` use a confusio-specific schema that differs from the
-GitHub-emulation shape:
+The fallback is intentionally conservative:
+
+- It preserves the canonical event family through `X-Confusio-Event`.
+- It derives the dotted body `type` from the internal event and action.
+- It keeps the full normalized `data` bag as `payload` when no provider-specific
+  payload pruning exists.
+- It falls back to the original raw `sender` and `repository` objects when the
+  normalized data bag does not provide promoted envelope fields.
+
+### Actor schema
+
+The top-level `actor` object and user/actor objects inside `payload` use a
+confusio-specific schema that differs from the GitHub-emulation shape:
 
 **Confusio-normalized actor:**
 ```json
@@ -2194,25 +2189,6 @@ creator field is `user` (which is ambiguous — it could refer to anyone).  Conf
 uses `author` for the resource creator and `sender` for the actor who triggered the
 webhook event.  These may be different people (e.g. someone else closes your issue).
 
-### `raw` field behaviour
-
-The `raw` field always contains the original JSON payload decoded from the forge
-request body, exactly as received.  No field renaming, translation, or filtering is
-applied.
-
-**Edge cases:**
-
-| Situation | `raw` value |
-|-----------|-------------|
-| Normal delivery | Decoded JSON object from forge body |
-| Forge sends empty body | `{}` (empty object) |
-| Forge sends a JSON array (unusual) | The decoded array |
-| Forge body cannot be decoded as JSON | `null`; confusio logs a warning |
-
-When `raw` is `null`, the `data` object is also `{}` and the event type is
-`"unknown"`.  The delivery is still queued so consumers can inspect the original bytes
-via the replay API.
-
 ### Consistency with GitHub-emulation contract
 
 The following table maps each confusio-normalized header to its GitHub-emulation
@@ -2222,25 +2198,27 @@ verification code with a simple header-name substitution.
 | Confusio-normalized header | GitHub-emulation equivalent | Same value? |
 |---------------------------|----------------------------|-------------|
 | `X-Confusio-Event` | `X-GitHub-Event` | Yes — same event family names |
-| `X-Confusio-Action` | _(in body only)_ | Confusio promotes action to a header; GitHub keeps it in `action` field |
 | `X-Confusio-Delivery` | `X-GitHub-Delivery` | Yes — both are UUID v4 |
-| `X-Confusio-Provider` | _(absent)_ | No GitHub equivalent |
-| `X-Confusio-Signature-256` | `X-Hub-Signature-256` | Same format (`sha256=<hex>`), different secret |
-| _(absent)_ | `X-Hub-Signature` | Confusio does not emit a SHA-1 fallback header |
+| `X-Confusio-Source` | _(absent)_ | No GitHub equivalent |
+| Provider-native signature header(s) | Provider-native signature header(s) | Same signing helper, using the target secret |
 | `Content-Type` | `Content-Type` | Same |
-| `User-Agent` | `User-Agent` | Same (`Confusio-Hookshot/<version>`) |
+| `User-Agent` | `User-Agent` | Same (`confusio/1.0`) |
 
 **Key differences to call out to consumer authors:**
 
-1. `X-Confusio-Action` is a header in the confusio shape; in GitHub-emulation the
-   action is only in the JSON body's `action` field.
-2. `X-Confusio-Provider` has no GitHub equivalent; use it to route events by source
+1. The action is encoded in the confusio body `type`; GitHub-emulation keeps it in the
+   JSON body's `action` field.
+2. `X-Confusio-Source` has no GitHub equivalent; use it to route events by source
    forge without inspecting the body.
-3. There is no SHA-1 fallback header (`X-Hub-Signature`) in the confusio shape.
-   Consumers must use `X-Confusio-Signature-256`.
-4. `source_url` in `data` objects corresponds to `html_url` in the GitHub-emulation
-   shape — same URL, different key name.
-5. `author` in `data` corresponds to `user` in the GitHub-emulation issue/PR objects.
+3. The confusio body is an envelope with `id`, `type`, `occurred_at`, `actor`,
+   `repository`, and `payload`; GitHub-emulation forwards GitHub-compatible webhook
+   payloads.
+4. Provider-native signature headers are reused for both shapes.  Consumers should
+   verify the header scheme associated with `X-Confusio-Source`.
+5. `source_url` in normalized payload objects corresponds to `html_url` in the
+   GitHub-emulation shape — same URL, different key name.
+6. `author` in normalized payload objects corresponds to `user` in the
+   GitHub-emulation issue/PR objects.
 
 ## Field-Level Mapping Tables
 
@@ -4399,11 +4377,15 @@ Marketplace listing.
 
 ## Delivery Semantics
 
-Every accepted inbound event is written to a durable outbox before any delivery
-attempt begins.  The outbox guarantees at-least-once delivery: if confusio crashes or
-is restarted between ingest and delivery, surviving events are retried on restart.
+The current delivery path is fire-and-record.  After an inbound webhook is verified and
+normalized, confusio walks the in-memory target registry and performs one synchronous
+HTTP POST to each target whose event filter matches.  The result of each POST is logged;
+failed deliveries are not retried and no delivery state is persisted.
 
-### Guarantee: at-least-once
+The durable outbox, replay, pause/resume, retry-budget, and circuit-breaker sections
+below describe planned behavior rather than the currently implemented runtime.
+
+### Planned guarantee: at-least-once
 
 Confusio guarantees that each event will be delivered **at least once** to each
 matching target.  It does **not** guarantee exactly-once delivery.  Consumers must
@@ -4423,7 +4405,7 @@ delivery ID generated when the event first arrived.  This ID is stable across re
 for the same delivery attempt.  Each _replay_ generates a fresh UUID so consumers can
 distinguish original deliveries from explicit re-sends by comparing IDs.
 
-### Durable outbox
+### Planned durable outbox
 
 The outbox is a filesystem directory tree persisted to disk before any HTTP delivery
 attempt.  On startup confusio scans the outbox for pending and in-flight deliveries and
@@ -4729,7 +4711,7 @@ body).  It is not separately configurable in the current design.
 
 ---
 
-## Replay API
+## Planned Replay API
 
 The replay API allows operators and consumers to inspect the delivery history of any
 event in the retention window and to trigger additional delivery attempts.
@@ -5061,6 +5043,24 @@ per-target state for this target).
 | `github_payload` or `confusio_payload` too large to store | Payloads larger than 25 MiB are truncated at 25 MiB with a `"_truncated": true` sentinel field added at the top level |
 
 ## Multi-Target Dispatch and Configuration
+
+Current configuration is static and supplied at startup through SCRIPTARGS:
+
+```sh
+sh ./confusio.com -p 8080 -- gitea \
+  webhook_target=https://example.com/webhook \
+  webhook_target_events=push,pull_request \
+  webhook_target_shape=confusio \
+  webhook_target_secret_file=/run/secrets/webhook-target
+```
+
+Only one target is registered from CLI configuration today.  `webhook_target_events`
+defaults to `*`, `webhook_target_shape` defaults to `github`, and the target secret is
+optional.  Delivery to matching targets is synchronous and fire-and-record, as described
+in [Delivery Semantics](#delivery-semantics).
+
+The persistent target resource and admin API sections below describe planned behavior
+rather than the currently implemented runtime.
 
 Confusio delivers each inbound event to every matching **target** — an HTTP endpoint
 registered by an operator.  Targets are independent: each has its own event-type filter,

--- a/internal/context.lua
+++ b/internal/context.lua
@@ -20,6 +20,10 @@
 --                             (e.g. "push", "issues"); set by b:build() via make_backend_builder.
 --                             The receiver pipeline calls backend.webhooks[event](raw_payload)
 --                             to normalise a forge event into confusio's internal event model.
+--     backend.webhook_translators — normalized outbound translator registry; keyed by
+--                             internal event name. Confusio-shape delivery calls these
+--                             with (internal_event, fields) and falls back to the shared
+--                             envelope factory when no event-specific translator exists.
 --   webhook_receiver  — webhook receive pipeline; function(); installed by .init.lua after
 --                       make_webhook_receiver(app) is called.  Handles POST /webhooks/{backend}:
 --                       signature verification, event dispatch, and response.  nil until wired.
@@ -33,6 +37,7 @@ function make_app(cfg) -- luacheck: globals make_app
       graphql = {},
       capabilities = {},
       webhooks = {},
+      webhook_translators = {},
     },
     allow_anonymous = true,
   }

--- a/internal/deliver.lua
+++ b/internal/deliver.lua
@@ -1,6 +1,6 @@
 -- Outbound HTTP delivery (fire-and-record).
 --
--- deliver_fire(target, backend, event_type, payload) performs one HTTP POST
+-- deliver_fire(target, backend, event_type, payload[, internal_event, translators]) performs one HTTP POST
 -- to target.url.  No retry, no circuit breaker.  The outcome is logged
 -- (HTTP status or error) and the function returns immediately.
 --
@@ -10,7 +10,7 @@
 --   secret (string)  — optional HMAC signing secret
 --
 -- Globals exported:
---   deliver_fire(target, backend, event_type, payload) → ok, http_status_or_nil, error_or_nil
+--   deliver_fire(target, backend, event_type, payload[, internal_event, translators]) → ok, http_status_or_nil, error_or_nil
 
 -- _deliver_headers: builds the outbound request headers table.
 -- For "github" shape: X-GitHub-Event, X-GitHub-Delivery, and provider-native signature headers.
@@ -42,10 +42,18 @@ end
 -- Returns (ok, http_status_or_nil, error_or_nil):
 --   ok=true  — delivery succeeded (HTTP 2xx)
 --   ok=false — delivery failed; http_status is nil on network error
-function deliver_fire(target, backend, event_type, payload) -- luacheck: globals deliver_fire
+function deliver_fire(target, backend, event_type, payload, internal_event, translators) -- luacheck: globals deliver_fire
   local t0 = os.clock()
-  local body = fanout_body(backend, event_type, payload, target.shape) -- luacheck: globals fanout_body
   local delivery_id = make_uuid() -- luacheck: globals make_uuid
+  local body = fanout_body( -- luacheck: globals fanout_body
+    backend,
+    event_type,
+    payload,
+    target.shape,
+    internal_event,
+    translators,
+    { id = delivery_id }
+  )
   local hdrs = _deliver_headers(backend, event_type, delivery_id, target.shape, body, target.secret)
 
   local pcall_ok, result = pcall(Fetch, target.url, { -- luacheck: globals Fetch

--- a/internal/fanout.lua
+++ b/internal/fanout.lua
@@ -7,12 +7,12 @@
 --
 -- "Shape" controls how the request body is serialised for the target:
 --   "github"   — re-encodes the raw inbound payload unchanged (GitHub-emulation)
---   "confusio" — wraps the payload in a metadata envelope {source, event, payload}
+--   "confusio" — emits the normalized event envelope
 --
 -- Globals exported:
---   fanout_body(backend, event_type, payload, shape) → body string
+--   fanout_body(backend, event_type, payload, shape[, internal_event, translators, fields]) → body string
 --   fanout_register_target(target)                   — register a static outbound target
---   fanout_dispatch(backend, event_type, payload)    — fire to all matching targets
+--   fanout_dispatch(backend, event_type, payload[, internal_event, translators]) — fire to all matching targets
 
 -- _fanout_targets: in-memory list of registered outbound targets.
 -- Each entry is a table: { url, events, shape, secret }
@@ -29,20 +29,45 @@ local function fanout_event_matches(event_type, events)
   return false
 end
 
+local function fallback_internal_event(backend, event_type, payload)
+  return make_internal_event({ -- luacheck: globals make_internal_event
+    event = event_type,
+    action = "",
+    provider = backend,
+    raw = payload,
+    data = {
+      payload = payload,
+    },
+  })
+end
+
+local function normalized_body(backend, event_type, payload, internal_event, translators, fields)
+  internal_event = internal_event or fallback_internal_event(backend, event_type, payload)
+  fields = fields or {}
+  local translator = nil
+  if type(translators) == "table" then
+    translator = translators[event_type] or translators["*"]
+  end
+  local envelope = nil
+  if type(translator) == "function" then
+    envelope = translator(internal_event, fields)
+  end
+  if type(envelope) ~= "table" then
+    envelope = make_normalized_webhook_envelope(internal_event, fields) -- luacheck: globals make_normalized_webhook_envelope
+  end
+  return EncodeJson(envelope) -- luacheck: globals EncodeJson
+end
+
 -- fanout_body: serialises the event for the given delivery shape.
 --   "github"   — re-encodes the raw inbound payload (fields forwarded as-is)
---   "confusio" — wraps in {source, event, payload} envelope
+--   "confusio" — emits the normalized event envelope
 -- Any unknown shape value falls back to "github" behaviour.
-function fanout_body(backend, event_type, payload, shape) -- luacheck: globals fanout_body
+function fanout_body(backend, event_type, payload, shape, internal_event, translators, fields) -- luacheck: globals fanout_body
   if shape == "confusio" then
-    return EncodeJson({ -- luacheck: globals EncodeJson
-      source = backend,
-      event = event_type,
-      payload = payload,
-    })
+    return normalized_body(backend, event_type, payload, internal_event, translators, fields)
   end
   -- "github" (default): forward the raw inbound payload unchanged.
-  return EncodeJson(payload)
+  return EncodeJson(payload) -- luacheck: globals EncodeJson
 end
 
 -- fanout_register_target: adds a static outbound target to the registry.
@@ -65,11 +90,11 @@ end
 -- fanout_dispatch: fires the inbound event to all matching registered targets.
 -- Delivery is fire-and-record: deliver_fire() is called for each matching target.
 -- Returns the number of targets that matched (regardless of delivery success).
-function fanout_dispatch(backend, event_type, payload) -- luacheck: globals fanout_dispatch deliver_fire
+function fanout_dispatch(backend, event_type, payload, internal_event, translators) -- luacheck: globals fanout_dispatch deliver_fire
   local count = 0
   for _, target in ipairs(_fanout_targets) do
     if fanout_event_matches(event_type, target.events) then
-      deliver_fire(target, backend, event_type, payload)
+      deliver_fire(target, backend, event_type, payload, internal_event, translators)
       count = count + 1
     end
   end

--- a/internal/registry.lua
+++ b/internal/registry.lua
@@ -1,8 +1,10 @@
 -- Backend builder: the required API for registering REST handlers, GraphQL
--- resolvers, provider capability modules, and inbound webhook event handlers.
+-- resolvers, provider capability modules, inbound webhook event handlers, and
+-- normalized outbound webhook translators.
 --
 -- make_backend_builder() returns a builder.  A backend file calls b:rest(name, fn),
--- b:graphql(key, fn), b:capability(name, module), b:webhook(event, fn), and
+-- b:graphql(key, fn), b:capability(name, module), b:webhook(event, fn),
+-- b:webhook_translator(event, fn), and
 -- b:set_allow_anonymous(v) to declare its handlers, resolvers, capabilities,
 -- webhook handlers, and metadata, then calls b:build() to commit them to the
 -- app context.
@@ -18,6 +20,12 @@
 -- backend.webhooks[event](raw_payload) to normalise a forge event into confusio's
 -- internal event model.  Strip patterns do NOT apply to webhook handlers.
 --
+-- Normalized outbound webhook translators live in app.backend.webhook_translators
+-- keyed by the internal event name (e.g. "push", "issues", "pull_request").  The
+-- confusio-shape delivery path calls translator(internal_event, fields) to build
+-- the normalized delivery envelope.  When no translator exists, the shared
+-- make_normalized_webhook_envelope fallback is used.
+--
 -- Direct assignment to app.backend.rest or graphql_resolvers is forbidden;
 -- make validate-builders enforces this at CI time.
 --
@@ -30,6 +38,7 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
     _graphql = {},
     _capabilities = {},
     _webhooks = {},
+    _webhook_translators = {},
     _anonymous = nil,
   }
 
@@ -74,6 +83,17 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
     return self
   end
 
+  -- Register a normalized outbound webhook translator.
+  -- event: internal event name (e.g. "push", "issues", "pull_request")
+  -- fn:    translator function called with (internal_event, fields).  Returns the
+  --        normalized delivery envelope for confusio-shape outbound delivery.
+  -- Strip patterns do NOT apply to webhook translators.
+  -- Returns self for method chaining.
+  function b:webhook_translator(event, fn)
+    self._webhook_translators[event] = fn
+    return self
+  end
+
   -- Declare the anonymous-access policy for this backend.
   -- v: true = allow unauthenticated requests; false = require Authorization header
   -- When not called, app.allow_anonymous is left at its current value.
@@ -97,6 +117,7 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
   --   graphql_resolvers[key]         = fn     for each registered GraphQL resolver
   --   app.backend.capabilities[name] = module for each registered capability module
   --   app.backend.webhooks[event]    = fn     for each registered webhook event handler
+  --   app.backend.webhook_translators[event] = fn for each normalized webhook translator
   --   app.allow_anonymous            = v      only when set_allow_anonymous was called
   function b:build(strip)
     for name, fn in pairs(self._rest) do
@@ -121,6 +142,9 @@ function make_backend_builder() -- luacheck: globals make_backend_builder
     end
     for event, fn in pairs(self._webhooks) do
       app.backend.webhooks[event] = fn
+    end
+    for event, fn in pairs(self._webhook_translators) do
+      app.backend.webhook_translators[event] = fn
     end
     if self._anonymous ~= nil then
       app.allow_anonymous = self._anonymous

--- a/internal/webhook_event.lua
+++ b/internal/webhook_event.lua
@@ -27,7 +27,84 @@
 --     so operators can identify unrecognized actions without breaking delivery.
 --
 -- Globals exported:
---   make_internal_event   — internal event factory
+--   make_internal_event              — internal event factory
+--   normalized_webhook_event_type    — normalized event namespace helper
+--   make_normalized_webhook_envelope — normalized event envelope factory
+
+local NORMALIZED_EVENT_BASES = {
+  branch_protection_configuration = "branch_protection_configuration",
+  branch_protection_rule = "branch_protection_rule",
+  check_run = "check_run",
+  check_suite = "check_suite",
+  code_scanning_alert = "code_scanning_alert",
+  create = "create",
+  custom_property = "custom_property",
+  custom_property_values = "custom_property_values",
+  delete = "delete",
+  dependabot_alert = "dependabot_alert",
+  deploy_key = "deploy_key",
+  deployment = "deployment",
+  deployment_protection_rule = "deployment.protection_rule",
+  deployment_review = "deployment.review",
+  deployment_status = "deployment.status",
+  discussion = "discussion",
+  discussion_comment = "discussion.comment",
+  fork = "fork",
+  github_app_authorization = "github_app_authorization",
+  gollum = "gollum",
+  installation = "installation",
+  installation_repositories = "installation.repositories",
+  installation_target = "installation.target",
+  issue_comment = "issue.comment",
+  issues = "issue",
+  label = "label",
+  marketplace_purchase = "marketplace_purchase",
+  member = "member",
+  membership = "membership",
+  merge_group = "merge_group",
+  meta = "meta",
+  milestone = "milestone",
+  org_block = "org_block",
+  organization = "organization",
+  package = "package",
+  page_build = "page_build",
+  personal_access_token_request = "personal_access_token_request",
+  ping = "ping",
+  project = "project",
+  project_card = "project.card",
+  project_column = "project.column",
+  projects_v2 = "projects_v2",
+  projects_v2_item = "projects_v2.item",
+  projects_v2_status_update = "projects_v2.status_update",
+  public = "public",
+  pull_request = "pull_request",
+  pull_request_review = "pull_request.review",
+  pull_request_review_comment = "pull_request.review_comment",
+  pull_request_review_thread = "pull_request.review_thread",
+  push = "push",
+  registry_package = "registry_package",
+  release = "release",
+  repository = "repository",
+  repository_advisory = "repository.advisory",
+  repository_dispatch = "repository.dispatch",
+  repository_import = "repository.import",
+  repository_ruleset = "repository.ruleset",
+  repository_vulnerability_alert = "repository.vulnerability_alert",
+  secret_scanning_alert = "secret_scanning_alert",
+  secret_scanning_alert_location = "secret_scanning_alert.location",
+  security_advisory = "security_advisory",
+  security_and_analysis = "security_and_analysis",
+  sponsorship = "sponsorship",
+  star = "star",
+  status = "status",
+  sub_issues = "sub_issues",
+  team = "team",
+  team_add = "team.add",
+  watch = "watch",
+  workflow_dispatch = "workflow.dispatch",
+  workflow_job = "workflow.job",
+  workflow_run = "workflow.run",
+}
 
 -- make_internal_event(fields) constructs the canonical internal event table.
 --
@@ -54,5 +131,69 @@ function make_internal_event(fields) -- luacheck: globals make_internal_event
     timestamp = fields.timestamp or "",
     raw = fields.raw or {},
     data = fields.data or {},
+  }
+end
+
+-- normalized_webhook_event_type(event, action) returns the stable dotted
+-- confusio event namespace used by normalized webhook deliveries.
+--
+-- Examples:
+--   issues/opened                  -> issue.opened
+--   issue_comment/created          -> issue.comment.created
+--   pull_request_review/submitted  -> pull_request.review.submitted
+--
+-- Action-less events return only their event-family name.
+function normalized_webhook_event_type(event, action) -- luacheck: globals normalized_webhook_event_type
+  local base = NORMALIZED_EVENT_BASES[event] or event or ""
+  if action and action ~= "" then
+    return base .. "." .. action
+  end
+  return base
+end
+
+local function fallback_time()
+  if type(now_iso8601) == "function" then -- luacheck: globals now_iso8601
+    return now_iso8601()
+  end
+  return os.date("!%Y-%m-%dT%H:%M:%SZ")
+end
+
+local function fallback_id()
+  if type(make_uuid) == "function" then -- luacheck: globals make_uuid
+    return make_uuid()
+  end
+  return ""
+end
+
+local function nonempty(value, fallback)
+  if value ~= nil and value ~= "" then
+    return value
+  end
+  return fallback
+end
+
+-- make_normalized_webhook_envelope(internal_event[, fields]) constructs the
+-- normalized delivery envelope shared by all backend-specific translators.
+--
+-- Envelope fields:
+--   id          (string) — delivery/event identifier
+--   type        (string) — dotted normalized event type
+--   occurred_at (string) — ISO 8601 event time
+--   actor       (table)  — normalized actor object
+--   repository  (table)  — normalized repository object
+--   payload     (table)  — event-family-specific normalized payload
+function make_normalized_webhook_envelope(internal_event, fields) -- luacheck: globals make_normalized_webhook_envelope
+  internal_event = internal_event or {}
+  fields = fields or {}
+  local data = internal_event.data or {}
+  local raw = internal_event.raw or {}
+  return {
+    id = fields.id or fallback_id(),
+    type = fields.type
+      or normalized_webhook_event_type(internal_event.event, internal_event.action),
+    occurred_at = nonempty(fields.occurred_at, nonempty(internal_event.timestamp, fallback_time())),
+    actor = fields.actor or data.actor or data.sender or raw.sender or {},
+    repository = fields.repository or data.repository or raw.repository or {},
+    payload = fields.payload or data.payload or data,
   }
 end

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -485,7 +485,13 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     -- event type.  Delivery is fire-and-record: each POST is attempted
     -- synchronously, the outcome is logged, and confusio responds immediately.
     -- No retry, no persistence.
-    fanout_dispatch(backend, internal_event.event, payload) -- luacheck: globals fanout_dispatch
+    fanout_dispatch(
+      backend,
+      internal_event.event,
+      payload,
+      internal_event,
+      a.backend.webhook_translators
+    ) -- luacheck: globals fanout_dispatch
 
     -- When the action was not recognized, surface it in a sidecar header so
     -- operators can identify unrecognized event variants without breaking delivery.

--- a/test/mock-target.lua
+++ b/test/mock-target.lua
@@ -39,6 +39,7 @@ function OnHttpRequest()
   -- default "github" shape, or X-Confusio-* headers for the "confusio" shape.
   if method == "POST" then
     local body = GetBody() -- luacheck: globals GetBody
+    local ok_body, body_json = pcall(DecodeJson, body or "") -- luacheck: globals DecodeJson
     local entry = {
       path = path,
       user_agent = GetHeader("User-Agent") or "", -- luacheck: globals GetHeader
@@ -50,6 +51,7 @@ function OnHttpRequest()
       hub_signature_256 = GetHeader("X-Hub-Signature-256") or "",
       hub_signature = GetHeader("X-Hub-Signature") or "",
       body = body or "",
+      body_json = ok_body and body_json or nil,
     }
     deliveries[#deliveries + 1] = entry
     SetHeader("Content-Type", "application/json")

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -1803,6 +1803,7 @@ ok(type(app.backend.rest) == "table", "app.backend.rest: is a table")
 ok(type(app.backend.graphql) == "table", "app.backend.graphql: is a table")
 ok(type(app.backend.capabilities) == "table", "app.backend.capabilities: is a table")
 ok(type(app.backend.webhooks) == "table", "app.backend.webhooks: is a table")
+ok(type(app.backend.webhook_translators) == "table", "app.backend.webhook_translators: is a table")
 ok(type(app.allow_anonymous) == "boolean", "app.allow_anonymous: is a boolean")
 ok(app.allow_anonymous == true, "app.allow_anonymous: default true (no backend loaded)")
 ok(type(app.route_match) == "function", "app.route_match: bound router lookup installed on app")
@@ -1821,6 +1822,10 @@ do
   ok(type(test_app.backend.graphql) == "table", "make_app: backend.graphql is a table")
   ok(type(test_app.backend.capabilities) == "table", "make_app: backend.capabilities is a table")
   ok(type(test_app.backend.webhooks) == "table", "make_app: backend.webhooks is a table")
+  ok(
+    type(test_app.backend.webhook_translators) == "table",
+    "make_app: backend.webhook_translators is a table"
+  )
   ok(test_app.allow_anonymous == true, "make_app: allow_anonymous defaults to true")
   ok(test_app ~= app, "make_app: returns a new independent table each call")
 end
@@ -1833,6 +1838,7 @@ do
   local saved_rest = app.backend.rest
   local saved_capabilities = app.backend.capabilities
   local saved_webhooks = app.backend.webhooks
+  local saved_webhook_translators = app.backend.webhook_translators
   local saved_resolvers = graphql_resolvers -- luacheck: globals graphql_resolvers
   local saved_anon = app.allow_anonymous
 
@@ -1840,6 +1846,7 @@ do
     app.backend.rest = saved_rest
     app.backend.capabilities = saved_capabilities
     app.backend.webhooks = saved_webhooks
+    app.backend.webhook_translators = saved_webhook_translators
     graphql_resolvers = saved_resolvers -- luacheck: globals graphql_resolvers
     app.allow_anonymous = saved_anon
   end
@@ -1852,6 +1859,10 @@ do
   ok(type(b.capability) == "function", "make_backend_builder: has capability method")
   ok(type(b.webhook) == "function", "make_backend_builder: has webhook method")
   ok(
+    type(b.webhook_translator) == "function",
+    "make_backend_builder: has webhook_translator method"
+  )
+  ok(
     type(b.set_allow_anonymous) == "function",
     "make_backend_builder: has set_allow_anonymous method"
   )
@@ -1863,13 +1874,18 @@ do
   ok(b2:graphql("Query.foo", function() end) == b2, "builder:graphql: returns self")
   ok(b2:capability("repos", {}) == b2, "builder:capability: returns self")
   ok(b2:webhook("push", function() end) == b2, "builder:webhook: returns self")
+  ok(
+    b2:webhook_translator("push", function() end) == b2,
+    "builder:webhook_translator: returns self"
+  )
   ok(b2:set_allow_anonymous(true) == b2, "builder:set_allow_anonymous: returns self")
 
   -- build() populates app.backend.rest, graphql_resolvers, app.backend.capabilities,
-  -- and app.backend.webhooks
+  -- app.backend.webhooks, and app.backend.webhook_translators
   app.backend.rest = {}
   app.backend.capabilities = {}
   app.backend.webhooks = {}
+  app.backend.webhook_translators = {}
   graphql_resolvers = {} -- luacheck: globals graphql_resolvers
   app.allow_anonymous = true
 
@@ -1877,11 +1893,13 @@ do
   local gql_fn = function() end
   local cap_repos = { get = function() end, list = function() end }
   local push_fn = function() end
+  local push_translator_fn = function() end
   local b3 = make_backend_builder()
   b3:rest("get_repo", get_fn)
   b3:graphql("Query.viewer", gql_fn)
   b3:capability("repos", cap_repos)
   b3:webhook("push", push_fn)
+  b3:webhook_translator("push", push_translator_fn)
   b3:set_allow_anonymous(false)
   b3:build()
 
@@ -1889,6 +1907,11 @@ do
   eq(graphql_resolvers["Query.viewer"], gql_fn, "builder:build: registers GraphQL resolver") -- luacheck: globals graphql_resolvers
   eq(app.backend.capabilities["repos"], cap_repos, "builder:build: registers capability module")
   eq(app.backend.webhooks["push"], push_fn, "builder:build: registers webhook event handler")
+  eq(
+    app.backend.webhook_translators["push"],
+    push_translator_fn,
+    "builder:build: registers normalized webhook translator"
+  )
   eq(app.allow_anonymous, false, "builder:build: sets allow_anonymous")
 
   -- build() without set_allow_anonymous leaves allow_anonymous unchanged
@@ -3189,15 +3212,41 @@ do
   eq(decoded_gb.ref, "refs/heads/main", "fanout_body github: payload fields forwarded")
   ok(decoded_gb.source == nil, "fanout_body github: no envelope wrapper")
 
-  -- "confusio" shape: body is {source, event, payload} envelope.
+  -- "confusio" shape: body is the normalized event envelope.
   local cb = fanout_body("gitea", "push", payload, "confusio")
   ok(type(cb) == "string", "fanout_body confusio: returns a string")
   local decoded_cb = DecodeJson(cb)
   ok(type(decoded_cb) == "table", "fanout_body confusio: body is valid JSON")
-  eq(decoded_cb.source, "gitea", "fanout_body confusio: source is backend name")
-  eq(decoded_cb.event, "push", "fanout_body confusio: event is event_type")
+  eq(decoded_cb.type, "push", "fanout_body confusio: type is normalized event type")
+  ok(type(decoded_cb.id) == "string", "fanout_body confusio: id is present")
   ok(type(decoded_cb.payload) == "table", "fanout_body confusio: payload is a table")
   eq(decoded_cb.payload.ref, "refs/heads/main", "fanout_body confusio: payload fields preserved")
+
+  local internal = make_internal_event({ -- luacheck: globals make_internal_event
+    event = "issues",
+    action = "opened",
+    provider = "gitea",
+    raw = payload,
+    data = {
+      payload = { normalized = true },
+    },
+  })
+  local tb = fanout_body("gitea", "issues", payload, "confusio", internal, {
+    issues = function(ev, fields)
+      return {
+        id = fields.id,
+        type = "custom." .. ev.event,
+        payload = ev.data.payload,
+      }
+    end,
+  }, { id = "delivery-123" })
+  local decoded_tb = DecodeJson(tb)
+  eq(decoded_tb.id, "delivery-123", "fanout_body confusio translator: receives delivery id")
+  eq(decoded_tb.type, "custom.issues", "fanout_body confusio translator: event translator used")
+  ok(
+    decoded_tb.payload.normalized == true,
+    "fanout_body confusio translator: normalized payload used"
+  )
 
   -- Unknown shape falls back to "github" behaviour.
   local ub = fanout_body("gitea", "push", payload, "unknown")
@@ -3366,6 +3415,13 @@ do
     _df_last_opts.headers["X-GitHub-Event"] == nil,
     "deliver_fire confusio shape: no X-GitHub-Event header"
   )
+  local confusio_body = DecodeJson(_df_last_opts.body)
+  eq(
+    confusio_body.id,
+    _df_last_opts.headers["X-Confusio-Delivery"],
+    "deliver_fire confusio shape: body id matches delivery header"
+  )
+  eq(confusio_body.type, "push", "deliver_fire confusio shape: body type is normalized event")
 
   -- deliver_fire: secret present → backend-native signature header included.
   local target_signed = {

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2864,6 +2864,14 @@ end
 -- ============================================================
 
 ok(type(make_internal_event) == "function", "make_internal_event: exported as global function")
+ok(
+  type(normalized_webhook_event_type) == "function",
+  "normalized_webhook_event_type: exported as global function"
+)
+ok(
+  type(make_normalized_webhook_envelope) == "function",
+  "make_normalized_webhook_envelope: exported as global function"
+)
 
 do
   -- All required fields present → table with correct keys.
@@ -2910,6 +2918,110 @@ do
   eq(ev4.timestamp, "", "make_internal_event: missing timestamp defaults to ''")
   eq(type(ev4.raw), "table", "make_internal_event: missing raw defaults to {}")
   eq(type(ev4.data), "table", "make_internal_event: missing data defaults to {}")
+end
+
+-- ============================================================
+-- normalized webhook event model core
+-- ============================================================
+
+do
+  eq(
+    normalized_webhook_event_type("issues", "opened"),
+    "issue.opened",
+    "normalized_webhook_event_type: issues action maps to issue namespace"
+  )
+  eq(
+    normalized_webhook_event_type("issue_comment", "created"),
+    "issue.comment.created",
+    "normalized_webhook_event_type: issue_comment action maps to dotted namespace"
+  )
+  eq(
+    normalized_webhook_event_type("pull_request_review", "submitted"),
+    "pull_request.review.submitted",
+    "normalized_webhook_event_type: pull_request_review maps to review namespace"
+  )
+  eq(
+    normalized_webhook_event_type("push", ""),
+    "push",
+    "normalized_webhook_event_type: empty action returns event namespace"
+  )
+  eq(
+    normalized_webhook_event_type("custom_backend_event", "created"),
+    "custom_backend_event.created",
+    "normalized_webhook_event_type: unknown event preserves backend event key"
+  )
+
+  local internal = make_internal_event({
+    event = "issue_comment",
+    action = "created",
+    provider = "gitea",
+    timestamp = "2026-04-28T10:11:12Z",
+    raw = {
+      sender = { login = "octocat" },
+      repository = { full_name = "octo/repo" },
+    },
+    data = {
+      payload = { comment = { id = 10, body = "nice" } },
+    },
+  })
+  local env = make_normalized_webhook_envelope(internal, { id = "delivery-1" })
+  eq(env.id, "delivery-1", "make_normalized_webhook_envelope: explicit id preserved")
+  eq(
+    env.type,
+    "issue.comment.created",
+    "make_normalized_webhook_envelope: type derived from event and action"
+  )
+  eq(
+    env.occurred_at,
+    "2026-04-28T10:11:12Z",
+    "make_normalized_webhook_envelope: timestamp preserved"
+  )
+  eq(env.actor.login, "octocat", "make_normalized_webhook_envelope: actor falls back to raw sender")
+  eq(
+    env.repository.full_name,
+    "octo/repo",
+    "make_normalized_webhook_envelope: repository falls back to raw repository"
+  )
+  eq(
+    env.payload.comment.id,
+    10,
+    "make_normalized_webhook_envelope: payload uses normalized data payload"
+  )
+
+  local override = make_normalized_webhook_envelope(internal, {
+    id = "delivery-2",
+    type = "issue.comment.custom",
+    occurred_at = "2026-04-28T12:00:00Z",
+    actor = { login = "override" },
+    repository = { full_name = "override/repo" },
+    payload = { ok = true },
+  })
+  eq(override.type, "issue.comment.custom", "make_normalized_webhook_envelope: type override")
+  eq(
+    override.occurred_at,
+    "2026-04-28T12:00:00Z",
+    "make_normalized_webhook_envelope: occurred_at override"
+  )
+  eq(override.actor.login, "override", "make_normalized_webhook_envelope: actor override")
+  eq(
+    override.repository.full_name,
+    "override/repo",
+    "make_normalized_webhook_envelope: repository override"
+  )
+  ok(override.payload.ok == true, "make_normalized_webhook_envelope: payload override")
+
+  local generated = make_normalized_webhook_envelope(make_internal_event({
+    event = "push",
+    provider = "gitea",
+    raw = {},
+    data = {},
+  }))
+  eq(#generated.id, 36, "make_normalized_webhook_envelope: generated id is UUID length")
+  ok(
+    generated.occurred_at:match("^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ$") ~= nil,
+    "make_normalized_webhook_envelope: empty timestamp falls back to current ISO time"
+  )
+  eq(generated.type, "push", "make_normalized_webhook_envelope: action-less event type")
 end
 
 -- ============================================================

--- a/test/webhook-delivery-azuredevops-confusio-shape.hurl
+++ b/test/webhook-delivery-azuredevops-confusio-shape.hurl
@@ -26,6 +26,12 @@ jsonpath "$[0].confusio_source" == "azuredevops"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice@example.com"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.issue.number" == 1
 
 # ── workitem.commented → issue_comment: created — confusio shape ──────────────
 
@@ -49,6 +55,11 @@ jsonpath "$[0].confusio_source" == "azuredevops"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T12:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "bob@example.com"
+jsonpath "$[0].body_json.payload.issue.number" == 1
+jsonpath "$[0].body_json.payload.comment.body" == "This is a comment on the work item"
 
 # ── git.pullrequest.created → pull_request: opened — confusio shape ──────────
 
@@ -72,6 +83,11 @@ jsonpath "$[0].confusio_source" == "azuredevops"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice@example.com"
+jsonpath "$[0].body_json.repository.full_name" == "myproject/my-repo"
+jsonpath "$[0].body_json.payload.pull_request.number" == 42
 
 # ── git.pullrequest.reviewervote → pull_request_review — confusio shape ───────
 
@@ -95,6 +111,11 @@ jsonpath "$[0].confusio_source" == "azuredevops"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T11:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "bob@example.com"
+jsonpath "$[0].body_json.repository.full_name" == "myproject/my-repo"
+jsonpath "$[0].body_json.payload.review.state" == "APPROVED"
 
 # ── build.complete → workflow_run — confusio shape ────────────────────────────
 
@@ -118,6 +139,11 @@ jsonpath "$[0].confusio_source" == "azuredevops"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.run.completed"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:10:00Z"
+jsonpath "$[0].body_json.payload.workflow_run.name" == "CI Pipeline"
+jsonpath "$[0].body_json.payload.workflow_run.conclusion" == "success"
+jsonpath "$[0].body_json.payload.workflow_run.head_sha" == "abc123def456"
 
 # ── git.push → push — confusio shape ─────────────────────────────────────────
 
@@ -141,3 +167,8 @@ jsonpath "$[0].confusio_source" == "azuredevops"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "bob@example.com"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.after" == "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"

--- a/test/webhook-delivery-bitbucket-confusio-shape.hurl
+++ b/test/webhook-delivery-bitbucket-confusio-shape.hurl
@@ -31,6 +31,12 @@ jsonpath "$[0].confusio_source" == "bitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.issue.number" == 1
 
 # ── issue_comment: created — confusio shape ───────────────────────────────────
 
@@ -55,6 +61,9 @@ jsonpath "$[0].confusio_source" == "bitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.payload.comment.id" == 101
 
 # ── pull_request: opened — confusio shape ─────────────────────────────────────
 
@@ -79,6 +88,9 @@ jsonpath "$[0].confusio_source" == "bitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.pull_request.number" == 1
 
 # ── pull_request_review: submitted (approved) — confusio shape ────────────────
 
@@ -103,6 +115,9 @@ jsonpath "$[0].confusio_source" == "bitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.actor.login" == "reviewer"
+jsonpath "$[0].body_json.payload.review.state" == "APPROVED"
 
 # ── status: success — confusio shape ──────────────────────────────────────────
 
@@ -127,6 +142,10 @@ jsonpath "$[0].confusio_source" == "bitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "status.success"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:05:00+00:00"
+jsonpath "$[0].body_json.payload.sha" == "abc1234567890abcdef1234567890abcdef12345"
+jsonpath "$[0].body_json.payload.context" == "my-ci/build"
 
 # ── push: push — confusio shape ───────────────────────────────────────────────
 
@@ -151,3 +170,7 @@ jsonpath "$[0].confusio_source" == "bitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.after" == "da1560886d4f094c3e6c9ef40349f7d38b5d27d0"

--- a/test/webhook-delivery-bitbucket_datacenter-confusio-shape.hurl
+++ b/test/webhook-delivery-bitbucket_datacenter-confusio-shape.hurl
@@ -31,6 +31,12 @@ jsonpath "$[0].confusio_source" == "bitbucket_datacenter"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.repository.full_name" == "OCTO/hello-world"
+jsonpath "$[0].body_json.payload.pull_request.number" == 1
 
 # ── pull_request_review: submitted (approved) — confusio shape ────────────────
 
@@ -55,6 +61,9 @@ jsonpath "$[0].confusio_source" == "bitbucket_datacenter"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.actor.login" == "reviewer"
+jsonpath "$[0].body_json.payload.review.state" == "APPROVED"
 
 # ── status: success — confusio shape ──────────────────────────────────────────
 
@@ -79,6 +88,11 @@ jsonpath "$[0].confusio_source" == "bitbucket_datacenter"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "status.success"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:05:00Z"
+jsonpath "$[0].body_json.repository.full_name" == "OCTO/hello-world"
+jsonpath "$[0].body_json.payload.sha" == "abc1234567890abcdef1234567890abcdef12345"
+jsonpath "$[0].body_json.payload.context" == "my-ci/build"
 
 # ── push: push — confusio shape ───────────────────────────────────────────────
 
@@ -103,3 +117,7 @@ jsonpath "$[0].confusio_source" == "bitbucket_datacenter"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.repository.full_name" == "OCTOCAT/hello-world"
+jsonpath "$[0].body_json.payload.after" == "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"

--- a/test/webhook-delivery-forgejo-confusio-shape.hurl
+++ b/test/webhook-delivery-forgejo-confusio-shape.hurl
@@ -31,6 +31,10 @@ jsonpath "$[0].confusio_source" == "forgejo"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.issue.number" == 1
 
 # ── issue_comment: created — confusio shape ───────────────────────────────────
 
@@ -55,6 +59,7 @@ jsonpath "$[0].confusio_source" == "forgejo"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
 
 # ── pull_request: opened — confusio shape ─────────────────────────────────────
 
@@ -79,6 +84,7 @@ jsonpath "$[0].confusio_source" == "forgejo"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
 
 # ── workflow_run: completed — confusio shape ──────────────────────────────────
 
@@ -103,6 +109,7 @@ jsonpath "$[0].confusio_source" == "forgejo"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.run.completed"
 
 # ── status: success — confusio shape ──────────────────────────────────────────
 
@@ -127,6 +134,7 @@ jsonpath "$[0].confusio_source" == "forgejo"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "status.success"
 
 # ── release: published — confusio shape ──────────────────────────────────────
 
@@ -151,3 +159,4 @@ jsonpath "$[0].confusio_source" == "forgejo"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "release.published"

--- a/test/webhook-delivery-gerrit-confusio-shape.hurl
+++ b/test/webhook-delivery-gerrit-confusio-shape.hurl
@@ -26,6 +26,12 @@ jsonpath "$[0].confusio_source" == "gerrit"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.occurred_at" == "1705312800"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.repository.full_name" == "myorg/my-repo"
+jsonpath "$[0].body_json.payload.review.state" == "APPROVED"
 
 # ── comment-added (changes_requested) → pull_request_review — confusio shape ──
 
@@ -49,6 +55,9 @@ jsonpath "$[0].confusio_source" == "gerrit"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.review.state" == "CHANGES_REQUESTED"
 
 # ── comment-added (no vote) → pull_request_review — confusio shape ────────────
 
@@ -72,3 +81,7 @@ jsonpath "$[0].confusio_source" == "gerrit"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.occurred_at" == "1705316400"
+jsonpath "$[0].body_json.actor.login" == "charlie"
+jsonpath "$[0].body_json.payload.review.state" == "COMMENTED"

--- a/test/webhook-delivery-gitbucket-confusio-shape.hurl
+++ b/test/webhook-delivery-gitbucket-confusio-shape.hurl
@@ -27,6 +27,13 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.issue.number" == 1
 
 # ── issue_comment: created — confusio shape ───────────────────────────────────
 
@@ -51,6 +58,9 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.comment.id" == 200
 
 # ── pull_request: opened — confusio shape ─────────────────────────────────────
 
@@ -75,6 +85,9 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.pull_request.number" == 5
 
 # ── pull_request_review: submitted — confusio shape ───────────────────────────
 
@@ -99,6 +112,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.payload.review.state" == "APPROVED"
 
 # ── milestone: created — confusio shape ───────────────────────────────────────
 
@@ -123,6 +138,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "milestone.created"
+jsonpath "$[0].body_json.payload.milestone.title" == "v1.0"
 
 # ── push: push — confusio shape ──────────────────────────────────────────────
 
@@ -147,6 +164,11 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.after" == "abc123def456abc123def456abc123def456abc123"
 
 # ── release: published — confusio shape ──────────────────────────────────────
 
@@ -171,6 +193,10 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "release.published"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.release.tag_name" == "v1.0.0"
 
 # ── code_scanning_alert: created — confusio shape ─────────────────────────────
 
@@ -195,6 +221,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "code_scanning_alert.created"
+jsonpath "$[0].body_json.payload.alert.number" == 1
 
 # ── secret_scanning_alert: created — confusio shape ───────────────────────────
 
@@ -219,6 +247,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "secret_scanning_alert.created"
+jsonpath "$[0].body_json.payload.alert.number" == 1
 
 # ── secret_scanning_alert_location: created — confusio shape ──────────────────
 
@@ -243,6 +273,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "secret_scanning_alert.location.created"
+jsonpath "$[0].body_json.payload.location.details.path" == "src/config.js"
 
 # ── security_advisory: published — confusio shape ─────────────────────────────
 
@@ -267,6 +299,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "security_advisory.published"
+jsonpath "$[0].body_json.payload.security_advisory.ghsa_id" == "GHSA-xx99-1234-5678"
 
 # ── repository_advisory: published — confusio shape ───────────────────────────
 
@@ -291,6 +325,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "repository.advisory.published"
+jsonpath "$[0].body_json.payload.repository_advisory.ghsa_id" == "GHSA-yy88-4321-8765"
 
 # ── repository_vulnerability_alert: create — confusio shape ───────────────────
 
@@ -315,6 +351,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "dependabot_alert.created"
+jsonpath "$[0].body_json.payload.alert.id" == 1
 
 # ── member: added — confusio shape ────────────────────────────────────────────
 
@@ -339,6 +377,9 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "member.added"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.payload.member.login" == "bob"
 
 # ── organization: member_added — confusio shape ───────────────────────────────
 
@@ -363,6 +404,9 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "organization.member_added"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.payload.organization.login" == "octocat"
 
 # ── membership: added — confusio shape ────────────────────────────────────────
 
@@ -387,6 +431,9 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "membership.added"
+jsonpath "$[0].body_json.payload.member.login" == "bob"
+jsonpath "$[0].body_json.payload.team.name" == "core"
 
 # ── team: created — confusio shape ────────────────────────────────────────────
 
@@ -411,6 +458,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "team.created"
+jsonpath "$[0].body_json.payload.team.name" == "core"
 
 # ── team_add — confusio shape ─────────────────────────────────────────────────
 
@@ -435,6 +484,9 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "team.add"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.team.name" == "core"
 
 # ── project: created — confusio shape ────────────────────────────────────────
 
@@ -459,6 +511,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "project.created"
+jsonpath "$[0].body_json.payload.project.name" == "My Project"
 
 # ── project_card: created — confusio shape ────────────────────────────────────
 
@@ -483,6 +537,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "project.card.created"
+jsonpath "$[0].body_json.payload.project_card.id" == 1
 
 # ── project_column: created — confusio shape ──────────────────────────────────
 
@@ -507,6 +563,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "project.column.created"
+jsonpath "$[0].body_json.payload.project_column.name" == "To Do"
 
 # ── projects_v2: created — confusio shape ────────────────────────────────────
 
@@ -531,6 +589,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "projects_v2.created"
+jsonpath "$[0].body_json.payload.projects_v2.title" == "My V2 Project"
 
 # ── projects_v2_item: created — confusio shape ───────────────────────────────
 
@@ -555,6 +615,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "projects_v2.item.created"
+jsonpath "$[0].body_json.payload.projects_v2_item.id" == 1
 
 # ── projects_v2_status_update: created — confusio shape ──────────────────────
 
@@ -579,6 +641,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "projects_v2.status_update.created"
+jsonpath "$[0].body_json.payload.projects_v2_status_update.id" == 1
 
 # ── discussion: created — confusio shape ─────────────────────────────────────
 
@@ -603,6 +667,8 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "discussion.created"
+jsonpath "$[0].body_json.payload.discussion.title" == "How do I configure X?"
 
 # ── package: published — confusio shape ──────────────────────────────────────
 
@@ -627,3 +693,5 @@ jsonpath "$[0].confusio_source" == "gitbucket"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "package.published"
+jsonpath "$[0].body_json.payload.package.name" == "my-lib"

--- a/test/webhook-delivery-gitea-confusio-shape.hurl
+++ b/test/webhook-delivery-gitea-confusio-shape.hurl
@@ -31,6 +31,13 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.issue.number" == 1
 
 # ── issue_comment: created — confusio shape ───────────────────────────────────
 
@@ -55,6 +62,9 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.comment.id" == 42
 
 # ── pull_request: opened — confusio shape ─────────────────────────────────────
 
@@ -79,6 +89,9 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.pull_request.number" == 7
 
 # ── workflow_run: completed — confusio shape ──────────────────────────────────
 
@@ -103,6 +116,8 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.run.completed"
+jsonpath "$[0].body_json.payload.workflow_run.conclusion" == "success"
 
 # ── status: success — confusio shape ──────────────────────────────────────────
 
@@ -127,6 +142,8 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "status.success"
+jsonpath "$[0].body_json.payload.sha" == "abc123def456abc123def456abc123def456abc123"
 
 # ── push: push — confusio shape ──────────────────────────────────────────────
 
@@ -151,6 +168,11 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.after" == "abc123def456abc123def456abc123def456abc123"
 
 # ── fork: fork — confusio shape ───────────────────────────────────────────────
 
@@ -175,6 +197,8 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "fork"
+jsonpath "$[0].body_json.payload.forkee.full_name" == "bob/hello-world"
 
 # ── release: published — confusio shape ──────────────────────────────────────
 
@@ -199,6 +223,10 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "release.published"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.release.tag_name" == "v1.0.0"
 
 # ── member: added — confusio shape ───────────────────────────────────────────
 
@@ -223,6 +251,8 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "member.added"
+jsonpath "$[0].body_json.payload.member.login" == "bob"
 
 # ── discussion: created — confusio shape ──────────────────────────────────────
 
@@ -247,6 +277,8 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "discussion.created"
+jsonpath "$[0].body_json.payload.discussion.title" == "How do I configure X?"
 # ── package: published — confusio shape ───────────────────────────────────────
 
 POST http://{{target}}/reset
@@ -270,3 +302,5 @@ jsonpath "$[0].confusio_source" == "gitea"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "package.published"
+jsonpath "$[0].body_json.payload.package.name" == "my-lib"

--- a/test/webhook-delivery-gitlab-confusio-shape.hurl
+++ b/test/webhook-delivery-gitlab-confusio-shape.hurl
@@ -31,6 +31,13 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.issue.number" == 1
 
 # ── issue_comment: created — confusio shape ───────────────────────────────────
 
@@ -55,6 +62,10 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T11:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.payload.comment.id" == 101
 
 # ── pull_request: opened — confusio shape ─────────────────────────────────────
 
@@ -79,6 +90,10 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T14:00:00Z"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.pull_request.number" == 1
 
 # ── workflow_run: completed — confusio shape ──────────────────────────────────
 
@@ -103,6 +118,10 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.run.completed"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T16:05:00Z"
+jsonpath "$[0].body_json.payload.workflow_run.conclusion" == "success"
+jsonpath "$[0].body_json.payload.workflow_run.head_sha" == "abc123"
 
 # ── workflow_job: completed — confusio shape ──────────────────────────────────
 
@@ -127,6 +146,10 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.job.completed"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T16:03:00Z"
+jsonpath "$[0].body_json.payload.workflow_job.name" == "test"
+jsonpath "$[0].body_json.payload.workflow_job.conclusion" == "success"
 
 # ── push: push — confusio shape ──────────────────────────────────────────────
 
@@ -151,6 +174,11 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00+00:00"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.after" == "da1560886d4f094c3e6c9ef40349f7d38b5d27d0"
 
 # ── release: published — confusio shape ──────────────────────────────────────
 
@@ -175,6 +203,10 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "release.published"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.release.tag_name" == "v1.0.0"
 
 # ── deployment: created — confusio shape ─────────────────────────────────────
 
@@ -199,6 +231,10 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "deployment.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T16:00:00Z"
+jsonpath "$[0].body_json.payload.deployment.id" == 15
+jsonpath "$[0].body_json.payload.deployment.environment" == "production"
 
 # ── member: added — confusio shape ───────────────────────────────────────────
 
@@ -223,6 +259,9 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "member.added"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.member.login" == "bob"
 
 # ── organization: created — confusio shape ────────────────────────────────────
 
@@ -247,6 +286,9 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "organization.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00.000Z"
+jsonpath "$[0].body_json.payload.organization.login" == "engineering"
 
 # ── membership: added — confusio shape ────────────────────────────────────────
 
@@ -271,3 +313,7 @@ jsonpath "$[0].confusio_source" == "gitlab"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "membership.added"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.payload.member.login" == "bob"
+jsonpath "$[0].body_json.payload.team.name" == "Engineering"

--- a/test/webhook-delivery-harness-confusio-shape.hurl
+++ b/test/webhook-delivery-harness-confusio-shape.hurl
@@ -26,6 +26,13 @@ jsonpath "$[0].confusio_source" == "harness"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "workflow.run.in_progress"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "myorg/my-repo"
+jsonpath "$[0].body_json.payload.workflow_run.status" == "in_progress"
+jsonpath "$[0].body_json.payload.workflow_run.head_sha" == "abc123def456"
 
 # ── pipeline_execution_success → workflow_run: completed — confusio shape ─────
 
@@ -49,6 +56,10 @@ jsonpath "$[0].confusio_source" == "harness"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.run.completed"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:10:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.workflow_run.conclusion" == "success"
 
 # ── stage_execution_started → workflow_job: in_progress — confusio shape ──────
 
@@ -72,6 +83,11 @@ jsonpath "$[0].confusio_source" == "harness"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.job.in_progress"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:01:40Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.workflow_job.name" == "Build Stage"
+jsonpath "$[0].body_json.payload.workflow_job.status" == "in_progress"
 
 # ── stage_execution_success → workflow_job: completed — confusio shape ────────
 
@@ -95,3 +111,7 @@ jsonpath "$[0].confusio_source" == "harness"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.job.completed"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:08:20Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.workflow_job.conclusion" == "success"

--- a/test/webhook-delivery-pagure-confusio-shape.hurl
+++ b/test/webhook-delivery-pagure-confusio-shape.hurl
@@ -27,6 +27,12 @@ jsonpath "$[0].confusio_source" == "pagure"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.id" isString
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.occurred_at" == "1705312800"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "myorg/my-repo"
+jsonpath "$[0].body_json.payload.issue.number" == 1
 
 # ── issue.comment.added → issue_comment: created — confusio shape ─────────────
 
@@ -51,6 +57,11 @@ jsonpath "$[0].confusio_source" == "pagure"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
+jsonpath "$[0].body_json.occurred_at" == "1705316400"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.comment.id" == 100
+jsonpath "$[0].body_json.payload.comment.body" == "I can reproduce this too."
 
 # ── pull-request.new → pull_request: opened — confusio shape ─────────────────
 
@@ -75,6 +86,11 @@ jsonpath "$[0].confusio_source" == "pagure"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "1705312800"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "myorg/my-repo"
+jsonpath "$[0].body_json.payload.pull_request.number" == 5
 
 # ── pull-request.closed → pull_request: closed — confusio shape ───────────────
 
@@ -99,6 +115,10 @@ jsonpath "$[0].confusio_source" == "pagure"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.closed"
+jsonpath "$[0].body_json.occurred_at" == "1705323600"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.pull_request.state" == "closed"
 
 # ── git.receive (push) → push — confusio shape ───────────────────────────────
 
@@ -123,3 +143,8 @@ jsonpath "$[0].confusio_source" == "pagure"
 jsonpath "$[0].confusio_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.after" == "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"


### PR DESCRIPTION
This PR now finishes the remaining specialized confusio-shape translators for Pagure, Gerrit, and Harness. The final pass documents the normalized envelope model, translator contract, fallback behavior, and delivery semantics.

Fixes #246.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (9)</summary>

- [x] Add Pagure, Gerrit, and Harness normalized translators and tests <!-- type:spec -->
- [x] Document normalized webhook event model <!-- type:spec -->
- [x] Add Azure DevOps normalized webhook translators and tests <!-- type:spec -->
- [x] Add Bitbucket-family normalized webhook translators and tests <!-- type:spec -->
- [x] Add GitLab normalized webhook translators and tests <!-- type:spec -->
- [x] Add GitBucket normalized webhook translators and tests <!-- type:spec -->
- [x] Add Gitea-family normalized webhook translators and tests <!-- type:spec -->
- [x] Route confusio-shape delivery through normalized translators <!-- type:spec -->
- [x] Add normalized webhook namespace and envelope core <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->