### PR TITLE
v3: Webhook — delivery logging (try-once, log all) (closes #250)

### DIFF
--- a/.init.lua
+++ b/.init.lua
@@ -56,6 +56,10 @@ end
 --   webhook_delivery_log_path=PATH   — structured delivery-attempt log path
 local positional_keys = { "backend", "base_url" }
 local pos_idx = 1
+local function webhook_target_config()
+  config.webhook_target = config.webhook_target or {}
+  return config.webhook_target
+end
 for _, a in ipairs(arg or {}) do
   local kv_key, kv_val = a:match("^([^=]+)=(.*)$")
   if kv_key then
@@ -64,24 +68,19 @@ for _, a in ipairs(arg or {}) do
     if wh_backend then
       config.webhook_secrets[wh_backend] = read_secret_file(kv_val)
     elseif kv_key == "webhook_target" then
-      config.webhook_target = config.webhook_target or {}
-      config.webhook_target.url = kv_val
+      webhook_target_config().url = kv_val
     elseif kv_key == "webhook_target_name" then
-      config.webhook_target = config.webhook_target or {}
-      config.webhook_target.name = kv_val
+      webhook_target_config().name = kv_val
     elseif kv_key == "webhook_target_events" then
-      config.webhook_target = config.webhook_target or {}
       local events = {}
       for e in kv_val:gmatch("[^,]+") do
         events[#events + 1] = e
       end
-      config.webhook_target.events = events
+      webhook_target_config().events = events
     elseif kv_key == "webhook_target_shape" then
-      config.webhook_target = config.webhook_target or {}
-      config.webhook_target.shape = kv_val
+      webhook_target_config().shape = kv_val
     elseif kv_key == "webhook_target_secret_file" then
-      config.webhook_target = config.webhook_target or {}
-      config.webhook_target.secret = read_secret_file(kv_val)
+      webhook_target_config().secret = read_secret_file(kv_val)
     elseif kv_key == "webhook_delivery_log_path" then
       config.webhook_delivery_log_path = kv_val
     end

--- a/.init.lua
+++ b/.init.lua
@@ -4,6 +4,7 @@
 config = {
   backend = "",
   base_url = "",
+  webhook_delivery_log_path = "webhook-deliveries.log",
   -- webhook_secrets: table mapping backend name → inbound signing secret.
   -- Populated by webhook_secret_file_BACKEND=/path SCRIPTARGS.
   -- Absent entry (or empty string) → trust-the-network for that backend.
@@ -48,9 +49,11 @@ end
 -- Key=value pairs (any arg containing "=") configure webhook options:
 --   webhook_secret_file_BACKEND=/path — path to 0600 file with inbound signing secret
 --   webhook_target=URL                — outbound delivery target URL
+--   webhook_target_name=NAME          — logical outbound target name (default: default)
 --   webhook_target_events=A,B,C      — comma-separated event filter (default: *)
 --   webhook_target_shape=SHAPE       — delivery shape: "github" (default) or "confusio"
 --   webhook_target_secret_file=/path — path to 0600 file with outbound HMAC signing secret
+--   webhook_delivery_log_path=PATH   — structured delivery-attempt log path
 local positional_keys = { "backend", "base_url" }
 local pos_idx = 1
 for _, a in ipairs(arg or {}) do
@@ -63,6 +66,9 @@ for _, a in ipairs(arg or {}) do
     elseif kv_key == "webhook_target" then
       config.webhook_target = config.webhook_target or {}
       config.webhook_target.url = kv_val
+    elseif kv_key == "webhook_target_name" then
+      config.webhook_target = config.webhook_target or {}
+      config.webhook_target.name = kv_val
     elseif kv_key == "webhook_target_events" then
       config.webhook_target = config.webhook_target or {}
       local events = {}
@@ -76,6 +82,8 @@ for _, a in ipairs(arg or {}) do
     elseif kv_key == "webhook_target_secret_file" then
       config.webhook_target = config.webhook_target or {}
       config.webhook_target.secret = read_secret_file(kv_val)
+    elseif kv_key == "webhook_delivery_log_path" then
+      config.webhook_delivery_log_path = kv_val
     end
   elseif positional_keys[pos_idx] then
     config[positional_keys[pos_idx]] = a
@@ -136,6 +144,7 @@ app.webhook_receiver = make_webhook_receiver(app)
 -- Register the single outbound target declared via webhook_target=URL at startup.
 -- Silently ignored if missing or malformed (missing url, wrong type).
 if config.webhook_target then
+  config.webhook_target.delivery_log_path = config.webhook_delivery_log_path
   fanout_register_target(config.webhook_target)
 end
 

--- a/.init.lua
+++ b/.init.lua
@@ -4,7 +4,6 @@
 config = {
   backend = "",
   base_url = "",
-  webhook_delivery_log_path = "webhook-deliveries.log",
   -- webhook_secrets: table mapping backend name → inbound signing secret.
   -- Populated by webhook_secret_file_BACKEND=/path SCRIPTARGS.
   -- Absent entry (or empty string) → trust-the-network for that backend.
@@ -53,7 +52,6 @@ end
 --   webhook_target_events=A,B,C      — comma-separated event filter (default: *)
 --   webhook_target_shape=SHAPE       — delivery shape: "github" (default) or "confusio"
 --   webhook_target_secret_file=/path — path to 0600 file with outbound HMAC signing secret
---   webhook_delivery_log_path=PATH   — structured delivery-attempt log path
 local positional_keys = { "backend", "base_url" }
 local pos_idx = 1
 local function webhook_target_config()
@@ -81,8 +79,6 @@ for _, a in ipairs(arg or {}) do
       webhook_target_config().shape = kv_val
     elseif kv_key == "webhook_target_secret_file" then
       webhook_target_config().secret = read_secret_file(kv_val)
-    elseif kv_key == "webhook_delivery_log_path" then
-      config.webhook_delivery_log_path = kv_val
     end
   elseif positional_keys[pos_idx] then
     config[positional_keys[pos_idx]] = a
@@ -143,7 +139,6 @@ app.webhook_receiver = make_webhook_receiver(app)
 -- Register the single outbound target declared via webhook_target=URL at startup.
 -- Silently ignored if missing or malformed (missing url, wrong type).
 if config.webhook_target then
-  config.webhook_target.delivery_log_path = config.webhook_delivery_log_path
   fanout_register_target(config.webhook_target)
 end
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,11 @@ Config is supplied as SCRIPTARGS after `--`.  Positional args set the backend an
 | SCRIPTARGS (positional) | `sh ./confusio.com -- <backend> [base_url]` |
 | SCRIPTARGS (inbound secret file) | `webhook_secret_file_BACKEND=/path` — path to 0600 file containing inbound signing secret |
 | SCRIPTARGS (outbound target) | `webhook_target=URL` — outbound delivery target URL |
+| SCRIPTARGS (target name) | `webhook_target_name=NAME` — logical outbound target name in delivery logs (default: `default`) |
 | SCRIPTARGS (target events) | `webhook_target_events=push,pull_request` — comma-separated filter (default: *) |
 | SCRIPTARGS (target shape) | `webhook_target_shape=confusio` — `github` (default) or `confusio` |
 | SCRIPTARGS (target secret file) | `webhook_target_secret_file=/path` — path to 0600 file containing outbound HMAC signing secret |
+| SCRIPTARGS (delivery log path) | `webhook_delivery_log_path=/path` — JSON Lines delivery-attempt log path (default: `webhook-deliveries.log`) |
 | Defaults | hardcoded in `.init.lua` |
 
 ## GitHub API reference
@@ -687,11 +689,13 @@ When a webhook event arrives from a forge backend, confusio can forward it to a 
 
 **Configuration:**
 - **`webhook_target=URL` SCRIPTARG** — URL of the single outbound target.  Optional; when absent, no deliveries are made.  Example: `sh ./confusio.com -- gitea webhook_target=https://hook.example.com`.
+- **`webhook_target_name=NAME`** — logical name for the configured outbound target in structured delivery logs (default: `default`).
 - **`webhook_target_events=A,B`** — comma-separated event filter (default: `*` = all events).
 - **`webhook_target_shape=github|confusio`** — delivery body shape (default: `github`).
 - **`webhook_target_secret_file=/path`** — path to a 0600-permission file containing the HMAC signing secret for the outbound target.
+- **`webhook_delivery_log_path=/path`** — JSON Lines delivery-attempt log path (default: `webhook-deliveries.log`).  Each attempted delivery appends one record with target name, backend, event type, delivery ID, latency, HTTP status when available, and error text when delivery fails before an HTTP response.
 - **`webhook_secret_file_BACKEND=/path`** provides per-backend inbound signing secrets (see above).
 
-**Dispatch flow:** After the webhook receiver validates an inbound event, `fanout_dispatch(backend, event_type, payload, internal_event, app.backend.webhook_translators)` fires `deliver_fire` for each registered target whose event subscription matches.  The default `github` shape forwards the raw payload; `confusio` shape uses `app.backend.webhook_translators[event_type]` when present and falls back to `make_normalized_webhook_envelope`.  `deliver_fire` makes one HTTP POST with optional HMAC signing and logs the outcome (HTTP status or error message) at `kLogWarn` on failure or `kLogVerbose` on success.  Returns `(ok, http_status_or_nil, error_or_nil)`.  The caller does not inspect the return values — the result is purely for log visibility.
+**Dispatch flow:** After the webhook receiver validates an inbound event, `fanout_dispatch(backend, event_type, payload, internal_event, app.backend.webhook_translators)` fires `deliver_fire` for each registered target whose event subscription matches.  The default `github` shape forwards the raw payload; `confusio` shape uses `app.backend.webhook_translators[event_type]` when present and falls back to `make_normalized_webhook_envelope`.  `deliver_fire` makes one HTTP POST with optional HMAC signing, writes a best-effort structured JSONL delivery-attempt record when a log path is configured, and logs the outcome (HTTP status or error message) at `kLogWarn` on failure or `kLogVerbose` on success.  Returns `(ok, http_status_or_nil, error_or_nil)`.  The caller does not inspect the return values — the result is purely for log visibility.
 
 - **Outbound signing mirrors the active backend's inbound scheme.** The `sign_for_backend` function in `internal/signing.lua` maps backend names to their native signature headers using the same schemes documented in `verify_signature` in `internal/webhooks.lua`.  The two must stay in sync when new backends are added.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,11 +101,10 @@ Config is supplied as SCRIPTARGS after `--`.  Positional args set the backend an
 | SCRIPTARGS (positional) | `sh ./confusio.com -- <backend> [base_url]` |
 | SCRIPTARGS (inbound secret file) | `webhook_secret_file_BACKEND=/path` — path to 0600 file containing inbound signing secret |
 | SCRIPTARGS (outbound target) | `webhook_target=URL` — outbound delivery target URL |
-| SCRIPTARGS (target name) | `webhook_target_name=NAME` — logical outbound target name in delivery logs (default: `default`) |
+| SCRIPTARGS (target name) | `webhook_target_name=NAME` — logical outbound target name in delivery log lines (default: `default`) |
 | SCRIPTARGS (target events) | `webhook_target_events=push,pull_request` — comma-separated filter (default: *) |
 | SCRIPTARGS (target shape) | `webhook_target_shape=confusio` — `github` (default) or `confusio` |
 | SCRIPTARGS (target secret file) | `webhook_target_secret_file=/path` — path to 0600 file containing outbound HMAC signing secret |
-| SCRIPTARGS (delivery log path) | `webhook_delivery_log_path=/path` — JSON Lines delivery-attempt log path (default: `webhook-deliveries.log`) |
 | Defaults | hardcoded in `.init.lua` |
 
 ## GitHub API reference
@@ -689,13 +688,12 @@ When a webhook event arrives from a forge backend, confusio can forward it to a 
 
 **Configuration:**
 - **`webhook_target=URL` SCRIPTARG** — URL of the single outbound target.  Optional; when absent, no deliveries are made.  Example: `sh ./confusio.com -- gitea webhook_target=https://hook.example.com`.
-- **`webhook_target_name=NAME`** — logical name for the configured outbound target in structured delivery logs (default: `default`).
+- **`webhook_target_name=NAME`** — logical name for the configured outbound target in delivery log lines (default: `default`).
 - **`webhook_target_events=A,B`** — comma-separated event filter (default: `*` = all events).
 - **`webhook_target_shape=github|confusio`** — delivery body shape (default: `github`).
 - **`webhook_target_secret_file=/path`** — path to a 0600-permission file containing the HMAC signing secret for the outbound target.
-- **`webhook_delivery_log_path=/path`** — JSON Lines delivery-attempt log path (default: `webhook-deliveries.log`).  Each attempted delivery appends one record with target name, backend, event type, delivery ID, latency, HTTP status when available, and error text when delivery fails before an HTTP response.
 - **`webhook_secret_file_BACKEND=/path`** provides per-backend inbound signing secrets (see above).
 
-**Dispatch flow:** After the webhook receiver validates an inbound event, `fanout_dispatch(backend, event_type, payload, internal_event, app.backend.webhook_translators)` fires `deliver_fire` for each registered target whose event subscription matches.  The default `github` shape forwards the raw payload; `confusio` shape uses `app.backend.webhook_translators[event_type]` when present and falls back to `make_normalized_webhook_envelope`.  `deliver_fire` makes one HTTP POST with optional HMAC signing, writes a best-effort structured JSONL delivery-attempt record when a log path is configured, and logs the outcome (HTTP status or error message) at `kLogWarn` on failure or `kLogVerbose` on success.  Returns `(ok, http_status_or_nil, error_or_nil)`.  The caller does not inspect the return values — the result is purely for log visibility.
+**Dispatch flow:** After the webhook receiver validates an inbound event, `fanout_dispatch(backend, event_type, payload, internal_event, app.backend.webhook_translators)` fires `deliver_fire` for each registered target whose event subscription matches.  The default `github` shape forwards the raw payload; `confusio` shape uses `app.backend.webhook_translators[event_type]` when present and falls back to `make_normalized_webhook_envelope`.  `deliver_fire` makes one HTTP POST with optional HMAC signing and emits a delivery-attempt log line to stderr with the target name, backend, event type, delivery ID, duration, HTTP status when available, and error text when delivery fails before an HTTP response.  It logs at `kLogWarn` on failure or `kLogVerbose` on success.  Returns `(ok, http_status_or_nil, error_or_nil)`.  The caller does not inspect the return values — the result is purely for log visibility.
 
 - **Outbound signing mirrors the active backend's inbound scheme.** The `sign_for_backend` function in `internal/signing.lua` maps backend names to their native signature headers using the same schemes documented in `verify_signature` in `internal/webhooks.lua`.  The two must stay in sync when new backends are added.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -31,7 +31,7 @@ selects per-target which shape to emit.
 - **Multi-target fan-out** — A single inbound event can be delivered to multiple
   consumers, each with independent shape selection and event-type filtering.
 - **Fire-and-record delivery** — Matching targets are POSTed synchronously during the
-  inbound request.  Every attempted delivery appends a structured log record, but no
+  inbound request.  Every attempted delivery is logged, but no
   retry, outbox, replay, or delivery-inspection layer is currently implemented.
 
 ### Non-Goals
@@ -4378,14 +4378,14 @@ Marketplace listing.
 
 The current delivery path is fire-and-record.  After an inbound webhook is verified and
 normalized, confusio walks the in-memory target registry and performs one synchronous
-HTTP POST to each target whose event filter matches.  The result of each POST is appended
-to the configured JSON Lines delivery log.  Failed deliveries are terminal for that
-attempt: confusio does not retry, persist delivery state, or expose a replay API.
+HTTP POST to each target whose event filter matches.  The result of each POST is logged.
+Failed deliveries are terminal for that attempt: confusio does not retry, persist
+delivery state, or expose a replay API.
 
 ### Current guarantee: try once, log all
 
 Each matching target receives one delivery attempt during the inbound request.  The
-attempt record includes the target name, event type, backend, delivery ID, latency,
+log line includes the target name, event type, backend, delivery ID, latency,
 HTTP status when a response is received, and error text when delivery fails before a
 response.  Logging is best-effort observability; the inbound response does not imply
 that downstream consumers processed the event, and consumers that miss an event must
@@ -5062,15 +5062,13 @@ sh ./confusio.com -p 8080 -- gitea \
   webhook_target_name=primary \
   webhook_target_events=push,pull_request \
   webhook_target_shape=confusio \
-  webhook_target_secret_file=/run/secrets/webhook-target \
-  webhook_delivery_log_path=/var/log/confusio/webhook-deliveries.log
+  webhook_target_secret_file=/run/secrets/webhook-target
 ```
 
 Only one target is registered from CLI configuration today.  `webhook_target_name`
 defaults to `default`, `webhook_target_events` defaults to `*`,
-`webhook_target_shape` defaults to `github`, `webhook_delivery_log_path` defaults to
-`webhook-deliveries.log`, and the target secret is optional.  Delivery to matching
-targets is synchronous and fire-and-record, as described in
+`webhook_target_shape` defaults to `github`, and the target secret is optional.
+Delivery to matching targets is synchronous and fire-and-record, as described in
 [Delivery Semantics](#delivery-semantics).
 
 The persistent target resource and admin API sections below describe planned behavior

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -31,8 +31,8 @@ selects per-target which shape to emit.
 - **Multi-target fan-out** — A single inbound event can be delivered to multiple
   consumers, each with independent shape selection and event-type filtering.
 - **Fire-and-record delivery** — Matching targets are POSTed synchronously during the
-  inbound request.  Delivery outcomes are logged, but no retry or persistence layer is
-  currently implemented.
+  inbound request.  Every attempted delivery appends a structured log record, but no
+  retry, outbox, replay, or delivery-inspection layer is currently implemented.
 
 ### Non-Goals
 
@@ -183,8 +183,7 @@ Confusio reads the following from every inbound webhook request:
 
 | Code | Meaning |
 |------|---------|
-| `200 OK` | Payload accepted, queued for delivery |
-| `202 Accepted` | Payload accepted asynchronously (used when the outbox is non-blocking) |
+| `200 OK` | Payload accepted; matching targets received their one synchronous delivery attempt |
 | `400 Bad Request` | Malformed payload or unsupported `Content-Type` |
 | `401 Unauthorized` | Signature verification failed |
 | `404 Not Found` | Unknown backend name in path |
@@ -4379,17 +4378,28 @@ Marketplace listing.
 
 The current delivery path is fire-and-record.  After an inbound webhook is verified and
 normalized, confusio walks the in-memory target registry and performs one synchronous
-HTTP POST to each target whose event filter matches.  The result of each POST is logged;
-failed deliveries are not retried and no delivery state is persisted.
+HTTP POST to each target whose event filter matches.  The result of each POST is appended
+to the configured JSON Lines delivery log.  Failed deliveries are terminal for that
+attempt: confusio does not retry, persist delivery state, or expose a replay API.
+
+### Current guarantee: try once, log all
+
+Each matching target receives one delivery attempt during the inbound request.  The
+attempt record includes the target name, event type, backend, delivery ID, latency,
+HTTP status when a response is received, and error text when delivery fails before a
+response.  Logging is best-effort observability; the inbound response does not imply
+that downstream consumers processed the event, and consumers that miss an event must
+reconcile from the upstream forge API.
 
 The durable outbox, replay, pause/resume, retry-budget, and circuit-breaker sections
 below describe planned behavior rather than the currently implemented runtime.
 
-### Planned guarantee: at-least-once
+### Deferred durable delivery design
 
-Confusio guarantees that each event will be delivered **at least once** to each
-matching target.  It does **not** guarantee exactly-once delivery.  Consumers must
-be idempotent with respect to duplicate deliveries.
+The possible future durable-delivery design would guarantee that each event is delivered
+**at least once** to each matching target.  It would **not** guarantee exactly-once
+delivery.  Consumers would still need to be idempotent with respect to duplicate
+deliveries.
 
 Duplicate deliveries arise in two scenarios:
 
@@ -5049,15 +5059,19 @@ Current configuration is static and supplied at startup through SCRIPTARGS:
 ```sh
 sh ./confusio.com -p 8080 -- gitea \
   webhook_target=https://example.com/webhook \
+  webhook_target_name=primary \
   webhook_target_events=push,pull_request \
   webhook_target_shape=confusio \
-  webhook_target_secret_file=/run/secrets/webhook-target
+  webhook_target_secret_file=/run/secrets/webhook-target \
+  webhook_delivery_log_path=/var/log/confusio/webhook-deliveries.log
 ```
 
-Only one target is registered from CLI configuration today.  `webhook_target_events`
-defaults to `*`, `webhook_target_shape` defaults to `github`, and the target secret is
-optional.  Delivery to matching targets is synchronous and fire-and-record, as described
-in [Delivery Semantics](#delivery-semantics).
+Only one target is registered from CLI configuration today.  `webhook_target_name`
+defaults to `default`, `webhook_target_events` defaults to `*`,
+`webhook_target_shape` defaults to `github`, `webhook_delivery_log_path` defaults to
+`webhook-deliveries.log`, and the target secret is optional.  Delivery to matching
+targets is synchronous and fire-and-record, as described in
+[Delivery Semantics](#delivery-semantics).
 
 The persistent target resource and admin API sections below describe planned behavior
 rather than the currently implemented runtime.
@@ -5197,8 +5211,8 @@ any content encoding).  The secret is the HMAC key.
 
 ### Fan-out dispatch logic
 
-When confusio successfully ingests and verifies an inbound event, it performs a
-synchronous fan-out pass before returning the HTTP response to the forge.
+In the deferred durable-delivery design, confusio would perform a fan-out pass before
+returning the HTTP response to the forge.
 
 **Fan-out steps:**
 

--- a/internal/deliver.lua
+++ b/internal/deliver.lua
@@ -9,7 +9,6 @@
 --   url               (string)  — destination endpoint
 --   shape             (string)  — "github" (default) or "confusio"
 --   secret            (string)  — optional HMAC signing secret
---   delivery_log_path (string)  — structured delivery-attempt log path
 --
 -- Globals exported:
 --   deliver_fire(target, backend, event_type, payload[, internal_event, translators]) → ok, http_status_or_nil, error_or_nil
@@ -38,7 +37,7 @@ local function _deliver_headers(backend, event_type, delivery_id, shape, body, s
   return headers
 end
 
-local function append_delivery_attempt_log(
+local function delivery_log_line(
   target,
   backend,
   event_type,
@@ -47,33 +46,21 @@ local function append_delivery_attempt_log(
   duration_ms,
   err
 )
-  local path = target.delivery_log_path or ""
-  if path == "" then
-    return
+  local status = http_status or 0
+  local line = string.format(
+    'deliver: "POST %s HTTP/1.1" %03d %dms target=%s backend=%s event=%s delivery=%s',
+    target.url or "",
+    status,
+    duration_ms,
+    target.name or "default",
+    backend,
+    event_type,
+    delivery_id
+  )
+  if err ~= nil then
+    line = line .. " error=" .. tostring(err)
   end
-
-  local record = {
-    timestamp = now_iso8601(), -- luacheck: globals now_iso8601
-    target_name = target.name or "default",
-    event_type = event_type,
-    delivery_id = delivery_id,
-    backend = backend,
-    status_code = http_status,
-    latency_ms = duration_ms,
-    error = err,
-  }
-  local line = EncodeJson(record) .. "\n" -- luacheck: globals EncodeJson
-  local ok_append, append_err = pcall(function()
-    local f = assert(io.open(path, "a"))
-    f:write(line)
-    f:close()
-  end)
-  if not ok_append then
-    Log( -- luacheck: globals Log kLogWarn
-      kLogWarn,
-      string.format("deliver: log_path=%s error=%s", path, tostring(append_err))
-    )
-  end
+  return line
 end
 
 -- deliver_fire: performs one HTTP POST delivery to target.url.
@@ -106,40 +93,18 @@ function deliver_fire(target, backend, event_type, payload, internal_event, tran
 
   if not pcall_ok then
     local err = tostring(result)
-    append_delivery_attempt_log(target, backend, event_type, delivery_id, nil, duration_ms, err)
     Log( -- luacheck: globals Log kLogWarn
       kLogWarn,
-      string.format(
-        "deliver: url=%s event=%s duration=%dms error=%s",
-        target.url,
-        event_type,
-        duration_ms,
-        err
-      )
+      delivery_log_line(target, backend, event_type, delivery_id, nil, duration_ms, err)
     )
     return false, nil, err
   end
 
   local http_status = result
   local ok = http_status >= 200 and http_status < 300
-  append_delivery_attempt_log(
-    target,
-    backend,
-    event_type,
-    delivery_id,
-    http_status,
-    duration_ms,
-    nil
-  )
   Log(
     ok and kLogVerbose or kLogWarn, -- luacheck: globals kLogVerbose
-    string.format(
-      "deliver: url=%s event=%s status=%d duration=%dms",
-      target.url,
-      event_type,
-      http_status,
-      duration_ms
-    )
+    delivery_log_line(target, backend, event_type, delivery_id, http_status, duration_ms, nil)
   )
   return ok, http_status, nil
 end

--- a/internal/deliver.lua
+++ b/internal/deliver.lua
@@ -38,6 +38,44 @@ local function _deliver_headers(backend, event_type, delivery_id, shape, body, s
   return headers
 end
 
+local function append_delivery_attempt_log(
+  target,
+  backend,
+  event_type,
+  delivery_id,
+  http_status,
+  duration_ms,
+  err
+)
+  local path = target.delivery_log_path or ""
+  if path == "" then
+    return
+  end
+
+  local record = {
+    timestamp = now_iso8601(), -- luacheck: globals now_iso8601
+    target_name = target.name or "default",
+    event_type = event_type,
+    delivery_id = delivery_id,
+    backend = backend,
+    status_code = http_status,
+    latency_ms = duration_ms,
+    error = err,
+  }
+  local line = EncodeJson(record) .. "\n" -- luacheck: globals EncodeJson
+  local ok_append, append_err = pcall(function()
+    local f = assert(io.open(path, "a"))
+    f:write(line)
+    f:close()
+  end)
+  if not ok_append then
+    Log( -- luacheck: globals Log kLogWarn
+      kLogWarn,
+      string.format("deliver: log_path=%s error=%s", path, tostring(append_err))
+    )
+  end
+end
+
 -- deliver_fire: performs one HTTP POST delivery to target.url.
 -- Logs the outcome (status, duration, error) and returns immediately.
 -- No retry, no circuit breaker.
@@ -68,6 +106,7 @@ function deliver_fire(target, backend, event_type, payload, internal_event, tran
 
   if not pcall_ok then
     local err = tostring(result)
+    append_delivery_attempt_log(target, backend, event_type, delivery_id, nil, duration_ms, err)
     Log( -- luacheck: globals Log kLogWarn
       kLogWarn,
       string.format(
@@ -83,6 +122,15 @@ function deliver_fire(target, backend, event_type, payload, internal_event, tran
 
   local http_status = result
   local ok = http_status >= 200 and http_status < 300
+  append_delivery_attempt_log(
+    target,
+    backend,
+    event_type,
+    delivery_id,
+    http_status,
+    duration_ms,
+    nil
+  )
   Log(
     ok and kLogVerbose or kLogWarn, -- luacheck: globals kLogVerbose
     string.format(

--- a/internal/deliver.lua
+++ b/internal/deliver.lua
@@ -5,9 +5,11 @@
 -- (HTTP status or error) and the function returns immediately.
 --
 -- target is a table with fields:
---   url    (string)  — destination endpoint
---   shape  (string)  — "github" (default) or "confusio"
---   secret (string)  — optional HMAC signing secret
+--   name              (string)  — logical target name
+--   url               (string)  — destination endpoint
+--   shape             (string)  — "github" (default) or "confusio"
+--   secret            (string)  — optional HMAC signing secret
+--   delivery_log_path (string)  — structured delivery-attempt log path
 --
 -- Globals exported:
 --   deliver_fire(target, backend, event_type, payload[, internal_event, translators]) → ok, http_status_or_nil, error_or_nil

--- a/internal/fanout.lua
+++ b/internal/fanout.lua
@@ -15,7 +15,7 @@
 --   fanout_dispatch(backend, event_type, payload[, internal_event, translators]) — fire to all matching targets
 
 -- _fanout_targets: in-memory list of registered outbound targets.
--- Each entry is a table: { url, events, shape, secret }
+-- Each entry is a table: { name, url, events, shape, secret, delivery_log_path }
 local _fanout_targets = {}
 
 -- fanout_event_matches: returns true when event_type is covered by the target's
@@ -72,17 +72,20 @@ end
 
 -- fanout_register_target: adds a static outbound target to the registry.
 -- target must be a table with at least a non-empty url field.
--- Optional fields: events (array; default {"*"}), shape (string; default "github"),
--- secret (string; used for HMAC signing).
+-- Optional fields: name (string; default "default"), events (array; default {"*"}),
+-- shape (string; default "github"), secret (string; used for HMAC signing),
+-- delivery_log_path (string; structured delivery-attempt log path).
 function fanout_register_target(target) -- luacheck: globals fanout_register_target
   if type(target) ~= "table" or type(target.url) ~= "string" or target.url == "" then
     return
   end
   local entry = {
+    name = target.name or "default",
     url = target.url,
     events = target.events or { "*" },
     shape = target.shape or "github",
     secret = target.secret or "",
+    delivery_log_path = target.delivery_log_path or "",
   }
   _fanout_targets[#_fanout_targets + 1] = entry
 end

--- a/internal/fanout.lua
+++ b/internal/fanout.lua
@@ -15,7 +15,7 @@
 --   fanout_dispatch(backend, event_type, payload[, internal_event, translators]) — fire to all matching targets
 
 -- _fanout_targets: in-memory list of registered outbound targets.
--- Each entry is a table: { name, url, events, shape, secret, delivery_log_path }
+-- Each entry is a table: { name, url, events, shape, secret }
 local _fanout_targets = {}
 
 -- fanout_event_matches: returns true when event_type is covered by the target's
@@ -73,8 +73,7 @@ end
 -- fanout_register_target: adds a static outbound target to the registry.
 -- target must be a table with at least a non-empty url field.
 -- Optional fields: name (string; default "default"), events (array; default {"*"}),
--- shape (string; default "github"), secret (string; used for HMAC signing),
--- delivery_log_path (string; structured delivery-attempt log path).
+-- shape (string; default "github"), secret (string; used for HMAC signing).
 function fanout_register_target(target) -- luacheck: globals fanout_register_target
   if type(target) ~= "table" or type(target.url) ~= "string" or target.url == "" then
     return
@@ -85,7 +84,6 @@ function fanout_register_target(target) -- luacheck: globals fanout_register_tar
     events = target.events or { "*" },
     shape = target.shape or "github",
     secret = target.secret or "",
-    delivery_log_path = target.delivery_log_path or "",
   }
   _fanout_targets[#_fanout_targets + 1] = entry
 end

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3496,6 +3496,49 @@ do
   ok(type(log_entry.latency_ms) == "number", "deliver_fire log: latency recorded")
   ok(log_entry.error == nil, "deliver_fire log: success has no error field")
 
+  -- deliver_fire: HTTP failures are recorded with status and no error string.
+  delivery_log_path = os.tmpname()
+  os.remove(delivery_log_path)
+  target_logged.delivery_log_path = delivery_log_path
+  _df_mock_status = 503
+  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
+  log_f = assert(io.open(delivery_log_path, "r"))
+  log_line = log_f:read("*l")
+  log_f:close()
+  os.remove(delivery_log_path)
+  log_entry = DecodeJson(log_line)
+  eq(log_entry.status_code, 503, "deliver_fire log: HTTP failure status recorded")
+  ok(log_entry.error == nil, "deliver_fire log: HTTP failure has no error field")
+  eq(
+    log_entry.delivery_id,
+    _df_last_opts.headers["X-GitHub-Delivery"],
+    "deliver_fire log: HTTP failure delivery id recorded"
+  )
+
+  -- deliver_fire: network failures are recorded with an error and no status.
+  delivery_log_path = os.tmpname()
+  os.remove(delivery_log_path)
+  target_logged.delivery_log_path = delivery_log_path
+  _df_mock_status = 200
+  _df_mock_error = "connection refused"
+  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
+  log_f = assert(io.open(delivery_log_path, "r"))
+  log_line = log_f:read("*l")
+  log_f:close()
+  os.remove(delivery_log_path)
+  log_entry = DecodeJson(log_line)
+  ok(log_entry.status_code == nil, "deliver_fire log: network failure has no status")
+  ok(
+    log_entry.error:find("connection refused", 1, true) ~= nil,
+    "deliver_fire log: network failure error recorded"
+  )
+  eq(
+    log_entry.delivery_id,
+    _df_last_opts.headers["X-GitHub-Delivery"],
+    "deliver_fire log: network failure delivery id recorded"
+  )
+  _df_mock_error = nil
+
   -- deliver_fire: outcome logging — Log is called with kLogWarn on failure
   -- and kLogVerbose on success.
   local _log_calls = {}

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3466,6 +3466,36 @@ do
     "deliver_fire with secret: X-Gitea-Signature header present for gitea backend"
   )
 
+  -- deliver_fire: delivery_log_path appends a structured JSON line.
+  local delivery_log_path = os.tmpname()
+  os.remove(delivery_log_path)
+  local target_logged = {
+    name = "logged-target",
+    url = "https://df-logged.example.com/hook",
+    shape = "github",
+    secret = "",
+    delivery_log_path = delivery_log_path,
+  }
+  _df_mock_status = 202
+  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
+  local log_f = assert(io.open(delivery_log_path, "r"))
+  local log_line = log_f:read("*l")
+  log_f:close()
+  os.remove(delivery_log_path)
+  local log_entry = DecodeJson(log_line)
+  eq(log_entry.target_name, "logged-target", "deliver_fire log: target name recorded")
+  eq(log_entry.event_type, "push", "deliver_fire log: event type recorded")
+  eq(
+    log_entry.delivery_id,
+    _df_last_opts.headers["X-GitHub-Delivery"],
+    "deliver_fire log: delivery id recorded"
+  )
+  eq(log_entry.backend, "gitea", "deliver_fire log: backend recorded")
+  eq(log_entry.status_code, 202, "deliver_fire log: status code recorded")
+  ok(type(log_entry.timestamp) == "string", "deliver_fire log: timestamp recorded")
+  ok(type(log_entry.latency_ms) == "number", "deliver_fire log: latency recorded")
+  ok(log_entry.error == nil, "deliver_fire log: success has no error field")
+
   -- deliver_fire: outcome logging — Log is called with kLogWarn on failure
   -- and kLogVerbose on success.
   local _log_calls = {}

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -204,7 +204,6 @@ end
 --   webhook_target_events=push,pull_request: event filter
 --   webhook_target_shape=github: delivery shape
 --   webhook_target_secret_file: path to 0600 file with outbound HMAC signing secret
---   webhook_delivery_log_path=/tmp/wt-deliveries.log: structured attempt log path
 arg = { -- luacheck: globals arg
   "testbackend",
   "webhook_secret_file_gitea=" .. _ws_secret_file,
@@ -213,7 +212,6 @@ arg = { -- luacheck: globals arg
   "webhook_target_events=push,pull_request",
   "webhook_target_shape=github",
   "webhook_target_secret_file=" .. _wt_secret_file,
-  "webhook_delivery_log_path=/tmp/wt-deliveries.log",
 }
 
 -- Load the module under test.
@@ -264,20 +262,11 @@ assert(
   "webhook_target_secret_file CLI arg: secret mismatch: "
     .. tostring((config.webhook_target or {}).secret)
 )
-assert(
-  config.webhook_delivery_log_path == "/tmp/wt-deliveries.log",
-  "webhook_delivery_log_path CLI arg: path mismatch: " .. tostring(config.webhook_delivery_log_path)
-)
-assert(
-  config.webhook_target.delivery_log_path == "/tmp/wt-deliveries.log",
-  "webhook target delivery log path should inherit configured path"
-)
 
 -- Clear coverage-only state so later tests see a clean config.
 -- (config and app.config reference the same table.)
 config.webhook_secrets = {}
 config.webhook_target = nil
-config.webhook_delivery_log_path = "webhook-deliveries.log"
 
 -- Restore dofile so later tests that call it work normally.
 dofile = _real_dofile -- luacheck: globals dofile
@@ -3312,7 +3301,6 @@ fanout_register_target({
   url = "https://fd-test.example.com/hook",
   name = "fd-wildcard",
   events = { "*" },
-  delivery_log_path = "/tmp/fd-deliveries.log",
 })
 
 _fd_calls = {}
@@ -3323,11 +3311,6 @@ eq(_fd_calls[1].backend, "gitea", "fanout_dispatch wildcard: backend passed to d
 eq(_fd_calls[1].event_type, "create", "fanout_dispatch wildcard: event_type passed")
 eq(_fd_calls[1].tgt.url, "https://fd-test.example.com/hook", "fanout_dispatch wildcard: target url")
 eq(_fd_calls[1].tgt.name, "fd-wildcard", "fanout_dispatch wildcard: target name")
-eq(
-  _fd_calls[1].tgt.delivery_log_path,
-  "/tmp/fd-deliveries.log",
-  "fanout_dispatch wildcard: target delivery log path"
-)
 
 -- fanout_dispatch with non-matching event type for an issues-only target.
 fanout_register_target({ url = "https://filtered.example.com/hook", events = { "issues" } })
@@ -3466,113 +3449,67 @@ do
     "deliver_fire with secret: X-Gitea-Signature header present for gitea backend"
   )
 
-  -- deliver_fire: delivery_log_path appends a structured JSON line.
-  local delivery_log_path = os.tmpname()
-  os.remove(delivery_log_path)
+  -- deliver_fire: delivery attempts are logged in Redbean-style request form.
   local target_logged = {
     name = "logged-target",
     url = "https://df-logged.example.com/hook",
     shape = "github",
     secret = "",
-    delivery_log_path = delivery_log_path,
   }
-  _df_mock_status = 202
-  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
-  local log_f = assert(io.open(delivery_log_path, "r"))
-  local log_line = log_f:read("*l")
-  log_f:close()
-  os.remove(delivery_log_path)
-  local log_entry = DecodeJson(log_line)
-  eq(log_entry.target_name, "logged-target", "deliver_fire log: target name recorded")
-  eq(log_entry.event_type, "push", "deliver_fire log: event type recorded")
-  eq(
-    log_entry.delivery_id,
-    _df_last_opts.headers["X-GitHub-Delivery"],
-    "deliver_fire log: delivery id recorded"
-  )
-  eq(log_entry.backend, "gitea", "deliver_fire log: backend recorded")
-  eq(log_entry.status_code, 202, "deliver_fire log: status code recorded")
-  ok(type(log_entry.timestamp) == "string", "deliver_fire log: timestamp recorded")
-  ok(type(log_entry.latency_ms) == "number", "deliver_fire log: latency recorded")
-  ok(log_entry.error == nil, "deliver_fire log: success has no error field")
-
-  -- deliver_fire: HTTP failures are recorded with status and no error string.
-  delivery_log_path = os.tmpname()
-  os.remove(delivery_log_path)
-  target_logged.delivery_log_path = delivery_log_path
-  _df_mock_status = 503
-  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
-  log_f = assert(io.open(delivery_log_path, "r"))
-  log_line = log_f:read("*l")
-  log_f:close()
-  os.remove(delivery_log_path)
-  log_entry = DecodeJson(log_line)
-  eq(log_entry.status_code, 503, "deliver_fire log: HTTP failure status recorded")
-  ok(log_entry.error == nil, "deliver_fire log: HTTP failure has no error field")
-  eq(
-    log_entry.delivery_id,
-    _df_last_opts.headers["X-GitHub-Delivery"],
-    "deliver_fire log: HTTP failure delivery id recorded"
-  )
-
-  -- deliver_fire: network failures are recorded with an error and no status.
-  delivery_log_path = os.tmpname()
-  os.remove(delivery_log_path)
-  target_logged.delivery_log_path = delivery_log_path
-  _df_mock_status = 200
-  _df_mock_error = "connection refused"
-  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
-  log_f = assert(io.open(delivery_log_path, "r"))
-  log_line = log_f:read("*l")
-  log_f:close()
-  os.remove(delivery_log_path)
-  log_entry = DecodeJson(log_line)
-  ok(log_entry.status_code == nil, "deliver_fire log: network failure has no status")
-  ok(
-    log_entry.error:find("connection refused", 1, true) ~= nil,
-    "deliver_fire log: network failure error recorded"
-  )
-  eq(
-    log_entry.delivery_id,
-    _df_last_opts.headers["X-GitHub-Delivery"],
-    "deliver_fire log: network failure delivery id recorded"
-  )
-  _df_mock_error = nil
-
-  -- deliver_fire: outcome logging — Log is called with kLogWarn on failure
-  -- and kLogVerbose on success.
   local _log_calls = {}
   local _real_Log = Log
   Log = function(level, msg) -- luacheck: globals Log
     _log_calls[#_log_calls + 1] = { level = level, msg = msg }
   end
 
-  -- Successful delivery: Log called at kLogVerbose with status in message.
-  _df_mock_status = 200
+  _df_mock_status = 202
   _log_calls = {}
-  deliver_fire(target_github, "gitea", "push", { ref = "refs/heads/main" })
+  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
   ok(#_log_calls == 1, "deliver_fire success: Log called once")
   eq(_log_calls[1].level, kLogVerbose, "deliver_fire success: logged at kLogVerbose") -- luacheck: globals kLogVerbose
-  ok(_log_calls[1].msg:find("status=200") ~= nil, "deliver_fire success: log contains status=200")
-  ok(_log_calls[1].msg:find("url=") ~= nil, "deliver_fire success: log contains url=")
-  ok(_log_calls[1].msg:find("event=push") ~= nil, "deliver_fire success: log contains event=push")
+  ok(
+    _log_calls[1].msg:find('"POST https://df%-logged%.example%.com/hook HTTP/1%.1" 202') ~= nil,
+    "deliver_fire success: log uses Redbean-style request format"
+  )
+  ok(_log_calls[1].msg:find("target=logged%-target") ~= nil, "deliver_fire success: target logged")
+  ok(_log_calls[1].msg:find("backend=gitea") ~= nil, "deliver_fire success: backend logged")
+  ok(_log_calls[1].msg:find("event=push") ~= nil, "deliver_fire success: event logged")
+  ok(
+    _log_calls[1].msg:find("delivery=" .. _df_last_opts.headers["X-GitHub-Delivery"], 1, true)
+      ~= nil,
+    "deliver_fire success: delivery id logged"
+  )
+  ok(_log_calls[1].msg:find("ms") ~= nil, "deliver_fire success: duration logged")
+  ok(_log_calls[1].msg:find("error=") == nil, "deliver_fire success: no error logged")
 
-  -- HTTP error delivery: Log called at kLogWarn.
+  -- deliver_fire: HTTP failures are logged with status and no error string.
   _df_mock_status = 503
   _log_calls = {}
-  deliver_fire(target_github, "gitea", "push", { ref = "refs/heads/main" })
+  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
   ok(#_log_calls == 1, "deliver_fire 503: Log called once")
   eq(_log_calls[1].level, kLogWarn, "deliver_fire 503: logged at kLogWarn") -- luacheck: globals kLogWarn
-  ok(_log_calls[1].msg:find("status=503") ~= nil, "deliver_fire 503: log contains status=503")
+  ok(
+    _log_calls[1].msg:find('"POST https://df%-logged%.example%.com/hook HTTP/1%.1" 503') ~= nil,
+    "deliver_fire 503: log contains request and status"
+  )
+  ok(_log_calls[1].msg:find("error=") == nil, "deliver_fire 503: no error logged")
 
-  -- Network error: Log called at kLogWarn with error in message.
+  -- deliver_fire: network failures are logged with an error and no status.
   _df_mock_status = 200
   _df_mock_error = "connection refused"
   _log_calls = {}
-  deliver_fire(target_github, "gitea", "push", { ref = "refs/heads/main" })
+  deliver_fire(target_logged, "gitea", "push", { ref = "refs/heads/main" })
   ok(#_log_calls == 1, "deliver_fire network error: Log called once")
   eq(_log_calls[1].level, kLogWarn, "deliver_fire network error: logged at kLogWarn")
+  ok(
+    _log_calls[1].msg:find('"POST https://df%-logged%.example%.com/hook HTTP/1%.1" 000') ~= nil,
+    "deliver_fire network error: log uses zero status"
+  )
   ok(_log_calls[1].msg:find("error=") ~= nil, "deliver_fire network error: log contains error=")
+  ok(
+    _log_calls[1].msg:find("connection refused", 1, true) ~= nil,
+    "deliver_fire network error: error text logged"
+  )
   _df_mock_error = nil
 
   -- Restore Log and Fetch.

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -200,16 +200,20 @@ end
 --   positional: backend name (backend file load is suppressed by the dofile stub)
 --   webhook_secret_file_BACKEND: path to 0600 file with inbound signing secret
 --   webhook_target=URL: outbound delivery target
+--   webhook_target_name=wt-coverage: logical outbound target name
 --   webhook_target_events=push,pull_request: event filter
 --   webhook_target_shape=github: delivery shape
 --   webhook_target_secret_file: path to 0600 file with outbound HMAC signing secret
+--   webhook_delivery_log_path=/tmp/wt-deliveries.log: structured attempt log path
 arg = { -- luacheck: globals arg
   "testbackend",
   "webhook_secret_file_gitea=" .. _ws_secret_file,
   "webhook_target=https://hook.example.com/wt-coverage",
+  "webhook_target_name=wt-coverage",
   "webhook_target_events=push,pull_request",
   "webhook_target_shape=github",
   "webhook_target_secret_file=" .. _wt_secret_file,
+  "webhook_delivery_log_path=/tmp/wt-deliveries.log",
 }
 
 -- Load the module under test.
@@ -240,6 +244,10 @@ assert(
   "webhook_target CLI arg: url mismatch: " .. tostring((config.webhook_target or {}).url)
 )
 assert(
+  config.webhook_target.name == "wt-coverage",
+  "webhook_target_name CLI arg: name mismatch: " .. tostring((config.webhook_target or {}).name)
+)
+assert(
   type(config.webhook_target.events) == "table",
   "webhook_target_events CLI arg: events should be a table after load"
 )
@@ -256,11 +264,20 @@ assert(
   "webhook_target_secret_file CLI arg: secret mismatch: "
     .. tostring((config.webhook_target or {}).secret)
 )
+assert(
+  config.webhook_delivery_log_path == "/tmp/wt-deliveries.log",
+  "webhook_delivery_log_path CLI arg: path mismatch: " .. tostring(config.webhook_delivery_log_path)
+)
+assert(
+  config.webhook_target.delivery_log_path == "/tmp/wt-deliveries.log",
+  "webhook target delivery log path should inherit configured path"
+)
 
 -- Clear coverage-only state so later tests see a clean config.
 -- (config and app.config reference the same table.)
 config.webhook_secrets = {}
 config.webhook_target = nil
+config.webhook_delivery_log_path = "webhook-deliveries.log"
 
 -- Restore dofile so later tests that call it work normally.
 dofile = _real_dofile -- luacheck: globals dofile
@@ -3291,7 +3308,12 @@ local fd0 = fanout_dispatch("gitea", "create", { ref = "refs/tags/v1.0" })
 eq(fd0, 0, "fanout_dispatch no matching targets: returns 0 for unsubscribed event")
 
 -- Register a wildcard target and verify dispatch calls deliver_fire.
-fanout_register_target({ url = "https://fd-test.example.com/hook", events = { "*" } })
+fanout_register_target({
+  url = "https://fd-test.example.com/hook",
+  name = "fd-wildcard",
+  events = { "*" },
+  delivery_log_path = "/tmp/fd-deliveries.log",
+})
 
 _fd_calls = {}
 local fd1 = fanout_dispatch("gitea", "create", { ref = "refs/tags/v1.0" })
@@ -3300,6 +3322,12 @@ ok(#_fd_calls == 1, "fanout_dispatch wildcard: deliver_fire called once")
 eq(_fd_calls[1].backend, "gitea", "fanout_dispatch wildcard: backend passed to deliver_fire")
 eq(_fd_calls[1].event_type, "create", "fanout_dispatch wildcard: event_type passed")
 eq(_fd_calls[1].tgt.url, "https://fd-test.example.com/hook", "fanout_dispatch wildcard: target url")
+eq(_fd_calls[1].tgt.name, "fd-wildcard", "fanout_dispatch wildcard: target name")
+eq(
+  _fd_calls[1].tgt.delivery_log_path,
+  "/tmp/fd-deliveries.log",
+  "fanout_dispatch wildcard: target delivery log path"
+)
 
 -- fanout_dispatch with non-matching event type for an issues-only target.
 fanout_register_target({ url = "https://filtered.example.com/hook", events = { "issues" } })
@@ -3312,11 +3340,13 @@ eq(
   "https://fd-test.example.com/hook",
   "fanout_dispatch filtered: correct target fired"
 )
+eq(_fd_calls[1].tgt.name, "fd-wildcard", "fanout_dispatch filtered: preserves named target")
 
 -- Matching event type delivers to both wildcard and issues targets.
 _fd_calls = {}
 local fd3 = fanout_dispatch("gitea", "issues", { action = "opened" })
 eq(fd3, 2, "fanout_dispatch match: wildcard and issues targets both match issues event")
+eq(_fd_calls[2].tgt.name, "default", "fanout_dispatch default: unnamed target defaults to default")
 
 deliver_fire = _real_deliver_fire -- luacheck: globals deliver_fire
 


### PR DESCRIPTION
Adds log-only webhook delivery observability for the try-once fanout path with named targets and Redbean-style stderr log lines.

Fixes #250.

The remaining work finishes the Redbean-style log formatting and updates the docs to describe stderr-based delivery logging without a configurable delivery log file.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (8)</summary>

- [x] [Simplify delivery logging documentation wording](https://github.com/rhencke/confusio/pull/328#discussion_r3158082568) <!-- type:thread -->
- [x] [match Redbean request log formatting for delivery logs](https://github.com/rhencke/confusio/pull/328#issuecomment-4340186521) <!-- type:thread -->
- [x] [Document stderr delivery logging configuration](https://github.com/rhencke/confusio/pull/328#discussion_r3158081247) <!-- type:thread -->
- [x] Assert success and failure delivery log entries <!-- type:spec -->
- [x] Document try-once log-only delivery semantics <!-- type:spec -->
- [x] Append structured webhook delivery attempt logs <!-- type:spec -->
- [x] Add webhook target names and delivery log path <!-- type:spec -->
- [x] [Factor webhook target config initialization](https://github.com/rhencke/confusio/pull/328#discussion_r3158079612) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->