### PR TITLE
v3: Webhook — bitbucket_datacenter source backend (closes #254)

### DIFF
--- a/docs/real-world-testing.md
+++ b/docs/real-world-testing.md
@@ -234,6 +234,11 @@ rhodecode, tuleap) generate ephemeral admin credentials at container boot; no GH
 are needed for them.  The bootstrap credentials are written into the test job's environment
 by the setup script (see *Setup and teardown automation*).
 
+`bitbucket_datacenter` is the Tier 2 exception: the container can boot without persistent
+provider credentials, but Atlassian requires a Data Center license before repository and
+webhook flows are usable.  If `REAL_WORLD_BITBUCKET_DC_LICENSE` is absent, the job should
+skip with a classified `missing-secret` result instead of reporting endpoint regressions.
+
 ### Token lifetime and rotation
 
 - **Prefer non-expiring tokens** where the provider allows.  Expiring tokens fail silently
@@ -912,6 +917,13 @@ Start with simpler bootstrap (gitbucket, onedev) then work toward the more compl
 (kallithea, tuleap, bitbucket_datacenter).  Phabricator/Phorge is lowest priority given
 Phabricator's archived upstream status.
 
+Bitbucket Datacenter real-world coverage should create a project and repository inside the
+ephemeral container, configure a webhook with an `X-Hub-Signature` secret, and drive native
+events for `repo:refs_changed`, `pr:*`, `pr:reviewer:*`, `build:status_*`, and repository
+lifecycle where the installed version exposes them.  If the evaluation license is missing or
+expired, the run should be recorded as a license/setup skip; the mock-backed unit coverage
+remains authoritative until a licensed container is reachable.
+
 **Exit criteria**: all Docker backends produce a result (pass or classified failure) for two
 consecutive weekly runs without the bootstrap script hanging or erroring.
 
@@ -935,7 +947,7 @@ consecutive weekly runs without the bootstrap script hanging or erroring.
 | Rate limiting by provider | Low (weekly cadence, 1 req/s) | Low — job skips for the week | `429` classification; weekly cadence is conservative |
 | Generator produces wrong assertions for `~` endpoints | Medium (initially) | Low — false positive failures | Override layer; conservative initial assertions; tighten iteratively |
 | Docker image tag changes break bootstrap | Medium | Medium — Tier 2 job fails at bootstrap | Pin image tags in workflow; schedule quarterly tag updates |
-| Bitbucket Datacenter evaluation license expires | High (30-day trial) | Medium — DC job fails | Investigate free developer license or community edition; note in bootstrap script |
+| Bitbucket Datacenter evaluation license expires | High (30-day trial) | Medium — DC job skips or fails before provider assertions | Classify as `license-expired`, open a rotation reminder issue, and keep mock-backed webhook coverage as the active signal until a fresh license is installed |
 | Generator or reporter script has a bug | Low | Low — entire run produces no results | Phase 0 validation against gitea before enabling other backends |
 | GHA secrets sprawl (16+ secrets) | Low | Low — maintainability concern | Document all secrets in `test/real-world/SECRETS.md`; consistent naming |
 

--- a/test/bitbucket_datacenter-repos.hurl
+++ b/test/bitbucket_datacenter-repos.hurl
@@ -149,6 +149,49 @@ HTTP 200
 header "Content-Type" == "application/json; charset=utf-8"
 jsonpath "$.url" isString
 
+# POST /repos/{owner}/{repo}/hooks
+POST http://{{host}}/repos/octocat/hello-world/hooks
+Content-Type: application/json
+```json
+{
+  "name": "web",
+  "config": {"url": "https://example.com/new-hook"},
+  "events": ["push", "pull_request"],
+  "active": true
+}
+```
+
+HTTP 201
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" isInteger
+jsonpath "$.config.url" isString
+jsonpath "$.active" isBoolean
+
+# PATCH /repos/{owner}/{repo}/hooks/{hook_id}
+PATCH http://{{host}}/repos/octocat/hello-world/hooks/1
+Content-Type: application/json
+```json
+{
+  "name": "web",
+  "config": {"url": "https://example.com/updated-hook"},
+  "events": ["push", "pull_request"],
+  "active": true
+}
+```
+
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json; charset=utf-8"
+jsonpath "$.id" isInteger
+jsonpath "$.config.url" isString
+jsonpath "$.active" isBoolean
+
+# DELETE /repos/{owner}/{repo}/hooks/{hook_id}
+DELETE http://{{host}}/repos/octocat/hello-world/hooks/1
+
+HTTP 204
+
 # GET /users/{username}/repos — via ~username personal project
 GET http://{{host}}/users/octocat/repos
 

--- a/test/mock-bitbucket_datacenter.lua
+++ b/test/mock-bitbucket_datacenter.lua
@@ -112,11 +112,25 @@ function OnHttpRequest()
     )
 
   -- Webhooks ----------------------------------------------------------------
+  elseif path == rb .. "/webhooks/1" and GetMethod() == "DELETE" then
+    SetStatus(200, "OK")
+  elseif path == rb .. "/webhooks/1" and GetMethod() == "PUT" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":1,"name":"web","url":"https://example.com/updated-hook",'
+        .. '"events":["repo:refs_changed","pr:opened"],"active":true}'
+    )
   elseif path == rb .. "/webhooks/1" then
     SetStatus(200, "OK")
     json(
       '{"id":1,"name":"web","url":"https://example.com/hook",'
         .. '"events":["repo:refs_changed"],"active":true}'
+    )
+  elseif path == rb .. "/webhooks" and GetMethod() == "POST" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":2,"name":"web","url":"https://example.com/new-hook",'
+        .. '"events":["repo:refs_changed","pr:opened"],"active":true}'
     )
   elseif path == rb .. "/webhooks" then
     SetStatus(200, "OK")

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -122,13 +122,13 @@ CONFUSIO_TS=$(date +%s)
 CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
 # Write secrets to 0600-permission files — never pass raw secrets on the CLI.
 WH_SECRET_DIR=$(mktemp -d)
-for wh_backend in gitea gitlab bitbucket gitbucket confusio; do
+for wh_backend in gitea gitlab bitbucket bitbucket_datacenter gitbucket confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -4,7 +4,7 @@
 # Variables injected by the test script (computed via openssl at runtime):
 #   gitea_sig   — HMAC-SHA256("{}", secret) as hex (for X-Gitea-Signature)
 #   gitlab_tok  — the shared secret verbatim (for X-Gitlab-Token)
-#   bb_sig      — "sha256=<hex>" (for X-Hub-Signature on bitbucket)
+#   bb_sig      — "sha256=<hex>" (for X-Hub-Signature on bitbucket and bitbucket_datacenter)
 #   gb_sig      — "sha1=<hex>" (for X-Hub-Signature on gitbucket)
 #   azuredevops_basic — base64("fido:webhooksecret") for Authorization: Basic
 #   confusio_sig — "sha256=<hex>, v=1, ts=<ts>" (for X-Confusio-Signature-256)
@@ -81,6 +81,37 @@ jsonpath "$.message" == "No webhook handlers registered"
 POST http://{{host}}/webhooks/bitbucket
 Content-Type: application/json
 X-Hub-Signature: sha256=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── bitbucket_datacenter: X-Hub-Signature, HMAC-SHA256, sha256= prefix ───────
+
+# Valid signature → passes verification (422)
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Hub-Signature: {{bb_sig}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad signature → 401
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
+X-Hub-Signature: sha256=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing signature header → 401
+POST http://{{host}}/webhooks/bitbucket_datacenter
+Content-Type: application/json
 {}
 
 HTTP 401


### PR DESCRIPTION
Adds Bitbucket Datacenter webhook coverage by extending the mock surface and documenting how real-world testing should be handled for this self-hosted backend.

Fixes #254.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (9)</summary>

- [x] Extend Bitbucket Datacenter webhook mocks <!-- type:spec -->
- [x] Document Bitbucket Datacenter real-world testing <!-- type:spec -->
- [x] Normalize Bitbucket Datacenter pull request events <!-- type:spec -->
- [x] Cover Bitbucket Datacenter webhook signatures <!-- type:spec -->
- [x] Normalize Bitbucket Datacenter review and status events <!-- type:spec -->
- [x] Normalize Bitbucket Datacenter ref and repo events <!-- type:spec -->
- [x] Add Bitbucket Datacenter webhook fixtures <!-- type:spec -->
- [x] Add Bitbucket Datacenter delivery tests <!-- type:spec -->
- [x] Fill Bitbucket Datacenter webhook matrix <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->