### PR TITLE
v3: Webhook — gitblit source backend (closes #258)

### DIFF
--- a/backends/gitblit.lua
+++ b/backends/gitblit.lua
@@ -95,6 +95,47 @@ local function translate_user(u)
   }
 end
 
+local ZERO_SHA = "0000000000000000000000000000000000000000"
+
+local function ref_name(ref)
+  return (ref or ""):match("^refs/heads/(.+)$")
+    or (ref or ""):match("^refs/tags/(.+)$")
+    or (ref or "")
+end
+
+local function ref_type(ref)
+  if (ref or ""):match("^refs/tags/") then
+    return "tag"
+  end
+  return "branch"
+end
+
+local function translate_push_commit(c)
+  if not c then
+    return {}
+  end
+  local author = c.author or {}
+  return {
+    id = c.id or "",
+    message = c.message or "",
+    timestamp = c.timestamp or "",
+    url = c.url or "",
+    author = {
+      name = author.name or "",
+      email = author.email or "",
+      username = "",
+    },
+    committer = {
+      name = author.name or "",
+      email = author.email or "",
+      username = "",
+    },
+    added = c.added or {},
+    removed = c.removed or {},
+    modified = c.modified or {},
+  }
+end
+
 -- Return all repos from LIST_REPOSITORIES whose name starts with prefix.
 local function list_repos_by_prefix(prefix)
   local ok, status, _, body = fetch_rpc("LIST_REPOSITORIES")
@@ -243,5 +284,127 @@ b:rest("search_users", function()
   end
   respond_json(200, { total_count = #items, incomplete_results = false, items = items })
 end)
+
+-- Gitblit post-receive webhooks carry one or more ref update commands in the
+-- body.  Confusio normalizes the first successful command into the matching
+-- GitHub ref event family: create, delete, or push.
+b:webhook("post-receive", function(payload)
+  local command = nil
+  for _, c in ipairs(payload.commands or {}) do
+    if not command and (c.result == nil or c.result == "OK") then
+      command = c
+    end
+  end
+  if not command then
+    return nil, "No successful Gitblit ref command"
+  end
+
+  local repo = translate_repo(payload.repository or {})
+  local sender = translate_user(payload.user or {})
+  local before = command.oldId or ""
+  local after = command.newId or ""
+  local raw_ref = command.refName or ""
+  local kind = ref_type(raw_ref)
+  local name = ref_name(raw_ref)
+  local command_type = command.type or ""
+
+  if command_type == "CREATE" or before == ZERO_SHA then
+    return make_internal_event({
+      event = "create",
+      action = "create",
+      provider = "gitblit",
+      raw = payload,
+      data = {
+        ref = name,
+        ref_type = kind,
+        master_branch = (payload.repository or {}).defaultBranch or "",
+        description = (payload.repository or {}).description,
+        pusher_type = "user",
+        repository = repo,
+        sender = sender,
+      },
+      timestamp = (payload.repository or {}).lastChange or "",
+    })
+  end
+
+  if command_type == "DELETE" or after == ZERO_SHA then
+    return make_internal_event({
+      event = "delete",
+      action = "delete",
+      provider = "gitblit",
+      raw = payload,
+      data = {
+        ref = name,
+        ref_type = kind,
+        master_branch = (payload.repository or {}).defaultBranch or "",
+        description = (payload.repository or {}).description,
+        pusher_type = "user",
+        repository = repo,
+        sender = sender,
+      },
+      timestamp = (payload.repository or {}).lastChange or "",
+    })
+  end
+
+  local commits = {}
+  for _, c in ipairs(command.commits or {}) do
+    commits[#commits + 1] = translate_push_commit(c)
+  end
+  local head_commit = #commits > 0 and commits[#commits] or nil
+  local user = payload.user or {}
+  return make_internal_event({
+    event = "push",
+    action = "push",
+    provider = "gitblit",
+    raw = payload,
+    data = {
+      ref = raw_ref,
+      before = before,
+      after = after,
+      created = false,
+      deleted = false,
+      forced = false,
+      compare = "",
+      commits = commits,
+      head_commit = head_commit,
+      pusher = {
+        name = user.displayName or user.name or "",
+        email = user.emailAddress or "",
+      },
+      repository = repo,
+      sender = sender,
+    },
+    timestamp = head_commit and head_commit.timestamp
+      or (payload.repository or {}).lastChange
+      or "",
+  })
+end)
+
+local function normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_gitblit_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type or normalized_webhook_event_type(internal_event.event, ""),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs({ "push", "create", "delete" }) do
+  b:webhook_translator(event, translate_gitblit_normalized_webhook)
+end
 
 b:build()

--- a/docs/real-world-testing.md
+++ b/docs/real-world-testing.md
@@ -63,7 +63,7 @@ value is `y` or starts with `~`.  Concretely:
 | pagure | 24 | 73 |
 | sourcehut | 19 | 68 |
 | harness | 17 | 72 |
-| gitblit | 13 | 73 |
+| gitblit | 16 | 74 |
 | radicle | 11 | 73 |
 | gerrit | 10 | 73 |
 | phabricator | 9 | 72 |
@@ -927,6 +927,12 @@ events for `repo:refs_changed`, `pr:*`, `pr:reviewer:*`, `build:status_*`, and r
 lifecycle where the installed version exposes them.  If the evaluation license is missing or
 expired, the run should be recorded as a license/setup skip; the mock-backed unit coverage
 remains authoritative until a licensed container is reachable.
+
+Gitblit real-world webhook coverage should run against the `gitblit/gitblit` container,
+configure the post-receive hook with `X-Gitblit-Token`, and drive one branch update, one
+branch creation, and one branch deletion against the fixture repository.  Those three
+post-receive commands are the supported Gitblit webhook surface and should assert both
+GitHub-shaped delivery headers and confusio-shaped normalized event bodies.
 
 **Exit criteria**: all Docker backends produce a result (pass or classified failure) for two
 consecutive weekly runs without the bootstrap script hanging or erroring.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2298,13 +2298,13 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2379,7 +2379,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -465,12 +465,15 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     -- Determine canonical event name.
     -- For header-based backends: read the event-type header.
     -- For body-based backends:   the event type is embedded in the payload.
-    --   Azure DevOps uses payload.eventType (e.g. "workitem.created", "git.repo.created").
+    --   Azure DevOps and Harness use payload.eventType.
+    --   Gitblit uses payload.event (e.g. "post-receive").
     --   Gerrit uses payload.type (e.g. "comment-added").
     local ev = event_header(backend)
     if ev == nil and type(payload) == "table" then
       if payload.eventType then
         ev = payload.eventType
+      elseif backend == "gitblit" and payload.event then
+        ev = payload.event
       elseif backend == "gerrit" and payload.type then
         ev = payload.type
       end

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,6 +1,6 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
 POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
-POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~no CI events,~no CI events,y,y,y,y,~no CI events,~no CI events,y,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
+POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~no CI events,~no CI events,y,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n
@@ -463,13 +463,13 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n
@@ -544,7 +544,7 @@ webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,
 webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/gitblit/create.json
+++ b/test/fixtures/webhooks/gitblit/create.json
@@ -1,0 +1,27 @@
+{
+  "event": "post-receive",
+  "repository": {
+    "name": "octocat/hello-world.git",
+    "description": "My first repository",
+    "HEAD": "refs/heads/main",
+    "defaultBranch": "main",
+    "lastChange": "2024-01-15T12:00:00Z",
+    "hasCommits": true
+  },
+  "user": {
+    "name": "bob",
+    "displayName": "Bob Jones",
+    "emailAddress": "bob@example.com",
+    "disabled": false
+  },
+  "url": "http://localhost",
+  "commands": [
+    {
+      "refName": "refs/heads/feature-branch",
+      "oldId": "0000000000000000000000000000000000000000",
+      "newId": "da1560886d4f094c3e6c9ef40349f7d38b5d27d0",
+      "type": "CREATE",
+      "result": "OK"
+    }
+  ]
+}

--- a/test/fixtures/webhooks/gitblit/delete.json
+++ b/test/fixtures/webhooks/gitblit/delete.json
@@ -1,0 +1,27 @@
+{
+  "event": "post-receive",
+  "repository": {
+    "name": "octocat/hello-world.git",
+    "description": "My first repository",
+    "HEAD": "refs/heads/main",
+    "defaultBranch": "main",
+    "lastChange": "2024-01-15T12:00:00Z",
+    "hasCommits": true
+  },
+  "user": {
+    "name": "bob",
+    "displayName": "Bob Jones",
+    "emailAddress": "bob@example.com",
+    "disabled": false
+  },
+  "url": "http://localhost",
+  "commands": [
+    {
+      "refName": "refs/heads/stale-branch",
+      "oldId": "95790bf891e76fee5db5ef17d2523a6f6e048239",
+      "newId": "0000000000000000000000000000000000000000",
+      "type": "DELETE",
+      "result": "OK"
+    }
+  ]
+}

--- a/test/fixtures/webhooks/gitblit/push.json
+++ b/test/fixtures/webhooks/gitblit/push.json
@@ -1,0 +1,38 @@
+{
+  "event": "post-receive",
+  "repository": {
+    "name": "octocat/hello-world.git",
+    "description": "My first repository",
+    "HEAD": "refs/heads/main",
+    "defaultBranch": "main",
+    "lastChange": "2024-01-15T10:00:00Z",
+    "hasCommits": true
+  },
+  "user": {
+    "name": "bob",
+    "displayName": "Bob Jones",
+    "emailAddress": "bob@example.com",
+    "disabled": false
+  },
+  "url": "http://localhost",
+  "commands": [
+    {
+      "refName": "refs/heads/main",
+      "oldId": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "newId": "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15",
+      "type": "UPDATE",
+      "result": "OK",
+      "commits": [
+        {
+          "id": "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15",
+          "message": "Update readme",
+          "author": {
+            "name": "Bob Jones",
+            "email": "bob@example.com"
+          },
+          "timestamp": "2024-01-15T10:00:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -241,13 +241,24 @@ run_delivery_phase test/webhook-delivery-gerrit-confusio-shape.hurl \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 19: GitBucket fixture-based delivery tests — every event × action triple.
+# Phase 19: Gitblit fixture-based delivery tests — post-receive ref commands.
+run_delivery_phase test/webhook-delivery-gitblit.hurl \
+  -- gitblit "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
+
+# Phase 20: Gitblit delivery with "confusio" shape — spot-checks normalized ref events.
+run_delivery_phase test/webhook-delivery-gitblit-confusio-shape.hurl \
+  -- gitblit "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
+  "webhook_target_shape=confusio"
+
+# Phase 21: GitBucket fixture-based delivery tests — every event × action triple.
 # GitBucket uses X-GitHub-Event header (GitHub-compatible format).
 run_delivery_phase test/webhook-delivery-gitbucket.hurl \
   -- gitbucket "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 20: GitBucket delivery with "confusio" shape — spot-checks X-Confusio-* headers.
+# Phase 22: GitBucket delivery with "confusio" shape — spot-checks X-Confusio-* headers.
 # Verifies X-Confusio-Source is "gitbucket" and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-gitbucket-confusio-shape.hurl \
   -- gitbucket "http://127.0.0.1:$MOCK_PORT" \

--- a/test/webhook-delivery-gitblit-confusio-shape.hurl
+++ b/test/webhook-delivery-gitblit-confusio-shape.hurl
@@ -1,0 +1,81 @@
+# Gitblit webhook delivery test - "confusio" shape variant.
+
+# -- UPDATE command -> push ---------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitblit
+Content-Type: application/json
+file,fixtures/webhooks/gitblit/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "push"
+jsonpath "$[0].confusio_source" == "gitblit"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.payload.before" == "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+jsonpath "$[0].body_json.payload.after" == "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"
+jsonpath "$[0].body_json.payload.head_commit.id" == "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"
+
+# -- CREATE command -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitblit
+Content-Type: application/json
+file,fixtures/webhooks/gitblit/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "gitblit"
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T12:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.ref" == "feature-branch"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# -- DELETE command -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitblit
+Content-Type: application/json
+file,fixtures/webhooks/gitblit/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "gitblit"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T12:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.ref" == "stale-branch"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"

--- a/test/webhook-delivery-gitblit.hurl
+++ b/test/webhook-delivery-gitblit.hurl
@@ -1,0 +1,69 @@
+# Gitblit webhook delivery tests.
+#
+# Gitblit embeds the event type in the JSON body as "event": "post-receive".
+# Ref commands are normalized to the matching GitHub event family.
+
+# -- UPDATE command -> push ---------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitblit
+Content-Type: application/json
+file,fixtures/webhooks/gitblit/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.event" == "post-receive"
+jsonpath "$[0].body_json.commands[0].type" == "UPDATE"
+
+# -- CREATE command -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitblit
+Content-Type: application/json
+file,fixtures/webhooks/gitblit/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.commands[0].refName" == "refs/heads/feature-branch"
+
+# -- DELETE command -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitblit
+Content-Type: application/json
+file,fixtures/webhooks/gitblit/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.commands[0].refName" == "refs/heads/stale-branch"


### PR DESCRIPTION
Fixes #258.

Adds Gitblit as a webhook source by translating post-receive ref payloads into push, create, and delete events. The remaining work updates the compatibility matrix and live-test notes to match the supported Gitblit webhook surface.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Finalize Gitblit webhook compat and live-test docs <!-- type:spec -->
- [x] Normalize Gitblit post-receive ref events <!-- type:spec -->
- [x] Add Gitblit push/create/delete webhook fixtures <!-- type:spec -->
- [x] Cover Gitblit webhook delivery shapes <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->