### PR TITLE
v3: Webhook — gitbucket source backend (closes #259)

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2351,7 +2351,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `opened` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `reopened` | ~ (reopen emits opened) | ✗ | ✗ | ✗ | ✗ | ~ (reopen emits opened) | ✗ | ✗ | ~ (reopen emits opened) | ~ (reopen emits opened) | ✗ | ~ (reopen emits opened) | ✗ | ✗ | ✗ | ~ (reopen emits opened) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `reopened` | ~ (reopen emits opened) | ✗ | ✗ | ✗ | ✗ | ~ (reopen emits opened) | ✗ | ✗ | ✗ | ~ (reopen emits opened) | ✗ | ~ (reopen emits opened) | ✗ | ✗ | ✗ | ~ (reopen emits opened) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Organization | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `renamed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -516,7 +516,7 @@ webhook milestone/closed,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook milestone/opened,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook milestone/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook milestone/deleted,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook milestone/reopened,~reopen emits opened,n,n,n,n,~reopen emits opened,n,n,~reopen emits opened,~reopen emits opened,n,~reopen emits opened,n,n,n,~reopen emits opened,n,n,n,n,n,n,n,n
+webhook milestone/reopened,~reopen emits opened,n,n,n,n,~reopen emits opened,n,n,n,~reopen emits opened,n,~reopen emits opened,n,n,n,~reopen emits opened,n,n,n,n,n,n,n,n
 webhook organization/created,n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook organization/deleted,n,n,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook organization/renamed,n,n,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/test/webhook-delivery-gitbucket-confusio-shape.hurl
+++ b/test/webhook-delivery-gitbucket-confusio-shape.hurl
@@ -141,6 +141,110 @@ jsonpath "$[0].github_event" == ""
 jsonpath "$[0].body_json.type" == "milestone.created"
 jsonpath "$[0].body_json.payload.milestone.title" == "v1.0"
 
+# ── custom_property: created — confusio shape ─────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: custom_property
+file,fixtures/webhooks/gitbucket/custom_property-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "custom_property"
+jsonpath "$[0].confusio_source" == "gitbucket"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "custom_property.created"
+jsonpath "$[0].body_json.payload.definition.property_name" == "environment"
+
+# ── custom_property: deleted — confusio shape ─────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: custom_property
+file,fixtures/webhooks/gitbucket/custom_property-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "custom_property"
+jsonpath "$[0].confusio_source" == "gitbucket"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "custom_property.deleted"
+jsonpath "$[0].body_json.payload.definition.property_name" == "environment"
+
+# ── custom_property: updated — confusio shape ─────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: custom_property
+file,fixtures/webhooks/gitbucket/custom_property-updated.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "custom_property"
+jsonpath "$[0].confusio_source" == "gitbucket"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "custom_property.updated"
+jsonpath "$[0].body_json.payload.definition.default_value" == "staging"
+
+# ── custom_property_values: updated — confusio shape ──────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: custom_property_values
+file,fixtures/webhooks/gitbucket/custom_property_values-updated.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "custom_property_values"
+jsonpath "$[0].confusio_source" == "gitbucket"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "custom_property_values.updated"
+jsonpath "$[0].body_json.payload.new_property_values[0].property_name" == "environment"
+
 # ── push: push — confusio shape ──────────────────────────────────────────────
 
 POST http://{{target}}/reset

--- a/test/webhook-delivery-gitbucket.hurl
+++ b/test/webhook-delivery-gitbucket.hurl
@@ -2362,6 +2362,50 @@ jsonpath "$[0].github_event" == "custom_property"
 jsonpath "$[0].github_delivery" isString
 jsonpath "$[0].user_agent" contains "confusio"
 
+# ── custom_property: deleted ──────────────────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: custom_property
+file,fixtures/webhooks/gitbucket/custom_property-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "custom_property"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+
+# ── custom_property: updated ──────────────────────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/gitbucket
+Content-Type: application/json
+X-GitHub-Event: custom_property
+file,fixtures/webhooks/gitbucket/custom_property-updated.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "custom_property"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+
 # ── custom_property_values: updated ──────────────────────────────────────────
 
 POST http://{{target}}/reset


### PR DESCRIPTION
Completes the GitBucket webhook source backend by closing the remaining milestone reopen compatibility gap. The final pass verifies fixture coverage, delivery behavior, compatibility claims, and docs all agree with the provider's actual webhook support.

Fixes #259.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Resolve GitBucket milestone reopen compatibility <!-- type:spec -->
- [x] Verify GitBucket webhook parity and docs <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->