### PR TITLE
v3: Webhook — kallithea source backend (closes #263)

### DIFF
--- a/backends/kallithea.lua
+++ b/backends/kallithea.lua
@@ -9,4 +9,276 @@ end)
 -- All issues, labels, milestones, and assignees endpoints fall back to the
 -- default empty-list / 404 handlers defined in .init.lua.
 
+local ZERO_SHA = "0000000000000000000000000000000000000000"
+
+local function split_repo_name(name)
+  local owner, repo = (name or ""):match("^([^/]+)/(.+)$")
+  return owner or "", repo or (name or "")
+end
+
+local function ref_name(ref)
+  return (ref or ""):match("^refs/heads/(.+)$")
+    or (ref or ""):match("^refs/tags/(.+)$")
+    or (ref or "")
+end
+
+local function ref_type(ref)
+  if (ref or ""):match("^refs/tags/") then
+    return "tag"
+  end
+  return "branch"
+end
+
+local function full_ref(ref)
+  if ref.ref and ref.ref ~= "" then
+    return ref.ref
+  elseif ref.ref_name and ref.ref_name ~= "" then
+    return ref.ref_name
+  elseif ref.type == "tags" then
+    return "refs/tags/" .. (ref.name or "")
+  end
+  return "refs/heads/" .. (ref.name or "")
+end
+
+local function translate_kallithea_user(payload)
+  local login = payload.username or payload.user or ""
+  return {
+    login = login,
+    id = 0,
+    node_id = "",
+    avatar_url = "",
+    html_url = login ~= "" and (config.base_url .. "/_admin/users/edit/" .. login) or "",
+    type = "User",
+    site_admin = false,
+    name = login,
+    email = payload.email or "",
+    blog = "",
+  }
+end
+
+local function translate_kallithea_repo(payload)
+  local full_name = payload.repo_name or payload.repository or ""
+  local owner, repo_name = split_repo_name(full_name)
+  return {
+    id = payload.repo_id or 0,
+    node_id = "",
+    name = repo_name,
+    full_name = full_name,
+    private = payload.private or false,
+    owner = {
+      login = owner,
+      id = payload.owner_id or 0,
+      node_id = "",
+      avatar_url = "",
+      url = "",
+      html_url = owner ~= "" and (config.base_url .. "/_admin/users/edit/" .. owner) or "",
+      type = "User",
+    },
+    html_url = full_name ~= "" and (config.base_url .. "/" .. full_name) or "",
+    description = payload.description,
+    fork = payload.fork_id ~= nil,
+    url = "",
+    git_url = "",
+    ssh_url = "",
+    clone_url = payload.clone_uri
+      or (full_name ~= "" and (config.base_url .. "/" .. full_name) or ""),
+    homepage = "",
+    size = 0,
+    stargazers_count = 0,
+    watchers_count = 0,
+    language = nil,
+    has_issues = false,
+    has_wiki = payload.enable_downloads or false,
+    forks_count = 0,
+    archived = false,
+    disabled = false,
+    open_issues_count = 0,
+    default_branch = payload.default_branch or "main",
+    visibility = payload.private and "private" or "public",
+    forks = 0,
+    open_issues = 0,
+    watchers = 0,
+    created_at = payload.created_on,
+    updated_at = payload.updated_on,
+    pushed_at = payload.pushed_at,
+  }
+end
+
+local function translate_kallithea_push_commit(c)
+  if not c then
+    return {}
+  end
+  local author = c.author or {}
+  local committer = c.committer or author
+  return {
+    id = c.id or c.sha or "",
+    message = c.message or "",
+    timestamp = c.timestamp or c.date or "",
+    url = c.url or "",
+    author = {
+      name = author.name or "",
+      email = author.email or "",
+      username = author.username or "",
+    },
+    committer = {
+      name = committer.name or "",
+      email = committer.email or "",
+      username = committer.username or "",
+    },
+    added = c.added or {},
+    removed = c.removed or {},
+    modified = c.modified or {},
+  }
+end
+
+local function ref_from_pushed_rev(rev)
+  local action, name = tostring(rev or ""):match("^([^=]+)=>(.+)$")
+  if action == "delete_branch" then
+    return {
+      ref = "refs/heads/" .. name,
+      old_rev = "",
+      new_rev = ZERO_SHA,
+    }
+  elseif action == "delete_tag" then
+    return {
+      ref = "refs/tags/" .. name,
+      old_rev = "",
+      new_rev = ZERO_SHA,
+    }
+  elseif action == "tag" then
+    return {
+      ref = "refs/tags/" .. name,
+      old_rev = ZERO_SHA,
+      new_rev = "",
+    }
+  end
+  return nil
+end
+
+local function first_ref_update(payload)
+  for _, r in ipairs(payload.refs or {}) do
+    if type(r) == "table" then
+      return r
+    end
+  end
+  for _, rev in ipairs(payload.pushed_revs or {}) do
+    local r = ref_from_pushed_rev(rev)
+    if r then
+      return r
+    end
+  end
+  return nil
+end
+
+local function kallithea_ref_webhook(payload)
+  local ref = first_ref_update(payload)
+  if not ref then
+    return nil, "No Kallithea ref update"
+  end
+
+  local raw_ref = full_ref(ref)
+  local before = ref.old_rev or ref.old or ""
+  local after = ref.new_rev or ref.new or ""
+  local repository = translate_kallithea_repo(payload)
+  local sender = translate_kallithea_user(payload)
+
+  if before == ZERO_SHA then
+    return make_internal_event({
+      event = "create",
+      action = "create",
+      provider = "kallithea",
+      raw = payload,
+      data = {
+        ref = ref_name(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = "",
+    })
+  end
+
+  if after == ZERO_SHA then
+    return make_internal_event({
+      event = "delete",
+      action = "delete",
+      provider = "kallithea",
+      raw = payload,
+      data = {
+        ref = ref_name(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = "",
+    })
+  end
+
+  local commits = {}
+  for _, c in ipairs(payload.commits or {}) do
+    commits[#commits + 1] = translate_kallithea_push_commit(c)
+  end
+  local head_commit = #commits > 0 and commits[#commits] or nil
+  return make_internal_event({
+    event = "push",
+    action = "push",
+    provider = "kallithea",
+    raw = payload,
+    data = {
+      ref = raw_ref,
+      before = before,
+      after = after,
+      created = false,
+      deleted = false,
+      forced = payload.forced or false,
+      compare = "",
+      commits = commits,
+      head_commit = head_commit,
+      pusher = {
+        name = payload.username or "",
+        email = payload.email or "",
+      },
+      repository = repository,
+      sender = sender,
+    },
+    timestamp = head_commit and head_commit.timestamp or "",
+  })
+end
+
+b:webhook("push", kallithea_ref_webhook)
+b:webhook("PUSH_HOOK", kallithea_ref_webhook)
+
+local function kallithea_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_kallithea_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type or normalized_webhook_event_type(internal_event.event, ""),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or kallithea_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs({ "push", "create", "delete" }) do
+  b:webhook_translator(event, translate_kallithea_normalized_webhook)
+end
+
 b:build()

--- a/backends/kallithea.lua
+++ b/backends/kallithea.lua
@@ -56,6 +56,22 @@ local function translate_kallithea_user(payload)
   }
 end
 
+local function translate_kallithea_named_user(login, email)
+  login = login or ""
+  return {
+    login = login,
+    id = 0,
+    node_id = "",
+    avatar_url = "",
+    html_url = login ~= "" and (config.base_url .. "/_admin/users/edit/" .. login) or "",
+    type = "User",
+    site_admin = false,
+    name = login,
+    email = email or "",
+    blog = "",
+  }
+end
+
 local function translate_kallithea_repo(payload)
   local full_name = payload.repo_name or payload.repository or ""
   local owner, repo_name = split_repo_name(full_name)
@@ -102,6 +118,13 @@ local function translate_kallithea_repo(payload)
     updated_at = payload.updated_on,
     pushed_at = payload.pushed_at,
   }
+end
+
+local function timestamp_string(value)
+  if value == nil then
+    return ""
+  end
+  return tostring(value)
 end
 
 local function translate_kallithea_push_commit(c)
@@ -251,8 +274,124 @@ local function kallithea_ref_webhook(payload)
   })
 end
 
+local function kallithea_repo_lifecycle_handler(action)
+  return function(payload)
+    return make_internal_event({
+      event = "repository",
+      action = action,
+      provider = "kallithea",
+      raw = payload,
+      data = {
+        action = action,
+        repository = translate_kallithea_repo(payload),
+        sender = translate_kallithea_named_user(
+          payload.created_by or payload.deleted_by or payload.username
+        ),
+      },
+      timestamp = timestamp_string(payload.updated_on or payload.deleted_on or payload.created_on),
+    })
+  end
+end
+
+local function translate_kallithea_pr_branch(repo_name, ref)
+  return {
+    label = repo_name ~= "" and (repo_name .. ":" .. (ref or "")) or (ref or ""),
+    ref = ref or "",
+    sha = "",
+    repo = translate_kallithea_repo({ repo_name = repo_name }),
+  }
+end
+
+local function translate_kallithea_pull_request(payload)
+  local pr = payload.pull_request or {}
+  local status = pr.status or "new"
+  local state = (status == "closed" or status == "merged") and "closed" or "open"
+  local target_repo = pr.org_repo_name or payload.repository or ""
+  local source_repo = pr.other_repo_name or payload.source_repository or target_repo
+  local number = payload.pull_request_id or pr.id or 0
+  return {
+    id = pr.id or payload.pull_request_id or 0,
+    node_id = "",
+    number = number,
+    state = state,
+    locked = false,
+    title = pr.title or "",
+    body = pr.description or "",
+    user = translate_kallithea_named_user(pr.owner or payload.created_by),
+    head = translate_kallithea_pr_branch(source_repo, pr.other_ref or payload.source_ref),
+    base = translate_kallithea_pr_branch(target_repo, pr.org_ref or payload.target_ref),
+    draft = false,
+    created_at = pr.created_on or "",
+    updated_at = pr.updated_on or "",
+    closed_at = state == "closed" and (pr.updated_on or "") or nil,
+    merged_at = status == "merged" and (pr.updated_on or "") or nil,
+    merge_commit_sha = nil,
+    merged_by = nil,
+    diff_url = "",
+    patch_url = "",
+    html_url = target_repo ~= ""
+        and (config.base_url .. "/" .. target_repo .. "/pull-request/" .. number)
+      or "",
+    url = "",
+    mergeable = state == "open" or nil,
+    comments = 0,
+    review_comments = 0,
+    commits = 0,
+    additions = 0,
+    deletions = 0,
+    changed_files = 0,
+  }
+end
+
+local function kallithea_pull_request_event(payload, action)
+  local pr = payload.pull_request or {}
+  return make_internal_event({
+    event = "pull_request",
+    action = action,
+    provider = "kallithea",
+    raw = payload,
+    data = {
+      action = action,
+      number = payload.pull_request_id or pr.id,
+      pull_request = translate_kallithea_pull_request(payload),
+      repository = translate_kallithea_repo({ repo_name = payload.repository or pr.org_repo_name }),
+      sender = translate_kallithea_named_user(payload.created_by or pr.owner),
+    },
+    timestamp = pr.updated_on or pr.created_on or "",
+  })
+end
+
 b:webhook("push", kallithea_ref_webhook)
 b:webhook("PUSH_HOOK", kallithea_ref_webhook)
+b:webhook("repository", function(payload)
+  local action = payload.action or "unknown"
+  if action == "created" then
+    return kallithea_repo_lifecycle_handler("created")(payload)
+  elseif action == "deleted" then
+    return kallithea_repo_lifecycle_handler("deleted")(payload)
+  end
+  return make_internal_event({
+    event = "repository",
+    action = "unknown",
+    raw_action = action,
+    provider = "kallithea",
+    raw = payload,
+    data = {
+      action = "unknown",
+      repository = translate_kallithea_repo(payload),
+      sender = translate_kallithea_named_user(payload.created_by or payload.deleted_by),
+    },
+    timestamp = timestamp_string(payload.updated_on or payload.deleted_on or payload.created_on),
+  })
+end)
+b:webhook("CREATE_REPO_HOOK", kallithea_repo_lifecycle_handler("created"))
+b:webhook("DELETE_REPO_HOOK", kallithea_repo_lifecycle_handler("deleted"))
+b:webhook("pull_request", function(payload)
+  return kallithea_pull_request_event(payload, payload.action or "opened")
+end)
+b:webhook("CREATE_PULLREQUEST_HOOK", function(payload)
+  return kallithea_pull_request_event(payload, "opened")
+end)
 
 local function kallithea_normalized_payload_without_envelope_fields(data)
   local payload = {}
@@ -264,12 +403,23 @@ local function kallithea_normalized_payload_without_envelope_fields(data)
   return payload
 end
 
+local KALLITHEA_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
 local function translate_kallithea_normalized_webhook(internal_event, fields)
   local data = internal_event.data or {}
   fields = fields or {}
   return make_normalized_webhook_envelope(internal_event, {
     id = fields.id,
-    type = fields.type or normalized_webhook_event_type(internal_event.event, ""),
+    type = fields.type
+      or (
+        KALLITHEA_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
     occurred_at = fields.occurred_at,
     actor = fields.actor or data.sender,
     repository = fields.repository or data.repository,
@@ -277,7 +427,7 @@ local function translate_kallithea_normalized_webhook(internal_event, fields)
   })
 end
 
-for _, event in ipairs({ "push", "create", "delete" }) do
+for _, event in ipairs({ "push", "create", "delete", "repository", "pull_request" }) do
   b:webhook_translator(event, translate_kallithea_normalized_webhook)
 end
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -164,6 +164,7 @@ delivered.  Confusio maps these to its canonical internal event family names.
 | bitbucket_datacenter | `X-Event-Key` | `repo:refs_changed`, `pr:opened` |
 | azuredevops | _(body field)_ | `git.push`, `git.pullrequest.created`, `build.complete`, `ms.vss-alerts.alert-created-event` |
 | codecommit | _(SNS `Message.detail-type`)_ | `CodeCommit Repository State Change` |
+| kallithea | _(body fields)_ | `push`, `CREATE_REPO_HOOK`, `CREATE_PULLREQUEST_HOOK` |
 | pagure | `X-Pagure-Event` | `issue`, `pull-request`, `git` |
 | sourcehut | _(body field `event`)_ | `push`, `patchset:created` |
 | All others | _(backend-specific — see [Signature Verification](#signature-verification))_ | — |
@@ -2299,13 +2300,13 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2365,7 +2366,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `updated` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Page Build | `page_build` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Ping | `ping` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `reopened` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2382,15 +2383,15 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `prereleased` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Registry Package | `published` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Repository | `created` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `deleted` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Repository | `created` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `deleted` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `renamed` | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `transferred` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2663,8 +2664,10 @@ Triggered on repository lifecycle events (created, deleted, renamed, etc.).
 - `changes` for `renamed`: Gitea-family includes a `changes` object with the old name.
   GitLab sends separate `rename` events with before/after fields.  Azure DevOps sends
   rename notifications via the service hook but without a structured `changes` payload.
-- Backends not listed (sourcehut, pagure, kallithea, etc.) do not emit repository
-  lifecycle events.  Confusio cannot generate `repository` events from these backends.
+- Kallithea emits repository create/delete hooks only.  Rename, visibility, transfer,
+  and default-branch changes are not currently available from the Kallithea translator.
+- Backends not listed (sourcehut, pagure, etc.) do not emit repository lifecycle
+  events.  Confusio cannot generate `repository` events from these backends.
 
 ---
 

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -112,6 +112,49 @@ local function verify_authorization_variant(secret, auth)
   return false
 end
 
+local KALLITHEA_BODY_TOKEN_FIELDS = {
+  "secret",
+  "token",
+  "auth_token",
+  "webhook_secret",
+  "webhook_token",
+  "authentication_token",
+}
+
+local function first_string_field(tbl, fields)
+  if type(tbl) ~= "table" then
+    return nil
+  end
+  for _, field in ipairs(fields) do
+    local value = tbl[field]
+    if type(value) == "string" or type(value) == "number" then
+      return tostring(value)
+    end
+  end
+  return nil
+end
+
+local function kallithea_body_token(payload)
+  return first_string_field(payload, KALLITHEA_BODY_TOKEN_FIELDS)
+    or first_string_field(payload and payload.data, KALLITHEA_BODY_TOKEN_FIELDS)
+    or first_string_field(payload and payload.payload, KALLITHEA_BODY_TOKEN_FIELDS)
+end
+
+local KALLITHEA_BODY_EVENT_FIELDS = {
+  "event",
+  "event_type",
+  "eventType",
+  "hook",
+  "hook_type",
+  "hookType",
+}
+
+local function kallithea_body_event(payload)
+  return first_string_field(payload, KALLITHEA_BODY_EVENT_FIELDS)
+    or first_string_field(payload and payload.data, KALLITHEA_BODY_EVENT_FIELDS)
+    or first_string_field(payload and payload.payload, KALLITHEA_BODY_EVENT_FIELDS)
+end
+
 -- verify_signature(backend, secret, body[, now]) authenticates the inbound request
 -- using the backend-native scheme.  Returns true on success, false on failure.
 -- When secret is nil or "" (trust-the-network mode) all requests are accepted.
@@ -333,11 +376,11 @@ local function verify_signature(backend, secret, body, now)
     if not ok_parse or type(parsed) ~= "table" then
       return false
     end
-    local tok = parsed.secret or (parsed.data and parsed.data.secret)
+    local tok = kallithea_body_token(parsed)
     if not tok then
       return false
     end
-    return ct_equal(secret, tostring(tok))
+    return ct_equal(secret, tok)
 
   -- Confusio-normalized: X-Confusio-Signature-256, HMAC-SHA256 with timestamp.
   -- Header format: "sha256=<hex>, v=1, ts=<unix>"
@@ -471,6 +514,7 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     --   Azure DevOps and Harness use payload.eventType.
     --   Gitblit uses payload.event (e.g. "post-receive").
     --   Gerrit uses payload.type (e.g. "comment-added").
+    --   Kallithea hook plugins embed an event/hook name in the JSON body.
     local ev = event_header(backend)
     if ev == nil and type(payload) == "table" then
       if payload.eventType then
@@ -479,6 +523,8 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
         ev = payload.event
       elseif backend == "gerrit" and payload.type then
         ev = payload.type
+      elseif backend == "kallithea" then
+        ev = kallithea_body_event(payload)
       end
     end
 

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,6 +1,6 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
 POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
-POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~no CI events,~no CI events,y,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
+POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~no CI events,y,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n
@@ -463,13 +463,13 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n,n
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n,n
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,y,n,n,n,n,n,n,n,n
@@ -529,7 +529,7 @@ webhook package/published,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook package/updated,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook page_build/page_build,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook ping/ping,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n,n
 webhook pull_request/closed,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
 webhook pull_request/reopened,n,n,n,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request/edited,n,n,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -546,15 +546,15 @@ webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,
 webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n,n
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/prereleased,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook registry_package/published,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook registry_package/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook repository/created,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook repository/deleted,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook repository/created,y,y,y,y,n,y,y,n,y,y,y,y,n,y,n,y,n,n,n,n,n,n,n,n
+webhook repository/deleted,y,y,y,y,n,y,y,n,y,y,y,y,n,y,n,y,n,n,n,n,n,n,n,n
 webhook repository/edited,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook repository/renamed,y,n,y,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook repository/transferred,n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/kallithea/create.json
+++ b/test/fixtures/webhooks/kallithea/create.json
@@ -1,0 +1,36 @@
+{
+  "event": "push",
+  "hook": "PUSH_HOOK",
+  "config": "/srv/kallithea/kallithea.ini",
+  "scm": "git",
+  "username": "alice",
+  "ip": "192.0.2.10",
+  "action": "push",
+  "repository": "octocat/hello-world",
+  "repo_name": "octocat/hello-world",
+  "repo_type": "git",
+  "pushed_revs": [
+    "5a1e9f3d7c2b4a6e8f90123456789abcdef01234"
+  ],
+  "refs": [
+    {
+      "ref": "refs/heads/feature-branch",
+      "type": "heads",
+      "name": "feature-branch",
+      "old_rev": "0000000000000000000000000000000000000000",
+      "new_rev": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234"
+    }
+  ],
+  "commits": [
+    {
+      "id": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234",
+      "message": "Start feature branch",
+      "timestamp": "2024-01-15T10:00:00Z",
+      "author": {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "username": "alice"
+      }
+    }
+  ]
+}

--- a/test/fixtures/webhooks/kallithea/delete.json
+++ b/test/fixtures/webhooks/kallithea/delete.json
@@ -1,0 +1,25 @@
+{
+  "event": "push",
+  "hook": "PUSH_HOOK",
+  "config": "/srv/kallithea/kallithea.ini",
+  "scm": "git",
+  "username": "alice",
+  "ip": "192.0.2.10",
+  "action": "push",
+  "repository": "octocat/hello-world",
+  "repo_name": "octocat/hello-world",
+  "repo_type": "git",
+  "pushed_revs": [
+    "delete_branch=>stale-branch"
+  ],
+  "refs": [
+    {
+      "ref": "refs/heads/stale-branch",
+      "type": "heads",
+      "name": "stale-branch",
+      "old_rev": "95790bf891e76fee5db5ef17d2523a6f6e048239",
+      "new_rev": "0000000000000000000000000000000000000000"
+    }
+  ],
+  "commits": []
+}

--- a/test/fixtures/webhooks/kallithea/pull_request-opened.json
+++ b/test/fixtures/webhooks/kallithea/pull_request-opened.json
@@ -1,0 +1,24 @@
+{
+  "event": "pull_request",
+  "hook": "CREATE_PULLREQUEST_HOOK",
+  "action": "opened",
+  "pull_request_id": 7,
+  "pull_request": {
+    "id": 7,
+    "title": "Add webhook fixtures",
+    "description": "Teach confusio about Kallithea hooks.",
+    "status": "new",
+    "created_on": "2024-01-15T11:00:00Z",
+    "updated_on": "2024-01-15T11:00:00Z",
+    "org_repo_name": "octocat/hello-world",
+    "other_repo_name": "alice/hello-world",
+    "org_ref": "main",
+    "other_ref": "feature-branch",
+    "owner": "alice"
+  },
+  "repository": "octocat/hello-world",
+  "source_repository": "alice/hello-world",
+  "target_ref": "main",
+  "source_ref": "feature-branch",
+  "created_by": "alice"
+}

--- a/test/fixtures/webhooks/kallithea/push.json
+++ b/test/fixtures/webhooks/kallithea/push.json
@@ -1,0 +1,37 @@
+{
+  "event": "push",
+  "hook": "PUSH_HOOK",
+  "config": "/srv/kallithea/kallithea.ini",
+  "scm": "git",
+  "username": "alice",
+  "ip": "192.0.2.10",
+  "action": "push",
+  "repository": "octocat/hello-world",
+  "repo_name": "octocat/hello-world",
+  "repo_type": "git",
+  "pushed_revs": [
+    "95790bf891e76fee5db5ef17d2523a6f6e048239",
+    "5a1e9f3d7c2b4a6e8f90123456789abcdef01234"
+  ],
+  "refs": [
+    {
+      "ref": "refs/heads/main",
+      "type": "heads",
+      "name": "main",
+      "old_rev": "95790bf891e76fee5db5ef17d2523a6f6e048239",
+      "new_rev": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234"
+    }
+  ],
+  "commits": [
+    {
+      "id": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234",
+      "message": "Update README",
+      "timestamp": "2024-01-15T10:05:00Z",
+      "author": {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "username": "alice"
+      }
+    }
+  ]
+}

--- a/test/fixtures/webhooks/kallithea/repository-created.json
+++ b/test/fixtures/webhooks/kallithea/repository-created.json
@@ -1,0 +1,18 @@
+{
+  "event": "repository",
+  "hook": "CREATE_REPO_HOOK",
+  "action": "created",
+  "repo_id": 100,
+  "repo_name": "octocat/hello-world",
+  "repo_type": "git",
+  "description": "Example repository",
+  "private": false,
+  "created_on": "2024-01-15T09:00:00Z",
+  "enable_downloads": true,
+  "enable_statistics": true,
+  "clone_uri": null,
+  "fork_id": null,
+  "group_id": null,
+  "owner_id": 1,
+  "created_by": "alice"
+}

--- a/test/fixtures/webhooks/kallithea/repository-deleted.json
+++ b/test/fixtures/webhooks/kallithea/repository-deleted.json
@@ -1,0 +1,19 @@
+{
+  "event": "repository",
+  "hook": "DELETE_REPO_HOOK",
+  "action": "deleted",
+  "repo_id": 100,
+  "repo_name": "octocat/hello-world",
+  "repo_type": "git",
+  "description": "Example repository",
+  "private": false,
+  "created_on": "2024-01-15T09:00:00Z",
+  "enable_downloads": true,
+  "enable_statistics": true,
+  "clone_uri": null,
+  "fork_id": null,
+  "group_id": null,
+  "owner_id": 1,
+  "deleted_by": "alice",
+  "deleted_on": 1705312800
+}

--- a/test/stub-webhooks.hurl
+++ b/test/stub-webhooks.hurl
@@ -47,13 +47,12 @@ HTTP 400
 jsonpath "$.message" == "Invalid JSON body"
 
 # Dispatch: valid request with an event type that has no registered handler → 422
-# Using X-Gitea-Event: push which is not yet implemented by any backend.
-# This exercises the dispatch stage regardless of which backend is configured.
+# Use a deliberately bogus event so this remains true for every configured backend.
 POST http://{{host}}/webhooks/gitea
 Content-Type: application/json
-X-Gitea-Event: push
+X-Gitea-Event: confusio_unknown_event
 {}
 
 HTTP 422
 [Asserts]
-jsonpath "$.message" == "Unrecognised event type: push"
+jsonpath "$.message" == "Unrecognised event type: confusio_unknown_event"

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -123,13 +123,13 @@ CONFUSIO_TS=$(date +%s)
 CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
 # Write secrets to 0600-permission files — never pass raw secrets on the CLI.
 WH_SECRET_DIR=$(mktemp -d)
-for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket gerrit confusio; do
+for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket gerrit kallithea confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -304,33 +304,44 @@ run_delivery_phase test/webhook-delivery-pagure-confusio-shape.hurl \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 29: Forgejo fixture-based delivery tests — every event × action triple.
+# Phase 29: Kallithea fixture-based delivery tests — native body-typed hooks.
+run_delivery_phase test/webhook-delivery-kallithea.hurl \
+  -- kallithea "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
+
+# Phase 30: Kallithea delivery with "confusio" shape — normalized hook envelopes.
+run_delivery_phase test/webhook-delivery-kallithea-confusio-shape.hurl \
+  -- kallithea "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
+  "webhook_target_shape=confusio"
+
+# Phase 31: Forgejo fixture-based delivery tests — every event × action triple.
 # Forgejo uses X-Gitea-Event header (API-compatible with Gitea).
 run_delivery_phase test/webhook-delivery-forgejo.hurl \
   -- forgejo "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 30: Forgejo delivery with "confusio" shape — spot-checks X-Confusio-* headers.
+# Phase 32: Forgejo delivery with "confusio" shape — spot-checks X-Confusio-* headers.
 # Verifies X-Confusio-Source is "forgejo" and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-forgejo-confusio-shape.hurl \
   -- forgejo "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 31: Codeberg fixture-based delivery tests — every event × action triple.
+# Phase 33: Codeberg fixture-based delivery tests — every event × action triple.
 # Codeberg uses X-Gitea-Event header (API-compatible with Gitea/Forgejo).
 run_delivery_phase test/webhook-delivery-codeberg.hurl \
   -- codeberg "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 32: Codeberg delivery with "confusio" shape — spot-checks X-Confusio-* headers.
+# Phase 34: Codeberg delivery with "confusio" shape — spot-checks X-Confusio-* headers.
 # Verifies X-Confusio-Source is "codeberg" and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-codeberg-confusio-shape.hurl \
   -- codeberg "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 33: Startup event synthesis — github shape.
+# Phase 35: Startup event synthesis — github shape.
 # Verifies that confusio synthesizes installation.created and
 # installation_repositories.added before accepting connections, and delivers
 # both to the configured outbound target.  No /reset is called — the hurl file
@@ -339,8 +350,8 @@ run_delivery_phase test/webhook-delivery-startup.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 34: Startup event synthesis — confusio shape.
-# Same as Phase 33 but with webhook_target_shape=confusio; verifies
+# Phase 36: Startup event synthesis — confusio shape.
+# Same as Phase 35 but with webhook_target_shape=confusio; verifies
 # X-Confusio-* headers are used and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-startup-confusio-shape.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2361,6 +2361,38 @@ do
     "webhook_receiver: gogs ignores X-Gitea-Event → 422"
   )
 
+  -- Kallithea embeds its event name in the JSON body.
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/kallithea",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"event":"push"}',
+    }),
+    200,
+    "webhook_receiver: kallithea root event handler succeeds → 200"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/kallithea",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"data":{"event_type":"push"}}',
+    }),
+    200,
+    "webhook_receiver: kallithea nested data.event_type handler succeeds → 200"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/kallithea",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"payload":{"hook_type":"push"}}',
+    }),
+    200,
+    "webhook_receiver: kallithea nested payload.hook_type handler succeeds → 200"
+  )
+
   -- 422 when handler returns nil (normalisation failed)
   app.backend.webhooks = {
     push = function(_payload)
@@ -2793,10 +2825,23 @@ do
     with_secret("kallithea", {}, '{"data":{"secret":"' .. SECRET .. '"}}') ~= 401,
     "verify_signature kallithea: secret in data.secret JSON field → not 401"
   )
+  ok(
+    with_secret("kallithea", {}, '{"payload":{"webhook_token":"' .. SECRET .. '"}}') ~= 401,
+    "verify_signature kallithea: secret in payload.webhook_token JSON field → not 401"
+  )
+  ok(
+    with_secret("kallithea", {}, '{"auth_token":"' .. SECRET .. '"}') ~= 401,
+    "verify_signature kallithea: secret in root auth_token JSON field → not 401"
+  )
   eq(
     with_secret("kallithea", {}, '{"secret":"bad"}'),
     401,
     "verify_signature kallithea: bad body secret → 401"
+  )
+  eq(
+    with_secret("kallithea", {}, '{"secret":{"nested":"' .. SECRET .. '"}}'),
+    401,
+    "verify_signature kallithea: non-scalar body secret → 401"
   )
   eq(
     with_secret("kallithea", {}, '{"event":"push"}'),

--- a/test/webhook-delivery-kallithea-confusio-shape.hurl
+++ b/test/webhook-delivery-kallithea-confusio-shape.hurl
@@ -1,0 +1,158 @@
+# Kallithea webhook delivery test — "confusio" shape variant.
+#
+# When webhook_target_shape=confusio, Kallithea deliveries use X-Confusio-*
+# headers and normalized event envelopes instead of GitHub-compatible headers.
+
+# ── PUSH_HOOK update -> push -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "push"
+jsonpath "$[0].confusio_source" == "kallithea"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:05:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.payload.head_commit.id" == "5a1e9f3d7c2b4a6e8f90123456789abcdef01234"
+
+# ── PUSH_HOOK create -> create ----------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "kallithea"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.ref" == "feature-branch"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# ── PUSH_HOOK delete -> delete ----------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "kallithea"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.ref" == "stale-branch"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# ── CREATE_REPO_HOOK -> repository.created ----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/repository-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "repository"
+jsonpath "$[0].confusio_source" == "kallithea"
+jsonpath "$[0].body_json.type" == "repository.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T09:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.action" == "created"
+
+# ── DELETE_REPO_HOOK -> repository.deleted ----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/repository-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "repository"
+jsonpath "$[0].confusio_source" == "kallithea"
+jsonpath "$[0].body_json.type" == "repository.deleted"
+jsonpath "$[0].body_json.occurred_at" == "1705312800"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.action" == "deleted"
+
+# ── CREATE_PULLREQUEST_HOOK -> pull_request.opened --------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/pull_request-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request"
+jsonpath "$[0].confusio_source" == "kallithea"
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T11:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.pull_request.number" == 7

--- a/test/webhook-delivery-kallithea.hurl
+++ b/test/webhook-delivery-kallithea.hurl
@@ -1,0 +1,136 @@
+# Kallithea webhook delivery tests.
+#
+# Kallithea embeds the event type in the JSON body, so no event-type header is
+# required.  The receiver normalizes ref, repository, and pull request hooks to
+# GitHub event families before delivery.
+
+# ── PUSH_HOOK update -> push -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.hook" == "PUSH_HOOK"
+jsonpath "$[0].body_json.refs[0].ref" == "refs/heads/main"
+
+# ── PUSH_HOOK create -> create ----------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.refs[0].name" == "feature-branch"
+
+# ── PUSH_HOOK delete -> delete ----------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.pushed_revs[0]" == "delete_branch=>stale-branch"
+
+# ── CREATE_REPO_HOOK -> repository created ----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/repository-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "repository"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.hook" == "CREATE_REPO_HOOK"
+jsonpath "$[0].body_json.action" == "created"
+
+# ── DELETE_REPO_HOOK -> repository deleted ----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/repository-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "repository"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.hook" == "DELETE_REPO_HOOK"
+jsonpath "$[0].body_json.action" == "deleted"
+
+# ── CREATE_PULLREQUEST_HOOK -> pull_request opened --------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+file,fixtures/webhooks/kallithea/pull_request-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.hook" == "CREATE_PULLREQUEST_HOOK"
+jsonpath "$[0].body_json.pull_request.id" == 7

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -9,6 +9,7 @@
 #   azuredevops_basic — base64("fido:webhooksecret") for Authorization: Basic
 #   gerrit_tok  — the shared secret verbatim or as Bearer token (for Authorization)
 #   gerrit_basic — base64("webhooksecret") for Authorization: Basic
+#   kallithea — shared secret is embedded in the request body
 #   confusio_sig — "sha256=<hex>, v=1, ts=<ts>" (for X-Confusio-Signature-256)
 #
 # Convention: valid credential → 422 (verification passed; no handlers registered
@@ -257,6 +258,52 @@ jsonpath "$.message" == "Signature verification failed"
 
 # Missing Authorization header → 401
 POST http://{{host}}/webhooks/gerrit
+Content-Type: application/json
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── kallithea: body-embedded shared secret ───────────────────────────────────
+
+# Valid root secret → passes verification (422)
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+{
+  "secret": "webhooksecret"
+}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Valid nested webhook token → passes verification (422)
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+{
+  "payload": {
+    "webhook_token": "webhooksecret"
+  }
+}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad body secret → 401
+POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+{
+  "secret": "wrongtoken"
+}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing body secret → 401
+POST http://{{host}}/webhooks/kallithea
 Content-Type: application/json
 {}
 


### PR DESCRIPTION
Adds Kallithea as a webhook source backend, with inbound token/event handling, native fixtures, and ref, repository, and pull request hook translation already in place.

Fixes #263.

The remaining work verifies Kallithea delivery behavior and documents the supported webhook coverage.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Add Kallithea webhook delivery coverage <!-- type:spec -->
- [x] Update Kallithea webhook matrix and docs <!-- type:spec -->
- [x] Implement Kallithea repository and pull request webhooks <!-- type:spec -->
- [x] Implement Kallithea ref webhook translation <!-- type:spec -->
- [x] Add Kallithea webhook fixtures <!-- type:spec -->
- [x] Harden Kallithea webhook token and event extraction <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->