### PR TITLE
v3: Webhook — onedev source backend (closes #266)

### DIFF
--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -163,6 +163,113 @@ local function translate_onedev_issue_comment(c)
   }
 end
 
+local function translate_onedev_pr_branch(project, branch, sha)
+  return {
+    label = branch or "",
+    ref = branch or "",
+    sha = sha or "",
+    repo = project and translate_onedev_repo(project) or nil,
+  }
+end
+
+local function onedev_pr_url(project, number)
+  local path = (project or {}).path or ""
+  if path == "" or not number then
+    return ""
+  end
+  return config.base_url .. "/" .. path .. "/~pulls/" .. number
+end
+
+local function translate_onedev_pull_request(pr)
+  if not pr then
+    return {}
+  end
+  local target_project = pr.targetProject or pr.project or {}
+  local source_project = pr.sourceProject or target_project
+  local latest_update = pr.latestUpdate or {}
+  local status = pr.status or "OPEN"
+  return {
+    id = pr.id or 0,
+    node_id = "",
+    number = pr.number or pr.id or 0,
+    state = status == "OPEN" and "open" or "closed",
+    locked = false,
+    title = pr.title or "",
+    body = pr.description or "",
+    user = translate_onedev_user(pr.submitter or {}),
+    head = translate_onedev_pr_branch(
+      source_project,
+      pr.sourceBranch,
+      latest_update.headCommitHash or pr.buildCommitHash or ""
+    ),
+    base = translate_onedev_pr_branch(
+      target_project,
+      pr.targetBranch,
+      latest_update.targetHeadCommitHash or pr.baseCommitHash or ""
+    ),
+    draft = false,
+    created_at = pr.submitDate or "",
+    updated_at = (pr.lastActivity or {}).date or pr.closeDate or pr.submitDate or "",
+    closed_at = pr.closeDate,
+    merged_at = status == "MERGED" and pr.closeDate or nil,
+    merge_commit_sha = (pr.mergePreview or {}).mergeCommitHash or "",
+    merged_by = nil,
+    diff_url = "",
+    patch_url = "",
+    html_url = onedev_pr_url(target_project, pr.number or pr.id),
+    url = "",
+    mergeable = nil,
+    comments = pr.commentCount or 0,
+    review_comments = 0,
+    additions = 0,
+    deletions = 0,
+    changed_files = 0,
+    labels = {},
+    assignees = {},
+    requested_reviewers = {},
+  }
+end
+
+local function translate_onedev_pr_comment(c)
+  if not c then
+    return {}
+  end
+  return {
+    id = c.id or 0,
+    node_id = "",
+    url = "",
+    body = c.content or "",
+    user = translate_onedev_user(c.user or {}),
+    created_at = c.date or "",
+    updated_at = c.date or "",
+    html_url = "",
+  }
+end
+
+local function translate_onedev_pr_review_comment(c, reply)
+  c = c or {}
+  reply = reply or {}
+  local mark = c.mark or c.compareContext or {}
+  local body_source = next(reply) and reply or c
+  return {
+    id = body_source.id or c.id or 0,
+    node_id = "",
+    path = mark.path or mark.newPath or mark.oldPath or c.path or "",
+    position = mark.line or mark.newLine or c.line,
+    original_position = mark.oldLine,
+    commit_id = mark.commitHash or mark.newCommitHash or c.commitHash or "",
+    original_commit_id = mark.oldCommitHash or "",
+    diff_hunk = "",
+    body = body_source.content or "",
+    user = translate_onedev_user(body_source.user or c.user or {}),
+    created_at = body_source.date or c.createDate or "",
+    updated_at = body_source.date or c.createDate or "",
+    html_url = "",
+    pull_request_url = "",
+    url = "",
+  }
+end
+
 -- Translate a OneDev branch object to GitHub format.
 -- OneDev: { name, commitHash }
 local function translate_onedev_branch(b)
@@ -741,6 +848,8 @@ local function onedev_event_repo(payload)
     payload.project
       or (payload.issue or {}).project
       or ((payload.comment or {}).issue or {}).project
+      or (payload.request or {}).targetProject
+      or ((payload.comment or {}).request or {}).targetProject
       or (payload.build or {}).project
       or (payload.pack or {}).project
       or {}
@@ -753,6 +862,9 @@ local function onedev_event_sender(payload)
     payload.user
       or (payload.issue or {}).submitter
       or (payload.comment or {}).user
+      or payload.assignee
+      or payload.reviewer
+      or (payload.request or {}).submitter
       or (payload.build or {}).submitter
       or (payload.pack or {}).user
       or {}
@@ -765,6 +877,9 @@ local function onedev_event_timestamp(payload, fallback)
     or (payload.issue or {}).updateDate
     or (payload.issue or {}).submitDate
     or (payload.comment or {}).date
+    or (payload.request or {}).closeDate
+    or ((payload.request or {}).lastActivity or {}).date
+    or (payload.request or {}).submitDate
     or (payload.build or {}).statusDate
     or (payload.build or {}).finishDate
     or (payload.build or {}).submitDate
@@ -776,6 +891,41 @@ end
 local function onedev_event_issue(payload)
   payload = payload or {}
   return translate_onedev_issue(payload.issue or ((payload.comment or {}).issue or {}))
+end
+
+local function onedev_event_pull_request(payload)
+  payload = payload or {}
+  return translate_onedev_pull_request(payload.request or ((payload.comment or {}).request or {}))
+end
+
+local function onedev_pull_request_issue(pr)
+  pr = pr or {}
+  local target_project = pr.targetProject or pr.project or {}
+  local status = pr.status or "OPEN"
+  local url = onedev_pr_url(target_project, pr.number or pr.id)
+  return {
+    id = pr.id or 0,
+    node_id = "",
+    number = pr.number or pr.id or 0,
+    title = pr.title or "",
+    body = pr.description or "",
+    state = status == "OPEN" and "open" or "closed",
+    user = translate_onedev_user(pr.submitter or {}),
+    assignees = {},
+    labels = {},
+    milestone = nil,
+    created_at = pr.submitDate or "",
+    updated_at = (pr.lastActivity or {}).date or pr.closeDate or pr.submitDate or "",
+    closed_at = pr.closeDate,
+    html_url = url,
+    pull_request = {
+      url = "",
+      html_url = url,
+      diff_url = "",
+      patch_url = "",
+      merged_at = status == "MERGED" and pr.closeDate or nil,
+    },
+  }
 end
 
 local ONEDEV_ISSUE_ACTIONS = {
@@ -841,6 +991,116 @@ local function onedev_issue_comment_webhook(payload)
       action = action,
       issue = onedev_event_issue(payload),
       comment = translate_onedev_issue_comment(payload.comment or {}),
+      repository = onedev_event_repo(payload),
+      sender = onedev_event_sender(payload),
+    },
+    timestamp = onedev_event_timestamp(payload),
+  })
+end
+
+local ONEDEV_PULL_REQUEST_ACTIONS = {
+  PullRequestOpened = "opened",
+  PullRequestUpdated = "synchronize",
+  PullRequestBuildCommitUpdated = "synchronize",
+  PullRequestMergePreviewUpdated = "synchronize",
+  PullRequestAssigned = "assigned",
+  PullRequestUnassigned = "unassigned",
+  PullRequestReviewRequested = "review_requested",
+  PullRequestReviewerRemoved = "review_request_removed",
+  PullRequestDeleted = "unknown",
+  PullRequestsDeleted = "unknown",
+  PullRequestTouched = "edited",
+  PullRequestCheckFailed = "edited",
+  PullRequestBuildEvent = "edited",
+}
+
+local function onedev_pull_request_changed_action(payload)
+  local raw_activity = payload.activity or ""
+  if raw_activity == "merged" or raw_activity == "discarded" then
+    return "closed"
+  elseif raw_activity == "reopened" then
+    return "reopened"
+  elseif raw_activity == "added commits" then
+    return "synchronize"
+  elseif raw_activity:match("^changed ") then
+    return "edited"
+  end
+  return ONEDEV_PULL_REQUEST_ACTIONS[payload.type or ""] or "unknown"
+end
+
+local function onedev_pull_request_webhook(payload)
+  payload = payload or {}
+  local action = onedev_pull_request_changed_action(payload)
+  local data = {
+    action = action,
+    number = (payload.request or {}).number,
+    pull_request = onedev_event_pull_request(payload),
+    repository = onedev_event_repo(payload),
+    sender = onedev_event_sender(payload),
+  }
+  if action == "assigned" or action == "unassigned" then
+    data.assignee = translate_onedev_user(payload.assignee or {})
+  elseif action == "review_requested" or action == "review_request_removed" then
+    data.requested_reviewer = translate_onedev_user(payload.reviewer or {})
+  end
+  return make_internal_event({
+    event = "pull_request",
+    action = action,
+    raw_action = action == "unknown" and (payload.activity or payload.type or "") or nil,
+    provider = config.backend,
+    raw = payload,
+    data = data,
+    timestamp = onedev_event_timestamp(payload),
+  })
+end
+
+local ONEDEV_PR_COMMENT_ACTIONS = {
+  PullRequestCommentCreated = "created",
+  PullRequestCommentEdited = "edited",
+}
+
+local function onedev_pull_request_comment_webhook(payload)
+  payload = payload or {}
+  local raw_action = payload.activity or payload.type or ""
+  local action = ONEDEV_PR_COMMENT_ACTIONS[payload.type or ""] or "unknown"
+  local request = payload.request or (payload.comment or {}).request or {}
+  return make_internal_event({
+    event = "issue_comment",
+    action = action,
+    raw_action = action == "unknown" and raw_action or nil,
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = action,
+      issue = onedev_pull_request_issue(request),
+      comment = translate_onedev_pr_comment(payload.comment or {}),
+      repository = onedev_event_repo(payload),
+      sender = onedev_event_sender(payload),
+    },
+    timestamp = onedev_event_timestamp(payload),
+  })
+end
+
+local ONEDEV_PR_REVIEW_COMMENT_ACTIONS = {
+  PullRequestCodeCommentCreated = "created",
+  PullRequestCodeCommentReplyCreated = "created",
+  PullRequestCodeCommentStatusChanged = "edited",
+}
+
+local function onedev_pull_request_review_comment_webhook(payload)
+  payload = payload or {}
+  local raw_action = payload.activity or payload.type or ""
+  local action = ONEDEV_PR_REVIEW_COMMENT_ACTIONS[payload.type or ""] or "unknown"
+  return make_internal_event({
+    event = "pull_request_review_comment",
+    action = action,
+    raw_action = action == "unknown" and raw_action or nil,
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = action,
+      comment = translate_onedev_pr_review_comment(payload.comment or {}, payload.reply or {}),
+      pull_request = onedev_event_pull_request(payload),
       repository = onedev_event_repo(payload),
       sender = onedev_event_sender(payload),
     },
@@ -1054,6 +1314,31 @@ b:webhook("IssueCommentCreated", onedev_issue_comment_webhook)
 b:webhook("IssueCommentEdited", onedev_issue_comment_webhook)
 
 for _, event in ipairs({
+  "PullRequestOpened",
+  "PullRequestChanged",
+  "PullRequestUpdated",
+  "PullRequestBuildCommitUpdated",
+  "PullRequestMergePreviewUpdated",
+  "PullRequestAssigned",
+  "PullRequestUnassigned",
+  "PullRequestReviewRequested",
+  "PullRequestReviewerRemoved",
+  "PullRequestDeleted",
+  "PullRequestsDeleted",
+  "PullRequestTouched",
+  "PullRequestCheckFailed",
+  "PullRequestBuildEvent",
+}) do
+  b:webhook(event, onedev_pull_request_webhook)
+end
+
+b:webhook("PullRequestCommentCreated", onedev_pull_request_comment_webhook)
+b:webhook("PullRequestCommentEdited", onedev_pull_request_comment_webhook)
+b:webhook("PullRequestCodeCommentCreated", onedev_pull_request_review_comment_webhook)
+b:webhook("PullRequestCodeCommentReplyCreated", onedev_pull_request_review_comment_webhook)
+b:webhook("PullRequestCodeCommentStatusChanged", onedev_pull_request_review_comment_webhook)
+
+for _, event in ipairs({
   "BuildSubmitted",
   "BuildPending",
   "BuildRunning",
@@ -1078,6 +1363,8 @@ local ONEDEV_NORMALIZED_WEBHOOK_EVENTS = {
   "push",
   "issues",
   "issue_comment",
+  "pull_request",
+  "pull_request_review_comment",
   "workflow_run",
   "package",
 }

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -738,26 +738,114 @@ end
 local function onedev_event_repo(payload)
   payload = payload or {}
   return translate_onedev_repo(
-    payload.project or (payload.build or {}).project or (payload.pack or {}).project or {}
+    payload.project
+      or (payload.issue or {}).project
+      or ((payload.comment or {}).issue or {}).project
+      or (payload.build or {}).project
+      or (payload.pack or {}).project
+      or {}
   )
 end
 
 local function onedev_event_sender(payload)
   payload = payload or {}
   return translate_onedev_user(
-    payload.user or (payload.build or {}).submitter or (payload.pack or {}).user or {}
+    payload.user
+      or (payload.issue or {}).submitter
+      or (payload.comment or {}).user
+      or (payload.build or {}).submitter
+      or (payload.pack or {}).user
+      or {}
   )
 end
 
 local function onedev_event_timestamp(payload, fallback)
   payload = payload or {}
   return payload.date
+    or (payload.issue or {}).updateDate
+    or (payload.issue or {}).submitDate
+    or (payload.comment or {}).date
     or (payload.build or {}).statusDate
     or (payload.build or {}).finishDate
     or (payload.build or {}).submitDate
     or (payload.pack or {}).publishDate
     or fallback
     or ""
+end
+
+local function onedev_event_issue(payload)
+  payload = payload or {}
+  return translate_onedev_issue(payload.issue or ((payload.comment or {}).issue or {}))
+end
+
+local ONEDEV_ISSUE_ACTIONS = {
+  IssueOpened = "opened",
+  IssueChanged = "edited",
+}
+
+local function onedev_issue_changed_action(payload)
+  local raw_activity = payload.activity or ""
+  local change_data = ((payload.change or {}).data or {})
+  local old_state = change_data.oldState or ""
+  local new_state = change_data.newState or raw_activity:match("^changed state to '(.+)'$") or ""
+  if raw_activity == "opened" then
+    return "opened"
+  elseif raw_activity == "closed" or (new_state ~= "" and new_state ~= "Open") then
+    return "closed"
+  elseif
+    raw_activity == "reopened"
+    or (old_state ~= "" and old_state ~= "Open" and new_state == "Open")
+    or (old_state == "" and new_state == "Open")
+  then
+    return "reopened"
+  else
+    return ONEDEV_ISSUE_ACTIONS[payload.type or ""] or "unknown"
+  end
+end
+
+local function onedev_issue_webhook(payload)
+  payload = payload or {}
+  local action = onedev_issue_changed_action(payload)
+  return make_internal_event({
+    event = "issues",
+    action = action,
+    raw_action = action == "unknown" and (payload.activity or payload.type or "") or nil,
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = action,
+      issue = onedev_event_issue(payload),
+      repository = onedev_event_repo(payload),
+      sender = onedev_event_sender(payload),
+    },
+    timestamp = onedev_event_timestamp(payload),
+  })
+end
+
+local ONEDEV_ISSUE_COMMENT_ACTIONS = {
+  IssueCommentCreated = "created",
+  IssueCommentEdited = "edited",
+}
+
+local function onedev_issue_comment_webhook(payload)
+  payload = payload or {}
+  local raw_action = payload.activity or payload.type or ""
+  local action = ONEDEV_ISSUE_COMMENT_ACTIONS[payload.type or ""] or "unknown"
+  return make_internal_event({
+    event = "issue_comment",
+    action = action,
+    raw_action = action == "unknown" and raw_action or nil,
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = action,
+      issue = onedev_event_issue(payload),
+      comment = translate_onedev_issue_comment(payload.comment or {}),
+      repository = onedev_event_repo(payload),
+      sender = onedev_event_sender(payload),
+    },
+    timestamp = onedev_event_timestamp(payload),
+  })
 end
 
 local function onedev_ref_updated_webhook(payload)
@@ -960,6 +1048,10 @@ local function onedev_package_webhook(payload)
 end
 
 b:webhook("RefUpdated", onedev_ref_updated_webhook)
+b:webhook("IssueOpened", onedev_issue_webhook)
+b:webhook("IssueChanged", onedev_issue_webhook)
+b:webhook("IssueCommentCreated", onedev_issue_comment_webhook)
+b:webhook("IssueCommentEdited", onedev_issue_comment_webhook)
 
 for _, event in ipairs({
   "BuildSubmitted",
@@ -984,6 +1076,8 @@ local ONEDEV_NORMALIZED_WEBHOOK_EVENTS = {
   "create",
   "delete",
   "push",
+  "issues",
+  "issue_comment",
   "workflow_run",
   "package",
 }

--- a/backends/onedev.lua
+++ b/backends/onedev.lua
@@ -707,4 +707,317 @@ b:rest("get_commit_check_runs", function(owner, repo_name, ref)
   respond_json(200, { total_count = #runs, check_runs = runs })
 end)
 
+-- Webhooks ------------------------------------------------------------------
+
+local ONEDEV_ZERO_SHA = string.rep("0", 40)
+
+local function onedev_object_id(value)
+  if type(value) == "string" then
+    return value
+  end
+  if type(value) == "table" then
+    return value.name or value.id or value.hash or value.value or value.string or ""
+  end
+  return ""
+end
+
+local function onedev_ref_kind(ref)
+  if ref:match("^refs/heads/") then
+    return "branch"
+  end
+  if ref:match("^refs/tags/") then
+    return "tag"
+  end
+  return "ref"
+end
+
+local function onedev_short_ref(ref)
+  return (ref:gsub("^refs/heads/", ""):gsub("^refs/tags/", ""))
+end
+
+local function onedev_event_repo(payload)
+  payload = payload or {}
+  return translate_onedev_repo(
+    payload.project or (payload.build or {}).project or (payload.pack or {}).project or {}
+  )
+end
+
+local function onedev_event_sender(payload)
+  payload = payload or {}
+  return translate_onedev_user(
+    payload.user or (payload.build or {}).submitter or (payload.pack or {}).user or {}
+  )
+end
+
+local function onedev_event_timestamp(payload, fallback)
+  payload = payload or {}
+  return payload.date
+    or (payload.build or {}).statusDate
+    or (payload.build or {}).finishDate
+    or (payload.build or {}).submitDate
+    or (payload.pack or {}).publishDate
+    or fallback
+    or ""
+end
+
+local function onedev_ref_updated_webhook(payload)
+  payload = payload or {}
+  local ref = payload.refName or payload.ref or ""
+  local before = onedev_object_id(payload.oldCommitId or payload.oldRev or payload.before)
+  local after = onedev_object_id(payload.newCommitId or payload.newRev or payload.after)
+  local repo = onedev_event_repo(payload)
+  local sender = onedev_event_sender(payload)
+  local ref_kind = onedev_ref_kind(ref)
+  local action
+  local event
+  local data
+
+  if before == ONEDEV_ZERO_SHA then
+    action = "create"
+    event = "create"
+    data = {
+      ref = onedev_short_ref(ref),
+      ref_type = ref_kind,
+      master_branch = repo.default_branch or "",
+      description = repo.description,
+      pusher_type = "user",
+      repository = repo,
+      sender = sender,
+    }
+  elseif after == ONEDEV_ZERO_SHA then
+    action = "delete"
+    event = "delete"
+    data = {
+      ref = onedev_short_ref(ref),
+      ref_type = ref_kind,
+      pusher_type = "user",
+      repository = repo,
+      sender = sender,
+    }
+  else
+    action = "push"
+    event = "push"
+    data = {
+      ref = ref,
+      before = before,
+      after = after,
+      created = false,
+      deleted = false,
+      forced = false,
+      compare = "",
+      commits = {},
+      head_commit = nil,
+      pusher = {
+        name = sender.name or sender.login or "",
+        email = sender.email or "",
+      },
+      repository = repo,
+      sender = sender,
+    }
+  end
+
+  return make_internal_event({
+    event = event,
+    action = action,
+    provider = config.backend,
+    raw = payload,
+    data = data,
+    timestamp = onedev_event_timestamp(payload),
+  })
+end
+
+local ONEDEV_BUILD_STATUS = {
+  WAITING = { action = "requested", status = "queued" },
+  PENDING = { action = "requested", status = "queued" },
+  RUNNING = { action = "in_progress", status = "in_progress" },
+  SUCCESSFUL = { action = "completed", status = "completed", conclusion = "success" },
+  FAILED = { action = "completed", status = "completed", conclusion = "failure" },
+  CANCELLED = { action = "completed", status = "completed", conclusion = "cancelled" },
+  CANCELED = { action = "completed", status = "completed", conclusion = "cancelled" },
+  TIMED_OUT = { action = "completed", status = "completed", conclusion = "timed_out" },
+}
+
+local ONEDEV_BUILD_EVENT_DEFAULTS = {
+  BuildSubmitted = { action = "requested", status = "queued" },
+  BuildPending = { action = "requested", status = "queued" },
+  BuildRunning = { action = "in_progress", status = "in_progress" },
+  BuildResumed = { action = "in_progress", status = "in_progress" },
+  BuildFinished = { action = "completed", status = "completed", conclusion = "failure" },
+}
+
+local function onedev_build_state(payload, build)
+  local raw_status = build.status or payload.activity or ""
+  local mapped = ONEDEV_BUILD_STATUS[raw_status] or ONEDEV_BUILD_EVENT_DEFAULTS[payload.type or ""]
+  return mapped or { action = "unknown", status = "queued" }, raw_status
+end
+
+local function onedev_build_webhook(payload)
+  payload = payload or {}
+  local build = payload.build or {}
+  local repo = onedev_event_repo(payload)
+  local sender = onedev_event_sender(payload)
+  local state, raw_status = onedev_build_state(payload, build)
+  local action = state.action
+  local build_url = payload.url or ""
+  if build_url == "" and repo.full_name and repo.full_name ~= "" and build.number then
+    build_url = config.base_url .. "/" .. repo.full_name .. "/~builds/" .. build.number
+  end
+  local run_name = build.jobName or build.name or tostring(build.number or build.id or 0)
+  local workflow_run = {
+    id = build.id or 0,
+    name = run_name,
+    head_branch = build.refName or "",
+    head_sha = build.commitHash or "",
+    run_number = build.number or build.id or 0,
+    event = "push",
+    display_title = run_name,
+    status = state.status,
+    conclusion = state.conclusion,
+    workflow_id = 0,
+    url = build_url,
+    html_url = build_url,
+    pull_requests = {},
+    created_at = build.submitDate or "",
+    updated_at = build.finishDate or build.statusDate or build.submitDate or "",
+    run_attempt = 1,
+    referenced_workflows = {},
+    actor = sender,
+    triggering_actor = sender,
+  }
+  local workflow = {
+    id = 0,
+    name = run_name,
+    path = "",
+    state = "active",
+    url = "",
+    html_url = "",
+    badge_url = "",
+    created_at = "",
+    updated_at = "",
+  }
+
+  return make_internal_event({
+    event = "workflow_run",
+    action = action,
+    raw_action = action == "unknown" and raw_status or nil,
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = action,
+      workflow_run = workflow_run,
+      workflow = workflow,
+      repository = repo,
+      sender = sender,
+    },
+    timestamp = onedev_event_timestamp(payload, workflow_run.updated_at),
+  })
+end
+
+local function onedev_package_webhook(payload)
+  payload = payload or {}
+  local pack = payload.pack or {}
+  local repo = onedev_event_repo(payload)
+  local sender = onedev_event_sender(payload)
+  local package_type = pack.type or pack.typeName or pack.packageType or ""
+  local published_at = pack.publishDate or payload.date or ""
+  local package_version = {
+    id = pack.id or 0,
+    name = pack.version or pack.name or "",
+    version = pack.version or "",
+    html_url = payload.url or "",
+    created_at = published_at,
+    updated_at = published_at,
+    metadata = {},
+  }
+  local package = {
+    id = pack.id or 0,
+    name = pack.name or pack.reference or pack.version or "",
+    package_type = package_type,
+    html_url = payload.url or "",
+    created_at = published_at,
+    updated_at = published_at,
+    owner = sender,
+    package_version = package_version,
+    registry = {
+      name = "OneDev",
+      type = package_type,
+      url = "",
+    },
+  }
+  return make_internal_event({
+    event = "package",
+    action = "published",
+    provider = config.backend,
+    raw = payload,
+    data = {
+      action = "published",
+      package = package,
+      repository = repo,
+      sender = sender,
+    },
+    timestamp = onedev_event_timestamp(payload, published_at),
+  })
+end
+
+b:webhook("RefUpdated", onedev_ref_updated_webhook)
+
+for _, event in ipairs({
+  "BuildSubmitted",
+  "BuildPending",
+  "BuildRunning",
+  "BuildFinished",
+  "BuildUpdated",
+  "BuildResumed",
+}) do
+  b:webhook(event, onedev_build_webhook)
+end
+
+b:webhook("PackPublished", onedev_package_webhook)
+
+local ONEDEV_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
+local ONEDEV_NORMALIZED_WEBHOOK_EVENTS = {
+  "create",
+  "delete",
+  "push",
+  "workflow_run",
+  "package",
+}
+
+local function onedev_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_onedev_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        ONEDEV_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or onedev_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+for _, event in ipairs(ONEDEV_NORMALIZED_WEBHOOK_EVENTS) do
+  b:webhook_translator(event, translate_onedev_normalized_webhook)
+end
+
 b:build()

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -140,7 +140,7 @@ receiver implementation, and a brief note on the signature scheme used.  The
 | `kallithea` | `POST /webhooks/kallithea` | _(self-hosted)_ | kallithea | Shared secret in request body |
 | `launchpad` | `POST /webhooks/launchpad` | `https://launchpad.net` | launchpad | `X-Hub-Signature` HMAC-SHA1 |
 | `notabug` | `POST /webhooks/notabug` | `https://notabug.org` | gitea | `X-Gogs-Signature` HMAC-SHA256 |
-| `onedev` | `POST /webhooks/onedev` | _(self-hosted)_ | onedev | Shared secret in `Authorization: Bearer` header |
+| `onedev` | `POST /webhooks/onedev` | _(self-hosted)_ | onedev | Shared secret in `X-OneDev-Signature` header |
 | `pagure` | `POST /webhooks/pagure` | `https://pagure.io` | pagure | `X-Pagure-Signature` HMAC-SHA512 + `X-Pagure-Signature-256` HMAC-SHA256 |
 | `phabricator` | `POST /webhooks/phabricator` | _(self-hosted)_ | phabricator | `X-Phabricator-Webhook-Signature` HMAC-SHA256 (Conduit key) |
 | `radicle` | `POST /webhooks/radicle` | `https://radicle.xyz` | radicle | Shared secret in `Authorization` header |
@@ -234,7 +234,7 @@ Four distinct schemes appear across the 24 backends:
 | **HMAC-SHA512** | Signature = `HMAC-SHA512(secret, body)`, hex-encoded | pagure (SHA-512 header, older instances) |
 | **HMAC-SHA1** | Signature = `HMAC-SHA1(secret, body)`, hex-encoded | gitbucket (GitHub legacy compat), launchpad |
 | **Shared token** | Secret echoed verbatim in a header; constant-time string compare | gitlab, gitblit, harness, onedev, rhodecode, sourceforge, tuleap, kallithea |
-| **Bearer / Basic** | Secret in Authorization header (Bearer or Basic form) | onedev (Bearer), azuredevops (Basic), gerrit (Basic or Bearer), radicle (raw) |
+| **Bearer / Basic** | Secret in Authorization header (Bearer or Basic form) | azuredevops (Basic), gerrit (Basic or Bearer), radicle (raw) |
 | **Asymmetric / platform** | ed25519 or platform-managed certificate signing | sourcehut, codecommit |
 
 ### Quick reference
@@ -257,7 +257,7 @@ Four distinct schemes appear across the 24 backends:
 | `kallithea` | _(body field)_ | Body-embedded token | see notes |
 | `launchpad` | `X-Hub-Signature` | HMAC-SHA1 | `sha1=<hex>` |
 | `notabug` | `X-Gogs-Signature` | HMAC-SHA256 | `<hex>` |
-| `onedev` | `Authorization` | Bearer token | `Bearer <secret>` |
+| `onedev` | `X-OneDev-Signature` | Shared token | verbatim |
 | `pagure` | `X-Pagure-Signature-256` / `X-Pagure-Signature` | HMAC-SHA256 / HMAC-SHA512 | `<hex>` |
 | `phabricator` | `X-Phabricator-Webhook-Signature` | HMAC-SHA256 | `<hex>` |
 | `radicle` | `Authorization` | Shared token | verbatim |
@@ -553,16 +553,16 @@ accept if constant_time_equal(secret, received_token)
 
 ### OneDev (onedev)
 
-OneDev sends the shared secret in a Bearer authorization header.
+OneDev sends the shared secret verbatim in the `X-OneDev-Signature` header.
 
 ```
-Header:    Authorization
-Format:    Bearer <secret>
+Header:    X-OneDev-Signature
+Format:    <secret>
 ```
 
 ```
-secret   = configured shared secret
-received = value of Authorization header, with "Bearer " prefix stripped
+secret   = configured webhook secret
+received = value of X-OneDev-Signature header
 
 accept if constant_time_equal(secret, received)
 ```

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2298,13 +2298,13 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2326,16 +2326,16 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | Fork | `fork` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Gollum | `created` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Issues | `opened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `closed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `reopened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Issues | `opened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `closed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `edited` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `reopened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `labeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `unlabeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `assigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `unassigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Issue Comments | `created` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Issue Comments | `created` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Labels | `created` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2360,28 +2360,28 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `member_added` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `member_invited` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `member_removed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Package | `published` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Package | `published` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Page Build | `page_build` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Ping | `ping` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `closed` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `reopened` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `synchronize` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `closed` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `reopened` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `edited` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `synchronize` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `labeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `unlabeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `assigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `unassigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `review_requested` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `review_request_removed` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `assigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `unassigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `review_requested` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `review_request_removed` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | PR Reviews | `submitted` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `dismissed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2404,9 +2404,9 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `added_to_repository` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `removed_from_repository` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Team Add | `team_add` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Workflow Run | `requested` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `in_progress` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `completed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Workflow Run | `requested` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `in_progress` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `completed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Workflow Job | `queued` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `in_progress` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `completed` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -3827,7 +3827,7 @@ events use a normalized envelope with the original payload preserved under `raw`
 |---|---|---|
 | `check_run` | ✓ pass-through | ✗ |
 | `check_suite` | ✓ pass-through | ✗ |
-| `workflow_run` | ✓ pass-through | Azure DevOps `build.complete`; GitLab/Gitea-family workflow events; Bitbucket Cloud `pipeline:span_created` pipeline-run spans |
+| `workflow_run` | ✓ pass-through | Azure DevOps `build.complete`; GitLab/Gitea-family workflow events; Bitbucket Cloud `pipeline:span_created` pipeline-run spans; OneDev build events |
 | `workflow_job` | ✓ pass-through | Bitbucket Cloud `pipeline:span_created` step/command/container/log spans |
 | `deployment_review` | ✓ pass-through | Azure DevOps release approval events |
 | `deployment_protection_rule` | ✓ pass-through | ✗ |
@@ -4211,6 +4211,8 @@ Action support for this event is generated in the [action support matrix](#gener
   removals from Gitea-family backends.
 - Forgejo and Codeberg inherit Gitea's `package` webhook handler.  Gogs and NotABug strip
   all package-related handlers; no `package` events will be delivered from those backends.
+- OneDev `PackPublished` events map to `package/published`; OneDev does not emit a
+  matching GitHub-style `package/updated` event.
 - Backends not listed (GitLab, Bitbucket, Azure DevOps, etc.) do not emit package
   registry lifecycle webhook events.
 

--- a/internal/signing.lua
+++ b/internal/signing.lua
@@ -66,7 +66,7 @@ function sign_for_backend(backend, secret, body) -- luacheck: globals sign_for_b
   elseif backend == "harness" then
     return { ["X-Harness-Token"] = secret }
   elseif backend == "onedev" then
-    return { ["Authorization"] = "Bearer " .. secret }
+    return { ["X-OneDev-Signature"] = secret }
   elseif backend == "gerrit" or backend == "radicle" then
     return { ["Authorization"] = secret }
   elseif backend == "gitblit" then

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -515,6 +515,7 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     --   Azure DevOps and Harness use payload.eventType.
     --   Gitblit uses payload.event (e.g. "post-receive").
     --   Gerrit uses payload.type (e.g. "comment-added").
+    --   OneDev uses payload.type (e.g. "RefUpdated").
     --   Kallithea hook plugins embed an event/hook name in the JSON body.
     local ev = event_header(backend)
     if ev == nil and type(payload) == "table" then
@@ -522,7 +523,7 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
         ev = payload.eventType
       elseif backend == "gitblit" and payload.event then
         ev = payload.event
-      elseif backend == "gerrit" and payload.type then
+      elseif (backend == "gerrit" or backend == "onedev") and payload.type then
         ev = payload.type
       elseif backend == "kallithea" then
         ev = kallithea_body_event(payload)

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -274,20 +274,16 @@ local function verify_signature(backend, secret, body, now)
     end
     return ct_equal(secret, tok)
 
-  -- OneDev: Authorization: Bearer <secret>
+  -- OneDev: X-OneDev-Signature, verbatim shared token
   elseif backend == "onedev" then
     if not secret or secret == "" then
       return true
     end
-    local auth = GetHeader("Authorization")
-    if not auth then
+    local tok = GetHeader("X-OneDev-Signature")
+    if not tok then
       return false
     end
-    local bearer = auth:match("^[Bb]earer (.+)$")
-    if not bearer then
-      return false
-    end
-    return ct_equal(secret, bearer)
+    return ct_equal(secret, tok)
 
   -- Radicle: Authorization header, raw verbatim token (no Bearer/Basic prefix)
   elseif backend == "radicle" then

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,6 +1,6 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
 POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
-POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
+POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~refs/issues/PRs/builds/packages,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n
@@ -463,13 +463,13 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n,n
+webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,n,n,n,n,n
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n,n
+webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,n,n,n,n,n
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -491,16 +491,16 @@ webhook discussion_comment/edited,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,
 webhook fork/fork,n,y,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n
 webhook gollum/created,n,n,n,y,n,y,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook gollum/edited,n,n,n,y,n,y,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook issues/opened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,n,y,n,n,n,n,n,n
-webhook issues/closed,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
-webhook issues/edited,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,n,y,n,n,n,n,n,n
-webhook issues/reopened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,y,n,n,n,n,n,n
+webhook issues/opened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,n,n,n,n,n,n
+webhook issues/closed,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,n,n,n,n,n,n
+webhook issues/edited,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,n,n,n,n,n,n
+webhook issues/reopened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,n,n,n,n,n,n
 webhook issues/labeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook issues/unlabeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook issues/assigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook issues/unassigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook issue_comment/created,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,n,y,n,n,n,n,n,n
-webhook issue_comment/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,y,y,n,n,n,n,n,n,n,n
+webhook issue_comment/created,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,n,n,n,n,n,n
+webhook issue_comment/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,n,n,n,n,n,n,n
 webhook issue_comment/deleted,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook label/created,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 webhook label/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
@@ -525,28 +525,28 @@ webhook organization/renamed,n,n,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook organization/member_added,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook organization/member_invited,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook organization/member_removed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook package/published,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n,n
+webhook package/published,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,y,n,n,n,n,n,n,n
 webhook package/updated,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n,n
 webhook page_build/page_build,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook ping/ping,n,n,n,y,n,y,n,n,y,y,n,y,n,n,y,n,n,n,n,n,n,n,n,n
-webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,y,y,n,y,n,n,n,n,n,n
-webhook pull_request/closed,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,n,y,n,n,n,n,n,n
-webhook pull_request/reopened,n,n,n,y,n,y,y,n,y,y,y,y,n,n,y,y,n,n,n,n,n,n,n,n
-webhook pull_request/edited,n,n,y,y,n,y,y,n,y,y,y,y,n,n,y,y,n,n,n,n,n,n,n,n
-webhook pull_request/synchronize,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,n,y,n,n,n,n,n,n
+webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,y,y,y,y,n,n,n,n,n,n
+webhook pull_request/closed,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,n,n,n,n,n,n
+webhook pull_request/reopened,n,n,n,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,n,n,n,n,n,n
+webhook pull_request/edited,n,n,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,n,n,n,n,n,n
+webhook pull_request/synchronize,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,n,n,n,n,n,n
 webhook pull_request/labeled,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request/unlabeled,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook pull_request/assigned,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook pull_request/unassigned,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook pull_request/review_requested,n,n,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook pull_request/review_request_removed,n,n,y,y,n,y,y,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
+webhook pull_request/assigned,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n
+webhook pull_request/unassigned,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n
+webhook pull_request/review_requested,n,n,y,y,n,y,y,n,y,y,y,y,n,n,n,y,y,n,n,n,n,n,n,n
+webhook pull_request/review_request_removed,n,n,y,y,n,y,y,n,y,y,y,y,n,n,n,y,y,n,n,n,n,n,n,n
 webhook pull_request_review/submitted,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 webhook pull_request_review/edited,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
 webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
+webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
+webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,n,y,n,n,n,n,n,n
+webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,n,n,n,n,n,n
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -569,9 +569,9 @@ webhook team/edited,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook team/added_to_repository,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook team/removed_from_repository,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook team_add/team_add,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook workflow_run/requested,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,n,n,n,n,n,n,n,n
-webhook workflow_run/in_progress,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,n,n,n,n,n,n,n,n
-webhook workflow_run/completed,y,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,n,n,n,n,n,n,n,n
+webhook workflow_run/requested,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,n,n,n,n,n,n
+webhook workflow_run/in_progress,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,n,n,n,n,n,n
+webhook workflow_run/completed,y,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,n,n,n,n,n,n
 webhook workflow_job/queued,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 webhook workflow_job/in_progress,n,y,n,y,n,y,n,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n
 webhook workflow_job/completed,n,y,n,y,n,y,n,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/onedev/create.json
+++ b/test/fixtures/webhooks/onedev/create.json
@@ -1,0 +1,19 @@
+{
+  "type": "RefUpdated",
+  "date": "2024-01-15T10:06:00Z",
+  "refName": "refs/heads/feature-branch",
+  "oldCommitId": "0000000000000000000000000000000000000000",
+  "newCommitId": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234",
+  "project": {
+    "id": 100,
+    "path": "octocat/hello-world",
+    "public": true,
+    "defaultBranch": "main"
+  },
+  "user": {
+    "id": 1,
+    "name": "alice",
+    "fullName": "Alice Example",
+    "email": "alice@example.com"
+  }
+}

--- a/test/fixtures/webhooks/onedev/delete.json
+++ b/test/fixtures/webhooks/onedev/delete.json
@@ -1,0 +1,19 @@
+{
+  "type": "RefUpdated",
+  "date": "2024-01-15T10:07:00Z",
+  "refName": "refs/heads/stale-branch",
+  "oldCommitId": "95790bf891e76fee5db5ef17d2523a6f6e048239",
+  "newCommitId": "0000000000000000000000000000000000000000",
+  "project": {
+    "id": 100,
+    "path": "octocat/hello-world",
+    "public": true,
+    "defaultBranch": "main"
+  },
+  "user": {
+    "id": 1,
+    "name": "alice",
+    "fullName": "Alice Example",
+    "email": "alice@example.com"
+  }
+}

--- a/test/fixtures/webhooks/onedev/issue_comment-created.json
+++ b/test/fixtures/webhooks/onedev/issue_comment-created.json
@@ -1,0 +1,37 @@
+{
+  "type": "IssueCommentCreated",
+  "activity": "commented",
+  "date": "2024-01-15T11:20:00Z",
+  "comment": {
+    "id": 42,
+    "content": "Confirmed, I can reproduce this.",
+    "date": "2024-01-15T11:20:00Z",
+    "issue": {
+      "id": 200,
+      "number": 7,
+      "title": "Bug report",
+      "description": "Something is broken",
+      "state": "Open",
+      "submitDate": "2024-01-15T10:55:00Z",
+      "updateDate": "2024-01-15T11:20:00Z",
+      "project": {
+        "id": 100,
+        "path": "octocat/hello-world",
+        "public": true,
+        "defaultBranch": "main"
+      },
+      "submitter": {
+        "id": 1,
+        "name": "alice",
+        "fullName": "Alice Example",
+        "email": "alice@example.com"
+      }
+    },
+    "user": {
+      "id": 2,
+      "name": "bob",
+      "fullName": "Bob Example",
+      "email": "bob@example.com"
+    }
+  }
+}

--- a/test/fixtures/webhooks/onedev/issues-closed.json
+++ b/test/fixtures/webhooks/onedev/issues-closed.json
@@ -1,0 +1,26 @@
+{
+  "type": "IssueChanged",
+  "activity": "closed",
+  "date": "2024-01-15T11:10:00Z",
+  "issue": {
+    "id": 200,
+    "number": 7,
+    "title": "Bug report",
+    "description": "Something is broken",
+    "state": "Closed",
+    "submitDate": "2024-01-15T10:55:00Z",
+    "updateDate": "2024-01-15T11:10:00Z",
+    "project": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "submitter": {
+      "id": 1,
+      "name": "alice",
+      "fullName": "Alice Example",
+      "email": "alice@example.com"
+    }
+  }
+}

--- a/test/fixtures/webhooks/onedev/issues-opened.json
+++ b/test/fixtures/webhooks/onedev/issues-opened.json
@@ -1,0 +1,26 @@
+{
+  "type": "IssueOpened",
+  "activity": "opened",
+  "date": "2024-01-15T11:00:00Z",
+  "issue": {
+    "id": 200,
+    "number": 7,
+    "title": "Bug report",
+    "description": "Something is broken",
+    "state": "Open",
+    "submitDate": "2024-01-15T10:55:00Z",
+    "updateDate": "2024-01-15T11:00:00Z",
+    "project": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "submitter": {
+      "id": 1,
+      "name": "alice",
+      "fullName": "Alice Example",
+      "email": "alice@example.com"
+    }
+  }
+}

--- a/test/fixtures/webhooks/onedev/package-published.json
+++ b/test/fixtures/webhooks/onedev/package-published.json
@@ -1,0 +1,24 @@
+{
+  "type": "PackPublished",
+  "date": "2024-01-15T14:00:00Z",
+  "url": "http://localhost/octocat/hello-world/~packages/npm/hello-world/1.0.0",
+  "pack": {
+    "id": 300,
+    "name": "hello-world",
+    "version": "1.0.0",
+    "type": "npm",
+    "publishDate": "2024-01-15T14:00:00Z",
+    "project": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "user": {
+      "id": 1,
+      "name": "alice",
+      "fullName": "Alice Example",
+      "email": "alice@example.com"
+    }
+  }
+}

--- a/test/fixtures/webhooks/onedev/pull_request-opened.json
+++ b/test/fixtures/webhooks/onedev/pull_request-opened.json
@@ -1,0 +1,40 @@
+{
+  "type": "PullRequestOpened",
+  "activity": "opened",
+  "date": "2024-01-15T12:00:00Z",
+  "request": {
+    "id": 500,
+    "number": 9,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "status": "OPEN",
+    "sourceBranch": "feature",
+    "targetBranch": "main",
+    "submitDate": "2024-01-15T12:00:00Z",
+    "targetProject": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "sourceProject": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "submitter": {
+      "id": 1,
+      "name": "alice",
+      "fullName": "Alice Example",
+      "email": "alice@example.com"
+    },
+    "latestUpdate": {
+      "headCommitHash": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234",
+      "targetHeadCommitHash": "95790bf891e76fee5db5ef17d2523a6f6e048239"
+    },
+    "lastActivity": {
+      "date": "2024-01-15T12:00:00Z"
+    }
+  }
+}

--- a/test/fixtures/webhooks/onedev/pull_request-synchronize.json
+++ b/test/fixtures/webhooks/onedev/pull_request-synchronize.json
@@ -1,0 +1,40 @@
+{
+  "type": "PullRequestChanged",
+  "activity": "added commits",
+  "date": "2024-01-15T12:10:00Z",
+  "request": {
+    "id": 500,
+    "number": 9,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "status": "OPEN",
+    "sourceBranch": "feature",
+    "targetBranch": "main",
+    "submitDate": "2024-01-15T12:00:00Z",
+    "targetProject": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "sourceProject": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "submitter": {
+      "id": 1,
+      "name": "alice",
+      "fullName": "Alice Example",
+      "email": "alice@example.com"
+    },
+    "latestUpdate": {
+      "headCommitHash": "71ee8f3d7c2b4a6e8f90123456789abcdef01234",
+      "targetHeadCommitHash": "95790bf891e76fee5db5ef17d2523a6f6e048239"
+    },
+    "lastActivity": {
+      "date": "2024-01-15T12:10:00Z"
+    }
+  }
+}

--- a/test/fixtures/webhooks/onedev/pull_request_review_comment-created.json
+++ b/test/fixtures/webhooks/onedev/pull_request_review_comment-created.json
@@ -1,0 +1,59 @@
+{
+  "type": "PullRequestCodeCommentCreated",
+  "activity": "code commented",
+  "date": "2024-01-15T12:20:00Z",
+  "request": {
+    "id": 500,
+    "number": 9,
+    "title": "Add new feature",
+    "description": "This PR adds a new feature.",
+    "status": "OPEN",
+    "sourceBranch": "feature",
+    "targetBranch": "main",
+    "submitDate": "2024-01-15T12:00:00Z",
+    "targetProject": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "sourceProject": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "submitter": {
+      "id": 1,
+      "name": "alice",
+      "fullName": "Alice Example",
+      "email": "alice@example.com"
+    }
+  },
+  "comment": {
+    "id": 77,
+    "content": "Please simplify this.",
+    "date": "2024-01-15T12:20:00Z",
+    "request": {
+      "id": 500,
+      "number": 9,
+      "targetProject": {
+        "id": 100,
+        "path": "octocat/hello-world",
+        "public": true,
+        "defaultBranch": "main"
+      }
+    },
+    "mark": {
+      "path": "src/app.lua",
+      "line": 12,
+      "commitHash": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234"
+    },
+    "user": {
+      "id": 2,
+      "name": "bob",
+      "fullName": "Bob Example",
+      "email": "bob@example.com"
+    }
+  }
+}

--- a/test/fixtures/webhooks/onedev/push.json
+++ b/test/fixtures/webhooks/onedev/push.json
@@ -1,0 +1,19 @@
+{
+  "type": "RefUpdated",
+  "date": "2024-01-15T10:05:00Z",
+  "refName": "refs/heads/main",
+  "oldCommitId": "95790bf891e76fee5db5ef17d2523a6f6e048239",
+  "newCommitId": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234",
+  "project": {
+    "id": 100,
+    "path": "octocat/hello-world",
+    "public": true,
+    "defaultBranch": "main"
+  },
+  "user": {
+    "id": 1,
+    "name": "alice",
+    "fullName": "Alice Example",
+    "email": "alice@example.com"
+  }
+}

--- a/test/fixtures/webhooks/onedev/workflow_run-completed.json
+++ b/test/fixtures/webhooks/onedev/workflow_run-completed.json
@@ -1,0 +1,26 @@
+{
+  "type": "BuildFinished",
+  "date": "2024-01-15T13:00:00Z",
+  "build": {
+    "id": 900,
+    "number": 22,
+    "jobName": "ci",
+    "status": "SUCCESSFUL",
+    "commitHash": "5a1e9f3d7c2b4a6e8f90123456789abcdef01234",
+    "refName": "refs/heads/main",
+    "submitDate": "2024-01-15T12:55:00Z",
+    "finishDate": "2024-01-15T13:00:00Z",
+    "project": {
+      "id": 100,
+      "path": "octocat/hello-world",
+      "public": true,
+      "defaultBranch": "main"
+    },
+    "submitter": {
+      "id": 1,
+      "name": "alice",
+      "fullName": "Alice Example",
+      "email": "alice@example.com"
+    }
+  }
+}

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -377,7 +377,18 @@ run_delivery_phase test/webhook-delivery-launchpad.hurl \
   -- launchpad "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 38: Startup event synthesis — github shape.
+# Phase 38: OneDev fixture-based delivery tests — native body-typed hooks.
+run_delivery_phase test/webhook-delivery-onedev.hurl \
+  -- onedev "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
+
+# Phase 39: OneDev delivery with "confusio" shape — normalized hook envelopes.
+run_delivery_phase test/webhook-delivery-onedev-confusio-shape.hurl \
+  -- onedev "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
+  "webhook_target_shape=confusio"
+
+# Phase 40: Startup event synthesis — github shape.
 # Verifies that confusio synthesizes installation.created and
 # installation_repositories.added before accepting connections, and delivers
 # both to the configured outbound target.  No /reset is called — the hurl file
@@ -386,8 +397,8 @@ run_delivery_phase test/webhook-delivery-startup.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 39: Startup event synthesis — confusio shape.
-# Same as Phase 38 but with webhook_target_shape=confusio; verifies
+# Phase 41: Startup event synthesis — confusio shape.
+# Same as Phase 40 but with webhook_target_shape=confusio; verifies
 # X-Confusio-* headers are used and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-startup-confusio-shape.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -138,13 +138,13 @@ CONFUSIO_TS=$(date +%s)
 CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
 # Write secrets to 0600-permission files — never pass raw secrets on the CLI.
 WH_SECRET_DIR=$(mktemp -d)
-for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad gerrit kallithea confusio; do
+for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad gerrit onedev kallithea confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT
@@ -158,6 +158,7 @@ $HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
   --variable "azuredevops_basic=$AZUREDEVOPS_BASIC" \
   --variable "gerrit_tok=$WH_SECRET" \
   --variable "gerrit_basic=$GERRIT_BASIC" \
+  --variable "onedev_tok=$WH_SECRET" \
   --variable "confusio_sig=$CONFUSIO_SIG" \
   test/webhooks-sig.hurl
 kill $WH_PID 2>/dev/null || true; sleep 0.3

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3036,27 +3036,23 @@ do
   )
   eq(with_secret("harness", {}), 401, "verify_signature harness: missing X-Harness-Token → 401")
 
-  -- ── Bearer token: onedev (Authorization: Bearer <secret>)
+  -- ── OneDev: X-OneDev-Signature, verbatim shared token
   ok(no_secret("onedev", {}) ~= 401, "verify_signature onedev: no secret → not 401")
   ok(
-    with_secret("onedev", { ["Authorization"] = "Bearer " .. SECRET }) ~= 401,
-    "verify_signature onedev: valid Bearer token → not 401"
-  )
-  ok(
-    with_secret("onedev", { ["Authorization"] = "bearer " .. SECRET }) ~= 401,
-    "verify_signature onedev: Bearer scheme is case-insensitive → not 401"
+    with_secret("onedev", { ["X-OneDev-Signature"] = SECRET }) ~= 401,
+    "verify_signature onedev: valid X-OneDev-Signature → not 401"
   )
   eq(
-    with_secret("onedev", { ["Authorization"] = "Bearer badtoken" }),
+    with_secret("onedev", { ["X-OneDev-Signature"] = "badtoken" }),
     401,
-    "verify_signature onedev: bad Bearer token → 401"
+    "verify_signature onedev: bad X-OneDev-Signature → 401"
   )
   eq(
-    with_secret("onedev", { ["Authorization"] = "Basic " .. SECRET }),
+    with_secret("onedev", { ["Authorization"] = "Bearer " .. SECRET }),
     401,
-    "verify_signature onedev: non-Bearer scheme → 401"
+    "verify_signature onedev: Authorization header is ignored → 401"
   )
-  eq(with_secret("onedev", {}), 401, "verify_signature onedev: missing Authorization → 401")
+  eq(with_secret("onedev", {}), 401, "verify_signature onedev: missing X-OneDev-Signature → 401")
 
   -- ── Verbatim Authorization header: radicle (raw token, no prefix)
   ok(no_secret("radicle", {}) ~= 401, "verify_signature radicle: no secret → not 401")
@@ -3374,6 +3370,15 @@ do
   -- GitLab: verbatim token.
   local sfb_gl = sign_for_backend("gitlab", SECRET, BODY)
   eq(sfb_gl["X-Gitlab-Token"], SECRET, "sign_for_backend gitlab: X-Gitlab-Token is the secret")
+
+  -- OneDev: verbatim token in X-OneDev-Signature.
+  local sfb_onedev = sign_for_backend("onedev", SECRET, BODY)
+  eq(
+    sfb_onedev["X-OneDev-Signature"],
+    SECRET,
+    "sign_for_backend onedev: X-OneDev-Signature is the secret"
+  )
+  ok(sfb_onedev["Authorization"] == nil, "sign_for_backend onedev: no Authorization header")
 
   -- HMAC-SHA1 via X-Hub-Signature.
   for _, be in ipairs({ "gitbucket", "launchpad" }) do

--- a/test/webhook-delivery-onedev-confusio-shape.hurl
+++ b/test/webhook-delivery-onedev-confusio-shape.hurl
@@ -1,0 +1,102 @@
+# OneDev webhook delivery test — "confusio" shape variant.
+#
+# When webhook_target_shape=confusio, deliveries use X-Confusio-* headers
+# and normalized envelopes instead of GitHub-compatible headers.
+
+# -- RefUpdated update -> push ------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "push"
+jsonpath "$[0].confusio_source" == "onedev"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:05:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
+
+# -- IssueOpened -> issues.opened -------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/issues-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "issues"
+jsonpath "$[0].confusio_source" == "onedev"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.issue.number" == 7
+
+# -- PullRequestChanged added commits -> pull_request.synchronize ------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/pull_request-synchronize.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request"
+jsonpath "$[0].confusio_source" == "onedev"
+jsonpath "$[0].body_json.type" == "pull_request.synchronize"
+jsonpath "$[0].body_json.payload.action" == "synchronize"
+jsonpath "$[0].body_json.payload.pull_request.number" == 9
+
+# -- BuildFinished SUCCESSFUL -> workflow_run.completed ----------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/workflow_run-completed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "workflow_run"
+jsonpath "$[0].confusio_source" == "onedev"
+jsonpath "$[0].body_json.type" == "workflow.run.completed"
+jsonpath "$[0].body_json.payload.action" == "completed"
+jsonpath "$[0].body_json.payload.workflow_run.conclusion" == "success"

--- a/test/webhook-delivery-onedev.hurl
+++ b/test/webhook-delivery-onedev.hurl
@@ -1,0 +1,237 @@
+# OneDev webhook delivery tests.
+#
+# OneDev embeds the native event type in the JSON body as "type".
+# These fixture tests cover the distinct normalized delivery families
+# registered by backends/onedev.lua.
+
+# -- RefUpdated update -> push ------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.type" == "RefUpdated"
+
+# -- RefUpdated create -> create --------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.refName" == "refs/heads/feature-branch"
+
+# -- RefUpdated delete -> delete --------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.refName" == "refs/heads/stale-branch"
+
+# -- IssueOpened -> issues opened -------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/issues-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.type" == "IssueOpened"
+
+# -- IssueChanged closed -> issues closed -----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/issues-closed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.activity" == "closed"
+
+# -- IssueCommentCreated -> issue_comment created ---------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/issue_comment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issue_comment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.comment.content" == "Confirmed, I can reproduce this."
+
+# -- PullRequestOpened -> pull_request opened -------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/pull_request-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.type" == "PullRequestOpened"
+
+# -- PullRequestChanged added commits -> pull_request synchronize ------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/pull_request-synchronize.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.activity" == "added commits"
+
+# -- PullRequestCodeCommentCreated -> pull_request_review_comment created ----
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/pull_request_review_comment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request_review_comment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.comment.mark.path" == "src/app.lua"
+
+# -- BuildFinished SUCCESSFUL -> workflow_run completed ----------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/workflow_run-completed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "workflow_run"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.build.status" == "SUCCESSFUL"
+
+# -- PackPublished -> package published -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+file,fixtures/webhooks/onedev/package-published.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "package"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.pack.name" == "hello-world"

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -10,6 +10,7 @@
 #   azuredevops_basic — base64("fido:webhooksecret") for Authorization: Basic
 #   gerrit_tok  — the shared secret verbatim or as Bearer token (for Authorization)
 #   gerrit_basic — base64("webhooksecret") for Authorization: Basic
+#   onedev_tok — the shared secret verbatim (for X-OneDev-Signature)
 #   kallithea — shared secret is embedded in the request body
 #   confusio_sig — "sha256=<hex>, v=1, ts=<ts>" (for X-Confusio-Signature-256)
 #
@@ -290,6 +291,47 @@ jsonpath "$.message" == "Signature verification failed"
 
 # Missing Authorization header → 401
 POST http://{{host}}/webhooks/gerrit
+Content-Type: application/json
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── onedev: X-OneDev-Signature, verbatim shared token ────────────────────────
+
+# Valid token → passes verification (422)
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+X-OneDev-Signature: {{onedev_tok}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad token → 401
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+X-OneDev-Signature: wrongtoken
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Bearer Authorization is not OneDev's native webhook signature → 401
+POST http://{{host}}/webhooks/onedev
+Content-Type: application/json
+Authorization: Bearer {{onedev_tok}}
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing signature header → 401
+POST http://{{host}}/webhooks/onedev
 Content-Type: application/json
 {}
 


### PR DESCRIPTION
Adds OneDev as a webhook source backend with native signature handling and mapped push, build, package, issue, comment, and pull request events.

Adds OneDev webhook fixtures, delivery tests, compatibility docs, and real-world testing notes.

Fixes #266.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Add OneDev webhook fixtures and delivery tests <!-- type:spec -->
- [x] Update OneDev webhook compatibility docs <!-- type:spec -->
- [x] Map OneDev pull request webhooks <!-- type:spec -->
- [x] Map OneDev issue and comment webhooks <!-- type:spec -->
- [x] Map OneDev push, build, and package webhooks <!-- type:spec -->
- [x] Correct OneDev native webhook signature scheme <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->