### PR TITLE
v3: Webhook — pagure source backend (closes #267)

### DIFF
--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -105,6 +105,29 @@ local function translate_pagure_tag(tag)
   }
 end
 
+local function translate_pagure_milestone(milestone)
+  if not milestone or milestone == "" then
+    return nil
+  end
+  if type(milestone) ~= "table" then
+    milestone = { title = tostring(milestone) }
+  end
+  local title = milestone.title or milestone.name or ""
+  local state = (milestone.closed or milestone.status == "Closed") and "closed" or "open"
+  return {
+    id = milestone.id or 0,
+    node_id = "",
+    number = milestone.id or 0,
+    title = title,
+    description = milestone.description or "",
+    state = state,
+    created_at = tostring(milestone.date_created or milestone.created_at or ""),
+    updated_at = tostring(milestone.last_updated or milestone.updated_at or ""),
+    due_on = milestone.due_on or milestone.date_due,
+    closed_at = milestone.closed_at or milestone.date_closed,
+  }
+end
+
 -- Translate a Pagure issue to GitHub format.
 -- Pagure states: "Open", "Closed"
 -- Pagure dates: Unix timestamps as strings
@@ -130,6 +153,10 @@ local function translate_pagure_issue(i)
     -- Try to return as-is if it looks like a timestamp (digits only)
     return tostring(v)
   end
+  local closed_at = nil
+  if state == "closed" then
+    closed_at = ts(i.closed_at or i.date_closed or i.closed_date or i.closed_on or i.last_updated)
+  end
   return {
     id = i.id or 0,
     number = i.id or 0,
@@ -139,26 +166,30 @@ local function translate_pagure_issue(i)
     user = user,
     assignees = assignees,
     labels = labels,
-    milestone = nil,
     created_at = ts(i.date_created),
     updated_at = ts(i.last_updated),
-    closed_at = nil,
+    closed_at = closed_at,
     html_url = config.base_url .. "/" .. (i.full_url or ""),
+    milestone = translate_pagure_milestone(i.milestone),
   }
 end
 
 -- Translate a Pagure comment to GitHub format.
-local function translate_pagure_comment(c)
+local function translate_pagure_comment(c, issue)
   if not c then
     return {}
+  end
+  local html_url = c.full_url and (config.base_url .. "/" .. c.full_url) or ""
+  if html_url == "" and issue and issue.full_url and c.id then
+    html_url = config.base_url .. "/" .. issue.full_url .. "#comment-" .. c.id
   end
   return {
     id = c.id or 0,
     body = c.comment or "",
     user = translate_pagure_user(c.user),
     created_at = tostring(c.date_created or ""),
-    updated_at = tostring(c.date_created or ""),
-    html_url = "",
+    updated_at = tostring(c.last_updated or c.date_updated or c.date_created or ""),
+    html_url = html_url,
   }
 end
 
@@ -1136,7 +1167,7 @@ b:webhook("issue.comment.added", function(payload)
     data = {
       action = "created",
       issue = translate_pagure_issue(msg.issue),
-      comment = translate_pagure_comment(msg.comment),
+      comment = translate_pagure_comment(msg.comment, msg.issue),
       repository = translate_pagure_repo(msg.project),
       sender = pagure_agent_user(msg.agent),
     },

--- a/backends/pagure.lua
+++ b/backends/pagure.lua
@@ -1058,7 +1058,7 @@ local function pagure_agent_user(agent)
 end
 
 -- Translate a Pagure pull request to GitHub format.
-local function translate_pagure_pull(pr)
+local function translate_pagure_pull(pr, project, actor)
   if not pr then
     return {}
   end
@@ -1066,6 +1066,8 @@ local function translate_pagure_pull(pr)
   local is_merged = status == "Merged"
   local gh_state = status == "Open" and "open" or "closed"
   local repo_from = pr.repo_from or {}
+  local head_repo = translate_pagure_repo(repo_from)
+  local base_repo = translate_pagure_repo(project)
   return {
     id = pr.id or 0,
     node_id = "",
@@ -1079,19 +1081,22 @@ local function translate_pagure_pull(pr)
       label = (repo_from.fullname or "") .. ":" .. (pr.branch_from or ""),
       ref = pr.branch_from or "",
       sha = pr.commit_stop or "",
+      repo = head_repo,
     },
     base = {
-      label = "" .. ":" .. (pr.branch or ""),
+      label = (project and project.fullname or "") .. ":" .. (pr.branch or ""),
       ref = pr.branch or "",
-      sha = "",
+      sha = pr.commit_start or "",
+      repo = base_repo,
     },
     draft = false,
     created_at = tostring(pr.date_created or ""),
     updated_at = tostring(pr.last_updated or ""),
     closed_at = (not is_merged and gh_state == "closed") and tostring(pr.last_updated or "") or nil,
     merged_at = is_merged and tostring(pr.last_updated or "") or nil,
-    merge_commit_sha = nil,
-    merged_by = nil,
+    merge_commit_sha = is_merged and (pr.commit_stop or nil) or nil,
+    merged = is_merged,
+    merged_by = is_merged and pagure_agent_user(pr.closed_by or pr.merged_by or actor) or nil,
     html_url = config.base_url .. "/" .. (pr.full_url or ""),
     url = "",
     mergeable = status == "Open" or nil,
@@ -1186,7 +1191,7 @@ b:webhook("pull-request.new", function(payload)
     data = {
       action = "opened",
       number = pr.id,
-      pull_request = translate_pagure_pull(pr),
+      pull_request = translate_pagure_pull(pr, msg.project, msg.agent),
       repository = translate_pagure_repo(msg.project),
       sender = pagure_agent_user(msg.agent),
     },
@@ -1205,7 +1210,7 @@ b:webhook("pull-request.updated", function(payload)
     data = {
       action = "synchronize",
       number = pr.id,
-      pull_request = translate_pagure_pull(pr),
+      pull_request = translate_pagure_pull(pr, msg.project, msg.agent),
       repository = translate_pagure_repo(msg.project),
       sender = pagure_agent_user(msg.agent),
     },
@@ -1224,7 +1229,7 @@ b:webhook("pull-request.closed", function(payload)
     data = {
       action = "closed",
       number = pr.id,
-      pull_request = translate_pagure_pull(pr),
+      pull_request = translate_pagure_pull(pr, msg.project, msg.agent),
       repository = translate_pagure_repo(msg.project),
       sender = pagure_agent_user(msg.agent),
     },

--- a/docs/real-world-testing.md
+++ b/docs/real-world-testing.md
@@ -60,7 +60,7 @@ value is `y` or starts with `~`.  Concretely:
 | bitbucket_datacenter | 39 | 78 |
 | azuredevops | 80 | 79 |
 | onedev | 21 | 72 |
-| pagure | 24 | 73 |
+| pagure | 40 | 76 |
 | sourcehut | 19 | 68 |
 | harness | 17 | 72 |
 | gitblit | 16 | 74 |
@@ -917,6 +917,16 @@ Backends: `azuredevops`, `harness`, `gitbucket` (Tier 2 standing in for no publi
 These are less homogeneous — each needs its own setup script and potentially more overrides.
 `sourcehut` write endpoints are deferred until a paid subscription is in place; read-only
 endpoints can be enabled immediately.
+
+Pagure live webhook coverage should configure a Pagure hook with a payload secret and drive
+native deliveries for `issue.new`, `issue.edit`, `issue.status.change`, `issue.comment.added`,
+`pull-request.new`, `pull-request.updated`, `pull-request.closed`, `git.receive`, and
+`project.forked`.  The `git.receive` cases should cover a normal push, branch or tag creation,
+and branch or tag deletion so the derived GitHub `push`, `create`, and `delete` events are all
+asserted.  Each run should check both GitHub-emulation delivery and the confusio-normalized
+shape, including `X-Pagure-Event`, `X-Confusio-Source: pagure`, and the preferred
+`X-Pagure-Signature-256` verification path with the SHA-512 fallback kept in mock-backed
+signature tests.
 
 **Exit criteria**: all enabled backends pass two consecutive weekly runs.
 

--- a/test/fixtures/webhooks/pagure/issue.comment.added.json
+++ b/test/fixtures/webhooks/pagure/issue.comment.added.json
@@ -11,6 +11,7 @@
       "assignee": null,
       "date_created": "1705312800",
       "last_updated": "1705316400",
+      "full_url": "myorg/my-repo/issue/1",
       "user": {"name": "alice", "fullname": "Alice Smith", "url_path": "user/alice"}
     },
     "comment": {

--- a/test/fixtures/webhooks/pagure/issue.new.json
+++ b/test/fixtures/webhooks/pagure/issue.new.json
@@ -8,9 +8,11 @@
       "content": "Something is broken",
       "status": "Open",
       "tags": [],
+      "milestone": "v1.0",
       "assignee": null,
       "date_created": "1705312800",
       "last_updated": "1705312800",
+      "full_url": "myorg/my-repo/issue/1",
       "user": {"name": "alice", "fullname": "Alice Smith", "url_path": "user/alice"}
     },
     "project": {

--- a/test/fixtures/webhooks/pagure/issue.status.change-closed.json
+++ b/test/fixtures/webhooks/pagure/issue.status.change-closed.json
@@ -11,6 +11,7 @@
       "assignee": null,
       "date_created": "1705312800",
       "last_updated": "1705320000",
+      "full_url": "myorg/my-repo/issue/1",
       "user": {"name": "alice", "fullname": "Alice Smith", "url_path": "user/alice"}
     },
     "project": {

--- a/test/fixtures/webhooks/pagure/pull-request.closed.json
+++ b/test/fixtures/webhooks/pagure/pull-request.closed.json
@@ -13,6 +13,7 @@
       "commit_stop": "abc123",
       "date_created": "1705312800",
       "last_updated": "1705323600",
+      "full_url": "myorg/my-repo/pull-request/5",
       "user": {"name": "alice", "fullname": "Alice Smith", "url_path": "user/alice"},
       "repo_from": {
         "name": "my-repo",

--- a/test/fixtures/webhooks/pagure/pull-request.new.json
+++ b/test/fixtures/webhooks/pagure/pull-request.new.json
@@ -13,6 +13,7 @@
       "commit_stop": "abc123",
       "date_created": "1705312800",
       "last_updated": "1705312800",
+      "full_url": "myorg/my-repo/pull-request/5",
       "user": {"name": "alice", "fullname": "Alice Smith", "url_path": "user/alice"},
       "repo_from": {
         "name": "my-repo",

--- a/test/fixtures/webhooks/pagure/pull-request.updated.json
+++ b/test/fixtures/webhooks/pagure/pull-request.updated.json
@@ -13,6 +13,7 @@
       "commit_stop": "bbb222",
       "date_created": "1705312800",
       "last_updated": "1705316400",
+      "full_url": "myorg/my-repo/pull-request/5",
       "user": {"name": "alice", "fullname": "Alice Smith", "url_path": "user/alice"},
       "repo_from": {
         "name": "my-repo",

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -131,6 +131,8 @@ GITEA_SIG=$(printf '%s' "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | a
 BB_SIG="sha256=${GITEA_SIG}"
 GB_SIG="sha1=$(printf '%s' "$WH_BODY" | openssl dgst -sha1 -hmac "$WH_SECRET" | awk '{print $NF}')"
 LAUNCHPAD_SIG="$GB_SIG"
+PAGURE_SIG_256="$GITEA_SIG"
+PAGURE_SIG_512=$(printf '%s' "$WH_BODY" | openssl dgst -sha512 -hmac "$WH_SECRET" | awk '{print $NF}')
 AZUREDEVOPS_SECRET="fido:$WH_SECRET"
 AZUREDEVOPS_BASIC=$(printf '%s' "$AZUREDEVOPS_SECRET" | openssl base64 -A)
 GERRIT_BASIC=$(printf '%s' "$WH_SECRET" | openssl base64 -A)
@@ -138,13 +140,13 @@ CONFUSIO_TS=$(date +%s)
 CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
 # Write secrets to 0600-permission files — never pass raw secrets on the CLI.
 WH_SECRET_DIR=$(mktemp -d)
-for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad gerrit onedev kallithea confusio; do
+for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad pagure gerrit onedev kallithea confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT
@@ -155,6 +157,8 @@ $HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
   --variable "bb_sig=$BB_SIG" \
   --variable "gb_sig=$GB_SIG" \
   --variable "launchpad_sig=$LAUNCHPAD_SIG" \
+  --variable "pagure_sig_256=$PAGURE_SIG_256" \
+  --variable "pagure_sig_512=$PAGURE_SIG_512" \
   --variable "azuredevops_basic=$AZUREDEVOPS_BASIC" \
   --variable "gerrit_tok=$WH_SECRET" \
   --variable "gerrit_basic=$GERRIT_BASIC" \

--- a/test/webhook-delivery-pagure-confusio-shape.hurl
+++ b/test/webhook-delivery-pagure-confusio-shape.hurl
@@ -33,6 +33,35 @@ jsonpath "$[0].body_json.occurred_at" == "1705312800"
 jsonpath "$[0].body_json.actor.login" == "alice"
 jsonpath "$[0].body_json.repository.full_name" == "myorg/my-repo"
 jsonpath "$[0].body_json.payload.issue.number" == 1
+jsonpath "$[0].body_json.payload.issue.html_url" contains "/myorg/my-repo/issue/1"
+jsonpath "$[0].body_json.payload.issue.milestone.title" == "v1.0"
+
+# ── issue.status.change → issues: closed — confusio shape ────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Event: issue.status.change
+file,fixtures/webhooks/pagure/issue.status.change-closed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "issues"
+jsonpath "$[0].confusio_source" == "pagure"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.closed"
+jsonpath "$[0].body_json.occurred_at" == "1705320000"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.issue.state" == "closed"
+jsonpath "$[0].body_json.payload.issue.closed_at" == "1705320000"
 
 # ── issue.comment.added → issue_comment: created — confusio shape ─────────────
 
@@ -62,6 +91,8 @@ jsonpath "$[0].body_json.occurred_at" == "1705316400"
 jsonpath "$[0].body_json.actor.login" == "bob"
 jsonpath "$[0].body_json.payload.comment.id" == 100
 jsonpath "$[0].body_json.payload.comment.body" == "I can reproduce this too."
+jsonpath "$[0].body_json.payload.comment.html_url" contains "/myorg/my-repo/issue/1#comment-100"
+jsonpath "$[0].body_json.payload.issue.html_url" contains "/myorg/my-repo/issue/1"
 
 # ── pull-request.new → pull_request: opened — confusio shape ─────────────────
 

--- a/test/webhook-delivery-pagure-confusio-shape.hurl
+++ b/test/webhook-delivery-pagure-confusio-shape.hurl
@@ -179,3 +179,89 @@ jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
 jsonpath "$[0].body_json.actor.login" == "bob"
 jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
 jsonpath "$[0].body_json.payload.after" == "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"
+
+# ── git.receive (create) → create — confusio shape ───────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Event: git.receive
+file,fixtures/webhooks/pagure/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "pagure"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.ref" == "feature-branch"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# ── git.receive (delete) → delete — confusio shape ───────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Event: git.receive
+file,fixtures/webhooks/pagure/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "pagure"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.ref" == "stale-branch"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# ── project.forked → fork — confusio shape ───────────────────────────────────
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Event: project.forked
+file,fixtures/webhooks/pagure/fork.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "fork"
+jsonpath "$[0].confusio_source" == "pagure"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "fork"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.forkee.full_name" == "forks/bob/hello-world"

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -216,6 +216,69 @@ HTTP 401
 [Asserts]
 jsonpath "$.message" == "Signature verification failed"
 
+# ── pagure: X-Pagure-Signature-256 SHA-256, X-Pagure-Signature SHA-512 ───────
+
+# Valid SHA-256 signature → passes verification (422)
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Signature-256: {{pagure_sig_256}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Valid SHA-512 signature → passes verification (422)
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Signature: {{pagure_sig_512}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Both valid signatures → passes verification (422)
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Signature-256: {{pagure_sig_256}}
+X-Pagure-Signature: {{pagure_sig_512}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad SHA-256 signature → 401
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Signature-256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Bad SHA-512 signature paired with valid SHA-256 → 401
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+X-Pagure-Signature-256: {{pagure_sig_256}}
+X-Pagure-Signature: deadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing signature header → 401
+POST http://{{host}}/webhooks/pagure
+Content-Type: application/json
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
 # ── azuredevops: Authorization: Basic base64(username:password) ──────────────
 
 # Valid Basic credentials → passes verification (422)


### PR DESCRIPTION
Fixes #267.

Completes Pagure webhook source coverage by verifying fixture-based delivery tests for the implemented issue, comment, pull request, git receive, and fork translations. Finishes the compatibility matrix and live-test notes once that final Pagure webhook surface is covered.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Add Pagure webhook fixtures and delivery coverage <!-- type:spec -->
- [x] Finalize Pagure webhook matrix and live-test notes <!-- type:spec -->
- [x] Translate Pagure git receive and fork webhooks <!-- type:spec -->
- [x] Translate Pagure pull request webhooks <!-- type:spec -->
- [x] Translate Pagure issue and comment webhooks <!-- type:spec -->
- [x] Wire Pagure webhook signature and event dispatch <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->