### PR TITLE
v3: Webhook — radicle source backend (closes #269)

### DIFF
--- a/backends/radicle.lua
+++ b/backends/radicle.lua
@@ -14,6 +14,33 @@ local auth = function()
 end
 local PAGES = { per_page = "perPage", page = "page" }
 local fetch_json = make_backend_transport("bearer", PAGES).fetch_json
+local ZERO_SHA = "0000000000000000000000000000000000000000"
+
+local function radicle_short_ref(ref)
+  return (ref or ""):match("^refs/[^/]+/(.+)") or (ref or "")
+end
+
+local function radicle_ref_type(ref)
+  return (ref or ""):match("^refs/tags/") and "tag" or "branch"
+end
+
+local function translate_radicle_user(u)
+  u = u or {}
+  local id = u.id or u.did or ""
+  local login = u.alias or u.username or u.login or u.name or id
+  return {
+    login = login or "",
+    id = 0,
+    node_id = id,
+    avatar_url = u.avatar_url or "",
+    url = "",
+    html_url = u.html_url or "",
+    type = "User",
+    site_admin = false,
+    name = u.name,
+    email = u.email,
+  }
+end
 
 -- Map a Radicle repository object to GitHub format.
 local function translate_radicle_repo(r)
@@ -21,11 +48,17 @@ local function translate_radicle_repo(r)
     return {}
   end
   -- Radicle project payload is under payloads["xyz.radicle.project"]
-  local proj = (r.payloads and r.payloads["xyz.radicle.project"]) or {}
+  local proj = (r.payloads and r.payloads["xyz.radicle.project"])
+    or {
+      name = r.name,
+      description = r.description,
+      defaultBranch = r.defaultBranch or r.default_branch,
+    }
   local delegates = r.delegates or {}
-  local owner_did = delegates[1] and delegates[1].id or ""
+  local owner = r.owner or {}
+  local owner_did = owner.id or owner.did or (delegates[1] and delegates[1].id) or ""
   -- DID looks like "did:key:z6Mk..."; extract the key part as login
-  local login = owner_did:match("did:key:(.+)$") or owner_did
+  local login = owner.alias or owner.login or owner_did:match("did:key:(.+)$") or owner_did
   return {
     id = 0,
     node_id = r.rid or "",
@@ -41,11 +74,11 @@ local function translate_radicle_repo(r)
       html_url = "",
       type = "User",
     },
-    html_url = config.base_url .. "/repos/" .. (r.rid or ""),
+    html_url = r.web_url or (config.base_url .. "/repos/" .. (r.rid or "")),
     description = proj.description,
     fork = false,
     url = "",
-    clone_url = r.rid and ("rad://" .. r.rid) or "",
+    clone_url = r.clone_url or (r.rid and ("rad://" .. r.rid) or ""),
     homepage = "",
     size = 0,
     stargazers_count = 0,
@@ -89,6 +122,245 @@ end
 
 local function translate_radicle_repos(repos)
   return translate_list(translate_radicle_repo, repos)
+end
+
+local function translate_radicle_commit(c)
+  c = c or {}
+  local author = c.author or {}
+  local committer = c.committer or author
+  return {
+    id = c.id or "",
+    tree_id = c.tree_id or "",
+    distinct = c.distinct ~= false,
+    message = c.message or "",
+    timestamp = c.timestamp or "",
+    url = c.url or "",
+    author = {
+      name = author.name or "",
+      email = author.email or "",
+      username = author.username or author.alias or author.name or "",
+    },
+    committer = {
+      name = committer.name or author.name or "",
+      email = committer.email or author.email or "",
+      username = committer.username or committer.alias or committer.name or author.name or "",
+    },
+  }
+end
+
+local function translate_radicle_commits(commits)
+  local result = {}
+  for _, commit in ipairs(commits or {}) do
+    result[#result + 1] = translate_radicle_commit(commit)
+  end
+  return result
+end
+
+local function radicle_ref_event(payload)
+  payload = payload or {}
+  local before = payload.before or ZERO_SHA
+  local after = payload.after or ZERO_SHA
+  local ref = payload.ref
+    or (payload.tag and ("refs/tags/" .. payload.tag))
+    or (payload.branch and ("refs/heads/" .. payload.branch))
+    or ""
+  local repository = translate_radicle_repo(payload.repository or {})
+  local sender = translate_radicle_user(payload.pusher or payload.sender)
+  local ref_type = radicle_ref_type(ref)
+  local ref_short = radicle_short_ref(ref)
+
+  if before == ZERO_SHA then
+    return make_internal_event({
+      event = "create",
+      action = "create",
+      provider = "radicle",
+      raw = payload,
+      data = {
+        ref = ref_short,
+        ref_type = ref_type,
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.occurred_at or "",
+    })
+  end
+
+  if after == ZERO_SHA then
+    return make_internal_event({
+      event = "delete",
+      action = "delete",
+      provider = "radicle",
+      raw = payload,
+      data = {
+        ref = ref_short,
+        ref_type = ref_type,
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.occurred_at or "",
+    })
+  end
+
+  local commits = translate_radicle_commits(payload.commits)
+  return make_internal_event({
+    event = "push",
+    action = "push",
+    provider = "radicle",
+    raw = payload,
+    data = {
+      ref = ref,
+      before = before,
+      after = after,
+      created = false,
+      deleted = false,
+      forced = payload.forced or false,
+      compare = payload.compare or "",
+      commits = commits,
+      head_commit = commits[#commits],
+      pusher = {
+        name = (payload.pusher or {}).name or (payload.pusher or {}).alias or "",
+        email = (payload.pusher or {}).email or "",
+      },
+      repository = repository,
+      sender = sender,
+    },
+    timestamp = payload.occurred_at or "",
+  })
+end
+
+local RADICLE_PATCH_ACTIONS = {
+  created = "opened",
+  updated = "synchronize",
+}
+
+local function translate_radicle_patch(payload)
+  payload = payload or {}
+  local patch = payload.patch or {}
+  local repository = translate_radicle_repo(payload.repository or {})
+  local author = translate_radicle_user(patch.author or payload.sender)
+  local number = tonumber(patch.number) or 0
+  return {
+    id = number,
+    node_id = patch.id or "",
+    number = number,
+    title = patch.title or "",
+    body = patch.description or "",
+    state = patch.state or "open",
+    draft = false,
+    html_url = patch.url or "",
+    url = patch.url or "",
+    user = author,
+    head = {
+      ref = patch.head_ref or ("patch/" .. tostring(number)),
+      sha = patch.head or "",
+      repo = repository,
+    },
+    base = {
+      ref = patch.target_branch or repository.default_branch or "",
+      sha = patch.base or "",
+      repo = repository,
+    },
+    created_at = patch.created_at or "",
+    updated_at = patch.updated_at or "",
+    closed_at = patch.closed_at,
+    merged = false,
+    merged_at = nil,
+  }
+end
+
+local function radicle_patch_event(payload)
+  payload = payload or {}
+  local raw_action = payload.action or ""
+  local action = RADICLE_PATCH_ACTIONS[raw_action]
+  local pr = translate_radicle_patch(payload)
+  return make_internal_event({
+    event = "pull_request",
+    action = action or "unknown",
+    raw_action = action and nil or raw_action,
+    provider = "radicle",
+    raw = payload,
+    data = {
+      action = action or "unknown",
+      number = pr.number,
+      pull_request = pr,
+      repository = translate_radicle_repo(payload.repository or {}),
+      sender = translate_radicle_user(payload.sender or (payload.patch or {}).author),
+      revisions = (payload.patch or {}).revisions,
+    },
+    timestamp = payload.occurred_at or pr.updated_at or pr.created_at or "",
+  })
+end
+
+local RADICLE_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
+local function radicle_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_radicle_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        RADICLE_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or radicle_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+local function translate_radicle_github_webhook(internal_event, _fields)
+  local data = internal_event.data or {}
+  local payload = {
+    action = data.action or internal_event.action,
+    repository = data.repository or {},
+    sender = data.sender or {},
+  }
+  if internal_event.event == "pull_request" then
+    payload.number = data.number
+    payload.pull_request = data.pull_request or {}
+  elseif internal_event.event == "push" then
+    payload.action = nil
+    payload.ref = data.ref or ""
+    payload.before = data.before or ""
+    payload.after = data.after or ""
+    payload.created = data.created or false
+    payload.deleted = data.deleted or false
+    payload.forced = data.forced or false
+    payload.compare = data.compare or ""
+    payload.commits = data.commits or {}
+    payload.head_commit = data.head_commit
+    payload.pusher = data.pusher or {}
+  elseif internal_event.event == "create" or internal_event.event == "delete" then
+    payload.ref = data.ref or ""
+    payload.ref_type = data.ref_type or ""
+    payload.master_branch = data.master_branch or ""
+    payload.description = data.description
+    payload.pusher_type = data.pusher_type or "user"
+  end
+  return payload
 end
 
 local b = make_backend_builder()
@@ -291,5 +563,13 @@ b:rest("get_repositories", function()
     fetch_json(append_page_params(base() .. "/repos?show=all", PAGES))
   )
 end)
+
+b:webhook("push", radicle_ref_event)
+b:webhook("patch", radicle_patch_event)
+
+for _, event in ipairs({ "push", "create", "delete", "pull_request" }) do
+  b:webhook_translator(event, translate_radicle_normalized_webhook)
+  b:webhook_github_translator(event, translate_radicle_github_webhook)
+end
 
 b:build()

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -167,6 +167,7 @@ delivered.  Confusio maps these to its canonical internal event family names.
 | kallithea | _(body fields)_ | `push`, `CREATE_REPO_HOOK`, `CREATE_PULLREQUEST_HOOK` |
 | pagure | `X-Pagure-Event` | `issue`, `pull-request`, `git` |
 | launchpad | `X-Launchpad-Event-Type` | `git:push:0.1`, `merge-proposal:0.1`, `bug:0.1` |
+| radicle | _(body field `event_type`)_ | `push`, `patch` |
 | sourcehut | _(body field `event`)_ | `push`, `patchset:created` |
 | All others | _(backend-specific — see [Signature Verification](#signature-verification))_ | — |
 
@@ -233,8 +234,8 @@ Four distinct schemes appear across the 24 backends:
 | **HMAC-SHA256** | Signature = `HMAC-SHA256(secret, body)`, hex-encoded | gitea, forgejo, codeberg, notabug, gogs, bitbucket, bitbucket_datacenter, phabricator, pagure (SHA-256 header) |
 | **HMAC-SHA512** | Signature = `HMAC-SHA512(secret, body)`, hex-encoded | pagure (SHA-512 header, older instances) |
 | **HMAC-SHA1** | Signature = `HMAC-SHA1(secret, body)`, hex-encoded | gitbucket (GitHub legacy compat), launchpad |
-| **Shared token** | Secret echoed verbatim in a header; constant-time string compare | gitlab, gitblit, harness, onedev, rhodecode, sourceforge, tuleap, kallithea |
-| **Bearer / Basic** | Secret in Authorization header (Bearer or Basic form) | azuredevops (Basic), gerrit (Basic or Bearer), radicle (raw) |
+| **Shared token** | Secret echoed verbatim in a header or body field; constant-time string compare | gitlab, gitblit, harness, onedev, radicle, rhodecode, sourceforge, tuleap, kallithea |
+| **Bearer / Basic** | Secret in Authorization header (Bearer or Basic form) | azuredevops (Basic), gerrit (Basic or Bearer) |
 | **Asymmetric / platform** | ed25519 or platform-managed certificate signing | sourcehut, codecommit |
 
 ### Quick reference
@@ -575,6 +576,9 @@ accept if constant_time_equal(secret, received)
 
 Radicle sends the shared secret in the `Authorization` header.  Current Radicle node
 versions do not use a `Bearer` or `Basic` prefix — the secret value is sent as-is.
+Radicle CI adapter requests identify the event family in the root `event_type` body
+field; current values are `push` for branch/tag ref changes and `patch` for patch
+create/update requests.
 
 ```
 secret   = configured shared secret

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -580,6 +580,11 @@ Radicle CI adapter requests identify the event family in the root `event_type` b
 field; current values are `push` for branch/tag ref changes and `patch` for patch
 create/update requests.
 
+Confusio maps Radicle `push` requests to GitHub `push`, `create`, or `delete`
+deliveries based on the `before` / `after` all-zero SHA convention.  Radicle `patch`
+requests currently map `created` to `pull_request.opened` and `updated` to
+`pull_request.synchronize`.
+
 ```
 secret   = configured shared secret
 received = value of Authorization header (verbatim, no prefix stripping)
@@ -2302,13 +2307,13 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2368,11 +2373,11 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `updated` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Page Build | `page_build` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Ping | `ping` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `reopened` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `synchronize` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `synchronize` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
 |  | `labeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `unlabeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `assigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2385,7 +2390,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2546,6 +2551,9 @@ Triggered when one or more commits are pushed to a branch or tag.
 - Gerrit `ref-updated` and `batch-ref-updated` events do not include commit lists or
   compare URLs; confusio emits an empty `commits` array, `head_commit: null`, and
   `compare: ""`.
+- Radicle `push` requests carry branch or tag ref changes in the body `event_type:
+  "push"` family.  Confusio forwards commit details when present and derives
+  create/delete from all-zero `before` / `after` SHAs.
 
 #### `commits[]` fields
 
@@ -2873,6 +2881,10 @@ Action support for this event is generated in the [action support matrix](#gener
   after merge via the `commit_stop` field.  `synchronize` maps to Pagure's `updated`
   event.  `edited` maps to `comment added` on the PR description; not all edit
   scenarios produce a confusio `edited` event.
+- **Radicle**: Patch events arrive as `event_type: "patch"`.  Confusio maps
+  `action: "created"` to `pull_request.opened` and `action: "updated"` to
+  `pull_request.synchronize`.  Closed, reopened, review, label, assignee, and reviewer
+  request actions are not emitted by the current Radicle adapter.
 
 ---
 

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -149,10 +149,19 @@ local KALLITHEA_BODY_EVENT_FIELDS = {
   "hookType",
 }
 
+local RADICLE_BODY_EVENT_FIELDS = {
+  "event_type",
+  "eventType",
+}
+
 local function kallithea_body_event(payload)
   return first_string_field(payload, KALLITHEA_BODY_EVENT_FIELDS)
     or first_string_field(payload and payload.data, KALLITHEA_BODY_EVENT_FIELDS)
     or first_string_field(payload and payload.payload, KALLITHEA_BODY_EVENT_FIELDS)
+end
+
+local function radicle_body_event(payload)
+  return first_string_field(payload, RADICLE_BODY_EVENT_FIELDS)
 end
 
 local function phabricator_phid_type(phid)
@@ -532,6 +541,7 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     --   Gerrit uses payload.type (e.g. "comment-added").
     --   OneDev uses payload.type (e.g. "RefUpdated").
     --   Kallithea hook plugins embed an event/hook name in the JSON body.
+    --   Radicle CI adapter requests use payload.event_type (e.g. "push", "patch").
     --   Phabricator webhooks embed object.type, or an equivalent PHID prefix.
     local ev = event_header(backend)
     if ev == nil and type(payload) == "table" then
@@ -543,6 +553,8 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
         ev = payload.type
       elseif backend == "kallithea" then
         ev = kallithea_body_event(payload)
+      elseif backend == "radicle" then
+        ev = radicle_body_event(payload)
       elseif backend == "phabricator" then
         ev = phabricator_body_event(payload)
       end

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,6 +1,6 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
 POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
-POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~refs/issues/PRs/builds/packages,~no CI events,y,~no CI events,~no CI events,~no CI events,~no CI events,~no CI events
+POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~refs/issues/PRs/builds/packages,~no CI events,y,~refs/patches only,~no CI events,~no CI events,~no CI events,~no CI events
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n
@@ -463,13 +463,13 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,n,n,n,n,n
+webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,n,n,n
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,n,n,n,n,n
+webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,n,n,n
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -529,11 +529,11 @@ webhook package/published,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,y,n,n,n,n,n,n,n
 webhook package/updated,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n,n
 webhook page_build/page_build,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook ping/ping,n,n,n,y,n,y,n,n,y,y,n,y,n,n,y,n,n,n,n,n,n,n,n,n
-webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,y,y,y,y,y,n,n,n,n,n
+webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,n
 webhook pull_request/closed,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
 webhook pull_request/reopened,n,n,n,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
 webhook pull_request/edited,n,n,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
-webhook pull_request/synchronize,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
+webhook pull_request/synchronize,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,y,y,n,n,n,n
 webhook pull_request/labeled,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request/unlabeled,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request/assigned,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n
@@ -546,7 +546,7 @@ webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,
 webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,n,n,n,n,n
+webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,n
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/radicle/create.json
+++ b/test/fixtures/webhooks/radicle/create.json
@@ -1,0 +1,41 @@
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push",
+  "event_id": "radicle-ref-create-1",
+  "occurred_at": "2024-01-15T10:04:00Z",
+  "repository": {
+    "rid": "rad:z3gqcJUoA1n9HaHKufZs1",
+    "name": "hello-world",
+    "description": "My first repo",
+    "default_branch": "main",
+    "web_url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",
+    "clone_url": "rad://rad:z3gqcJUoA1n9HaHKufZs1",
+    "owner": {
+      "id": "did:key:z6MkGxABC123",
+      "alias": "octocat"
+    }
+  },
+  "pusher": {
+    "id": "did:key:z6MkAlice",
+    "alias": "alice",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "ref": "refs/heads/feature/radicle-fixtures",
+  "branch": "feature/radicle-fixtures",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "3333333333333333333333333333333333333333",
+  "commits": [
+    {
+      "id": "3333333333333333333333333333333333333333",
+      "message": "Start Radicle fixture work",
+      "timestamp": "2024-01-15T10:04:00Z",
+      "url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/commits/3333333333333333333333333333333333333333",
+      "author": {
+        "name": "Alice Example",
+        "email": "alice@example.com"
+      }
+    }
+  ]
+}

--- a/test/fixtures/webhooks/radicle/delete.json
+++ b/test/fixtures/webhooks/radicle/delete.json
@@ -1,0 +1,30 @@
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push",
+  "event_id": "radicle-ref-delete-1",
+  "occurred_at": "2024-01-15T10:06:00Z",
+  "repository": {
+    "rid": "rad:z3gqcJUoA1n9HaHKufZs1",
+    "name": "hello-world",
+    "description": "My first repo",
+    "default_branch": "main",
+    "web_url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",
+    "clone_url": "rad://rad:z3gqcJUoA1n9HaHKufZs1",
+    "owner": {
+      "id": "did:key:z6MkGxABC123",
+      "alias": "octocat"
+    }
+  },
+  "pusher": {
+    "id": "did:key:z6MkAlice",
+    "alias": "alice",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "ref": "refs/heads/feature/radicle-fixtures",
+  "branch": "feature/radicle-fixtures",
+  "before": "3333333333333333333333333333333333333333",
+  "after": "0000000000000000000000000000000000000000",
+  "commits": []
+}

--- a/test/fixtures/webhooks/radicle/patch-created.json
+++ b/test/fixtures/webhooks/radicle/patch-created.json
@@ -1,0 +1,45 @@
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "patch",
+  "event_id": "radicle-patch-created-1",
+  "occurred_at": "2024-01-15T10:30:00Z",
+  "repository": {
+    "rid": "rad:z3gqcJUoA1n9HaHKufZs1",
+    "name": "hello-world",
+    "description": "My first repo",
+    "default_branch": "main",
+    "web_url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",
+    "clone_url": "rad://rad:z3gqcJUoA1n9HaHKufZs1",
+    "owner": {
+      "id": "did:key:z6MkGxABC123",
+      "alias": "octocat"
+    }
+  },
+  "sender": {
+    "id": "did:key:z6MkAlice",
+    "alias": "alice",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "action": "created",
+  "patch": {
+    "id": "patches/1",
+    "number": 1,
+    "title": "Add checkout flow",
+    "description": "Implement checkout flow.",
+    "state": "open",
+    "target_branch": "main",
+    "base": "1111111111111111111111111111111111111111",
+    "head": "4444444444444444444444444444444444444444",
+    "url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/patches/1",
+    "author": {
+      "id": "did:key:z6MkAlice",
+      "alias": "alice",
+      "name": "Alice Example",
+      "email": "alice@example.com"
+    },
+    "created_at": "2024-01-15T10:30:00Z",
+    "updated_at": "2024-01-15T10:30:00Z"
+  }
+}

--- a/test/fixtures/webhooks/radicle/patch-updated.json
+++ b/test/fixtures/webhooks/radicle/patch-updated.json
@@ -1,0 +1,55 @@
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "patch",
+  "event_id": "radicle-patch-updated-1",
+  "occurred_at": "2024-01-15T10:50:00Z",
+  "repository": {
+    "rid": "rad:z3gqcJUoA1n9HaHKufZs1",
+    "name": "hello-world",
+    "description": "My first repo",
+    "default_branch": "main",
+    "web_url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",
+    "clone_url": "rad://rad:z3gqcJUoA1n9HaHKufZs1",
+    "owner": {
+      "id": "did:key:z6MkGxABC123",
+      "alias": "octocat"
+    }
+  },
+  "sender": {
+    "id": "did:key:z6MkAlice",
+    "alias": "alice",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "action": "updated",
+  "patch": {
+    "id": "patches/1",
+    "number": 1,
+    "title": "Add checkout flow",
+    "description": "Implement checkout flow and tests.",
+    "state": "open",
+    "target_branch": "main",
+    "base": "1111111111111111111111111111111111111111",
+    "head": "5555555555555555555555555555555555555555",
+    "url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/patches/1",
+    "author": {
+      "id": "did:key:z6MkAlice",
+      "alias": "alice",
+      "name": "Alice Example",
+      "email": "alice@example.com"
+    },
+    "created_at": "2024-01-15T10:30:00Z",
+    "updated_at": "2024-01-15T10:50:00Z",
+    "revisions": [
+      {
+        "id": "4444444444444444444444444444444444444444",
+        "created_at": "2024-01-15T10:30:00Z"
+      },
+      {
+        "id": "5555555555555555555555555555555555555555",
+        "created_at": "2024-01-15T10:50:00Z"
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/radicle/push.json
+++ b/test/fixtures/webhooks/radicle/push.json
@@ -1,0 +1,41 @@
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push",
+  "event_id": "radicle-push-1",
+  "occurred_at": "2024-01-15T10:05:00Z",
+  "repository": {
+    "rid": "rad:z3gqcJUoA1n9HaHKufZs1",
+    "name": "hello-world",
+    "description": "My first repo",
+    "default_branch": "main",
+    "web_url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",
+    "clone_url": "rad://rad:z3gqcJUoA1n9HaHKufZs1",
+    "owner": {
+      "id": "did:key:z6MkGxABC123",
+      "alias": "octocat"
+    }
+  },
+  "pusher": {
+    "id": "did:key:z6MkAlice",
+    "alias": "alice",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "ref": "refs/heads/main",
+  "branch": "main",
+  "before": "1111111111111111111111111111111111111111",
+  "after": "2222222222222222222222222222222222222222",
+  "commits": [
+    {
+      "id": "2222222222222222222222222222222222222222",
+      "message": "Update README",
+      "timestamp": "2024-01-15T10:05:00Z",
+      "url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/commits/2222222222222222222222222222222222222222",
+      "author": {
+        "name": "Alice Example",
+        "email": "alice@example.com"
+      }
+    }
+  ]
+}

--- a/test/fixtures/webhooks/radicle/tag-create.json
+++ b/test/fixtures/webhooks/radicle/tag-create.json
@@ -1,0 +1,30 @@
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push",
+  "event_id": "radicle-tag-create-1",
+  "occurred_at": "2024-01-15T11:00:00Z",
+  "repository": {
+    "rid": "rad:z3gqcJUoA1n9HaHKufZs1",
+    "name": "hello-world",
+    "description": "My first repo",
+    "default_branch": "main",
+    "web_url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",
+    "clone_url": "rad://rad:z3gqcJUoA1n9HaHKufZs1",
+    "owner": {
+      "id": "did:key:z6MkGxABC123",
+      "alias": "octocat"
+    }
+  },
+  "pusher": {
+    "id": "did:key:z6MkAlice",
+    "alias": "alice",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "ref": "refs/tags/v1.0.0",
+  "tag": "v1.0.0",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "2222222222222222222222222222222222222222",
+  "commits": []
+}

--- a/test/fixtures/webhooks/radicle/tag-delete.json
+++ b/test/fixtures/webhooks/radicle/tag-delete.json
@@ -1,0 +1,30 @@
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push",
+  "event_id": "radicle-tag-delete-1",
+  "occurred_at": "2024-01-15T11:05:00Z",
+  "repository": {
+    "rid": "rad:z3gqcJUoA1n9HaHKufZs1",
+    "name": "hello-world",
+    "description": "My first repo",
+    "default_branch": "main",
+    "web_url": "https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",
+    "clone_url": "rad://rad:z3gqcJUoA1n9HaHKufZs1",
+    "owner": {
+      "id": "did:key:z6MkGxABC123",
+      "alias": "octocat"
+    }
+  },
+  "pusher": {
+    "id": "did:key:z6MkAlice",
+    "alias": "alice",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "ref": "refs/tags/v1.0.0",
+  "tag": "v1.0.0",
+  "before": "2222222222222222222222222222222222222222",
+  "after": "0000000000000000000000000000000000000000",
+  "commits": []
+}

--- a/test/mock-radicle.lua
+++ b/test/mock-radicle.lua
@@ -24,7 +24,111 @@ function OnHttpRequest()
     .. '"delegates":[{"id":"did:key:z6MkGxABC123"}],'
     .. '"private":false}'
 
+  local WEBHOOK_REPO = '{"rid":"rad:z3gqcJUoA1n9HaHKufZs1","name":"hello-world",'
+    .. '"description":"My first repo","default_branch":"main",'
+    .. '"web_url":"https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1",'
+    .. '"clone_url":"rad://rad:z3gqcJUoA1n9HaHKufZs1",'
+    .. '"owner":{"id":"did:key:z6MkGxABC123","alias":"octocat"}}'
+
+  local WEBHOOK_USER = '{"id":"did:key:z6MkAlice","alias":"alice",'
+    .. '"name":"Alice Example","email":"alice@example.com"}'
+
+  local WEBHOOK_FIXTURES = {
+    push = '{"request":"trigger","version":1,"event_type":"push",'
+      .. '"event_id":"radicle-push-1","occurred_at":"2024-01-15T10:05:00Z",'
+      .. '"repository":'
+      .. WEBHOOK_REPO
+      .. ',"pusher":'
+      .. WEBHOOK_USER
+      .. ',"ref":"refs/heads/main","branch":"main",'
+      .. '"before":"1111111111111111111111111111111111111111",'
+      .. '"after":"2222222222222222222222222222222222222222",'
+      .. '"commits":[{"id":"2222222222222222222222222222222222222222",'
+      .. '"message":"Update README","timestamp":"2024-01-15T10:05:00Z",'
+      .. '"url":"https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/commits/2222222222222222222222222222222222222222",'
+      .. '"author":{"name":"Alice Example","email":"alice@example.com"}}]}',
+    create = '{"request":"trigger","version":1,"event_type":"push",'
+      .. '"event_id":"radicle-ref-create-1","occurred_at":"2024-01-15T10:04:00Z",'
+      .. '"repository":'
+      .. WEBHOOK_REPO
+      .. ',"pusher":'
+      .. WEBHOOK_USER
+      .. ',"ref":"refs/heads/feature/radicle-fixtures",'
+      .. '"branch":"feature/radicle-fixtures",'
+      .. '"before":"0000000000000000000000000000000000000000",'
+      .. '"after":"3333333333333333333333333333333333333333",'
+      .. '"commits":[{"id":"3333333333333333333333333333333333333333",'
+      .. '"message":"Start Radicle fixture work","timestamp":"2024-01-15T10:04:00Z",'
+      .. '"url":"https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/commits/3333333333333333333333333333333333333333",'
+      .. '"author":{"name":"Alice Example","email":"alice@example.com"}}]}',
+    delete = '{"request":"trigger","version":1,"event_type":"push",'
+      .. '"event_id":"radicle-ref-delete-1","occurred_at":"2024-01-15T10:06:00Z",'
+      .. '"repository":'
+      .. WEBHOOK_REPO
+      .. ',"pusher":'
+      .. WEBHOOK_USER
+      .. ',"ref":"refs/heads/feature/radicle-fixtures",'
+      .. '"branch":"feature/radicle-fixtures",'
+      .. '"before":"3333333333333333333333333333333333333333",'
+      .. '"after":"0000000000000000000000000000000000000000","commits":[]}',
+    ["tag-create"] = '{"request":"trigger","version":1,"event_type":"push",'
+      .. '"event_id":"radicle-tag-create-1","occurred_at":"2024-01-15T11:00:00Z",'
+      .. '"repository":'
+      .. WEBHOOK_REPO
+      .. ',"pusher":'
+      .. WEBHOOK_USER
+      .. ',"ref":"refs/tags/v1.0.0","tag":"v1.0.0",'
+      .. '"before":"0000000000000000000000000000000000000000",'
+      .. '"after":"2222222222222222222222222222222222222222","commits":[]}',
+    ["tag-delete"] = '{"request":"trigger","version":1,"event_type":"push",'
+      .. '"event_id":"radicle-tag-delete-1","occurred_at":"2024-01-15T11:05:00Z",'
+      .. '"repository":'
+      .. WEBHOOK_REPO
+      .. ',"pusher":'
+      .. WEBHOOK_USER
+      .. ',"ref":"refs/tags/v1.0.0","tag":"v1.0.0",'
+      .. '"before":"2222222222222222222222222222222222222222",'
+      .. '"after":"0000000000000000000000000000000000000000","commits":[]}',
+    ["patch-created"] = '{"request":"trigger","version":1,"event_type":"patch",'
+      .. '"event_id":"radicle-patch-created-1","occurred_at":"2024-01-15T10:30:00Z",'
+      .. '"repository":'
+      .. WEBHOOK_REPO
+      .. ',"sender":'
+      .. WEBHOOK_USER
+      .. ',"action":"created","patch":{"id":"patches/1","number":1,'
+      .. '"title":"Add checkout flow","description":"Implement checkout flow.",'
+      .. '"state":"open","target_branch":"main",'
+      .. '"base":"1111111111111111111111111111111111111111",'
+      .. '"head":"4444444444444444444444444444444444444444",'
+      .. '"url":"https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/patches/1",'
+      .. '"author":'
+      .. WEBHOOK_USER
+      .. ',"created_at":"2024-01-15T10:30:00Z",'
+      .. '"updated_at":"2024-01-15T10:30:00Z"}}',
+    ["patch-updated"] = '{"request":"trigger","version":1,"event_type":"patch",'
+      .. '"event_id":"radicle-patch-updated-1","occurred_at":"2024-01-15T10:50:00Z",'
+      .. '"repository":'
+      .. WEBHOOK_REPO
+      .. ',"sender":'
+      .. WEBHOOK_USER
+      .. ',"action":"updated","patch":{"id":"patches/1","number":1,'
+      .. '"title":"Add checkout flow","description":"Implement checkout flow and tests.",'
+      .. '"state":"open","target_branch":"main",'
+      .. '"base":"1111111111111111111111111111111111111111",'
+      .. '"head":"5555555555555555555555555555555555555555",'
+      .. '"url":"https://radicle.example/nodes/z6MkGxABC123/rad:z3gqcJUoA1n9HaHKufZs1/patches/1",'
+      .. '"author":'
+      .. WEBHOOK_USER
+      .. ',"created_at":"2024-01-15T10:30:00Z",'
+      .. '"updated_at":"2024-01-15T10:50:00Z",'
+      .. '"revisions":[{"id":"4444444444444444444444444444444444444444",'
+      .. '"created_at":"2024-01-15T10:30:00Z"},'
+      .. '{"id":"5555555555555555555555555555555555555555",'
+      .. '"created_at":"2024-01-15T10:50:00Z"}]}}',
+  }
+
   local rb = "/api/v1/repos/" .. rid
+  local webhook_fixture = path:match("^" .. rb:gsub("%-", "%%-") .. "/webhook%-fixtures/([^/]+)$")
 
   if path == "/api/v1" then
     SetStatus(200, "OK")
@@ -72,6 +176,11 @@ function OnHttpRequest()
   elseif path:find("^" .. rb:gsub("%-", "%%-") .. "/blob/") then
     SetStatus(200, "OK")
     raw("file content\n")
+
+  -- Webhook fixtures -------------------------------------------------------
+  elseif WEBHOOK_FIXTURES[webhook_fixture] then
+    SetStatus(200, "OK")
+    json(WEBHOOK_FIXTURES[webhook_fixture])
 
   -- Migrations ----------------------------------------------------------------
   -- Radicle has no GitHub-style org/user migration API; confusio

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -140,13 +140,13 @@ CONFUSIO_TS=$(date +%s)
 CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
 # Write secrets to 0600-permission files — never pass raw secrets on the CLI.
 WH_SECRET_DIR=$(mktemp -d)
-for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad phabricator pagure gerrit onedev kallithea confusio; do
+for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad phabricator pagure gerrit onedev radicle kallithea confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_radicle=$WH_SECRET_DIR/radicle.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT
@@ -164,6 +164,7 @@ $HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
   --variable "gerrit_tok=$WH_SECRET" \
   --variable "gerrit_basic=$GERRIT_BASIC" \
   --variable "onedev_tok=$WH_SECRET" \
+  --variable "radicle_tok=$WH_SECRET" \
   --variable "confusio_sig=$CONFUSIO_SIG" \
   test/webhooks-sig.hurl
 kill $WH_PID 2>/dev/null || true; sleep 0.3

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -405,7 +405,18 @@ run_delivery_phase test/webhook-delivery-phabricator-confusio-shape.hurl \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 42: Startup event synthesis — github shape.
+# Phase 42: Radicle fixture-based delivery tests — native body-typed events.
+run_delivery_phase test/webhook-delivery-radicle.hurl \
+  -- radicle "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
+
+# Phase 43: Radicle delivery with "confusio" shape — normalized hook envelopes.
+run_delivery_phase test/webhook-delivery-radicle-confusio-shape.hurl \
+  -- radicle "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
+  "webhook_target_shape=confusio"
+
+# Phase 44: Startup event synthesis — github shape.
 # Verifies that confusio synthesizes installation.created and
 # installation_repositories.added before accepting connections, and delivers
 # both to the configured outbound target.  No /reset is called — the hurl file
@@ -414,8 +425,8 @@ run_delivery_phase test/webhook-delivery-startup.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 43: Startup event synthesis — confusio shape.
-# Same as Phase 42 but with webhook_target_shape=confusio; verifies
+# Phase 45: Startup event synthesis — confusio shape.
+# Same as Phase 44 but with webhook_target_shape=confusio; verifies
 # X-Confusio-* headers are used and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-startup-confusio-shape.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3154,6 +3154,36 @@ do
     "webhook_receiver: kallithea nested payload.hook_type handler succeeds → 200"
   )
 
+  -- Radicle CI adapter requests embed the event family in the JSON body.
+  app.backend.webhooks = {
+    push = function(_payload)
+      return { event = "push" }, nil
+    end,
+    patch = function(_payload)
+      return { event = "pull_request" }, nil
+    end,
+  }
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/radicle",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"request":"trigger","version":1,"event_type":"push"}',
+    }),
+    200,
+    "webhook_receiver: radicle event_type push handler succeeds → 200"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/radicle",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"request":"trigger","version":1,"event_type":"patch"}',
+    }),
+    200,
+    "webhook_receiver: radicle event_type patch handler succeeds → 200"
+  )
+
   -- Phabricator embeds the object family in object.type or the PHID prefix.
   app.backend.webhooks = {
     TASK = function(_payload)

--- a/test/webhook-delivery-radicle-confusio-shape.hurl
+++ b/test/webhook-delivery-radicle-confusio-shape.hurl
@@ -1,0 +1,179 @@
+# Radicle webhook delivery test — "confusio" shape variant.
+#
+# When webhook_target_shape=confusio, Radicle deliveries use X-Confusio-*
+# headers and normalized event envelopes instead of GitHub-compatible headers.
+
+# ── push ref update -> push -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "push"
+jsonpath "$[0].confusio_source" == "radicle"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:05:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.payload.head_commit.id" == "2222222222222222222222222222222222222222"
+
+# ── branch create -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "radicle"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.ref" == "feature/radicle-fixtures"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# ── branch delete -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "radicle"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.ref" == "feature/radicle-fixtures"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# ── tag create -> create ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/tag-create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "radicle"
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.payload.ref" == "v1.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"
+
+# ── tag delete -> delete ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/tag-delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "radicle"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.payload.ref" == "v1.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"
+
+# ── patch created -> pull_request.opened -----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/patch-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request"
+jsonpath "$[0].confusio_source" == "radicle"
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:30:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.pull_request.number" == 1
+
+# ── patch updated -> pull_request.synchronize ------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/patch-updated.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request"
+jsonpath "$[0].confusio_source" == "radicle"
+jsonpath "$[0].body_json.type" == "pull_request.synchronize"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:50:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.action" == "synchronize"
+jsonpath "$[0].body_json.payload.pull_request.head.sha" == "5555555555555555555555555555555555555555"

--- a/test/webhook-delivery-radicle.hurl
+++ b/test/webhook-delivery-radicle.hurl
@@ -1,0 +1,166 @@
+# Radicle webhook delivery tests.
+#
+# Radicle CI adapter requests embed the event family in event_type, so no
+# event-type header is required.  Ref changes map to push/create/delete, and
+# patch events map to pull_request actions.
+
+# ── push ref update -> push -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.before" == "1111111111111111111111111111111111111111"
+jsonpath "$[0].body_json.after" == "2222222222222222222222222222222222222222"
+jsonpath "$[0].body_json.commits[0].id" == "2222222222222222222222222222222222222222"
+
+# ── branch create -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature/radicle-fixtures"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+
+# ── branch delete -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature/radicle-fixtures"
+jsonpath "$[0].body_json.ref_type" == "branch"
+
+# ── tag create -> create ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/tag-create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v1.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"
+
+# ── tag delete -> delete ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/tag-delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v1.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"
+
+# ── patch created -> pull_request opened -----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/patch-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "opened"
+jsonpath "$[0].body_json.number" == 1
+jsonpath "$[0].body_json.pull_request.title" == "Add checkout flow"
+jsonpath "$[0].body_json.pull_request.base.ref" == "main"
+
+# ── patch updated -> pull_request synchronize ------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+file,fixtures/webhooks/radicle/patch-updated.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "synchronize"
+jsonpath "$[0].body_json.number" == 1
+jsonpath "$[0].body_json.pull_request.head.sha" == "5555555555555555555555555555555555555555"

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -12,6 +12,7 @@
 #   gerrit_tok  — the shared secret verbatim or as Bearer token (for Authorization)
 #   gerrit_basic — base64("webhooksecret") for Authorization: Basic
 #   onedev_tok — the shared secret verbatim (for X-OneDev-Signature)
+#   radicle_tok — the shared secret verbatim (for Authorization)
 #   kallithea — shared secret is embedded in the request body
 #   confusio_sig — "sha256=<hex>, v=1, ts=<ts>" (for X-Confusio-Signature-256)
 #
@@ -429,6 +430,63 @@ jsonpath "$.message" == "Signature verification failed"
 POST http://{{host}}/webhooks/onedev
 Content-Type: application/json
 {}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── radicle: Authorization raw shared secret, event_type in body ─────────────
+
+# Valid raw Authorization token and event_type → passes verification and extracts event
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+Authorization: {{radicle_tok}}
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push"
+}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "Unrecognised event type: push"
+
+# Bad Authorization token → 401
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+Authorization: wrongtoken
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push"
+}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Bearer Authorization is not Radicle's native webhook signature → 401
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+Authorization: Bearer {{radicle_tok}}
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push"
+}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing Authorization header → 401
+POST http://{{host}}/webhooks/radicle
+Content-Type: application/json
+{
+  "request": "trigger",
+  "version": 1,
+  "event_type": "push"
+}
 
 HTTP 401
 [Asserts]


### PR DESCRIPTION
Adds delivery coverage for Radicle ref and patch webhook events, including GitHub-compatible and normalized outbound shapes. Records the supported Radicle webhook behavior in compatibility and docs notes.

Fixes #269.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Add Radicle webhook delivery tests <!-- type:spec -->
- [x] Update Radicle webhook compatibility and docs <!-- type:spec -->
- [x] Translate Radicle ref and patch webhook events <!-- type:spec -->
- [x] Add Radicle webhook fixtures and mock routes <!-- type:spec -->
- [x] Verify Radicle webhook auth and event typing <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->