### PR TITLE
v3: Webhook — sourceforge source backend (closes #271)

### DIFF
--- a/backends/sourceforge.lua
+++ b/backends/sourceforge.lua
@@ -2,10 +2,306 @@
 if config.base_url == "" then
   config.base_url = "https://sourceforge.net"
 end
+
+local ZERO_SHA = "0000000000000000000000000000000000000000"
+
+local function ref_name(ref)
+  return (ref or ""):match("^refs/heads/(.+)$")
+    or (ref or ""):match("^refs/tags/(.+)$")
+    or (ref or "")
+end
+
+local function ref_type(ref)
+  if (ref or ""):match("^refs/tags/") then
+    return "tag"
+  end
+  return "branch"
+end
+
+local function sourceforge_repo_parts(repo)
+  repo = repo or {}
+  local project, tool = tostring(repo.full_name or ""):match("^/p/([^/]+)/([^/]+)/?$")
+  if project then
+    return project, tool
+  end
+  project, tool = tostring(repo.url or repo.homepage or ""):match("/p/([^/]+)/([^/]+)/?$")
+  if project then
+    return project, tool
+  end
+  project, tool = tostring(repo.full_name or ""):match("^([^/]+)/(.+)$")
+  return project or "", tool or repo.name or ""
+end
+
+local function translate_sourceforge_user(u)
+  u = u or {}
+  local login = u.username or u.login or u.name or ""
+  return {
+    login = login,
+    id = 0,
+    node_id = "",
+    avatar_url = u.avatar_url or "",
+    url = u.url or "",
+    html_url = u.url or "",
+    type = "User",
+    site_admin = false,
+    name = u.name or login,
+    email = u.email or "",
+  }
+end
+
+local function sourceforge_repo_url(owner, name, repo)
+  if repo and repo.url and repo.url ~= "" then
+    return repo.url
+  end
+  if repo and repo.homepage and repo.homepage ~= "" then
+    return repo.homepage
+  end
+  if owner ~= "" and name ~= "" then
+    return config.base_url .. "/p/" .. owner .. "/" .. name .. "/"
+  end
+  return ""
+end
+
+local function translate_sourceforge_repo(repo)
+  repo = repo or {}
+  local owner, name = sourceforge_repo_parts(repo)
+  local url = sourceforge_repo_url(owner, name, repo)
+  local full_name = owner ~= "" and name ~= "" and (owner .. "/" .. name)
+    or (repo.full_name or name)
+  return {
+    id = 0,
+    node_id = "",
+    name = name,
+    full_name = full_name,
+    private = false,
+    owner = {
+      login = owner,
+      id = 0,
+      node_id = "",
+      avatar_url = "",
+      url = "",
+      html_url = owner ~= "" and (config.base_url .. "/p/" .. owner .. "/") or "",
+      type = "Organization",
+    },
+    html_url = url,
+    description = repo.description,
+    fork = false,
+    url = "",
+    git_url = repo.git_url or "",
+    ssh_url = repo.ssh_url or "",
+    clone_url = repo.clone_url or repo.url or "",
+    homepage = repo.homepage or url,
+    size = 0,
+    stargazers_count = 0,
+    watchers_count = 0,
+    language = nil,
+    has_issues = false,
+    has_wiki = false,
+    forks_count = 0,
+    archived = false,
+    disabled = false,
+    open_issues_count = 0,
+    default_branch = repo.default_branch or "master",
+    visibility = "public",
+    forks = 0,
+    open_issues = 0,
+    watchers = 0,
+    created_at = repo.created_at,
+    updated_at = repo.updated_at,
+    pushed_at = repo.pushed_at,
+  }
+end
+
+local function translate_sourceforge_commit(c)
+  c = c or {}
+  local author = c.author or {}
+  local committer = c.committer or author
+  return {
+    id = c.id or c.sha or "",
+    message = c.message or "",
+    timestamp = c.timestamp or c.date or "",
+    url = c.url or "",
+    author = {
+      name = author.name or "",
+      email = author.email or "",
+      username = author.username or author.login or author.name or "",
+    },
+    committer = {
+      name = committer.name or author.name or "",
+      email = committer.email or author.email or "",
+      username = committer.username or committer.login or committer.name or author.name or "",
+    },
+    added = c.added or {},
+    removed = c.removed or {},
+    modified = c.modified or {},
+  }
+end
+
+local function sourceforge_commits(commits)
+  local result = {}
+  for _, commit in ipairs(commits or {}) do
+    result[#result + 1] = translate_sourceforge_commit(commit)
+  end
+  return result
+end
+
+local function sourceforge_sender(payload)
+  return translate_sourceforge_user(payload.sender or payload.pusher or payload.author)
+end
+
+local function sourceforge_pusher(payload)
+  local pusher = payload.pusher or payload.sender or payload.author or {}
+  return {
+    name = pusher.name or pusher.username or pusher.login or "",
+    email = pusher.email or "",
+  }
+end
+
+local function sourceforge_ref_webhook(payload)
+  payload = payload or {}
+  local raw_ref = payload.ref or ""
+  local before = payload.before or ""
+  local after = payload.after or ""
+  local repository = translate_sourceforge_repo(payload.repository)
+  local sender = sourceforge_sender(payload)
+
+  if before == ZERO_SHA then
+    return make_internal_event({
+      event = "create",
+      action = "create",
+      provider = "sourceforge",
+      raw = payload,
+      data = {
+        ref = ref_name(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.timestamp or "",
+    })
+  end
+
+  if after == ZERO_SHA then
+    return make_internal_event({
+      event = "delete",
+      action = "delete",
+      provider = "sourceforge",
+      raw = payload,
+      data = {
+        ref = ref_name(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.timestamp or "",
+    })
+  end
+
+  local commits = sourceforge_commits(payload.commits)
+  local head_commit = #commits > 0 and commits[#commits] or nil
+  return make_internal_event({
+    event = "push",
+    action = "push",
+    provider = "sourceforge",
+    raw = payload,
+    data = {
+      ref = raw_ref,
+      before = before,
+      after = after,
+      created = false,
+      deleted = false,
+      forced = payload.forced or false,
+      compare = payload.compare or payload.compare_url or "",
+      commits = commits,
+      head_commit = head_commit,
+      pusher = sourceforge_pusher(payload),
+      repository = repository,
+      sender = sender,
+    },
+    timestamp = payload.timestamp or (head_commit and head_commit.timestamp) or "",
+  })
+end
+
+local SOURCEFORGE_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
+local function sourceforge_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_sourceforge_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        SOURCEFORGE_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or sourceforge_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+local function translate_sourceforge_github_webhook(internal_event)
+  local data = internal_event.data or {}
+  local payload = {
+    action = data.action or internal_event.action,
+    repository = data.repository or {},
+    sender = data.sender or {},
+  }
+  if internal_event.event == "push" then
+    payload.action = nil
+    payload.ref = data.ref or ""
+    payload.before = data.before or ""
+    payload.after = data.after or ""
+    payload.created = data.created or false
+    payload.deleted = data.deleted or false
+    payload.forced = data.forced or false
+    payload.compare = data.compare or ""
+    payload.commits = data.commits or {}
+    payload.head_commit = data.head_commit
+    payload.pusher = data.pusher or {}
+  elseif internal_event.event == "create" or internal_event.event == "delete" then
+    payload.ref = data.ref or ""
+    payload.ref_type = data.ref_type or ""
+    payload.master_branch = data.master_branch or ""
+    payload.description = data.description
+    payload.pusher_type = data.pusher_type or "user"
+  end
+  return payload
+end
+
 local b = make_backend_builder()
 b:rest("get_root", function()
   proxy_health_check(pcall(Fetch, config.base_url .. "/rest/p"))
 end)
+
+b:webhook("repo-push", sourceforge_ref_webhook)
+
+for _, event in ipairs({ "push", "create", "delete" }) do
+  b:webhook_translator(event, translate_sourceforge_normalized_webhook)
+  b:webhook_github_translator(event, translate_sourceforge_github_webhook)
+end
 
 -- Issues -----------------------------------------------------------------------
 -- SourceForge uses the Allura ticket tracker, whose REST API shape differs

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -145,7 +145,7 @@ receiver implementation, and a brief note on the signature scheme used.  The
 | `phabricator` | `POST /webhooks/phabricator` | _(self-hosted)_ | phabricator | `X-Phabricator-Webhook-Signature` HMAC-SHA256 (Conduit key) |
 | `radicle` | `POST /webhooks/radicle` | `https://radicle.xyz` | radicle | Shared secret in `Authorization` header |
 | `rhodecode` | `POST /webhooks/rhodecode` | _(self-hosted)_ | rhodecode | Shared secret in `X-RhodeCode-Signature` header |
-| `sourceforge` | `POST /webhooks/sourceforge` | `https://sourceforge.net` | sourceforge | Shared secret in `X-Sourceforge-Webhook-Secret` header |
+| `sourceforge` | `POST /webhooks/sourceforge` | `https://sourceforge.net` | sourceforge | `X-Allura-Signature` HMAC-SHA1 |
 | `sourcehut` | `POST /webhooks/sourcehut` | `https://sr.ht` | sourcehut | `X-Payload-Signature` ed25519 (public key published by sr.ht) |
 | `tuleap` | `POST /webhooks/tuleap` | _(self-hosted)_ | tuleap | `X-Tuleap-Webhook-Secret` shared secret |
 
@@ -233,8 +233,8 @@ Four distinct schemes appear across the 24 backends:
 |--------|-------------|----------|
 | **HMAC-SHA256** | Signature = `HMAC-SHA256(secret, body)`, hex-encoded | gitea, forgejo, codeberg, notabug, gogs, bitbucket, bitbucket_datacenter, phabricator, pagure (SHA-256 header) |
 | **HMAC-SHA512** | Signature = `HMAC-SHA512(secret, body)`, hex-encoded | pagure (SHA-512 header, older instances) |
-| **HMAC-SHA1** | Signature = `HMAC-SHA1(secret, body)`, hex-encoded | gitbucket (GitHub legacy compat), launchpad |
-| **Shared token** | Secret echoed verbatim in a header or body field; constant-time string compare | gitlab, gitblit, harness, onedev, radicle, rhodecode, sourceforge, tuleap, kallithea |
+| **HMAC-SHA1** | Signature = `HMAC-SHA1(secret, body)`, hex-encoded | gitbucket (GitHub legacy compat), launchpad, sourceforge |
+| **Shared token** | Secret echoed verbatim in a header or body field; constant-time string compare | gitlab, gitblit, harness, onedev, radicle, rhodecode, tuleap, kallithea |
 | **Bearer / Basic** | Secret in Authorization header (Bearer or Basic form) | azuredevops (Basic), gerrit (Basic or Bearer) |
 | **Asymmetric / platform** | ed25519 or platform-managed certificate signing | sourcehut, codecommit |
 
@@ -263,7 +263,7 @@ Four distinct schemes appear across the 24 backends:
 | `phabricator` | `X-Phabricator-Webhook-Signature` | HMAC-SHA256 | `<hex>` |
 | `radicle` | `Authorization` | Shared token | verbatim |
 | `rhodecode` | `X-RhodeCode-Signature` | Shared token | verbatim |
-| `sourceforge` | `X-Sourceforge-Webhook-Secret` | Shared token | verbatim |
+| `sourceforge` | `X-Allura-Signature` | HMAC-SHA1 | `sha1=<hex>` |
 | `sourcehut` | `X-Payload-Signature` | ed25519 | base64 |
 | `tuleap` | `X-Tuleap-Webhook-Secret` | Shared token | verbatim |
 
@@ -626,16 +626,19 @@ accept if constant_time_equal(expected, received)
 
 ### SourceForge
 
-SourceForge sends the shared secret in `X-Sourceforge-Webhook-Secret`.
+SourceForge runs Allura for project webhooks. Allura signs the raw JSON payload
+with the configured webhook secret and sends the digest in `X-Allura-Signature`.
 
 ```
 secret   = configured shared secret
-received = value of X-Sourceforge-Webhook-Secret
+expected = "sha1=" ++ HMAC-SHA1(secret, body) as lowercase hex
+received = value of X-Allura-Signature
 
-accept if constant_time_equal(secret, received)
+accept if constant_time_equal(expected, received)
 ```
 
-**Configuration:** Set when registering the webhook in SourceForge project settings.
+**Configuration:** Set `secret` when registering the webhook in SourceForge or
+Allura project settings; Allura may generate one if left blank.
 
 ---
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -640,6 +640,13 @@ accept if constant_time_equal(expected, received)
 **Configuration:** Set `secret` when registering the webhook in SourceForge or
 Allura project settings; Allura may generate one if left blank.
 
+**Supported events:** SourceForge / Allura repository hooks do not send an event
+type header.  Confusio infers Allura `repo-push` payloads from the documented
+ref update shape and translates them to GitHub-compatible `push`, `create`, or
+`delete` events.  Branch and tag create/delete events are derived when `before`
+or `after` is the all-zero SHA; other SourceForge webhook families are not
+mapped.
+
 ---
 
 ### Tuleap
@@ -2310,13 +2317,13 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2393,7 +2400,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2557,6 +2564,10 @@ Triggered when one or more commits are pushed to a branch or tag.
 - Radicle `push` requests carry branch or tag ref changes in the body `event_type:
   "push"` family.  Confusio forwards commit details when present and derives
   create/delete from all-zero `before` / `after` SHAs.
+- SourceForge / Allura `repo-push` events do not include an event header.  Confusio
+  infers the event from the body, forwards commit `id`, `url`, `timestamp`, and
+  `message` when present, and derives create/delete from all-zero `before` /
+  `after` SHAs.
 
 #### `commits[]` fields
 
@@ -2585,6 +2596,9 @@ Triggered when one or more commits are pushed to a branch or tag.
   forges include only the author.
 - `added` / `removed` / `modified`: Only GitHub and GitLab include per-file diff lists
   in push events.  All other backends emit `[]` for these three fields.
+- SourceForge / Allura documents commit `id`, `url`, `timestamp`, and `message`.
+  Author, committer, and file lists are empty unless present in the delivered
+  payload.
 
 **Confusio-normalized differences:** In the confusio shape, `commits[].author` uses
 the actor schema (`id`, `login`, `display_name`, `source_url`) rather than the git
@@ -2620,11 +2634,12 @@ field structure.
 **Backend-specific gaps:**
 - `gerrit`: Gerrit `ref-updated` events become `create` or `delete` when `oldRev` or
   `newRev` is the all-zero SHA.
-- `sourcehut`, `pagure`, `phabricator`, `launchpad`, `radicle`: Create/delete events
-  may arrive embedded in a push event rather than as discrete event types.  Confusio
-  splits them when the push `before` or `after` is all-zero.
-- `codecommit`, `kallithea`, `rhodecode`, `tuleap`, `sourceforge`: Create/delete events
-  may not be delivered at all depending on forge configuration.  If no event is
+- `sourcehut`, `pagure`, `phabricator`, `launchpad`, `radicle`, `sourceforge`:
+  Create/delete events may arrive embedded in a push event rather than as
+  discrete event types.  Confusio splits them when the push `before` or `after`
+  is all-zero.
+- `codecommit`, `kallithea`, `rhodecode`, `tuleap`: Create/delete events may not
+  be delivered at all depending on forge configuration.  If no event is
   received, the `create` / `delete` event will not be emitted.
 
 ---

--- a/internal/signing.lua
+++ b/internal/signing.lua
@@ -74,7 +74,7 @@ function sign_for_backend(backend, secret, body) -- luacheck: globals sign_for_b
   elseif backend == "rhodecode" then
     return { ["X-RhodeCode-Signature"] = secret }
   elseif backend == "sourceforge" then
-    return { ["X-Sourceforge-Webhook-Secret"] = secret }
+    return { ["X-Allura-Signature"] = "sha1=" .. hmac_hex("sha1", secret, body) }
   elseif backend == "tuleap" then
     return { ["X-Tuleap-Webhook-Secret"] = secret }
   elseif backend == "azuredevops" then

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -349,16 +349,16 @@ local function verify_signature(backend, secret, body, now)
     end
     return ct_equal(secret, tok)
 
-  -- SourceForge: X-Sourceforge-Webhook-Secret, verbatim shared token
+  -- SourceForge / Allura: X-Allura-Signature, HMAC-SHA1, prefix "sha1="
   elseif backend == "sourceforge" then
     if not secret or secret == "" then
       return true
     end
-    local tok = GetHeader("X-Sourceforge-Webhook-Secret")
-    if not tok then
+    local sig = GetHeader("X-Allura-Signature")
+    if not sig then
       return false
     end
-    return ct_equal(secret, tok)
+    return ct_equal("sha1=" .. hmac_hex("sha1", secret, body), sig)
 
   -- Tuleap: X-Tuleap-Webhook-Secret, verbatim shared token
   elseif backend == "tuleap" then

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -179,6 +179,16 @@ local function phabricator_body_event(payload)
     or phabricator_phid_type(payload and payload.objectPHID)
 end
 
+local function sourceforge_body_event(payload)
+  if type(payload) ~= "table" or type(payload.repository) ~= "table" then
+    return nil
+  end
+  if payload.ref or payload.before or payload.after or payload.commits then
+    return "repo-push"
+  end
+  return nil
+end
+
 -- verify_signature(backend, secret, body[, now]) authenticates the inbound request
 -- using the backend-native scheme.  Returns true on success, false on failure.
 -- When secret is nil or "" (trust-the-network mode) all requests are accepted.
@@ -543,6 +553,8 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     --   Kallithea hook plugins embed an event/hook name in the JSON body.
     --   Radicle CI adapter requests use payload.event_type (e.g. "push", "patch").
     --   Phabricator webhooks embed object.type, or an equivalent PHID prefix.
+    --   SourceForge / Allura repo-push webhooks have no event header, so infer
+    --   them from their documented ref/update fields.
     local ev = event_header(backend)
     if ev == nil and type(payload) == "table" then
       if payload.eventType then
@@ -557,6 +569,8 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
         ev = radicle_body_event(payload)
       elseif backend == "phabricator" then
         ev = phabricator_body_event(payload)
+      elseif backend == "sourceforge" then
+        ev = sourceforge_body_event(payload)
       end
     end
 

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -463,13 +463,13 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,n,n,n
+webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,n,n
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,n,n,n
+webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,n,n
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -546,7 +546,7 @@ webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,
 webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,n
+webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,n
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/sourceforge/create.json
+++ b/test/fixtures/webhooks/sourceforge/create.json
@@ -1,0 +1,27 @@
+{
+  "before": "0000000000000000000000000000000000000000",
+  "after": "3333333333333333333333333333333333333333",
+  "ref": "refs/heads/feature/sourceforge-fixtures",
+  "repository": {
+    "full_name": "/p/octocat/hello-world/",
+    "name": "hello-world",
+    "url": "https://sourceforge.net/p/octocat/hello-world/",
+    "homepage": "https://sourceforge.net/p/octocat/hello-world/",
+    "description": "Hello World repository",
+    "default_branch": "main"
+  },
+  "pusher": {
+    "username": "alice",
+    "name": "Alice",
+    "email": "alice@example.com",
+    "url": "https://sourceforge.net/u/alice/"
+  },
+  "commits": [
+    {
+      "id": "3333333333333333333333333333333333333333",
+      "url": "https://sourceforge.net/p/octocat/hello-world/ci/3333333/",
+      "timestamp": "2024-01-15T10:10:00Z",
+      "message": "Create feature branch"
+    }
+  ]
+}

--- a/test/fixtures/webhooks/sourceforge/delete.json
+++ b/test/fixtures/webhooks/sourceforge/delete.json
@@ -1,0 +1,20 @@
+{
+  "before": "4444444444444444444444444444444444444444",
+  "after": "0000000000000000000000000000000000000000",
+  "ref": "refs/heads/feature/sourceforge-fixtures",
+  "repository": {
+    "full_name": "/p/octocat/hello-world/",
+    "name": "hello-world",
+    "url": "https://sourceforge.net/p/octocat/hello-world/",
+    "homepage": "https://sourceforge.net/p/octocat/hello-world/",
+    "description": "Hello World repository",
+    "default_branch": "main"
+  },
+  "pusher": {
+    "username": "alice",
+    "name": "Alice",
+    "email": "alice@example.com",
+    "url": "https://sourceforge.net/u/alice/"
+  },
+  "commits": []
+}

--- a/test/fixtures/webhooks/sourceforge/push.json
+++ b/test/fixtures/webhooks/sourceforge/push.json
@@ -1,0 +1,27 @@
+{
+  "before": "1111111111111111111111111111111111111111",
+  "after": "2222222222222222222222222222222222222222",
+  "ref": "refs/heads/main",
+  "repository": {
+    "full_name": "/p/octocat/hello-world/",
+    "name": "hello-world",
+    "url": "https://sourceforge.net/p/octocat/hello-world/",
+    "homepage": "https://sourceforge.net/p/octocat/hello-world/",
+    "description": "Hello World repository",
+    "default_branch": "main"
+  },
+  "pusher": {
+    "username": "alice",
+    "name": "Alice",
+    "email": "alice@example.com",
+    "url": "https://sourceforge.net/u/alice/"
+  },
+  "commits": [
+    {
+      "id": "2222222222222222222222222222222222222222",
+      "url": "https://sourceforge.net/p/octocat/hello-world/ci/2222222/",
+      "timestamp": "2024-01-15T10:05:00Z",
+      "message": "Update README"
+    }
+  ]
+}

--- a/test/fixtures/webhooks/sourceforge/tag-create.json
+++ b/test/fixtures/webhooks/sourceforge/tag-create.json
@@ -1,0 +1,27 @@
+{
+  "before": "0000000000000000000000000000000000000000",
+  "after": "5555555555555555555555555555555555555555",
+  "ref": "refs/tags/v1.0.0",
+  "repository": {
+    "full_name": "/p/octocat/hello-world/",
+    "name": "hello-world",
+    "url": "https://sourceforge.net/p/octocat/hello-world/",
+    "homepage": "https://sourceforge.net/p/octocat/hello-world/",
+    "description": "Hello World repository",
+    "default_branch": "main"
+  },
+  "pusher": {
+    "username": "alice",
+    "name": "Alice",
+    "email": "alice@example.com",
+    "url": "https://sourceforge.net/u/alice/"
+  },
+  "commits": [
+    {
+      "id": "5555555555555555555555555555555555555555",
+      "url": "https://sourceforge.net/p/octocat/hello-world/ci/5555555/",
+      "timestamp": "2024-01-15T10:15:00Z",
+      "message": "Tag v1.0.0"
+    }
+  ]
+}

--- a/test/fixtures/webhooks/sourceforge/tag-delete.json
+++ b/test/fixtures/webhooks/sourceforge/tag-delete.json
@@ -1,0 +1,20 @@
+{
+  "before": "5555555555555555555555555555555555555555",
+  "after": "0000000000000000000000000000000000000000",
+  "ref": "refs/tags/v1.0.0",
+  "repository": {
+    "full_name": "/p/octocat/hello-world/",
+    "name": "hello-world",
+    "url": "https://sourceforge.net/p/octocat/hello-world/",
+    "homepage": "https://sourceforge.net/p/octocat/hello-world/",
+    "description": "Hello World repository",
+    "default_branch": "main"
+  },
+  "pusher": {
+    "username": "alice",
+    "name": "Alice",
+    "email": "alice@example.com",
+    "url": "https://sourceforge.net/u/alice/"
+  },
+  "commits": []
+}

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -418,7 +418,18 @@ run_delivery_phase test/webhook-delivery-radicle-confusio-shape.hurl \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 44: Startup event synthesis — github shape.
+# Phase 44: SourceForge fixture-based delivery tests — Allura repo-push events.
+run_delivery_phase test/webhook-delivery-sourceforge.hurl \
+  -- sourceforge "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
+
+# Phase 45: SourceForge delivery with "confusio" shape — normalized ref events.
+run_delivery_phase test/webhook-delivery-sourceforge-confusio-shape.hurl \
+  -- sourceforge "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
+  "webhook_target_shape=confusio"
+
+# Phase 46: Startup event synthesis — github shape.
 # Verifies that confusio synthesizes installation.created and
 # installation_repositories.added before accepting connections, and delivers
 # both to the configured outbound target.  No /reset is called — the hurl file
@@ -427,8 +438,8 @@ run_delivery_phase test/webhook-delivery-startup.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 45: Startup event synthesis — confusio shape.
-# Same as Phase 44 but with webhook_target_shape=confusio; verifies
+# Phase 47: Startup event synthesis — confusio shape.
+# Same as Phase 46 but with webhook_target_shape=confusio; verifies
 # X-Confusio-* headers are used and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-startup-confusio-shape.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -131,6 +131,7 @@ GITEA_SIG=$(printf '%s' "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | a
 BB_SIG="sha256=${GITEA_SIG}"
 GB_SIG="sha1=$(printf '%s' "$WH_BODY" | openssl dgst -sha1 -hmac "$WH_SECRET" | awk '{print $NF}')"
 LAUNCHPAD_SIG="$GB_SIG"
+SOURCEFORGE_SIG="$GB_SIG"
 PAGURE_SIG_256="$GITEA_SIG"
 PAGURE_SIG_512=$(printf '%s' "$WH_BODY" | openssl dgst -sha512 -hmac "$WH_SECRET" | awk '{print $NF}')
 AZUREDEVOPS_SECRET="fido:$WH_SECRET"
@@ -140,13 +141,13 @@ CONFUSIO_TS=$(date +%s)
 CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
 # Write secrets to 0600-permission files — never pass raw secrets on the CLI.
 WH_SECRET_DIR=$(mktemp -d)
-for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad phabricator pagure gerrit onedev radicle kallithea confusio; do
+for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad phabricator pagure gerrit onedev radicle kallithea sourceforge confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_radicle=$WH_SECRET_DIR/radicle.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_radicle=$WH_SECRET_DIR/radicle.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_sourceforge=$WH_SECRET_DIR/sourceforge.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT
@@ -165,6 +166,7 @@ $HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
   --variable "gerrit_basic=$GERRIT_BASIC" \
   --variable "onedev_tok=$WH_SECRET" \
   --variable "radicle_tok=$WH_SECRET" \
+  --variable "sourceforge_sig=$SOURCEFORGE_SIG" \
   --variable "confusio_sig=$CONFUSIO_SIG" \
   test/webhooks-sig.hurl
 kill $WH_PID 2>/dev/null || true; sleep 0.3

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3567,21 +3567,21 @@ do
     "verify_signature rhodecode: missing X-RhodeCode-Signature → 401"
   )
 
-  -- ── Verbatim shared token: sourceforge (X-Sourceforge-Webhook-Secret)
+  -- ── SourceForge / Allura: X-Allura-Signature, HMAC-SHA1, sha1= prefix
   ok(no_secret("sourceforge", {}) ~= 401, "verify_signature sourceforge: no secret → not 401")
   ok(
-    with_secret("sourceforge", { ["X-Sourceforge-Webhook-Secret"] = SECRET }) ~= 401,
-    "verify_signature sourceforge: valid X-Sourceforge-Webhook-Secret → not 401"
+    with_secret("sourceforge", { ["X-Allura-Signature"] = "sha1=" .. STUB_HEX }) ~= 401,
+    "verify_signature sourceforge: valid X-Allura-Signature → not 401"
   )
   eq(
-    with_secret("sourceforge", { ["X-Sourceforge-Webhook-Secret"] = "bad" }),
+    with_secret("sourceforge", { ["X-Allura-Signature"] = "sha1=deadbeef" }),
     401,
-    "verify_signature sourceforge: bad X-Sourceforge-Webhook-Secret → 401"
+    "verify_signature sourceforge: bad X-Allura-Signature → 401"
   )
   eq(
     with_secret("sourceforge", {}),
     401,
-    "verify_signature sourceforge: missing X-Sourceforge-Webhook-Secret → 401"
+    "verify_signature sourceforge: missing X-Allura-Signature → 401"
   )
 
   -- ── Verbatim shared token: tuleap (X-Tuleap-Webhook-Secret)
@@ -3821,6 +3821,18 @@ do
     )
     ok(h["X-Hub-Signature-256"] == nil, "sign_for_backend " .. be .. ": no X-Hub-Signature-256")
   end
+
+  -- SourceForge / Allura: HMAC-SHA1 via X-Allura-Signature.
+  local sfb_sourceforge = sign_for_backend("sourceforge", SECRET, BODY)
+  eq(
+    sfb_sourceforge["X-Allura-Signature"],
+    "sha1=" .. STUB_HEX,
+    "sign_for_backend sourceforge: X-Allura-Signature sha1= present"
+  )
+  ok(
+    sfb_sourceforge["X-Sourceforge-Webhook-Secret"] == nil,
+    "sign_for_backend sourceforge: no legacy shared-token header"
+  )
 
   -- Default (unknown backend): GitHub-style.
   local sfb_def = sign_for_backend("unknown_backend", SECRET, BODY)

--- a/test/webhook-delivery-sourceforge-confusio-shape.hurl
+++ b/test/webhook-delivery-sourceforge-confusio-shape.hurl
@@ -1,0 +1,128 @@
+# SourceForge webhook delivery test - "confusio" shape variant.
+#
+# SourceForge / Allura repo-push events are inferred from the JSON body and
+# delivered as normalized push/create/delete envelopes.
+
+# -- repo-push ref update -> push --------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "push"
+jsonpath "$[0].confusio_source" == "sourceforge"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:05:00Z"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.payload.head_commit.id" == "2222222222222222222222222222222222222222"
+
+# -- branch create -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "sourceforge"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.ref" == "feature/sourceforge-fixtures"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# -- branch delete -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "sourceforge"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.ref" == "feature/sourceforge-fixtures"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# -- tag create -> create ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/tag-create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "sourceforge"
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.payload.ref" == "v1.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"
+
+# -- tag delete -> delete ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/tag-delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "sourceforge"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.payload.ref" == "v1.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"

--- a/test/webhook-delivery-sourceforge.hurl
+++ b/test/webhook-delivery-sourceforge.hurl
@@ -1,0 +1,121 @@
+# SourceForge webhook delivery tests.
+#
+# SourceForge / Allura repo-push deliveries do not carry an event header.
+# confusio infers repo-push from the documented ref/update fields and maps it
+# to GitHub-compatible push/create/delete deliveries.
+
+# -- repo-push ref update -> push --------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.before" == "1111111111111111111111111111111111111111"
+jsonpath "$[0].body_json.after" == "2222222222222222222222222222222222222222"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.sender.login" == "alice"
+jsonpath "$[0].body_json.commits[0].id" == "2222222222222222222222222222222222222222"
+
+# -- branch create -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature/sourceforge-fixtures"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+
+# -- branch delete -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature/sourceforge-fixtures"
+jsonpath "$[0].body_json.ref_type" == "branch"
+
+# -- tag create -> create ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/tag-create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v1.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"
+
+# -- tag delete -> delete ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+file,fixtures/webhooks/sourceforge/tag-delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v1.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -7,6 +7,7 @@
 #   bb_sig      — "sha256=<hex>" (for X-Hub-Signature on bitbucket and bitbucket_datacenter)
 #   gb_sig      — "sha1=<hex>" (for X-Hub-Signature on gitbucket)
 #   launchpad_sig — "sha1=<hex>" (for X-Hub-Signature on launchpad)
+#   sourceforge_sig — "sha1=<hex>" (for X-Allura-Signature on sourceforge)
 #   phabricator_sig — HMAC-SHA256("{}", secret) as hex (for X-Phabricator-Webhook-Signature)
 #   azuredevops_basic — base64("fido:webhooksecret") for Authorization: Basic
 #   gerrit_tok  — the shared secret verbatim or as Bearer token (for Authorization)
@@ -531,6 +532,47 @@ jsonpath "$.message" == "Signature verification failed"
 
 # Missing body secret → 401
 POST http://{{host}}/webhooks/kallithea
+Content-Type: application/json
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── sourceforge: X-Allura-Signature, HMAC-SHA1, sha1= prefix ────────────────
+
+# Valid signature → passes verification (422)
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+X-Allura-Signature: {{sourceforge_sig}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad signature → 401
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+X-Allura-Signature: sha1=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Legacy shared-secret header is not Allura's native webhook signature → 401
+POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+X-Sourceforge-Webhook-Secret: webhooksecret
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing signature header → 401
+POST http://{{host}}/webhooks/sourceforge
 Content-Type: application/json
 {}
 


### PR DESCRIPTION
Adds SourceForge webhook backend support for Allura-compatible signing and repo-push translation.

Fixes #271.

The remaining pass adds SourceForge fixtures, delivery coverage, and compatibility/docs updates for the supported webhook surface.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add SourceForge webhook fixtures and delivery tests <!-- type:spec -->
- [x] Update SourceForge webhook compatibility and docs <!-- type:spec -->
- [x] Translate SourceForge repo-push events <!-- type:spec -->
- [x] Align SourceForge webhook signing with Allura <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->