### PR TITLE
v3: Webhook — sourcehut source backend (closes #272)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -107,6 +107,7 @@ globals = {
   -- Outbound delivery signing: internal/signing.lua
   "sign_github",
   "sign_for_backend",
+  "SourcehutVerifyEd25519",
   -- Fan-out dispatcher: internal/fanout.lua
   "fanout_body",
   "fanout_dispatch",

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -836,6 +836,216 @@ local function sourcehut_git_event(payload)
   })
 end
 
+local function sourcehut_job_payload(payload)
+  payload = sourcehut_payload(payload)
+  return payload.job or payload.newJob or payload.build
+end
+
+local function sourcehut_job_state(job, forced_action)
+  job = job or {}
+  local status_key = tostring(job.status or job.state or ""):lower()
+  local states = {
+    success = { "completed", "completed", "success" },
+    failed = { "completed", "completed", "failure" },
+    timeout = { "completed", "completed", "failure" },
+    cancelled = { "completed", "completed", "cancelled" },
+    canceled = { "completed", "completed", "cancelled" },
+    running = { "in_progress", "in_progress", nil },
+    queued = { "requested", "queued", nil },
+    pending = { "requested", "queued", nil },
+  }
+  local mapped = states[status_key] or { "in_progress", "in_progress", nil }
+  local action = forced_action or mapped[1]
+  return action, mapped[2], mapped[3]
+end
+
+local function sourcehut_job_name(job)
+  job = job or {}
+  return job.note or job.name or job.manifest or ("Sourcehut job " .. tostring(job.id or 0))
+end
+
+local function sourcehut_job_ref(job)
+  job = job or {}
+  return sourcehut_first_nonempty(job.ref, job.branch, job.head_branch)
+end
+
+local function sourcehut_job_sha(job)
+  job = job or {}
+  return sourcehut_first_nonempty(job.commit, job.commitId, job.commit_id, job.sha, job.head_sha)
+end
+
+local function translate_srht_workflow(job)
+  job = job or {}
+  local name = sourcehut_job_name(job)
+  return {
+    id = job.id or 0,
+    name = name,
+    path = job.url or job.webUrl or job.web_url or "",
+    state = "active",
+    url = "",
+    html_url = job.url or job.webUrl or job.web_url or "",
+    badge_url = "",
+    created_at = job.created,
+    updated_at = job.updated or job.created,
+  }
+end
+
+local function translate_srht_workflow_run(job, payload, action)
+  job = job or {}
+  local _, status, conclusion = sourcehut_job_state(job, action)
+  local sender = sourcehut_sender(payload)
+  local name = sourcehut_job_name(job)
+  return {
+    id = job.id or 0,
+    name = name,
+    head_branch = ref_name(sourcehut_job_ref(job)),
+    head_sha = sourcehut_job_sha(job),
+    run_number = job.id or 0,
+    event = "push",
+    display_title = name,
+    status = status,
+    conclusion = conclusion,
+    workflow_id = job.id or 0,
+    url = "",
+    html_url = job.url or job.webUrl or job.web_url or "",
+    pull_requests = {},
+    created_at = job.created,
+    updated_at = job.updated or job.created,
+    run_attempt = 1,
+    referenced_workflows = {},
+    actor = sender,
+    triggering_actor = sender,
+  }
+end
+
+local function sourcehut_job_event(payload, forced_action)
+  payload = payload or {}
+  local job = sourcehut_job_payload(payload) or {}
+  local action = sourcehut_job_state(job, forced_action)
+  local repository = sourcehut_repository(payload)
+  local workflow_run = translate_srht_workflow_run(job, payload, action)
+  return make_internal_event({
+    event = "workflow_run",
+    action = action,
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      action = action,
+      workflow = translate_srht_workflow(job),
+      workflow_run = workflow_run,
+      repository = repository,
+      sender = sourcehut_sender(payload),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date
+      or workflow_run.updated_at
+      or workflow_run.created_at
+      or "",
+  })
+end
+
+local function sourcehut_patchset_payload(payload)
+  payload = sourcehut_payload(payload)
+  return payload.patchset or payload.newPatchset
+end
+
+local function sourcehut_patchset_sender(patchset)
+  patchset = patchset or {}
+  return translate_srht_user(patchset.submitter or patchset.owner or patchset.author)
+end
+
+local function translate_srht_patchset(patchset, payload)
+  patchset = patchset or {}
+  local repository = sourcehut_repository(payload)
+  local sender = sourcehut_patchset_sender(patchset)
+  local number = patchset.id or patchset.number or 0
+  local base_ref = sourcehut_first_nonempty(
+    patchset.targetBranch,
+    patchset.target_branch,
+    patchset.base,
+    repository.default_branch
+  )
+  return {
+    id = patchset.id or 0,
+    node_id = patchset.rid or "",
+    number = number,
+    state = "open",
+    locked = false,
+    title = patchset.subject or patchset.title or "",
+    user = sender,
+    body = patchset.coverLetter or patchset.cover_letter or patchset.body or "",
+    created_at = patchset.created,
+    updated_at = patchset.updated or patchset.created,
+    closed_at = nil,
+    merged_at = nil,
+    merge_commit_sha = nil,
+    assignee = nil,
+    assignees = {},
+    requested_reviewers = {},
+    requested_teams = {},
+    labels = {},
+    milestone = nil,
+    draft = false,
+    commits_url = "",
+    review_comments_url = "",
+    review_comment_url = "",
+    comments_url = "",
+    statuses_url = "",
+    head = {
+      label = sourcehut_first_nonempty(patchset.ref, patchset.branch, "patchset/" .. number),
+      ref = sourcehut_first_nonempty(patchset.ref, patchset.branch, "patchset/" .. number),
+      sha = sourcehut_first_nonempty(patchset.commit, patchset.commitId, patchset.sha),
+      user = sender,
+      repo = repository,
+    },
+    base = {
+      label = base_ref,
+      ref = base_ref,
+      sha = sourcehut_first_nonempty(patchset.baseCommit, patchset.base_commit, patchset.baseSha),
+      user = repository.owner or {},
+      repo = repository,
+    },
+    html_url = patchset.url or patchset.webUrl or patchset.web_url or "",
+    url = "",
+    diff_url = "",
+    patch_url = "",
+    merged = false,
+    mergeable = nil,
+    rebaseable = nil,
+    mergeable_state = "unknown",
+    merged_by = nil,
+    comments = 0,
+    review_comments = 0,
+    commits = 0,
+    additions = 0,
+    deletions = 0,
+    changed_files = 0,
+  }
+end
+
+local function sourcehut_patchset_event(payload)
+  payload = payload or {}
+  local patchset = sourcehut_patchset_payload(payload) or {}
+  local pull_request = translate_srht_patchset(patchset, payload)
+  local sender = sourcehut_sender(payload)
+  return make_internal_event({
+    event = "pull_request",
+    action = "opened",
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      action = "opened",
+      number = pull_request.number,
+      pull_request = pull_request,
+      repository = sourcehut_repository(payload),
+      sender = sender.login ~= "" and sender or sourcehut_patchset_sender(patchset),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date
+      or pull_request.updated_at
+      or pull_request.created_at
+      or "",
+  })
+end
+
 local SOURCEHUT_ACTIONLESS_NORMALIZED_EVENTS = {
   create = true,
   delete = true,
@@ -909,6 +1119,12 @@ local function translate_sourcehut_github_webhook(internal_event, _fields)
   elseif internal_event.event == "label" then
     payload.label = data.label or {}
     payload.changes = data.changes or {}
+  elseif internal_event.event == "workflow_run" then
+    payload.workflow_run = data.workflow_run or {}
+    payload.workflow = data.workflow or {}
+  elseif internal_event.event == "pull_request" then
+    payload.number = data.number
+    payload.pull_request = data.pull_request or {}
   end
   return payload
 end
@@ -1404,6 +1620,14 @@ end)
 
 b:webhook("EVENT_CREATED", sourcehut_event_created)
 
+b:webhook("JOB_CREATED", function(payload)
+  return sourcehut_job_event(payload, "requested")
+end)
+
+b:webhook("JOB_UPDATED", sourcehut_job_event)
+
+b:webhook("PATCHSET_RECEIVED", sourcehut_patchset_event)
+
 for _, event in ipairs({
   "push",
   "create",
@@ -1412,6 +1636,8 @@ for _, event in ipairs({
   "issues",
   "issue_comment",
   "label",
+  "workflow_run",
+  "pull_request",
 }) do
   b:webhook_translator(event, translate_sourcehut_normalized_webhook)
   b:webhook_github_translator(event, translate_sourcehut_github_webhook)

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -31,25 +31,68 @@ local _t = make_backend_transport("token", PAGES)
 local fetch_json = _t.fetch_json
 local proxy_handler = _t.proxy_handler
 
+local ZERO_SHA = "0000000000000000000000000000000000000000"
+
+local function strip_tilde(value)
+  value = value or ""
+  return value:sub(1, 1) == "~" and value:sub(2) or value
+end
+
+local function sourcehut_canonical(entity)
+  entity = entity or {}
+  return entity.canonical_name or entity.canonicalName or entity.username or entity.name or ""
+end
+
+local function sourcehut_login(entity)
+  local canonical = sourcehut_canonical(entity)
+  if canonical ~= "" then
+    return strip_tilde(canonical)
+  end
+  return (entity or {}).login or ""
+end
+
+local function ref_name(ref)
+  return (ref or ""):match("^refs/heads/(.+)$")
+    or (ref or ""):match("^refs/tags/(.+)$")
+    or (ref or "")
+end
+
+local function ref_type(ref)
+  if (ref or ""):match("^refs/tags/") then
+    return "tag"
+  end
+  return "branch"
+end
+
 -- Map a Sourcehut repository object to GitHub format.
 local function translate_srht_repo(r)
   if not r then
     return {}
   end
   local owner = r.owner or {}
-  local canonical = owner.canonical_name or ""
-  -- canonical_name is like "~username", strip the tilde for login
-  local login = canonical:sub(1, 1) == "~" and canonical:sub(2) or canonical
+  local canonical = sourcehut_canonical(owner)
+  local login = sourcehut_login(owner)
   local vis = r.visibility or "public"
+  local private = vis == "private" or vis == "PRIVATE"
+  local head = r.HEAD or r.head or {}
+  local default_branch = ""
+  if type(head) == "table" then
+    default_branch = (head.name or ""):match("^refs/heads/(.+)") or head.name or ""
+  else
+    default_branch = tostring(head or ""):match("^refs/heads/(.+)") or tostring(head or "")
+  end
+  if default_branch == "" then
+    default_branch = "main"
+  end
   return {
     id = r.id or 0,
-    node_id = "",
+    node_id = r.rid or "",
     name = r.name,
     full_name = login .. "/" .. (r.name or ""),
-    private = vis == "private",
+    private = private,
     owner = {
       login = login,
-      id = 0,
+      id = owner.id or 0,
       node_id = "",
       avatar_url = "",
       url = "",
@@ -72,15 +115,32 @@ local function translate_srht_repo(r)
     archived = false,
     disabled = false,
     open_issues_count = 0,
-    default_branch = r.HEAD and ((r.HEAD.name or ""):match("^refs/heads/(.+)") or r.HEAD.name)
-      or "main",
-    visibility = vis == "private" and "private" or "public",
+    default_branch = default_branch,
+    visibility = private and "private" or "public",
     forks = 0,
     open_issues = 0,
     watchers = 0,
     created_at = r.created,
     updated_at = r.updated,
     pushed_at = r.updated,
+  }
+end
+
+local function translate_srht_user(u)
+  u = u or {}
+  local canonical = sourcehut_canonical(u)
+  local login = sourcehut_login(u)
+  return {
+    login = login,
+    id = u.id or 0,
+    node_id = "",
+    avatar_url = "",
+    url = u.url or "",
+    html_url = canonical ~= "" and (config.base_url .. "/" .. canonical) or "",
+    type = "User",
+    site_admin = false,
+    name = u.name or u.username or login,
+    email = u.email or "",
   }
 end
 
@@ -225,16 +285,321 @@ local function translate_srht_commit(c)
     return {}
   end
   local author = c.author or {}
+  local committer = c.committer or author
+  local author_date = author.time or c.timestamp or ""
+  local committer_date = committer.time or author_date
   return {
     sha = c.id or "",
     commit = {
       message = c.message or "",
-      author = { name = author.name or "", email = author.email or "", date = c.timestamp or "" },
-      committer = { name = author.name or "", email = author.email or "", date = c.timestamp or "" },
+      author = { name = author.name or "", email = author.email or "", date = author_date },
+      committer = {
+        name = committer.name or "",
+        email = committer.email or "",
+        date = committer_date,
+      },
     },
     author = { login = author.name or "", id = 0, avatar_url = "" },
-    committer = { login = author.name or "", id = 0, avatar_url = "" },
+    committer = { login = committer.name or "", id = 0, avatar_url = "" },
   }
+end
+
+local function sourcehut_payload(payload)
+  if type(payload) == "table" and type(payload.data) == "table" then
+    return payload.data
+  end
+  return payload or {}
+end
+
+local function sourcehut_webhook(payload)
+  payload = sourcehut_payload(payload)
+  return payload.webhook or payload
+end
+
+local function sourcehut_event_name(payload)
+  local webhook = sourcehut_webhook(payload)
+  return webhook.event or webhook.event_type or webhook.eventType or ""
+end
+
+local function sourcehut_sender(payload)
+  payload = sourcehut_payload(payload)
+  return translate_srht_user(
+    payload.pusher
+      or payload.sender
+      or payload.actor
+      or payload.repository and payload.repository.owner
+  )
+end
+
+local function sourcehut_repository(payload)
+  payload = sourcehut_payload(payload)
+  return translate_srht_repo(payload.repository or {})
+end
+
+local function sourcehut_update_ref(update)
+  update = update or {}
+  local ref = update.ref or update.reference or {}
+  if type(ref) == "table" then
+    return ref.name or update.name or update.refName or ""
+  end
+  return ref or update.name or update.refName or ""
+end
+
+local function sourcehut_object_id(value)
+  if type(value) == "table" then
+    return value.id or value.target or value.sha or value.oid or ""
+  end
+  return value or ""
+end
+
+local function sourcehut_first_nonempty(...)
+  for i = 1, select("#", ...) do
+    local value = select(i, ...)
+    if value ~= nil and value ~= "" then
+      return value
+    end
+  end
+  return ""
+end
+
+local function sourcehut_update_before(update)
+  update = update or {}
+  return sourcehut_object_id(update.old or update.oldTarget or update.from or update.before)
+end
+
+local function sourcehut_update_after(update)
+  update = update or {}
+  local ref = update.ref or update.reference or {}
+  return sourcehut_first_nonempty(
+    sourcehut_object_id(update.new or update.newTarget or update.to or update.after),
+    type(ref) == "table" and (ref.target or "") or ""
+  )
+end
+
+local function sourcehut_first_update(payload)
+  payload = sourcehut_payload(payload)
+  for _, update in ipairs(payload.updates or {}) do
+    if type(update) == "table" then
+      return update
+    end
+  end
+  return payload.update
+end
+
+local function sourcehut_commit_identity(sig)
+  sig = sig or {}
+  local login = sourcehut_login(sig)
+  return {
+    name = sig.name or sig.username or login,
+    email = sig.email or "",
+    username = sig.username or login,
+  }
+end
+
+local function translate_srht_push_commit(c)
+  c = c or {}
+  local author = c.author or {}
+  local committer = c.committer or author
+  local author_time = author.time or c.timestamp or ""
+  local committer_time = committer.time or author_time
+  return {
+    id = c.id or c.sha or "",
+    tree_id = type(c.tree) == "table" and (c.tree.id or "") or c.tree or "",
+    distinct = c.distinct ~= false,
+    message = c.message or "",
+    timestamp = committer_time,
+    url = c.url or "",
+    author = {
+      name = author.name or "",
+      email = author.email or "",
+      username = author.name or "",
+    },
+    committer = {
+      name = committer.name or "",
+      email = committer.email or "",
+      username = committer.name or "",
+    },
+    added = c.added or {},
+    removed = c.removed or {},
+    modified = c.modified or {},
+  }
+end
+
+local function sourcehut_update_commits(update)
+  local commits = {}
+  update = update or {}
+  local raw_commits = update.commits or update.log and update.log.results or update.results or {}
+  for _, commit in ipairs(raw_commits) do
+    commits[#commits + 1] = translate_srht_push_commit(commit)
+  end
+  return commits
+end
+
+local function sourcehut_repo_event(payload, action)
+  payload = payload or {}
+  local data = sourcehut_payload(payload)
+  local repository = translate_srht_repo(data.repository or {})
+  return make_internal_event({
+    event = "repository",
+    action = action,
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      action = action,
+      repository = repository,
+      sender = sourcehut_sender(payload),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date or data.date or repository.updated_at or "",
+  })
+end
+
+local function sourcehut_git_event(payload)
+  payload = payload or {}
+  local update = sourcehut_first_update(payload)
+  if not update then
+    return nil, "No Sourcehut ref update"
+  end
+
+  local raw_ref = sourcehut_update_ref(update)
+  local before = sourcehut_update_before(update)
+  local after = sourcehut_update_after(update)
+  local repository = sourcehut_repository(payload)
+  local sender = sourcehut_sender(payload)
+
+  if before == "" then
+    before = ZERO_SHA
+  end
+  if after == "" then
+    after = ZERO_SHA
+  end
+
+  if before == ZERO_SHA then
+    return make_internal_event({
+      event = "create",
+      action = "create",
+      provider = "sourcehut",
+      raw = payload,
+      data = {
+        ref = ref_name(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = (sourcehut_webhook(payload) or {}).date or "",
+    })
+  end
+
+  if after == ZERO_SHA then
+    return make_internal_event({
+      event = "delete",
+      action = "delete",
+      provider = "sourcehut",
+      raw = payload,
+      data = {
+        ref = ref_name(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = (sourcehut_webhook(payload) or {}).date or "",
+    })
+  end
+
+  local commits = sourcehut_update_commits(update)
+  local head_commit = #commits > 0 and commits[#commits] or nil
+  return make_internal_event({
+    event = "push",
+    action = "",
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      ref = raw_ref,
+      before = before,
+      after = after,
+      created = false,
+      deleted = false,
+      forced = update.forced or false,
+      compare = update.compare or update.compareUrl or "",
+      commits = commits,
+      head_commit = head_commit,
+      pusher = sourcehut_commit_identity((sourcehut_payload(payload).pusher or {})),
+      repository = repository,
+      sender = sender,
+      sourcehut_event = sourcehut_event_name(payload),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date
+      or (head_commit and head_commit.timestamp)
+      or "",
+  })
+end
+
+local SOURCEHUT_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
+local function sourcehut_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_sourcehut_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        SOURCEHUT_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or sourcehut_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+local function translate_sourcehut_github_webhook(internal_event, _fields)
+  local data = internal_event.data or {}
+  local payload = {
+    action = data.action or internal_event.action,
+    repository = data.repository or {},
+    sender = data.sender or {},
+  }
+  if internal_event.event == "push" then
+    payload.action = nil
+    payload.ref = data.ref or ""
+    payload.before = data.before or ""
+    payload.after = data.after or ""
+    payload.created = data.created or false
+    payload.deleted = data.deleted or false
+    payload.forced = data.forced or false
+    payload.compare = data.compare or ""
+    payload.commits = data.commits or {}
+    payload.head_commit = data.head_commit
+    payload.pusher = data.pusher or {}
+  elseif internal_event.event == "create" or internal_event.event == "delete" then
+    payload.ref = data.ref or ""
+    payload.ref_type = data.ref_type or ""
+    payload.master_branch = data.master_branch or ""
+    payload.description = data.description
+    payload.pusher_type = data.pusher_type or "user"
+  end
+  return payload
 end
 
 local b = make_backend_builder()
@@ -688,5 +1053,25 @@ b:graphql("node.Issue", function(local_id, _ctx)
   end
   return graphql_translate_issue(translate_srht_ticket(data), owner, repo)
 end)
+
+b:webhook("REPO_CREATED", function(payload)
+  return sourcehut_repo_event(payload, "created")
+end)
+
+b:webhook("REPO_UPDATE", function(payload)
+  return sourcehut_repo_event(payload, "edited")
+end)
+
+b:webhook("REPO_DELETED", function(payload)
+  return sourcehut_repo_event(payload, "deleted")
+end)
+
+b:webhook("GIT_PRE_RECEIVE", sourcehut_git_event)
+b:webhook("GIT_POST_RECEIVE", sourcehut_git_event)
+
+for _, event in ipairs({ "push", "create", "delete", "repository" }) do
+  b:webhook_translator(event, translate_sourcehut_normalized_webhook)
+  b:webhook_github_translator(event, translate_sourcehut_github_webhook)
+end
 
 b:build()

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -144,6 +144,68 @@ local function translate_srht_user(u)
   }
 end
 
+local function translate_srht_label(label)
+  label = label or {}
+  return {
+    id = label.id or 0,
+    node_id = label.rid or "",
+    url = "",
+    name = label.name or "",
+    color = (label.backgroundColor or label.background_color or ""):gsub("^#", ""),
+    description = label.description or "",
+    default = false,
+  }
+end
+
+local function translate_srht_labels(labels)
+  local result = {}
+  for _, label in ipairs(labels or {}) do
+    result[#result + 1] = translate_srht_label(label)
+  end
+  return result
+end
+
+local function translate_srht_tracker_repo(tracker)
+  tracker = tracker or {}
+  local owner = tracker.owner or {}
+  local canonical = sourcehut_canonical(owner)
+  local login = sourcehut_login(owner)
+  local vis = tracker.visibility or "PUBLIC"
+  local private = vis == "private" or vis == "PRIVATE"
+  return {
+    id = tracker.id or 0,
+    node_id = tracker.rid or "",
+    name = tracker.name or "",
+    full_name = login ~= "" and (login .. "/" .. (tracker.name or "")) or (tracker.name or ""),
+    private = private,
+    owner = translate_srht_user(owner),
+    html_url = canonical ~= "" and (todo_base():gsub("/api$", "") .. "/" .. canonical) or "",
+    description = tracker.description,
+    fork = false,
+    url = "",
+    clone_url = "",
+    homepage = "",
+    size = 0,
+    stargazers_count = 0,
+    watchers_count = 0,
+    language = nil,
+    has_issues = true,
+    has_wiki = false,
+    forks_count = 0,
+    archived = false,
+    disabled = false,
+    open_issues_count = 0,
+    default_branch = "",
+    visibility = private and "private" or "public",
+    forks = 0,
+    open_issues = 0,
+    watchers = 0,
+    created_at = tracker.created,
+    updated_at = tracker.updated,
+    pushed_at = tracker.updated,
+  }
+end
+
 -- Translate GitHub create/update request body to Sourcehut format.
 local function translate_srht_req(body_str)
   local req = DecodeJson(body_str or "{}")
@@ -181,20 +243,25 @@ local function translate_srht_ticket(t)
     return {}
   end
   local submitter = t.submitter or {}
-  local canonical = submitter.canonical_name or ""
-  local login = canonical:sub(1, 1) == "~" and canonical:sub(2) or (submitter.name or canonical)
   local status = t.status or "reported"
-  local state = (status == "resolved" or status == "closed") and "closed" or "open"
+  local state = (
+    status == "resolved"
+    or status == "closed"
+    or status == "RESOLVED"
+    or status == "CLOSED"
+  )
+      and "closed"
+    or "open"
   return {
     id = t.id or 0,
-    node_id = "",
+    node_id = t.rid or "",
     number = t.id or 0,
-    title = t.title or "",
+    title = t.subject or t.title or "",
     body = t.body or "",
     state = state,
-    user = { login = login, id = 0, node_id = "", avatar_url = "", url = "", type = "User" },
-    assignees = {},
-    labels = {},
+    user = translate_srht_user(submitter),
+    assignees = translate_list(translate_srht_user, t.assignees),
+    labels = translate_srht_labels(t.labels),
     milestone = nil,
     created_at = t.created or "",
     updated_at = t.updated or t.created or "",
@@ -334,6 +401,236 @@ end
 local function sourcehut_repository(payload)
   payload = sourcehut_payload(payload)
   return translate_srht_repo(payload.repository or {})
+end
+
+local function sourcehut_ticket_payload(payload)
+  payload = sourcehut_payload(payload)
+  return payload.ticket or payload.newTicket or payload.ticketEvent and payload.ticketEvent.ticket
+end
+
+local function sourcehut_label_payload(payload)
+  payload = sourcehut_payload(payload)
+  return payload.label or payload.newLabel
+end
+
+local function sourcehut_event_payload(payload)
+  payload = sourcehut_payload(payload)
+  return payload.newEvent or payload.eventRecord or payload.ticketEvent or payload.event_detail
+end
+
+local function sourcehut_issue_repository(payload, ticket, label)
+  payload = sourcehut_payload(payload)
+  ticket = ticket or sourcehut_ticket_payload(payload) or {}
+  label = label or sourcehut_label_payload(payload) or {}
+  return translate_srht_tracker_repo(
+    payload.tracker or ticket.tracker or label.tracker or (payload.repository or {}).tracker
+  )
+end
+
+local function sourcehut_ticket_sender(ticket)
+  ticket = ticket or {}
+  return translate_srht_user(ticket.submitter or ticket.author)
+end
+
+local function sourcehut_ticket_event(payload, action)
+  payload = payload or {}
+  local ticket = sourcehut_ticket_payload(payload) or {}
+  local sender = sourcehut_sender(payload)
+  return make_internal_event({
+    event = "issues",
+    action = action,
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      action = action,
+      issue = translate_srht_ticket(ticket),
+      repository = sourcehut_issue_repository(payload, ticket),
+      sender = sender.login ~= "" and sender or sourcehut_ticket_sender(ticket),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date or ticket.updated or ticket.created or "",
+  })
+end
+
+local function sourcehut_deleted_ticket_event(payload)
+  payload = payload or {}
+  local data = sourcehut_payload(payload)
+  local ticket_id = data.ticketId or data.ticket_id or 0
+  return make_internal_event({
+    event = "issues",
+    action = "deleted",
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      action = "deleted",
+      issue = { id = ticket_id, number = ticket_id, state = "closed", labels = {} },
+      repository = sourcehut_issue_repository(payload),
+      sender = sourcehut_sender(payload),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date or "",
+  })
+end
+
+local function sourcehut_label_event(payload, action)
+  payload = payload or {}
+  local label = sourcehut_label_payload(payload) or {}
+  local sender = sourcehut_sender(payload)
+  return make_internal_event({
+    event = "label",
+    action = action,
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      action = action,
+      label = translate_srht_label(label),
+      changes = {},
+      repository = sourcehut_issue_repository(payload, nil, label),
+      sender = sender.login ~= "" and sender or translate_srht_user((label.tracker or {}).owner),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date or label.updated or label.created or "",
+  })
+end
+
+local function sourcehut_comment_from_event(event, change)
+  event = event or {}
+  change = change or {}
+  return {
+    id = change.id or event.id or 0,
+    node_id = "",
+    url = "",
+    body = change.text or "",
+    user = translate_srht_user(change.author),
+    created_at = event.created or "",
+    updated_at = event.created or "",
+    html_url = "",
+  }
+end
+
+local function sourcehut_ticket_activity_sender(change, ticket)
+  change = change or {}
+  return translate_srht_user(
+    change.author or change.editor or change.labeler or change.user or ticket and ticket.submitter
+  )
+end
+
+local function sourcehut_status_action(change)
+  change = change or {}
+  local new_status = change.newStatus or change.new_status or ""
+  local old_status = change.oldStatus or change.old_status or ""
+  if new_status == "RESOLVED" or new_status == "CLOSED" or new_status == "resolved" then
+    return "closed"
+  end
+  if old_status == "RESOLVED" or old_status == "CLOSED" or old_status == "resolved" then
+    return "reopened"
+  end
+  return "edited"
+end
+
+local function sourcehut_event_created(payload)
+  payload = payload or {}
+  local event = sourcehut_event_payload(payload) or {}
+  local ticket = event.ticket or {}
+  local change = (event.changes or {})[1] or {}
+  local event_type = change.eventType or change.event_type or ""
+
+  if event_type == "CREATED" then
+    return make_internal_event({
+      event = "issues",
+      action = "opened",
+      provider = "sourcehut",
+      raw = payload,
+      data = {
+        action = "opened",
+        issue = translate_srht_ticket(ticket),
+        repository = sourcehut_issue_repository(payload, ticket),
+        sender = sourcehut_ticket_activity_sender(change, ticket),
+      },
+      timestamp = (sourcehut_webhook(payload) or {}).date or event.created or "",
+    })
+  end
+
+  if event_type == "COMMENT" then
+    return make_internal_event({
+      event = "issue_comment",
+      action = "created",
+      provider = "sourcehut",
+      raw = payload,
+      data = {
+        action = "created",
+        issue = translate_srht_ticket(ticket),
+        comment = sourcehut_comment_from_event(event, change),
+        repository = sourcehut_issue_repository(payload, ticket),
+        sender = sourcehut_ticket_activity_sender(change, ticket),
+      },
+      timestamp = (sourcehut_webhook(payload) or {}).date or event.created or "",
+    })
+  end
+
+  if event_type == "LABEL_ADDED" or event_type == "LABEL_REMOVED" then
+    local action = event_type == "LABEL_ADDED" and "labeled" or "unlabeled"
+    return make_internal_event({
+      event = "issues",
+      action = action,
+      provider = "sourcehut",
+      raw = payload,
+      data = {
+        action = action,
+        issue = translate_srht_ticket(ticket),
+        label = translate_srht_label(change.label),
+        repository = sourcehut_issue_repository(payload, ticket, change.label),
+        sender = sourcehut_ticket_activity_sender(change, ticket),
+      },
+      timestamp = (sourcehut_webhook(payload) or {}).date or event.created or "",
+    })
+  end
+
+  if event_type == "STATUS_CHANGE" then
+    local action = sourcehut_status_action(change)
+    return make_internal_event({
+      event = "issues",
+      action = action,
+      provider = "sourcehut",
+      raw = payload,
+      data = {
+        action = action,
+        issue = translate_srht_ticket(ticket),
+        repository = sourcehut_issue_repository(payload, ticket),
+        sender = sourcehut_ticket_activity_sender(change, ticket),
+      },
+      timestamp = (sourcehut_webhook(payload) or {}).date or event.created or "",
+    })
+  end
+
+  if event_type == "ASSIGNED_USER" or event_type == "UNASSIGNED_USER" then
+    local action = event_type == "ASSIGNED_USER" and "assigned" or "unassigned"
+    return make_internal_event({
+      event = "issues",
+      action = action,
+      provider = "sourcehut",
+      raw = payload,
+      data = {
+        action = action,
+        issue = translate_srht_ticket(ticket),
+        assignee = translate_srht_user(change.user or change.assignee),
+        repository = sourcehut_issue_repository(payload, ticket),
+        sender = sourcehut_ticket_activity_sender(change, ticket),
+      },
+      timestamp = (sourcehut_webhook(payload) or {}).date or event.created or "",
+    })
+  end
+
+  return make_internal_event({
+    event = "issues",
+    action = "edited",
+    provider = "sourcehut",
+    raw = payload,
+    data = {
+      action = "edited",
+      issue = translate_srht_ticket(ticket),
+      repository = sourcehut_issue_repository(payload, ticket),
+      sender = sourcehut_ticket_activity_sender(change, ticket),
+    },
+    timestamp = (sourcehut_webhook(payload) or {}).date or event.created or "",
+  })
 end
 
 local function sourcehut_update_ref(update)
@@ -598,6 +895,20 @@ local function translate_sourcehut_github_webhook(internal_event, _fields)
     payload.master_branch = data.master_branch or ""
     payload.description = data.description
     payload.pusher_type = data.pusher_type or "user"
+  elseif internal_event.event == "issues" then
+    payload.issue = data.issue or {}
+    if data.label then
+      payload.label = data.label
+    end
+    if data.assignee then
+      payload.assignee = data.assignee
+    end
+  elseif internal_event.event == "issue_comment" then
+    payload.issue = data.issue or {}
+    payload.comment = data.comment or {}
+  elseif internal_event.event == "label" then
+    payload.label = data.label or {}
+    payload.changes = data.changes or {}
   end
   return payload
 end
@@ -1069,7 +1380,39 @@ end)
 b:webhook("GIT_PRE_RECEIVE", sourcehut_git_event)
 b:webhook("GIT_POST_RECEIVE", sourcehut_git_event)
 
-for _, event in ipairs({ "push", "create", "delete", "repository" }) do
+b:webhook("TICKET_CREATED", function(payload)
+  return sourcehut_ticket_event(payload, "opened")
+end)
+
+b:webhook("TICKET_UPDATE", function(payload)
+  return sourcehut_ticket_event(payload, "edited")
+end)
+
+b:webhook("TICKET_DELETED", sourcehut_deleted_ticket_event)
+
+b:webhook("LABEL_CREATED", function(payload)
+  return sourcehut_label_event(payload, "created")
+end)
+
+b:webhook("LABEL_UPDATE", function(payload)
+  return sourcehut_label_event(payload, "edited")
+end)
+
+b:webhook("LABEL_DELETED", function(payload)
+  return sourcehut_label_event(payload, "deleted")
+end)
+
+b:webhook("EVENT_CREATED", sourcehut_event_created)
+
+for _, event in ipairs({
+  "push",
+  "create",
+  "delete",
+  "repository",
+  "issues",
+  "issue_comment",
+  "label",
+}) do
   b:webhook_translator(event, translate_sourcehut_normalized_webhook)
   b:webhook_github_translator(event, translate_sourcehut_github_webhook)
 end

--- a/backends/sourcehut.lua
+++ b/backends/sourcehut.lua
@@ -75,7 +75,7 @@ local function translate_srht_repo(r)
   local vis = r.visibility or "public"
   local private = vis == "private" or vis == "PRIVATE"
   local head = r.HEAD or r.head or {}
-  local default_branch = ""
+  local default_branch
   if type(head) == "table" then
     default_branch = (head.name or ""):match("^refs/heads/(.+)") or head.name or ""
   else

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -168,7 +168,7 @@ delivered.  Confusio maps these to its canonical internal event family names.
 | pagure | `X-Pagure-Event` | `issue`, `pull-request`, `git` |
 | launchpad | `X-Launchpad-Event-Type` | `git:push:0.1`, `merge-proposal:0.1`, `bug:0.1` |
 | radicle | _(body field `event_type`)_ | `push`, `patch` |
-| sourcehut | _(body field `event`)_ | `push`, `patchset:created` |
+| sourcehut | _(body field `event`)_ | `GIT_POST_RECEIVE`, `EVENT_CREATED`, `PATCHSET_RECEIVED` |
 | All others | _(backend-specific — see [Signature Verification](#signature-verification))_ | — |
 
 ### Request format
@@ -836,8 +836,9 @@ accept if ed25519_verify(public_key, message, signature) == true
 ```
 
 **No shared secret is configured** — authentication is established by sr.ht's published
-key.  Confusio should re-fetch the well-known key on verification failure to handle
-key rotation, then retry once before rejecting.
+public key.  Configure that base64 public key with `webhook_secret_file_sourcehut`;
+when no key is configured, confusio uses the same trust-the-network mode as other
+webhook backends.
 
 ---
 
@@ -2317,13 +2318,13 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2345,20 +2346,20 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | Fork | `fork` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Gollum | `created` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Issues | `opened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `closed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `reopened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `labeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `unlabeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `assigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `unassigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Issue Comments | `created` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Issues | `opened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `closed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `edited` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `reopened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `labeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `unlabeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `assigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `unassigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
+| Issue Comments | `created` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Labels | `created` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `deleted` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Labels | `created` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `deleted` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
 | Member | `added` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `removed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2383,7 +2384,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `updated` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Page Build | `page_build` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Ping | `ping` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ |
 |  | `closed` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `reopened` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2400,16 +2401,16 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `prereleased` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Registry Package | `published` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Repository | `created` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `deleted` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Repository | `created` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `deleted` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `edited` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
 |  | `renamed` | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `transferred` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `publicized` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2423,9 +2424,9 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `added_to_repository` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `removed_from_repository` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Team Add | `team_add` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Workflow Run | `requested` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `in_progress` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `completed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Workflow Run | `requested` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `in_progress` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `completed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
 | Workflow Job | `queued` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `in_progress` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `completed` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2694,8 +2695,10 @@ Triggered on repository lifecycle events (created, deleted, renamed, etc.).
   rename notifications via the service hook but without a structured `changes` payload.
 - Kallithea emits repository create/delete hooks only.  Rename, visibility, transfer,
   and default-branch changes are not currently available from the Kallithea translator.
-- Backends not listed (sourcehut, pagure, etc.) do not emit repository lifecycle
-  events.  Confusio cannot generate `repository` events from these backends.
+- Sourcehut emits `REPO_CREATED`, `REPO_UPDATE`, and `REPO_DELETED`; confusio maps
+  those to `repository` `created`, `edited`, and `deleted`.
+- Backends not listed (pagure, etc.) do not emit repository lifecycle events.
+  Confusio cannot generate `repository` events from these backends.
 
 ---
 
@@ -2812,8 +2815,11 @@ Action support for this event is generated in the [action support matrix](#gener
 - `edited` action: For most backends, the edit event does not include a `changes`
   object (before/after values).  GitHub and GitLab include `changes`; others do not.
   Confusio emits `changes: {}` when not available.
-- Backends not listed (sourcehut, gerrit, harness, rhodecode, etc.) do not emit
-  issue lifecycle events.
+- Sourcehut ticket hooks map to `issues` events.  Direct ticket create/update
+  hooks produce `opened` and `edited`; ticket activity hooks produce `closed`,
+  `reopened`, `labeled`, `unlabeled`, `assigned`, and `unassigned`.
+- Backends not listed (gerrit, harness, rhodecode, etc.) do not emit issue
+  lifecycle events.
 
 ---
 
@@ -2987,9 +2993,10 @@ Action support for this event is generated in the [action support matrix](#gener
   webhook system sends generic `PullRequestChanged` notifications when a reviewer's
   status changes; it does not produce a separate reviewer-vote event with a distinct
   event type.  No handler is registered.
-- **Sourcehut** has no pull-request model.  Code review on Sourcehut is conducted
-  via mailing-list patch series (lists.sr.ht), which does not emit webhook review
-  events.  No handler is registered.
+- **Sourcehut** has no GitHub-style pull-request review model.  Code review on
+  Sourcehut is conducted via mailing-list patch series (lists.sr.ht); patchset
+  receipt maps to `pull_request.opened`, but review submission/dismissal events
+  are not emitted.  No review handler is registered.
 - **Pagure** does not emit a discrete pull-request review webhook event.  Pagure's
   webhook system covers PR lifecycle (opened, updated, closed) but has no separate
   reviewer-approval or review-submission event.  No handler is registered.

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -239,6 +239,12 @@ local RADICLE_BODY_EVENT_FIELDS = {
   "eventType",
 }
 
+local SOURCEHUT_BODY_EVENT_FIELDS = {
+  "event",
+  "event_type",
+  "eventType",
+}
+
 local function kallithea_body_event(payload)
   return first_string_field(payload, KALLITHEA_BODY_EVENT_FIELDS)
     or first_string_field(payload and payload.data, KALLITHEA_BODY_EVENT_FIELDS)
@@ -247,6 +253,15 @@ end
 
 local function radicle_body_event(payload)
   return first_string_field(payload, RADICLE_BODY_EVENT_FIELDS)
+end
+
+local function sourcehut_body_event(payload)
+  return first_string_field(payload, SOURCEHUT_BODY_EVENT_FIELDS)
+    or first_string_field(payload and payload.webhook, SOURCEHUT_BODY_EVENT_FIELDS)
+    or first_string_field(
+      payload and payload.data and payload.data.webhook,
+      SOURCEHUT_BODY_EVENT_FIELDS
+    )
 end
 
 local function phabricator_phid_type(phid)
@@ -644,6 +659,7 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     --   OneDev uses payload.type (e.g. "RefUpdated").
     --   Kallithea hook plugins embed an event/hook name in the JSON body.
     --   Radicle CI adapter requests use payload.event_type (e.g. "push", "patch").
+    --   Sourcehut GraphQL webhooks commonly use payload.data.webhook.event.
     --   Phabricator webhooks embed object.type, or an equivalent PHID prefix.
     --   SourceForge / Allura repo-push webhooks have no event header, so infer
     --   them from their documented ref/update fields.
@@ -659,6 +675,8 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
         ev = kallithea_body_event(payload)
       elseif backend == "radicle" then
         ev = radicle_body_event(payload)
+      elseif backend == "sourcehut" then
+        ev = sourcehut_body_event(payload)
       elseif backend == "phabricator" then
         ev = phabricator_body_event(payload)
       elseif backend == "sourceforge" then

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -90,6 +90,91 @@ local function hmac_hex(alg, secret, body)
   return to_hex(GetCryptoHash(alg, body, secret)) -- luacheck: globals GetCryptoHash
 end
 
+local function strip_ascii_space(s)
+  return tostring(s or ""):gsub("%s+", "")
+end
+
+local function shell_quote(s)
+  return "'" .. tostring(s):gsub("'", "'\\''") .. "'"
+end
+
+local function write_file(path, body)
+  local f = io.open(path, "wb")
+  if not f then
+    return false
+  end
+  f:write(body)
+  f:close()
+  return true
+end
+
+local ED25519_SPKI_DER_PREFIX =
+  string.char(0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00)
+
+local function openssl_ed25519_verify(public_key, body, signature)
+  local base = os.tmpname()
+  local key_path = base .. ".pub.der"
+  local body_path = base .. ".body"
+  local sig_path = base .. ".sig"
+
+  local ok = write_file(key_path, ED25519_SPKI_DER_PREFIX .. public_key)
+    and write_file(body_path, body)
+    and write_file(sig_path, signature)
+  if not ok then
+    os.remove(base)
+    os.remove(key_path)
+    os.remove(body_path)
+    os.remove(sig_path)
+    return false
+  end
+
+  local cmd = table.concat({
+    "openssl pkeyutl -verify -rawin -pubin -keyform DER",
+    "-inkey",
+    shell_quote(key_path),
+    "-sigfile",
+    shell_quote(sig_path),
+    "-in",
+    shell_quote(body_path),
+    ">/dev/null 2>&1",
+  }, " ")
+  local ok_exec, _, code = os.execute(cmd)
+  os.remove(base)
+  os.remove(key_path)
+  os.remove(body_path)
+  os.remove(sig_path)
+  return ok_exec == true or code == 0
+end
+
+local function sourcehut_ed25519_verify(public_key, body, signature)
+  if type(SourcehutVerifyEd25519) == "function" then -- luacheck: globals SourcehutVerifyEd25519
+    return SourcehutVerifyEd25519(public_key, body, signature)
+  end
+  return openssl_ed25519_verify(public_key, body, signature)
+end
+
+local function verify_sourcehut_signature(public_key_b64, body)
+  if not public_key_b64 or public_key_b64 == "" then
+    return true
+  end
+
+  local sig_b64 = GetHeader("X-Payload-Signature")
+  if not sig_b64 then
+    return false
+  end
+
+  local ok_key, public_key = pcall(DecodeBase64, strip_ascii_space(public_key_b64))
+  local ok_sig, signature = pcall(DecodeBase64, strip_ascii_space(sig_b64))
+  if not ok_key or not ok_sig or type(public_key) ~= "string" or type(signature) ~= "string" then
+    return false
+  end
+  if #public_key ~= 32 or #signature ~= 64 then
+    return false
+  end
+
+  return sourcehut_ed25519_verify(public_key, body, signature)
+end
+
 local function verify_authorization_variant(secret, auth)
   if not auth then
     return false
@@ -445,11 +530,18 @@ local function verify_signature(backend, secret, body, now)
     local basestring = "v1:" .. ts_str .. ":" .. body
     return ct_equal(hmac_hex("sha256", secret, basestring), hex)
 
-  -- CodeCommit (SNS X.509), Sourcehut (ed25519):
-  -- Complex asymmetric and platform-managed schemes not yet implemented.
-  -- Trust-the-network when no secret configured; reject otherwise so operators
-  -- restrict access via network policy until full verification ships.
-  elseif backend == "codecommit" or backend == "sourcehut" then
+  -- Sourcehut: X-Payload-Signature, Ed25519 over raw body.
+  -- The configured "secret" is the base64-encoded 32-byte public key used to
+  -- verify sr.ht's detached payload signature.  With no key configured, retain
+  -- the global trust-the-network mode used by other webhook backends.
+  elseif backend == "sourcehut" then
+    return verify_sourcehut_signature(secret, body)
+
+  -- CodeCommit (SNS X.509):
+  -- Complex platform-managed scheme not yet implemented. Trust-the-network
+  -- when no secret configured; reject otherwise so operators restrict access
+  -- via network policy until full verification ships.
+  elseif backend == "codecommit" then
     return not secret or secret == ""
   else
     return false

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,6 +1,6 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
 POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
-POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~refs/issues/PRs/builds/packages,~no CI events,y,~refs/patches only,~no CI events,~no CI events,~no CI events,~no CI events
+POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~refs/issues/PRs/builds/packages,~no CI events,y,~refs/patches only,~no CI events,~no CI events,y,~no CI events
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n
@@ -463,13 +463,13 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,n,n
+webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,n
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,n,n
+webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,n
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -491,20 +491,20 @@ webhook discussion_comment/edited,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,
 webhook fork/fork,n,y,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n
 webhook gollum/created,n,n,n,y,n,y,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook gollum/edited,n,n,n,y,n,y,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook issues/opened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
-webhook issues/closed,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,y,n,n,n,n,n
-webhook issues/edited,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
-webhook issues/reopened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,y,n,n,n,n,n
-webhook issues/labeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook issues/unlabeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook issues/assigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook issues/unassigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook issue_comment/created,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
+webhook issues/opened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,n
+webhook issues/closed,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,y,n,n,n,y,n
+webhook issues/edited,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,n
+webhook issues/reopened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,y,n,n,n,y,n
+webhook issues/labeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,y,n
+webhook issues/unlabeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,y,n
+webhook issues/assigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,y,n
+webhook issues/unassigned,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,y,n
+webhook issue_comment/created,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,n
 webhook issue_comment/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,n,n,n,n,n,n,n
 webhook issue_comment/deleted,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
-webhook label/created,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook label/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook label/deleted,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
+webhook label/created,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,y,n
+webhook label/edited,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,y,n
+webhook label/deleted,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,n,n,n,n,n,n,n,y,n
 webhook member/added,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 webhook member/removed,n,n,n,y,n,y,n,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 webhook member/edited,n,n,n,n,n,n,n,n,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -529,7 +529,7 @@ webhook package/published,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,y,n,n,n,n,n,n,n
 webhook package/updated,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n,n
 webhook page_build/page_build,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook ping/ping,n,n,n,y,n,y,n,n,y,y,n,y,n,n,y,n,n,n,n,n,n,n,n,n
-webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,y,y,y,y,y,y,n,n,n,n
+webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,y,y,y,y,y,y,n,n,y,n
 webhook pull_request/closed,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
 webhook pull_request/reopened,n,n,n,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
 webhook pull_request/edited,n,n,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
@@ -546,16 +546,16 @@ webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,
 webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,n
+webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,n
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/prereleased,n,n,n,y,n,y,n,n,n,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook registry_package/published,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook registry_package/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook repository/created,y,y,y,y,n,y,y,n,y,y,y,y,n,y,n,n,n,n,y,n,n,n,n,n
-webhook repository/deleted,y,y,y,y,n,y,y,n,y,y,y,y,n,y,n,n,n,n,y,n,n,n,n,n
-webhook repository/edited,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n
+webhook repository/created,y,y,y,y,n,y,y,n,y,y,y,y,n,y,n,n,n,n,y,n,n,n,y,n
+webhook repository/deleted,y,y,y,y,n,y,y,n,y,y,y,y,n,y,n,n,n,n,y,n,n,n,y,n
+webhook repository/edited,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,y,n,n,n,y,n
 webhook repository/renamed,y,n,y,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,y,n,n,n,n,n
 webhook repository/transferred,n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook repository/publicized,n,n,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -569,9 +569,9 @@ webhook team/edited,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook team/added_to_repository,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook team/removed_from_repository,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook team_add/team_add,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook workflow_run/requested,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n
-webhook workflow_run/in_progress,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n
-webhook workflow_run/completed,y,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,y,n,n,n,n,n
+webhook workflow_run/requested,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,y,n,n,n,y,n
+webhook workflow_run/in_progress,n,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,y,n,n,n,y,n
+webhook workflow_run/completed,y,y,n,y,n,y,n,n,n,y,y,y,y,n,y,n,y,n,y,n,n,n,y,n
 webhook workflow_job/queued,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,y,n,n,n,n,n
 webhook workflow_job/in_progress,n,y,n,y,n,y,n,n,n,y,y,y,y,n,n,n,n,n,y,n,n,n,n,n
 webhook workflow_job/completed,n,y,n,y,n,y,n,n,n,y,y,y,y,n,n,n,n,n,y,n,n,n,n,n

--- a/test/fixtures/webhooks/sourcehut/create.json
+++ b/test/fixtures/webhooks/sourcehut/create.json
@@ -1,0 +1,20 @@
+{
+  "event": "GIT_POST_RECEIVE",
+  "webhook": { "event": "GIT_POST_RECEIVE", "date": "2024-01-15T11:00:00Z" },
+  "pusher": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "My first repo",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "updates": [
+    {
+      "ref": { "name": "refs/heads/feature" },
+      "old": { "id": "0000000000000000000000000000000000000000" },
+      "new": { "id": "abc123def456abc123def456abc123def456abcd" }
+    }
+  ]
+}

--- a/test/fixtures/webhooks/sourcehut/delete.json
+++ b/test/fixtures/webhooks/sourcehut/delete.json
@@ -1,0 +1,20 @@
+{
+  "event": "GIT_POST_RECEIVE",
+  "webhook": { "event": "GIT_POST_RECEIVE", "date": "2024-01-15T11:05:00Z" },
+  "pusher": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "My first repo",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "updates": [
+    {
+      "ref": { "name": "refs/heads/feature" },
+      "old": { "id": "abc123def456abc123def456abc123def456abcd" },
+      "new": { "id": "0000000000000000000000000000000000000000" }
+    }
+  ]
+}

--- a/test/fixtures/webhooks/sourcehut/issue_comment-created.json
+++ b/test/fixtures/webhooks/sourcehut/issue_comment-created.json
@@ -1,0 +1,31 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:15:00Z" },
+  "newEvent": {
+    "id": 2,
+    "created": "2024-01-15T12:15:00Z",
+    "ticket": {
+      "id": 1,
+      "title": "Found a bug",
+      "body": "Something broke.",
+      "status": "reported",
+      "created": "2024-01-15T12:00:00Z",
+      "updated": "2024-01-15T12:15:00Z",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "COMMENT",
+        "id": 2,
+        "text": "I can reproduce this.",
+        "author": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-assigned.json
+++ b/test/fixtures/webhooks/sourcehut/issues-assigned.json
@@ -1,0 +1,26 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:40:00Z" },
+  "newEvent": {
+    "created": "2024-01-15T12:40:00Z",
+    "ticket": {
+      "id": 1,
+      "title": "Found a bug",
+      "status": "reported",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "ASSIGNED_USER",
+        "user": { "canonical_name": "~bob", "name": "bob" },
+        "editor": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-closed.json
+++ b/test/fixtures/webhooks/sourcehut/issues-closed.json
@@ -1,0 +1,27 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:30:00Z" },
+  "newEvent": {
+    "created": "2024-01-15T12:30:00Z",
+    "ticket": {
+      "id": 1,
+      "title": "Found a bug",
+      "status": "resolved",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "STATUS_CHANGE",
+        "oldStatus": "REPORTED",
+        "newStatus": "RESOLVED",
+        "editor": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-deleted.json
+++ b/test/fixtures/webhooks/sourcehut/issues-deleted.json
@@ -1,0 +1,12 @@
+{
+  "event": "TICKET_DELETED",
+  "webhook": { "event": "TICKET_DELETED", "date": "2024-01-15T12:10:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "ticketId": 1,
+  "tracker": {
+    "id": 1,
+    "name": "hello-world",
+    "visibility": "PUBLIC",
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-edited.json
+++ b/test/fixtures/webhooks/sourcehut/issues-edited.json
@@ -1,0 +1,20 @@
+{
+  "event": "TICKET_UPDATE",
+  "webhook": { "event": "TICKET_UPDATE", "date": "2024-01-15T12:05:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "ticket": {
+    "id": 1,
+    "title": "Found a bug (updated)",
+    "body": "Something broke, with more detail.",
+    "status": "reported",
+    "created": "2024-01-15T12:00:00Z",
+    "updated": "2024-01-15T12:05:00Z",
+    "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+    "tracker": {
+      "id": 1,
+      "name": "hello-world",
+      "visibility": "PUBLIC",
+      "owner": { "canonical_name": "~octocat", "name": "octocat" }
+    }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-labeled.json
+++ b/test/fixtures/webhooks/sourcehut/issues-labeled.json
@@ -1,0 +1,26 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:20:00Z" },
+  "newEvent": {
+    "created": "2024-01-15T12:20:00Z",
+    "ticket": {
+      "id": 1,
+      "title": "Found a bug",
+      "status": "reported",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "LABEL_ADDED",
+        "label": { "id": 5, "name": "bug", "backgroundColor": "#d73a4a" },
+        "labeler": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-opened-event_created.json
+++ b/test/fixtures/webhooks/sourcehut/issues-opened-event_created.json
@@ -1,0 +1,28 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:01:00Z" },
+  "newEvent": {
+    "created": "2024-01-15T12:01:00Z",
+    "ticket": {
+      "id": 2,
+      "title": "New ticket from activity stream",
+      "body": "Created through EVENT_CREATED.",
+      "status": "reported",
+      "created": "2024-01-15T12:01:00Z",
+      "updated": "2024-01-15T12:01:00Z",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "CREATED",
+        "author": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-opened.json
+++ b/test/fixtures/webhooks/sourcehut/issues-opened.json
@@ -1,0 +1,20 @@
+{
+  "event": "TICKET_CREATED",
+  "webhook": { "event": "TICKET_CREATED", "date": "2024-01-15T12:00:00Z" },
+  "ticket": {
+    "id": 1,
+    "title": "Found a bug",
+    "body": "Something broke.",
+    "status": "reported",
+    "created": "2024-01-15T12:00:00Z",
+    "updated": "2024-01-15T12:00:00Z",
+    "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+    "tracker": {
+      "id": 1,
+      "name": "hello-world",
+      "description": "Issues",
+      "visibility": "PUBLIC",
+      "owner": { "canonical_name": "~octocat", "name": "octocat" }
+    }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-reopened.json
+++ b/test/fixtures/webhooks/sourcehut/issues-reopened.json
@@ -1,0 +1,27 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:35:00Z" },
+  "newEvent": {
+    "created": "2024-01-15T12:35:00Z",
+    "ticket": {
+      "id": 1,
+      "title": "Found a bug",
+      "status": "reported",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "STATUS_CHANGE",
+        "oldStatus": "RESOLVED",
+        "newStatus": "REPORTED",
+        "editor": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-unassigned.json
+++ b/test/fixtures/webhooks/sourcehut/issues-unassigned.json
@@ -1,0 +1,26 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:45:00Z" },
+  "newEvent": {
+    "created": "2024-01-15T12:45:00Z",
+    "ticket": {
+      "id": 1,
+      "title": "Found a bug",
+      "status": "reported",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "UNASSIGNED_USER",
+        "user": { "canonical_name": "~bob", "name": "bob" },
+        "editor": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/issues-unlabeled.json
+++ b/test/fixtures/webhooks/sourcehut/issues-unlabeled.json
@@ -1,0 +1,26 @@
+{
+  "event": "EVENT_CREATED",
+  "webhook": { "event": "EVENT_CREATED", "date": "2024-01-15T12:25:00Z" },
+  "newEvent": {
+    "created": "2024-01-15T12:25:00Z",
+    "ticket": {
+      "id": 1,
+      "title": "Found a bug",
+      "status": "reported",
+      "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+      "tracker": {
+        "id": 1,
+        "name": "hello-world",
+        "visibility": "PUBLIC",
+        "owner": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    },
+    "changes": [
+      {
+        "eventType": "LABEL_REMOVED",
+        "label": { "id": 5, "name": "bug", "backgroundColor": "#d73a4a" },
+        "labeler": { "canonical_name": "~octocat", "name": "octocat" }
+      }
+    ]
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/label-created.json
+++ b/test/fixtures/webhooks/sourcehut/label-created.json
@@ -1,0 +1,15 @@
+{
+  "event": "LABEL_CREATED",
+  "webhook": { "event": "LABEL_CREATED", "date": "2024-01-15T13:00:00Z" },
+  "newLabel": {
+    "id": 5,
+    "name": "bug",
+    "backgroundColor": "#d73a4a",
+    "tracker": {
+      "id": 1,
+      "name": "hello-world",
+      "visibility": "PUBLIC",
+      "owner": { "canonical_name": "~octocat", "name": "octocat" }
+    }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/label-deleted.json
+++ b/test/fixtures/webhooks/sourcehut/label-deleted.json
@@ -1,0 +1,15 @@
+{
+  "event": "LABEL_DELETED",
+  "webhook": { "event": "LABEL_DELETED", "date": "2024-01-15T13:10:00Z" },
+  "label": {
+    "id": 5,
+    "name": "bug",
+    "backgroundColor": "#d73a4a",
+    "tracker": {
+      "id": 1,
+      "name": "hello-world",
+      "visibility": "PUBLIC",
+      "owner": { "canonical_name": "~octocat", "name": "octocat" }
+    }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/label-edited.json
+++ b/test/fixtures/webhooks/sourcehut/label-edited.json
@@ -1,0 +1,15 @@
+{
+  "event": "LABEL_UPDATE",
+  "webhook": { "event": "LABEL_UPDATE", "date": "2024-01-15T13:05:00Z" },
+  "label": {
+    "id": 5,
+    "name": "bug",
+    "backgroundColor": "#0075ca",
+    "tracker": {
+      "id": 1,
+      "name": "hello-world",
+      "visibility": "PUBLIC",
+      "owner": { "canonical_name": "~octocat", "name": "octocat" }
+    }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/pull_request-opened.json
+++ b/test/fixtures/webhooks/sourcehut/pull_request-opened.json
@@ -1,0 +1,26 @@
+{
+  "event": "PATCHSET_RECEIVED",
+  "webhook": { "event": "PATCHSET_RECEIVED", "date": "2024-01-15T15:00:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "My first repo",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "newPatchset": {
+    "id": 7,
+    "subject": "Add feature",
+    "coverLetter": "Please review.",
+    "created": "2024-01-15T15:00:00Z",
+    "updated": "2024-01-15T15:00:00Z",
+    "submitter": { "canonical_name": "~octocat", "name": "octocat" },
+    "ref": "refs/patches/7",
+    "commit": "def456abc123def456abc123def456abc123def4",
+    "targetBranch": "main",
+    "baseCommit": "abc123def456abc123def456abc123def456abcd",
+    "url": "https://lists.sr.ht/~octocat/hello-world/patches/7"
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/push-pre_receive.json
+++ b/test/fixtures/webhooks/sourcehut/push-pre_receive.json
@@ -1,0 +1,28 @@
+{
+  "event": "GIT_PRE_RECEIVE",
+  "webhook": { "event": "GIT_PRE_RECEIVE", "date": "2024-01-15T11:09:00Z" },
+  "pusher": { "canonical_name": "~octocat", "name": "octocat", "email": "octocat@example.com" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "My first repo",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "def456abc123" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "updates": [
+    {
+      "ref": { "name": "refs/heads/main" },
+      "old": { "id": "abc123def456abc123def456abc123def456abcd" },
+      "new": { "id": "def456abc123def456abc123def456abc123def4" },
+      "commits": [
+        {
+          "id": "def456abc123def456abc123def456abc123def4",
+          "message": "Update README",
+          "timestamp": "2024-01-15T11:08:00Z",
+          "author": { "name": "Octocat", "email": "octocat@example.com" }
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/webhooks/sourcehut/push.json
+++ b/test/fixtures/webhooks/sourcehut/push.json
@@ -1,0 +1,28 @@
+{
+  "event": "GIT_POST_RECEIVE",
+  "webhook": { "event": "GIT_POST_RECEIVE", "date": "2024-01-15T11:10:00Z" },
+  "pusher": { "canonical_name": "~octocat", "name": "octocat", "email": "octocat@example.com" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "My first repo",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "def456abc123" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "updates": [
+    {
+      "ref": { "name": "refs/heads/main" },
+      "old": { "id": "abc123def456abc123def456abc123def456abcd" },
+      "new": { "id": "def456abc123def456abc123def456abc123def4" },
+      "commits": [
+        {
+          "id": "def456abc123def456abc123def456abc123def4",
+          "message": "Update README",
+          "timestamp": "2024-01-15T11:09:00Z",
+          "author": { "name": "Octocat", "email": "octocat@example.com" }
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/webhooks/sourcehut/repository-created.json
+++ b/test/fixtures/webhooks/sourcehut/repository-created.json
@@ -1,0 +1,15 @@
+{
+  "event": "REPO_CREATED",
+  "webhook": { "event": "REPO_CREATED", "date": "2024-01-15T10:00:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "My first repo",
+    "visibility": "public",
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:00:00Z",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/repository-deleted.json
+++ b/test/fixtures/webhooks/sourcehut/repository-deleted.json
@@ -1,0 +1,15 @@
+{
+  "event": "REPO_DELETED",
+  "webhook": { "event": "REPO_DELETED", "date": "2024-01-15T10:10:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "My first repo",
+    "visibility": "public",
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:10:00Z",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/repository-edited.json
+++ b/test/fixtures/webhooks/sourcehut/repository-edited.json
@@ -1,0 +1,15 @@
+{
+  "event": "REPO_UPDATE",
+  "webhook": { "event": "REPO_UPDATE", "date": "2024-01-15T10:05:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "description": "Updated description",
+    "visibility": "public",
+    "created": "2024-01-15T10:00:00Z",
+    "updated": "2024-01-15T10:05:00Z",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/workflow_run-completed.json
+++ b/test/fixtures/webhooks/sourcehut/workflow_run-completed.json
@@ -1,0 +1,22 @@
+{
+  "event": "JOB_UPDATED",
+  "webhook": { "event": "JOB_UPDATED", "date": "2024-01-15T14:05:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "job": {
+    "id": 42,
+    "status": "success",
+    "note": "ci/test",
+    "ref": "refs/heads/main",
+    "commit": "abc123def456",
+    "created": "2024-01-15T14:00:00Z",
+    "updated": "2024-01-15T14:05:00Z",
+    "url": "https://builds.sr.ht/~octocat/job/42"
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/workflow_run-in_progress.json
+++ b/test/fixtures/webhooks/sourcehut/workflow_run-in_progress.json
@@ -1,0 +1,22 @@
+{
+  "event": "JOB_UPDATED",
+  "webhook": { "event": "JOB_UPDATED", "date": "2024-01-15T14:02:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "job": {
+    "id": 42,
+    "status": "running",
+    "note": "ci/test",
+    "ref": "refs/heads/main",
+    "commit": "abc123def456",
+    "created": "2024-01-15T14:00:00Z",
+    "updated": "2024-01-15T14:02:00Z",
+    "url": "https://builds.sr.ht/~octocat/job/42"
+  }
+}

--- a/test/fixtures/webhooks/sourcehut/workflow_run-requested.json
+++ b/test/fixtures/webhooks/sourcehut/workflow_run-requested.json
@@ -1,0 +1,22 @@
+{
+  "event": "JOB_CREATED",
+  "webhook": { "event": "JOB_CREATED", "date": "2024-01-15T14:00:00Z" },
+  "sender": { "canonical_name": "~octocat", "name": "octocat" },
+  "repository": {
+    "id": 1,
+    "name": "hello-world",
+    "visibility": "public",
+    "HEAD": { "name": "refs/heads/main", "target": "abc123def456" },
+    "owner": { "canonical_name": "~octocat", "name": "octocat" }
+  },
+  "newJob": {
+    "id": 42,
+    "status": "queued",
+    "note": "ci/test",
+    "ref": "refs/heads/main",
+    "commit": "abc123def456",
+    "created": "2024-01-15T14:00:00Z",
+    "updated": "2024-01-15T14:00:00Z",
+    "url": "https://builds.sr.ht/~octocat/job/42"
+  }
+}

--- a/test/mock-sourcehut.lua
+++ b/test/mock-sourcehut.lua
@@ -77,6 +77,34 @@ function OnHttpRequest()
     SetStatus(200, "OK")
     raw("file content\n")
 
+  -- Webhooks ---------------------------------------------------------------
+  elseif path == rp .. "/webhooks/1" and GetMethod() == "DELETE" then
+    SetStatus(204, "No Content")
+  elseif path == rp .. "/webhooks/1" and GetMethod() == "PUT" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":1,"url":"https://example.com/updated-hook",'
+        .. '"events":["REPO_UPDATE","GIT_POST_RECEIVE"],"enabled":true}'
+    )
+  elseif path == rp .. "/webhooks/1" then
+    SetStatus(200, "OK")
+    json(
+      '{"id":1,"url":"https://example.com/hook",' .. '"events":["GIT_POST_RECEIVE"],"enabled":true}'
+    )
+  elseif path == rp .. "/webhooks" and GetMethod() == "POST" then
+    SetStatus(201, "Created")
+    json(
+      '{"id":2,"url":"https://example.com/new-hook",'
+        .. '"events":["GIT_POST_RECEIVE","PATCHSET_RECEIVED"],"enabled":true}'
+    )
+  elseif path == rp .. "/webhooks" then
+    SetStatus(200, "OK")
+    json(
+      '{"results":[{"id":1,"url":"https://example.com/hook",'
+        .. '"events":["GIT_POST_RECEIVE"],"enabled":true}],'
+        .. '"total":1,"cursor":null}'
+    )
+
   -- todo.sr.ht Issues (tracker) --------------------------------------------
   -- Paths: /api/~octocat/trackers/hello-world/tickets[/{id}[/events]]
   elseif path == "/api/~octocat/trackers/hello-world/tickets" then

--- a/test/sourcehut-webhooks.hurl
+++ b/test/sourcehut-webhooks.hurl
@@ -1,0 +1,204 @@
+# Sourcehut webhook normalizer tests.
+#
+# Sourcehut embeds the event name in the JSON body. Trust-the-network mode is
+# used here, so X-Payload-Signature is omitted.
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/repository-created.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/repository-edited.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/repository-deleted.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/create.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/delete.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/push.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/push-pre_receive.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-opened.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-opened-event_created.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-edited.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-deleted.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issue_comment-created.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-labeled.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-unlabeled.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-closed.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-reopened.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-assigned.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-unassigned.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/label-created.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/label-edited.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/label-deleted.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/workflow_run-requested.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/workflow_run-in_progress.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/workflow_run-completed.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/pull_request-opened.json;
+
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -442,7 +442,18 @@ run_delivery_phase test/webhook-delivery-sourceforge-confusio-shape.hurl \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 46: Startup event synthesis — github shape.
+# Phase 46: Sourcehut fixture-based delivery tests — native body-typed events.
+run_delivery_phase test/webhook-delivery-sourcehut.hurl \
+  -- sourcehut "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
+
+# Phase 47: Sourcehut delivery with "confusio" shape — normalized hook envelopes.
+run_delivery_phase test/webhook-delivery-sourcehut-confusio-shape.hurl \
+  -- sourcehut "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
+  "webhook_target_shape=confusio"
+
+# Phase 48: Startup event synthesis — github shape.
 # Verifies that confusio synthesizes installation.created and
 # installation_repositories.added before accepting connections, and delivers
 # both to the configured outbound target.  No /reset is called — the hurl file
@@ -451,8 +462,8 @@ run_delivery_phase test/webhook-delivery-startup.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 47: Startup event synthesis — confusio shape.
-# Same as Phase 46 but with webhook_target_shape=confusio; verifies
+# Phase 49: Startup event synthesis — confusio shape.
+# Same as Phase 48 but with webhook_target_shape=confusio; verifies
 # X-Confusio-* headers are used and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-startup-confusio-shape.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -141,13 +141,25 @@ CONFUSIO_TS=$(date +%s)
 CONFUSIO_SIG="sha256=$(printf 'v1:%s:%s' "$CONFUSIO_TS" "$WH_BODY" | openssl dgst -sha256 -hmac "$WH_SECRET" | awk '{print $NF}'), v=1, ts=${CONFUSIO_TS}"
 # Write secrets to 0600-permission files — never pass raw secrets on the CLI.
 WH_SECRET_DIR=$(mktemp -d)
+SOURCEHUT_KEY="$WH_SECRET_DIR/sourcehut-ed25519.pem"
+SOURCEHUT_BODY="$WH_SECRET_DIR/sourcehut-body.json"
+SOURCEHUT_SIG_BIN="$WH_SECRET_DIR/sourcehut.sig"
+SOURCEHUT_PUB_DER="$WH_SECRET_DIR/sourcehut.pub.der"
+printf '%s' "$WH_BODY" > "$SOURCEHUT_BODY"
+openssl genpkey -algorithm Ed25519 -out "$SOURCEHUT_KEY" >/dev/null 2>&1
+openssl pkey -in "$SOURCEHUT_KEY" -pubout -outform DER -out "$SOURCEHUT_PUB_DER" >/dev/null 2>&1
+SOURCEHUT_PUBLIC_KEY=$(tail -c 32 "$SOURCEHUT_PUB_DER" | openssl base64 -A)
+openssl pkeyutl -sign -rawin -inkey "$SOURCEHUT_KEY" -in "$SOURCEHUT_BODY" -out "$SOURCEHUT_SIG_BIN"
+SOURCEHUT_SIG=$(openssl base64 -A < "$SOURCEHUT_SIG_BIN")
 for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad phabricator pagure gerrit onedev radicle kallithea sourceforge confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
+printf '%s' "$SOURCEHUT_PUBLIC_KEY" > "$WH_SECRET_DIR/sourcehut.secret"
+chmod 600 "$WH_SECRET_DIR/sourcehut.secret"
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_radicle=$WH_SECRET_DIR/radicle.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_sourceforge=$WH_SECRET_DIR/sourceforge.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_radicle=$WH_SECRET_DIR/radicle.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_sourceforge=$WH_SECRET_DIR/sourceforge.secret webhook_secret_file_sourcehut=$WH_SECRET_DIR/sourcehut.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT
@@ -167,6 +179,7 @@ $HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
   --variable "onedev_tok=$WH_SECRET" \
   --variable "radicle_tok=$WH_SECRET" \
   --variable "sourceforge_sig=$SOURCEFORGE_SIG" \
+  --variable "sourcehut_sig=$SOURCEHUT_SIG" \
   --variable "confusio_sig=$CONFUSIO_SIG" \
   test/webhooks-sig.hurl
 kill $WH_PID 2>/dev/null || true; sleep 0.3

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2860,6 +2860,187 @@ do
 end
 
 -- ============================================================
+-- Sourcehut webhook handlers
+-- ============================================================
+
+do
+  local saved_rest = app.backend.rest
+  local saved_capabilities = app.backend.capabilities
+  local saved_webhooks = app.backend.webhooks
+  local saved_webhook_translators = app.backend.webhook_translators
+  local saved_webhook_github_translators = app.backend.webhook_github_translators
+  local saved_resolvers = graphql_resolvers -- luacheck: globals graphql_resolvers
+  local saved_base_url = config.base_url
+  local saved_backend = config.backend
+
+  app.backend.rest = {}
+  app.backend.capabilities = {}
+  app.backend.webhooks = {}
+  app.backend.webhook_translators = {}
+  app.backend.webhook_github_translators = {}
+  graphql_resolvers = {} -- luacheck: globals graphql_resolvers
+  config.base_url = ""
+  config.backend = "sourcehut"
+  _real_dofile("backends/sourcehut.lua")
+
+  ok(app.backend.webhooks.REPO_CREATED ~= nil, "sourcehut webhook: REPO_CREATED registered")
+  ok(app.backend.webhooks.REPO_UPDATE ~= nil, "sourcehut webhook: REPO_UPDATE registered")
+  ok(app.backend.webhooks.REPO_DELETED ~= nil, "sourcehut webhook: REPO_DELETED registered")
+  ok(app.backend.webhooks.GIT_PRE_RECEIVE ~= nil, "sourcehut webhook: GIT_PRE_RECEIVE registered")
+  ok(app.backend.webhooks.GIT_POST_RECEIVE ~= nil, "sourcehut webhook: GIT_POST_RECEIVE registered")
+  ok(app.backend.webhook_translators.push ~= nil, "sourcehut webhook: push translator registered")
+  ok(
+    app.backend.webhook_github_translators.push ~= nil,
+    "sourcehut webhook: push GitHub-shape translator registered"
+  )
+  ok(
+    app.backend.webhook_translators.repository ~= nil,
+    "sourcehut webhook: repository translator registered"
+  )
+  ok(
+    app.backend.webhook_github_translators.repository ~= nil,
+    "sourcehut webhook: repository GitHub-shape translator registered"
+  )
+
+  local repo_payload = {
+    data = {
+      webhook = { event = "REPO_CREATED", date = "2026-05-02T01:02:03Z" },
+      repository = {
+        id = 272,
+        rid = "repo-rid",
+        name = "confusio",
+        description = "Webhook kennel",
+        visibility = "PUBLIC",
+        owner = { id = 7, canonicalName = "~fido", name = "Fido" },
+        HEAD = { name = "refs/heads/main" },
+        created = "2026-05-01T00:00:00Z",
+        updated = "2026-05-02T01:00:00Z",
+      },
+    },
+  }
+  local repo_event = app.backend.webhooks.REPO_CREATED(repo_payload)
+  eq(repo_event.event, "repository", "sourcehut webhook: REPO_CREATED maps to repository")
+  eq(repo_event.action, "created", "sourcehut webhook: REPO_CREATED maps to created")
+  eq(repo_event.provider, "sourcehut", "sourcehut webhook: repository sets provider")
+  eq(
+    repo_event.data.repository.full_name,
+    "fido/confusio",
+    "sourcehut webhook: repository full_name translated"
+  )
+  eq(
+    repo_event.data.sender.login,
+    "fido",
+    "sourcehut webhook: repository sender falls back to owner"
+  )
+  local repo_envelope = app.backend.webhook_translators.repository(repo_event)
+  eq(repo_envelope.type, "repository.created", "sourcehut webhook: normalized repository type")
+  local repo_github_payload = app.backend.webhook_github_translators.repository(repo_event)
+  eq(
+    repo_github_payload.repository.name,
+    "confusio",
+    "sourcehut webhook: GitHub-shape repository includes repository"
+  )
+  eq(
+    app.backend.webhooks.REPO_UPDATE(repo_payload).action,
+    "edited",
+    "sourcehut webhook: REPO_UPDATE maps to edited"
+  )
+  eq(
+    app.backend.webhooks.REPO_DELETED(repo_payload).action,
+    "deleted",
+    "sourcehut webhook: REPO_DELETED maps to deleted"
+  )
+
+  local git_payload = {
+    data = {
+      webhook = { event = "GIT_POST_RECEIVE", date = "2026-05-02T02:03:04Z" },
+      repository = {
+        id = 272,
+        name = "confusio",
+        visibility = "PUBLIC",
+        owner = { canonicalName = "~fido" },
+        HEAD = { name = "refs/heads/main" },
+      },
+      pusher = { canonicalName = "~rob", name = "Rob" },
+      updates = {
+        {
+          ref = { name = "refs/heads/main" },
+          old = { id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+          new = { id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+          log = {
+            results = {
+              {
+                id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                message = "Teach sourcehut pushes",
+                author = {
+                  name = "Fido",
+                  email = "fido@example.test",
+                  time = "2026-05-02T02:00:00Z",
+                },
+                committer = {
+                  name = "Rob",
+                  email = "rob@example.test",
+                  time = "2026-05-02T02:01:00Z",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+  local push_event = app.backend.webhooks.GIT_POST_RECEIVE(git_payload)
+  eq(push_event.event, "push", "sourcehut webhook: GIT_POST_RECEIVE maps to push")
+  eq(push_event.action, "", "sourcehut webhook: push is action-less")
+  eq(push_event.data.ref, "refs/heads/main", "sourcehut webhook: push keeps ref")
+  eq(
+    push_event.data.head_commit.id,
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "sourcehut webhook: push sets head commit"
+  )
+  eq(push_event.data.sender.login, "rob", "sourcehut webhook: push sets sender from pusher")
+  local push_envelope = app.backend.webhook_translators.push(push_event)
+  eq(push_envelope.type, "push", "sourcehut webhook: normalized push uses actionless type")
+  local push_github_payload = app.backend.webhook_github_translators.push(push_event)
+  eq(
+    push_github_payload.head_commit.message,
+    "Teach sourcehut pushes",
+    "sourcehut webhook: GitHub-shape push includes head commit"
+  )
+  eq(push_github_payload.pusher.name, "Rob", "sourcehut webhook: GitHub-shape push includes pusher")
+
+  local create_event = app.backend.webhooks.GIT_PRE_RECEIVE({
+    data = {
+      webhook = { event = "GIT_PRE_RECEIVE" },
+      repository = {
+        name = "confusio",
+        owner = { canonicalName = "~fido" },
+        HEAD = { name = "refs/heads/main" },
+      },
+      updates = {
+        {
+          ref = { name = "refs/tags/v1.0.0" },
+          old = { id = "0000000000000000000000000000000000000000" },
+          new = { id = "cccccccccccccccccccccccccccccccccccccccc" },
+        },
+      },
+    },
+  })
+  eq(create_event.event, "create", "sourcehut webhook: zero old id maps to create")
+  eq(create_event.data.ref, "v1.0.0", "sourcehut webhook: create strips tag ref")
+  eq(create_event.data.ref_type, "tag", "sourcehut webhook: create detects tag ref")
+
+  app.backend.rest = saved_rest
+  app.backend.capabilities = saved_capabilities
+  app.backend.webhooks = saved_webhooks
+  app.backend.webhook_translators = saved_webhook_translators
+  app.backend.webhook_github_translators = saved_webhook_github_translators
+  graphql_resolvers = saved_resolvers -- luacheck: globals graphql_resolvers
+  config.base_url = saved_base_url
+  config.backend = saved_backend
+end
+
+-- ============================================================
 -- NotABug webhook handlers
 -- ============================================================
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2908,6 +2908,12 @@ do
   ok(app.backend.webhooks.LABEL_UPDATE ~= nil, "sourcehut webhook: LABEL_UPDATE registered")
   ok(app.backend.webhooks.LABEL_DELETED ~= nil, "sourcehut webhook: LABEL_DELETED registered")
   ok(app.backend.webhooks.EVENT_CREATED ~= nil, "sourcehut webhook: EVENT_CREATED registered")
+  ok(app.backend.webhooks.JOB_CREATED ~= nil, "sourcehut webhook: JOB_CREATED registered")
+  ok(app.backend.webhooks.JOB_UPDATED ~= nil, "sourcehut webhook: JOB_UPDATED registered")
+  ok(
+    app.backend.webhooks.PATCHSET_RECEIVED ~= nil,
+    "sourcehut webhook: PATCHSET_RECEIVED registered"
+  )
   ok(
     app.backend.webhook_translators.issues ~= nil,
     "sourcehut webhook: issues translator registered"
@@ -2921,6 +2927,22 @@ do
     "sourcehut webhook: issue_comment translator registered"
   )
   ok(app.backend.webhook_translators.label ~= nil, "sourcehut webhook: label translator registered")
+  ok(
+    app.backend.webhook_translators.workflow_run ~= nil,
+    "sourcehut webhook: workflow_run translator registered"
+  )
+  ok(
+    app.backend.webhook_github_translators.workflow_run ~= nil,
+    "sourcehut webhook: workflow_run GitHub-shape translator registered"
+  )
+  ok(
+    app.backend.webhook_translators.pull_request ~= nil,
+    "sourcehut webhook: pull_request translator registered"
+  )
+  ok(
+    app.backend.webhook_github_translators.pull_request ~= nil,
+    "sourcehut webhook: pull_request GitHub-shape translator registered"
+  )
 
   local repo_payload = {
     data = {
@@ -3212,6 +3234,113 @@ do
     },
   })
   eq(closed_event.action, "closed", "sourcehut webhook: resolved status maps to closed")
+
+  local job_payload = {
+    data = {
+      webhook = { event = "JOB_UPDATED", date = "2026-05-02T06:07:08Z" },
+      repository = {
+        id = 272,
+        name = "confusio",
+        visibility = "PUBLIC",
+        owner = { canonicalName = "~fido", username = "fido" },
+        HEAD = { name = "refs/heads/main" },
+      },
+      sender = { canonicalName = "~rob", username = "rob" },
+      job = {
+        id = 88,
+        note = "sourcehut build",
+        status = "success",
+        commit = "dddddddddddddddddddddddddddddddddddddddd",
+        branch = "refs/heads/main",
+        url = "https://builds.sr.ht/~fido/job/88",
+        created = "2026-05-02T06:00:00Z",
+        updated = "2026-05-02T06:05:00Z",
+      },
+    },
+  }
+  local job_event = app.backend.webhooks.JOB_UPDATED(job_payload)
+  eq(job_event.event, "workflow_run", "sourcehut webhook: JOB_UPDATED maps to workflow_run")
+  eq(job_event.action, "completed", "sourcehut webhook: successful job maps to completed")
+  eq(
+    job_event.data.workflow_run.conclusion,
+    "success",
+    "sourcehut webhook: successful job conclusion"
+  )
+  eq(
+    job_event.data.workflow_run.head_sha,
+    "dddddddddddddddddddddddddddddddddddddddd",
+    "sourcehut webhook: job commit maps to head_sha"
+  )
+  local job_envelope = app.backend.webhook_translators.workflow_run(job_event)
+  eq(job_envelope.type, "workflow.run.completed", "sourcehut webhook: normalized workflow_run type")
+  local job_github_payload = app.backend.webhook_github_translators.workflow_run(job_event)
+  eq(
+    job_github_payload.workflow_run.status,
+    "completed",
+    "sourcehut webhook: GitHub-shape workflow_run includes status"
+  )
+  eq(
+    app.backend.webhooks.JOB_CREATED({
+      data = {
+        webhook = { event = "JOB_CREATED" },
+        job = { id = 89, status = "queued" },
+      },
+    }).action,
+    "requested",
+    "sourcehut webhook: JOB_CREATED maps to requested"
+  )
+
+  local patchset_payload = {
+    data = {
+      webhook = { event = "PATCHSET_RECEIVED", date = "2026-05-02T07:08:09Z" },
+      repository = {
+        id = 272,
+        name = "confusio",
+        visibility = "PUBLIC",
+        owner = { canonicalName = "~fido", username = "fido" },
+        HEAD = { name = "refs/heads/main" },
+      },
+      patchset = {
+        id = 17,
+        rid = "patchset-rid",
+        subject = "Teach sourcehut patchsets",
+        coverLetter = "This came in by mail.",
+        ref = "patches/v1",
+        targetBranch = "main",
+        commit = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        created = "2026-05-02T07:00:00Z",
+        updated = "2026-05-02T07:01:00Z",
+        url = "https://lists.sr.ht/~fido/confusio/patches/17",
+        submitter = { canonicalName = "~rob", username = "rob" },
+      },
+    },
+  }
+  local patchset_event = app.backend.webhooks.PATCHSET_RECEIVED(patchset_payload)
+  eq(
+    patchset_event.event,
+    "pull_request",
+    "sourcehut webhook: PATCHSET_RECEIVED maps to pull_request"
+  )
+  eq(patchset_event.action, "opened", "sourcehut webhook: patchset maps to opened")
+  eq(
+    patchset_event.data.number,
+    17,
+    "sourcehut webhook: patchset number maps to pull_request number"
+  )
+  eq(
+    patchset_event.data.pull_request.title,
+    "Teach sourcehut patchsets",
+    "sourcehut webhook: patchset subject maps to pull_request title"
+  )
+  local patchset_envelope = app.backend.webhook_translators.pull_request(patchset_event)
+  eq(patchset_envelope.type, "pull_request.opened", "sourcehut webhook: normalized patchset type")
+  local patchset_github_payload =
+    app.backend.webhook_github_translators.pull_request(patchset_event)
+  eq(
+    patchset_github_payload.pull_request.head.ref,
+    "patches/v1",
+    "sourcehut webhook: GitHub-shape patchset includes head ref"
+  )
 
   app.backend.rest = saved_rest
   app.backend.capabilities = saved_capabilities

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -2901,6 +2901,26 @@ do
     app.backend.webhook_github_translators.repository ~= nil,
     "sourcehut webhook: repository GitHub-shape translator registered"
   )
+  ok(app.backend.webhooks.TICKET_CREATED ~= nil, "sourcehut webhook: TICKET_CREATED registered")
+  ok(app.backend.webhooks.TICKET_UPDATE ~= nil, "sourcehut webhook: TICKET_UPDATE registered")
+  ok(app.backend.webhooks.TICKET_DELETED ~= nil, "sourcehut webhook: TICKET_DELETED registered")
+  ok(app.backend.webhooks.LABEL_CREATED ~= nil, "sourcehut webhook: LABEL_CREATED registered")
+  ok(app.backend.webhooks.LABEL_UPDATE ~= nil, "sourcehut webhook: LABEL_UPDATE registered")
+  ok(app.backend.webhooks.LABEL_DELETED ~= nil, "sourcehut webhook: LABEL_DELETED registered")
+  ok(app.backend.webhooks.EVENT_CREATED ~= nil, "sourcehut webhook: EVENT_CREATED registered")
+  ok(
+    app.backend.webhook_translators.issues ~= nil,
+    "sourcehut webhook: issues translator registered"
+  )
+  ok(
+    app.backend.webhook_github_translators.issues ~= nil,
+    "sourcehut webhook: issues GitHub-shape translator registered"
+  )
+  ok(
+    app.backend.webhook_translators.issue_comment ~= nil,
+    "sourcehut webhook: issue_comment translator registered"
+  )
+  ok(app.backend.webhook_translators.label ~= nil, "sourcehut webhook: label translator registered")
 
   local repo_payload = {
     data = {
@@ -3029,6 +3049,169 @@ do
   eq(create_event.event, "create", "sourcehut webhook: zero old id maps to create")
   eq(create_event.data.ref, "v1.0.0", "sourcehut webhook: create strips tag ref")
   eq(create_event.data.ref_type, "tag", "sourcehut webhook: create detects tag ref")
+
+  local ticket_payload = {
+    data = {
+      webhook = { event = "TICKET_CREATED", date = "2026-05-02T03:04:05Z" },
+      ticket = {
+        id = 42,
+        rid = "ticket-rid",
+        subject = "Open the tracker gate",
+        body = "It sticks.",
+        status = "REPORTED",
+        created = "2026-05-02T03:00:00Z",
+        updated = "2026-05-02T03:01:00Z",
+        submitter = { canonicalName = "~fido", username = "fido" },
+        tracker = {
+          id = 9,
+          rid = "tracker-rid",
+          name = "confusio",
+          visibility = "PUBLIC",
+          owner = { canonicalName = "~fido", username = "fido" },
+        },
+        labels = {
+          {
+            id = 5,
+            name = "bug",
+            backgroundColor = "#ff0000",
+          },
+        },
+      },
+    },
+  }
+  local issue_event = app.backend.webhooks.TICKET_CREATED(ticket_payload)
+  eq(issue_event.event, "issues", "sourcehut webhook: TICKET_CREATED maps to issues")
+  eq(issue_event.action, "opened", "sourcehut webhook: TICKET_CREATED maps to opened")
+  eq(issue_event.data.issue.number, 42, "sourcehut webhook: ticket issue number")
+  eq(issue_event.data.issue.title, "Open the tracker gate", "sourcehut webhook: ticket subject")
+  eq(issue_event.data.issue.labels[1].name, "bug", "sourcehut webhook: ticket labels translated")
+  eq(
+    issue_event.data.repository.full_name,
+    "fido/confusio",
+    "sourcehut webhook: ticket tracker maps to repository"
+  )
+  local issue_envelope = app.backend.webhook_translators.issues(issue_event)
+  eq(issue_envelope.type, "issue.opened", "sourcehut webhook: normalized issue type")
+  local issue_github_payload = app.backend.webhook_github_translators.issues(issue_event)
+  eq(
+    issue_github_payload.issue.title,
+    "Open the tracker gate",
+    "sourcehut webhook: GitHub-shape issue includes issue"
+  )
+  eq(
+    app.backend.webhooks.TICKET_UPDATE(ticket_payload).action,
+    "edited",
+    "sourcehut webhook: TICKET_UPDATE maps to edited"
+  )
+  local deleted_issue_event = app.backend.webhooks.TICKET_DELETED({
+    data = {
+      webhook = { event = "TICKET_DELETED" },
+      ticketId = 42,
+    },
+  })
+  eq(deleted_issue_event.action, "deleted", "sourcehut webhook: TICKET_DELETED maps to deleted")
+  eq(deleted_issue_event.data.issue.number, 42, "sourcehut webhook: deleted ticket keeps number")
+
+  local label_payload = {
+    data = {
+      webhook = { event = "LABEL_CREATED", date = "2026-05-02T04:05:06Z" },
+      label = {
+        id = 6,
+        name = "triage",
+        backgroundColor = "#00ff00",
+        tracker = {
+          name = "confusio",
+          owner = { canonicalName = "~fido", username = "fido" },
+        },
+      },
+    },
+  }
+  local label_event = app.backend.webhooks.LABEL_CREATED(label_payload)
+  eq(label_event.event, "label", "sourcehut webhook: LABEL_CREATED maps to label")
+  eq(label_event.action, "created", "sourcehut webhook: LABEL_CREATED maps to created")
+  eq(label_event.data.label.color, "00ff00", "sourcehut webhook: label color strips hash")
+  local label_envelope = app.backend.webhook_translators.label(label_event)
+  eq(label_envelope.type, "label.created", "sourcehut webhook: normalized label type")
+  local label_github_payload = app.backend.webhook_github_translators.label(label_event)
+  eq(
+    label_github_payload.label.name,
+    "triage",
+    "sourcehut webhook: GitHub-shape label includes label"
+  )
+  eq(
+    app.backend.webhooks.LABEL_UPDATE(label_payload).action,
+    "edited",
+    "sourcehut webhook: LABEL_UPDATE maps to edited"
+  )
+  eq(
+    app.backend.webhooks.LABEL_DELETED(label_payload).action,
+    "deleted",
+    "sourcehut webhook: LABEL_DELETED maps to deleted"
+  )
+
+  local comment_event = app.backend.webhooks.EVENT_CREATED({
+    data = {
+      webhook = { event = "EVENT_CREATED", date = "2026-05-02T05:06:07Z" },
+      newEvent = {
+        id = 77,
+        created = "2026-05-02T05:00:00Z",
+        ticket = ticket_payload.data.ticket,
+        changes = {
+          {
+            eventType = "COMMENT",
+            author = { canonicalName = "~rob", username = "rob" },
+            text = "I found the latch.",
+          },
+        },
+      },
+    },
+  })
+  eq(comment_event.event, "issue_comment", "sourcehut webhook: COMMENT maps to issue_comment")
+  eq(comment_event.action, "created", "sourcehut webhook: COMMENT maps to created")
+  eq(comment_event.data.comment.body, "I found the latch.", "sourcehut webhook: comment body")
+  local comment_github_payload = app.backend.webhook_github_translators.issue_comment(comment_event)
+  eq(
+    comment_github_payload.comment.body,
+    "I found the latch.",
+    "sourcehut webhook: GitHub-shape comment includes body"
+  )
+
+  local labeled_event = app.backend.webhooks.EVENT_CREATED({
+    data = {
+      newEvent = {
+        id = 78,
+        ticket = ticket_payload.data.ticket,
+        changes = {
+          {
+            eventType = "LABEL_ADDED",
+            labeler = { canonicalName = "~rob", username = "rob" },
+            label = label_payload.data.label,
+          },
+        },
+      },
+    },
+  })
+  eq(labeled_event.event, "issues", "sourcehut webhook: LABEL_ADDED maps to issues")
+  eq(labeled_event.action, "labeled", "sourcehut webhook: LABEL_ADDED maps to labeled")
+  eq(labeled_event.data.label.name, "triage", "sourcehut webhook: LABEL_ADDED keeps label")
+
+  local closed_event = app.backend.webhooks.EVENT_CREATED({
+    data = {
+      newEvent = {
+        id = 79,
+        ticket = ticket_payload.data.ticket,
+        changes = {
+          {
+            eventType = "STATUS_CHANGE",
+            editor = { canonicalName = "~rob", username = "rob" },
+            oldStatus = "IN_PROGRESS",
+            newStatus = "RESOLVED",
+          },
+        },
+      },
+    },
+  })
+  eq(closed_event.action, "closed", "sourcehut webhook: resolved status maps to closed")
 
   app.backend.rest = saved_rest
   app.backend.capabilities = saved_capabilities

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -34,7 +34,7 @@ reset_request()
 -- Override Redbean HTTP context built-ins before loading .init.lua.
 -- luacheck: push
 -- luacheck: globals SetStatus SetHeader Write GetHeader GetPath GetParam GetMethod GetBody Route
--- luacheck: globals GetCryptoHash DecodeBase64
+-- luacheck: globals GetCryptoHash DecodeBase64 SourcehutVerifyEd25519
 SetStatus = function(code, _reason)
   _last_status = code
 end
@@ -79,6 +79,9 @@ end
 -- Stub DecodeBase64: identity decode for Basic auth verification tests.
 DecodeBase64 = function(s)
   return s
+end
+SourcehutVerifyEd25519 = function(public_key, body, signature)
+  return public_key == string.rep("k", 32) and body == "{}" and signature == string.rep("s", 64)
 end
 -- Stub Fetch: records outbound calls so startup synthesis (synthesize_startup_events)
 -- and deliver_fire tests do not make real network requests.  Returns a 200 response.
@@ -3668,20 +3671,69 @@ do
     "verify_signature kallithea: invalid JSON body → 401"
   )
 
-  -- ── Trust-the-network-only backends: codecommit, sourcehut
-  -- These use asymmetric/platform-managed schemes not yet implemented.
+  -- ── Trust-the-network-only backend: codecommit
+  -- SNS signature verification is not yet implemented.
   -- No secret → accepted; any secret configured → always rejected.
-  for _, be in ipairs({ "codecommit", "sourcehut" }) do
-    ok(
-      no_secret(be, {}) ~= 401,
-      "verify_signature " .. be .. ": no secret (trust-the-network) → not 401"
-    )
-    eq(
-      call_sig(be, {}, nil, { [be] = SECRET }),
-      401,
-      "verify_signature " .. be .. ": secret configured (unimplemented scheme) → 401"
-    )
-  end
+  ok(
+    no_secret("codecommit", {}) ~= 401,
+    "verify_signature codecommit: no secret (trust-the-network) → not 401"
+  )
+  eq(
+    call_sig("codecommit", {}, nil, { codecommit = SECRET }),
+    401,
+    "verify_signature codecommit: secret configured (unimplemented scheme) → 401"
+  )
+
+  -- ── Sourcehut: X-Payload-Signature, Ed25519 over raw body
+  -- Unit tests use identity base64 decoding and a stub verifier.  The hurl
+  -- suite exercises the OpenSSL-backed verifier with a real Ed25519 keypair.
+  local SOURCEHUT_PUBLIC_KEY = string.rep("k", 32)
+  local SOURCEHUT_SIGNATURE = string.rep("s", 64)
+  ok(no_secret("sourcehut", {}) ~= 401, "verify_signature sourcehut: no public key → not 401")
+  ok(
+    call_sig(
+      "sourcehut",
+      { ["X-Payload-Signature"] = SOURCEHUT_SIGNATURE },
+      nil,
+      { sourcehut = SOURCEHUT_PUBLIC_KEY }
+    ) ~= 401,
+    "verify_signature sourcehut: valid X-Payload-Signature → not 401"
+  )
+  eq(
+    call_sig(
+      "sourcehut",
+      { ["X-Payload-Signature"] = string.rep("x", 64) },
+      nil,
+      { sourcehut = SOURCEHUT_PUBLIC_KEY }
+    ),
+    401,
+    "verify_signature sourcehut: bad X-Payload-Signature → 401"
+  )
+  eq(
+    call_sig("sourcehut", {}, nil, { sourcehut = SOURCEHUT_PUBLIC_KEY }),
+    401,
+    "verify_signature sourcehut: missing X-Payload-Signature → 401"
+  )
+  eq(
+    call_sig(
+      "sourcehut",
+      { ["X-Payload-Signature"] = "short" },
+      nil,
+      { sourcehut = SOURCEHUT_PUBLIC_KEY }
+    ),
+    401,
+    "verify_signature sourcehut: malformed signature length → 401"
+  )
+  eq(
+    call_sig(
+      "sourcehut",
+      { ["X-Payload-Signature"] = SOURCEHUT_SIGNATURE },
+      nil,
+      { sourcehut = "short" }
+    ),
+    401,
+    "verify_signature sourcehut: malformed public key length → 401"
+  )
 
   -- ── Confusio-normalized: X-Confusio-Signature-256, HMAC-SHA256 + timestamp
   -- Header format: "sha256=<hex>, v=1, ts=<unix>"

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3187,6 +3187,46 @@ do
     "webhook_receiver: radicle event_type patch handler succeeds → 200"
   )
 
+  -- Sourcehut GraphQL webhooks can embed the event name under data.webhook.
+  app.backend.webhooks = {
+    push = function(_payload)
+      return { event = "push" }, nil
+    end,
+    ["patchset:created"] = function(_payload)
+      return { event = "pull_request" }, nil
+    end,
+  }
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/sourcehut",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"event":"push"}',
+    }),
+    200,
+    "webhook_receiver: sourcehut root event handler succeeds → 200"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/sourcehut",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"webhook":{"event":"push"}}',
+    }),
+    200,
+    "webhook_receiver: sourcehut webhook.event handler succeeds → 200"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/sourcehut",
+      headers = { ["Content-Type"] = "application/json" },
+      body = '{"data":{"webhook":{"event":"patchset:created"}}}',
+    }),
+    200,
+    "webhook_receiver: sourcehut data.webhook.event handler succeeds → 200"
+  )
+
   -- Phabricator embeds the object family in object.type or the PHID prefix.
   app.backend.webhooks = {
     TASK = function(_payload)

--- a/test/webhook-delivery-sourcehut-confusio-shape.hurl
+++ b/test/webhook-delivery-sourcehut-confusio-shape.hurl
@@ -1,0 +1,176 @@
+# Sourcehut webhook delivery test — "confusio" shape variant.
+#
+# Spot-checks each translated Sourcehut event family with X-Confusio-* headers
+# and normalized envelope bodies.
+
+# -- REPO_CREATED -> repository.created --------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/repository-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "repository"
+jsonpath "$[0].confusio_source" == "sourcehut"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "repository.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "octocat"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+
+# -- GIT_POST_RECEIVE ref update -> push -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "push"
+jsonpath "$[0].confusio_source" == "sourcehut"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T11:10:00Z"
+jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.payload.head_commit.id" == "def456abc123def456abc123def456abc123def4"
+
+# -- TICKET_CREATED -> issue.opened ------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "issues"
+jsonpath "$[0].confusio_source" == "sourcehut"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T12:00:00Z"
+jsonpath "$[0].body_json.payload.issue.number" == 1
+
+# -- EVENT_CREATED comment -> issue.comment.created --------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issue_comment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "issue_comment"
+jsonpath "$[0].confusio_source" == "sourcehut"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "issue.comment.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T12:15:00Z"
+jsonpath "$[0].body_json.payload.comment.body" == "I can reproduce this."
+
+# -- LABEL_CREATED -> label.created ------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/label-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "label"
+jsonpath "$[0].confusio_source" == "sourcehut"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "label.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T13:00:00Z"
+jsonpath "$[0].body_json.payload.label.name" == "bug"
+
+# -- JOB_UPDATED success -> workflow.run.completed ---------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/workflow_run-completed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "workflow_run"
+jsonpath "$[0].confusio_source" == "sourcehut"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "workflow.run.completed"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T14:05:00Z"
+jsonpath "$[0].body_json.payload.workflow_run.conclusion" == "success"
+
+# -- PATCHSET_RECEIVED -> pull_request.opened --------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/pull_request-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request"
+jsonpath "$[0].confusio_source" == "sourcehut"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T15:00:00Z"
+jsonpath "$[0].body_json.payload.number" == 7
+jsonpath "$[0].body_json.payload.pull_request.title" == "Add feature"

--- a/test/webhook-delivery-sourcehut.hurl
+++ b/test/webhook-delivery-sourcehut.hurl
@@ -1,0 +1,569 @@
+# Sourcehut webhook delivery tests.
+#
+# Sourcehut GraphQL webhook payloads embed the native event name in the JSON
+# body, so no event-type header is required.  These fixtures cover the native
+# sourcehut events translated by the backend and verify github-shaped fanout.
+
+# -- REPO_CREATED -> repository: created -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/repository-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "repository"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+jsonpath "$[0].body_json.sender.login" == "octocat"
+
+# -- REPO_UPDATE -> repository: edited ---------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/repository-edited.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "repository"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.repository.description" == "Updated description"
+
+# -- REPO_DELETED -> repository: deleted -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/repository-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "repository"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "deleted"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+
+# -- GIT_POST_RECEIVE branch create -> create --------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+
+# -- GIT_POST_RECEIVE branch delete -> delete --------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature"
+jsonpath "$[0].body_json.ref_type" == "branch"
+
+# -- GIT_POST_RECEIVE ref update -> push -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.before" == "abc123def456abc123def456abc123def456abcd"
+jsonpath "$[0].body_json.after" == "def456abc123def456abc123def456abc123def4"
+jsonpath "$[0].body_json.commits[0].id" == "def456abc123def456abc123def456abc123def4"
+
+# -- GIT_PRE_RECEIVE ref update -> push --------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/push-pre_receive.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.after" == "def456abc123def456abc123def456abc123def4"
+
+# -- TICKET_CREATED -> issues: opened ----------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "opened"
+jsonpath "$[0].body_json.issue.number" == 1
+jsonpath "$[0].body_json.issue.title" == "Found a bug"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+
+# -- EVENT_CREATED ticket creation -> issues: opened -------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-opened-event_created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "opened"
+jsonpath "$[0].body_json.issue.number" == 2
+jsonpath "$[0].body_json.issue.title" == "New ticket from activity stream"
+
+# -- TICKET_UPDATE -> issues: edited -----------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-edited.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.issue.title" == "Found a bug (updated)"
+
+# -- TICKET_DELETED -> issues: deleted ---------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "deleted"
+jsonpath "$[0].body_json.issue.number" == 1
+
+# -- EVENT_CREATED comment -> issue_comment: created -------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issue_comment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issue_comment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.issue.number" == 1
+jsonpath "$[0].body_json.comment.body" == "I can reproduce this."
+
+# -- EVENT_CREATED label added -> issues: labeled ----------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-labeled.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "labeled"
+jsonpath "$[0].body_json.label.name" == "bug"
+
+# -- EVENT_CREATED label removed -> issues: unlabeled ------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-unlabeled.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "unlabeled"
+jsonpath "$[0].body_json.label.name" == "bug"
+
+# -- EVENT_CREATED status resolved -> issues: closed -------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-closed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "closed"
+jsonpath "$[0].body_json.issue.state" == "closed"
+
+# -- EVENT_CREATED status reopened -> issues: reopened -----------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-reopened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "reopened"
+jsonpath "$[0].body_json.issue.state" == "open"
+
+# -- EVENT_CREATED assigned user -> issues: assigned -------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-assigned.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "assigned"
+jsonpath "$[0].body_json.assignee.login" == "bob"
+
+# -- EVENT_CREATED unassigned user -> issues: unassigned ---------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/issues-unassigned.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "unassigned"
+jsonpath "$[0].body_json.assignee.login" == "bob"
+
+# -- LABEL_CREATED -> label: created -----------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/label-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "label"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.label.name" == "bug"
+jsonpath "$[0].body_json.repository.full_name" == "octocat/hello-world"
+
+# -- LABEL_UPDATE -> label: edited ------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/label-edited.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "label"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.label.color" == "0075ca"
+
+# -- LABEL_DELETED -> label: deleted ----------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/label-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "label"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "deleted"
+jsonpath "$[0].body_json.label.name" == "bug"
+
+# -- JOB_CREATED -> workflow_run: requested ----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/workflow_run-requested.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "workflow_run"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "requested"
+jsonpath "$[0].body_json.workflow_run.name" == "ci/test"
+jsonpath "$[0].body_json.workflow_run.status" == "queued"
+
+# -- JOB_UPDATED running -> workflow_run: in_progress ------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/workflow_run-in_progress.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "workflow_run"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "in_progress"
+jsonpath "$[0].body_json.workflow_run.status" == "in_progress"
+
+# -- JOB_UPDATED success -> workflow_run: completed --------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/workflow_run-completed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "workflow_run"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "completed"
+jsonpath "$[0].body_json.workflow_run.status" == "completed"
+jsonpath "$[0].body_json.workflow_run.conclusion" == "success"
+
+# -- PATCHSET_RECEIVED -> pull_request: opened -------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+file,fixtures/webhooks/sourcehut/pull_request-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "opened"
+jsonpath "$[0].body_json.number" == 7
+jsonpath "$[0].body_json.pull_request.title" == "Add feature"
+jsonpath "$[0].body_json.pull_request.base.ref" == "main"

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -15,6 +15,7 @@
 #   onedev_tok — the shared secret verbatim (for X-OneDev-Signature)
 #   radicle_tok — the shared secret verbatim (for Authorization)
 #   kallithea — shared secret is embedded in the request body
+#   sourcehut_sig — Ed25519("{}") as base64 (for X-Payload-Signature)
 #   confusio_sig — "sha256=<hex>, v=1, ts=<ts>" (for X-Confusio-Signature-256)
 #
 # Convention: valid credential → 422 (verification passed; no handlers registered
@@ -573,6 +574,37 @@ jsonpath "$.message" == "Signature verification failed"
 
 # Missing signature header → 401
 POST http://{{host}}/webhooks/sourceforge
+Content-Type: application/json
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── sourcehut: X-Payload-Signature, Ed25519 detached signature ───────────────
+
+# Valid signature → passes verification (422)
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+X-Payload-Signature: {{sourcehut_sig}}
+{}
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad signature → 401
+POST http://{{host}}/webhooks/sourcehut
+Content-Type: application/json
+X-Payload-Signature: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing signature header → 401
+POST http://{{host}}/webhooks/sourcehut
 Content-Type: application/json
 {}
 


### PR DESCRIPTION
Completes the sourcehut webhook translation layer and pins the native event surface with fixtures and mock routes.

Remaining work adds delivery coverage, then updates the docs and compatibility matrix.

Fixes #272.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (8)</summary>

- [x] Add sourcehut webhook delivery tests <!-- type:spec -->
- [x] Update sourcehut webhook docs and matrix <!-- type:spec -->
- [x] Add sourcehut webhook fixtures and mock routes <!-- type:spec -->
- [x] Translate sourcehut CI and patchset events <!-- type:spec -->
- [x] Translate sourcehut issue and label events <!-- type:spec -->
- [x] Translate sourcehut repo and git events <!-- type:spec -->
- [x] Add sourcehut webhook event dispatch <!-- type:spec -->
- [x] Add sourcehut webhook signature verification <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->