### PR TITLE
v3: Webhook — tuleap source backend (closes #273)

### DIFF
--- a/backends/tuleap.lua
+++ b/backends/tuleap.lua
@@ -291,6 +291,79 @@ local function tuleap_artifact_event(action)
   end
 end
 
+local TULEAP_ACTIONLESS_NORMALIZED_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
+local function tuleap_normalized_payload_without_envelope_fields(data)
+  local payload = {}
+  for k, v in pairs(data or {}) do
+    if k ~= "sender" and k ~= "repository" then
+      payload[k] = v
+    end
+  end
+  return payload
+end
+
+local function translate_tuleap_normalized_webhook(internal_event, fields)
+  local data = internal_event.data or {}
+  fields = fields or {}
+  return make_normalized_webhook_envelope(internal_event, {
+    id = fields.id,
+    type = fields.type
+      or (
+        TULEAP_ACTIONLESS_NORMALIZED_EVENTS[internal_event.event]
+          and normalized_webhook_event_type(internal_event.event, "")
+        or normalized_webhook_event_type(internal_event.event, internal_event.action)
+      ),
+    occurred_at = fields.occurred_at,
+    actor = fields.actor or data.sender,
+    repository = fields.repository or data.repository,
+    payload = fields.payload or tuleap_normalized_payload_without_envelope_fields(data),
+  })
+end
+
+local function translate_tuleap_github_webhook(internal_event, _fields)
+  local data = internal_event.data or {}
+  local payload = {
+    action = data.action or internal_event.action,
+    repository = data.repository or {},
+    sender = data.sender or {},
+  }
+  if internal_event.event == "project" then
+    payload.project = data.project or {}
+  elseif internal_event.event == "push" then
+    payload.action = nil
+    payload.ref = data.ref or ""
+    payload.before = data.before or ""
+    payload.after = data.after or ""
+    payload.created = data.created or false
+    payload.deleted = data.deleted or false
+    payload.forced = data.forced or false
+    payload.compare = data.compare or ""
+    payload.commits = data.commits or {}
+    payload.head_commit = data.head_commit
+    payload.pusher = data.pusher or {}
+  elseif internal_event.event == "create" or internal_event.event == "delete" then
+    payload.ref = data.ref or ""
+    payload.ref_type = data.ref_type or ""
+    payload.master_branch = data.master_branch or ""
+    payload.description = data.description
+    payload.pusher_type = data.pusher_type or "user"
+  elseif internal_event.event == "issues" then
+    payload.issue = data.issue or {}
+    if data.label then
+      payload.label = data.label
+    end
+    if data.assignee then
+      payload.assignee = data.assignee
+    end
+  end
+  return payload
+end
+
 local function tuleap_git_event(payload)
   payload = payload or {}
   local raw_ref = payload.ref or ""
@@ -537,5 +610,10 @@ b:webhook("project_create", tuleap_project_created_event)
 b:webhook("git_push", tuleap_git_event)
 b:webhook("artifact_create", tuleap_artifact_event("opened"))
 b:webhook("artifact_update", tuleap_artifact_event("edited"))
+
+for _, event in ipairs({ "project", "push", "create", "delete", "issues" }) do
+  b:webhook_translator(event, translate_tuleap_normalized_webhook)
+  b:webhook_github_translator(event, translate_tuleap_github_webhook)
+end
 
 b:build()

--- a/backends/tuleap.lua
+++ b/backends/tuleap.lua
@@ -207,6 +207,90 @@ local function tuleap_project_created_event(payload)
   })
 end
 
+local function tuleap_artifact_field(artifact, label)
+  for _, field in ipairs((artifact or {}).values or {}) do
+    if field.label == label then
+      return field
+    end
+  end
+  return nil
+end
+
+local function tuleap_artifact_field_value(artifact, label)
+  local field = tuleap_artifact_field(artifact, label)
+  if not field then
+    return nil
+  end
+  if field.value ~= nil then
+    return field.value
+  end
+  if field.values and field.values[1] then
+    return field.values[1].label
+  end
+  return nil
+end
+
+local function tuleap_artifact_id(artifact)
+  return tuleap_artifact_field_value(artifact, "Artifact ID") or (artifact or {}).id or 0
+end
+
+local function tuleap_artifact_state(artifact)
+  local status = tostring(tuleap_artifact_field_value(artifact, "Status") or ""):lower()
+  if status == "closed" or status == "done" or status == "resolved" then
+    return "closed"
+  end
+  return "open"
+end
+
+local function translate_tuleap_artifact(artifact)
+  artifact = artifact or {}
+  local issue_id = tuleap_artifact_id(artifact)
+  local submitted_by = artifact.submitted_by_details or {}
+  return {
+    id = issue_id,
+    node_id = "",
+    number = issue_id,
+    title = tuleap_artifact_field_value(artifact, "Title") or "",
+    body = tuleap_artifact_field_value(artifact, "Description") or "",
+    state = tuleap_artifact_state(artifact),
+    user = translate_tuleap_user(submitted_by),
+    assignees = {},
+    labels = {},
+    milestone = nil,
+    created_at = artifact.submitted_on or "",
+    updated_at = tuleap_artifact_field_value(artifact, "Last Update On")
+      or artifact.submitted_on
+      or "",
+    closed_at = nil,
+    html_url = "",
+  }
+end
+
+local function tuleap_artifact_event(action)
+  return function(payload)
+    payload = payload or {}
+    local artifact = payload.current or {}
+    local sender = translate_tuleap_user(
+      payload.user or artifact.last_modified_by or artifact.submitted_by_details
+    )
+    return make_internal_event({
+      event = "issues",
+      action = action,
+      provider = "tuleap",
+      raw = payload,
+      data = {
+        action = action,
+        issue = translate_tuleap_artifact(artifact),
+        repository = {},
+        sender = sender,
+      },
+      timestamp = tuleap_artifact_field_value(artifact, "Last Update On")
+        or artifact.submitted_on
+        or "",
+    })
+  end
+end
+
 local function tuleap_git_event(payload)
   payload = payload or {}
   local raw_ref = payload.ref or ""
@@ -451,5 +535,7 @@ end)
 
 b:webhook("project_create", tuleap_project_created_event)
 b:webhook("git_push", tuleap_git_event)
+b:webhook("artifact_create", tuleap_artifact_event("opened"))
+b:webhook("artifact_update", tuleap_artifact_event("edited"))
 
 b:build()

--- a/backends/tuleap.lua
+++ b/backends/tuleap.lua
@@ -13,6 +13,20 @@ local auth = function()
   return make_fetch_opts("bearer")
 end
 local fetch_json = make_backend_transport("bearer").fetch_json
+local ZERO_SHA = "0000000000000000000000000000000000000000"
+
+local function short_ref(ref)
+  return (ref or ""):match("^refs/heads/(.+)$")
+    or (ref or ""):match("^refs/tags/(.+)$")
+    or (ref or "")
+end
+
+local function ref_type(ref)
+  if (ref or ""):match("^refs/tags/") then
+    return "tag"
+  end
+  return "branch"
+end
 
 -- Translate a Tuleap git repository object to GitHub format.
 local function translate_tuleap_repo(r)
@@ -20,12 +34,21 @@ local function translate_tuleap_repo(r)
     return {}
   end
   local project = r.project or {}
-  local shortname = project.shortname or ""
+  local name = r.name or ""
+  local full_name = r.full_name or ""
+  local shortname = project.shortname
+    or project.path
+    or project.name
+    or full_name:match("^([^/]+)/")
+    or ""
+  if full_name == "" then
+    full_name = shortname ~= "" and (shortname .. "/" .. name) or name
+  end
   return {
     id = r.id or 0,
     node_id = "",
-    name = r.name or "",
-    full_name = shortname .. "/" .. (r.name or ""),
+    name = name,
+    full_name = full_name,
     private = false,
     owner = {
       login = shortname,
@@ -68,18 +91,191 @@ local function translate_tuleap_user(u)
   if not u then
     return {}
   end
+  local login = u.username or u.login or u.name or u.real_name or ""
+  local html_url = u.user_url or ""
+  if html_url == "" then
+    html_url = config.base_url .. "/users/" .. login
+  elseif html_url:match("^/") then
+    html_url = config.base_url .. html_url
+  end
   return {
-    login = u.username or "",
+    login = login,
     id = u.id or 0,
     node_id = "",
     avatar_url = u.avatar_url or "",
-    html_url = config.base_url .. "/users/" .. (u.username or ""),
+    html_url = html_url,
     type = "User",
     site_admin = false,
-    name = u.real_name or u.display_name or u.username or "",
-    email = "",
+    name = u.real_name or u.display_name or login,
+    email = u.email or "",
     blog = "",
   }
+end
+
+local function tuleap_project_url(path)
+  if path and path ~= "" then
+    return config.base_url .. "/projects/" .. path
+  end
+  return ""
+end
+
+local function translate_tuleap_project_webhook(payload)
+  payload = payload or {}
+  local sender = translate_tuleap_user({
+    id = payload.owner_id,
+    username = payload.owner_username or payload.owner_name,
+    real_name = payload.owner_name,
+    email = payload.owner_email,
+  })
+  return {
+    id = payload.project_id or payload.id or 0,
+    node_id = "",
+    name = payload.name or payload.path or "",
+    body = payload.description or "",
+    url = "",
+    html_url = tuleap_project_url(payload.path),
+    owner_url = sender.html_url or "",
+    creator = sender,
+    created_at = payload.created_at or "",
+    updated_at = payload.updated_at or payload.created_at or "",
+    path = payload.path or "",
+    path_with_namespace = payload.path_with_namespace or payload.path or "",
+    visibility = payload.project_visibility or payload.visibility or "",
+  }
+end
+
+local function translate_tuleap_commit(c)
+  c = c or {}
+  local author = c.author or {}
+  local committer = c.committer or author
+  return {
+    id = c.id or c.sha or "",
+    message = c.message or "",
+    timestamp = c.timestamp or c.date or "",
+    url = c.url or "",
+    author = {
+      name = author.name or "",
+      email = author.email or "",
+      username = author.username or author.login or author.name or "",
+    },
+    committer = {
+      name = committer.name or author.name or "",
+      email = committer.email or author.email or "",
+      username = committer.username or committer.login or committer.name or author.name or "",
+    },
+    added = c.added or {},
+    removed = c.removed or {},
+    modified = c.modified or {},
+  }
+end
+
+local function translate_tuleap_commits(commits)
+  local result = {}
+  for _, commit in ipairs(commits or {}) do
+    result[#result + 1] = translate_tuleap_commit(commit)
+  end
+  return result
+end
+
+local function tuleap_sender(payload)
+  return translate_tuleap_user(payload.sender or payload.user or payload.pusher)
+end
+
+local function tuleap_pusher(payload)
+  local pusher = payload.pusher or payload.sender or payload.user or {}
+  return {
+    name = pusher.name or pusher.username or pusher.login or pusher.real_name or "",
+    email = pusher.email or "",
+  }
+end
+
+local function tuleap_project_created_event(payload)
+  payload = payload or {}
+  local project = translate_tuleap_project_webhook(payload)
+  local sender = project.creator or {}
+  return make_internal_event({
+    event = "project",
+    action = "created",
+    provider = "tuleap",
+    raw = payload,
+    data = {
+      action = "created",
+      project = project,
+      sender = sender,
+    },
+    timestamp = payload.created_at or payload.updated_at or "",
+  })
+end
+
+local function tuleap_git_event(payload)
+  payload = payload or {}
+  local raw_ref = payload.ref or ""
+  local before = payload.before or ""
+  local after = payload.after or ""
+  local repository = translate_tuleap_repo(payload.repository)
+  local sender = tuleap_sender(payload)
+
+  if before == ZERO_SHA then
+    return make_internal_event({
+      event = "create",
+      action = "create",
+      provider = "tuleap",
+      raw = payload,
+      data = {
+        ref = short_ref(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.timestamp or "",
+    })
+  end
+
+  if after == ZERO_SHA then
+    return make_internal_event({
+      event = "delete",
+      action = "delete",
+      provider = "tuleap",
+      raw = payload,
+      data = {
+        ref = short_ref(raw_ref),
+        ref_type = ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.timestamp or "",
+    })
+  end
+
+  local commits = translate_tuleap_commits(payload.commits)
+  local head_commit = #commits > 0 and commits[#commits] or nil
+  return make_internal_event({
+    event = "push",
+    action = "push",
+    provider = "tuleap",
+    raw = payload,
+    data = {
+      ref = raw_ref,
+      before = before,
+      after = after,
+      created = false,
+      deleted = false,
+      forced = payload.forced or false,
+      compare = payload.compare or payload.compare_url or "",
+      commits = commits,
+      head_commit = head_commit,
+      pusher = tuleap_pusher(payload),
+      repository = repository,
+      sender = sender,
+    },
+    timestamp = payload.timestamp or (head_commit and head_commit.timestamp) or "",
+  })
 end
 
 -- Returns limit and offset query params for Tuleap pagination.
@@ -252,5 +448,8 @@ b:rest("search_users", function()
     return { total_count = #items, incomplete_results = false, items = items }
   end, fetch_json(users_url(q)))
 end)
+
+b:webhook("project_create", tuleap_project_created_event)
+b:webhook("git_push", tuleap_git_event)
 
 b:build()

--- a/docs/real-world-testing.md
+++ b/docs/real-world-testing.md
@@ -72,7 +72,7 @@ value is `y` or starts with `~`.  Concretely:
 | kallithea | 5 | 73 |
 | rhodecode | 5 | 73 |
 | sourceforge | 5 | 69 |
-| tuleap | 5 | 79 |
+| tuleap | 12 | 79 |
 
 ### What a "passing" test means
 
@@ -951,6 +951,12 @@ configure the post-receive hook with `X-Gitblit-Token`, and drive one branch upd
 branch creation, and one branch deletion against the fixture repository.  Those three
 post-receive commands are the supported Gitblit webhook surface and should assert both
 GitHub-shaped delivery headers and confusio-shaped normalized event bodies.
+
+Tuleap real-world webhook coverage should run against the
+`tuleap/tuleap-community-edition` container, configure a webhook secret, and drive
+project creation, Git branch/tag update/create/delete, and tracker artifact
+create/update payloads.  The live run should assert both GitHub-shaped delivery
+headers and confusio-shaped normalized event bodies.
 
 **Exit criteria**: all Docker backends produce a result (pass or classified failure) for two
 consecutive weekly runs without the bootstrap script hanging or erroring.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -662,6 +662,13 @@ accept if constant_time_equal(secret, received)
 
 **Configuration:** Set in Tuleap webhook settings as "Secret".
 
+**Supported events:** Tuleap sends form-encoded webhook bodies with a JSON `payload`
+field.  Confusio accepts project creation, Git ref updates, and tracker artifact
+create/update payloads.  Git ref updates translate to GitHub-compatible `push`,
+`create`, or `delete` events depending on the `before` / `after` all-zero SHA
+markers; artifact create/update payloads translate to `issues.opened` and
+`issues.edited`.
+
 ---
 
 ### Gerrit
@@ -2318,13 +2325,13 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2346,9 +2353,9 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | Fork | `fork` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Gollum | `created` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Issues | `opened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+| Issues | `opened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ |
 |  | `closed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
-|  | `edited` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
+|  | `edited` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ |
 |  | `reopened` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ |
 |  | `labeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
 |  | `unlabeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ |
@@ -2401,7 +2408,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 | PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2480,7 +2487,7 @@ Webhook event/action support is generated from `internal/catalog.lua` and
 |  | `pending_tier_change` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `tier_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Project | `closed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `reopened` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2639,9 +2646,11 @@ field structure.
   Create/delete events may arrive embedded in a push event rather than as
   discrete event types.  Confusio splits them when the push `before` or `after`
   is all-zero.
-- `codecommit`, `kallithea`, `rhodecode`, `tuleap`: Create/delete events may not
+- `codecommit`, `kallithea`, `rhodecode`: Create/delete events may not
   be delivered at all depending on forge configuration.  If no event is
   received, the `create` / `delete` event will not be emitted.
+- `tuleap`: Create/delete events are derived from Git webhook payloads when the
+  `before` or `after` SHA is all-zero.
 
 ---
 

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -3,7 +3,8 @@
 -- Processing stages:
 --   1. Route    — extract backend name from path; 404 for unknown backend
 --   2. Method   — POST only; 405 for other methods
---   3. Format   — Content-Type must be application/json; 400 otherwise
+--   3. Format   — Content-Type must be application/json, except Tuleap
+--                 also accepts application/x-www-form-urlencoded payload=<json>
 --   4. Verify   — backend-specific signature checked against raw body; 401 on failure
 --   5. Dispatch — decoded payload passed to app.backend.webhooks[event]; 422 for unknown
 --   6. Respond  — 200 on success
@@ -287,6 +288,71 @@ local function sourceforge_body_event(payload)
     return "repo-push"
   end
   return nil
+end
+
+local function url_decode_component(s)
+  s = tostring(s or "")
+  local i = 1
+  while true do
+    local p = s:find("%%", i, true)
+    if not p then
+      break
+    end
+    local hex = s:sub(p + 1, p + 2)
+    if #hex ~= 2 or not hex:match("^%x%x$") then
+      return nil
+    end
+    i = p + 3
+  end
+  return (
+    s:gsub("+", " "):gsub("%%(%x%x)", function(hex)
+      return string.char(tonumber(hex, 16))
+    end)
+  )
+end
+
+local function form_field(body, name)
+  for pair in (body .. "&"):gmatch("([^&]*)&") do
+    if pair ~= "" then
+      local raw_key, raw_value = pair:match("^([^=]*)=?(.*)$")
+      local key = url_decode_component(raw_key)
+      if not key then
+        return nil, "Malformed form body"
+      end
+      if key == name then
+        local value = url_decode_component(raw_value)
+        if not value then
+          return nil, "Malformed form body"
+        end
+        return value, nil
+      end
+    end
+  end
+  return nil, "Missing form field: " .. name
+end
+
+local function parse_webhook_payload(backend, content_type, body)
+  if content_type:find("application/json", 1, true) then
+    local ok_parse, payload = pcall(DecodeJson, body)
+    if not ok_parse or type(payload) ~= "table" then
+      return nil, "Invalid JSON body"
+    end
+    return payload, nil
+  end
+
+  if backend == "tuleap" and content_type:find("application/x-www-form-urlencoded", 1, true) then
+    local payload_json, form_err = form_field(body, "payload")
+    if not payload_json then
+      return nil, form_err or "Invalid form body"
+    end
+    local ok_parse, payload = pcall(DecodeJson, payload_json)
+    if not ok_parse or type(payload) ~= "table" then
+      return nil, "Invalid JSON body"
+    end
+    return payload, nil
+  end
+
+  return nil, "Content-Type must be application/json"
 end
 
 -- verify_signature(backend, secret, body[, now]) authenticates the inbound request
@@ -622,9 +688,13 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
       return
     end
 
-    -- Content-Type: must include application/json.
+    -- Content-Type: must include application/json for most backends.  Tuleap
+    -- natively sends form-encoded requests with a payload=<json> field.
     local ct = GetHeader("Content-Type") or ""
-    if not ct:find("application/json", 1, true) then
+    local is_json = ct:find("application/json", 1, true) ~= nil
+    local is_tuleap_form = backend == "tuleap"
+      and ct:find("application/x-www-form-urlencoded", 1, true) ~= nil
+    if not is_json and not is_tuleap_form then
       respond_json(400, { message = "Content-Type must be application/json" })
       return
     end
@@ -643,10 +713,11 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
       return
     end
 
-    -- Decode JSON body.
-    local ok_parse, payload = pcall(DecodeJson, body)
-    if not ok_parse or type(payload) ~= "table" then
-      respond_json(400, { message = "Invalid JSON body" })
+    -- Decode JSON body. Tuleap's form body is verified as raw bytes first,
+    -- then the URL-encoded payload field is decoded as the JSON payload.
+    local payload, parse_err = parse_webhook_payload(backend, ct, body)
+    if not payload then
+      respond_json(400, { message = parse_err or "Invalid JSON body" })
       return
     end
 

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -290,6 +290,28 @@ local function sourceforge_body_event(payload)
   return nil
 end
 
+local function tuleap_body_event(payload)
+  if type(payload) ~= "table" then
+    return nil
+  end
+
+  local project_event = first_string_field(payload, { "event_name" })
+  if project_event then
+    return project_event
+  end
+
+  if type(payload.repository) == "table" and (payload.ref or payload.before or payload.after) then
+    return "git_push"
+  end
+
+  local action = first_string_field(payload, { "action" })
+  if action == "create" or action == "update" then
+    return "artifact_" .. action
+  end
+
+  return nil
+end
+
 local function url_decode_component(s)
   s = tostring(s or "")
   local i = 1
@@ -734,6 +756,8 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
     --   Phabricator webhooks embed object.type, or an equivalent PHID prefix.
     --   SourceForge / Allura repo-push webhooks have no event header, so infer
     --   them from their documented ref/update fields.
+    --   Tuleap has no event header; project webhooks use event_name, Git push
+    --   payloads have ref/update fields, and tracker artifact hooks use action.
     local ev = event_header(backend)
     if ev == nil and type(payload) == "table" then
       if payload.eventType then
@@ -752,6 +776,8 @@ function make_webhook_receiver(a) -- luacheck: globals make_webhook_receiver
         ev = phabricator_body_event(payload)
       elseif backend == "sourceforge" then
         ev = sourceforge_body_event(payload)
+      elseif backend == "tuleap" then
+        ev = tuleap_body_event(payload)
       end
     end
 

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -1,6 +1,6 @@
 endpoint,azuredevops,bitbucket,bitbucket_datacenter,codeberg,codecommit,forgejo,gerrit,gitblit,gitbucket,gitea,gitlab,gogs,harness,kallithea,launchpad,notabug,onedev,pagure,phabricator,radicle,rhodecode,sourceforge,sourcehut,tuleap
 POST /graphql,"~repository only; no issues, no viewer","~no labels, no reactions; commit email always empty",~no viewer; repository and pulls only,y,n,y,~repository scalar fields only,n,y,y,y,"~no releases, no packages",n,n,~issues only; no repository scalar fields,y,n,~no pull requests,n,n,n,n,~no pull requests,n
-POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~refs/issues/PRs/builds/packages,~no CI events,y,~refs/patches only,~no CI events,~no CI events,y,~no CI events
+POST /webhooks/{backend},y,y,y,y,~no CI events,y,~no CI events,~push/create/delete only,~no CI events,y,y,y,y,~refs/repos/PRs only,~push/bugs/MPs/builds/packages,y,~refs/issues/PRs/builds/packages,~no CI events,y,~refs/patches only,~no CI events,~no CI events,y,y
 GET /repos/{owner}/{repo},y,y,y,y,y,y,y,y,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,~
 PATCH /repos/{owner}/{repo},y,y,y,y,n,y,y,n,y,y,y,y,y,n,n,y,y,y,n,y,n,n,y,n
 DELETE /repos/{owner}/{repo},y,y,y,y,n,y,n,n,y,y,y,y,y,n,n,y,y,y,n,~stub; returns 405,n,n,y,n
@@ -463,13 +463,13 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,n
+webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,y
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,n
+webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,y
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -491,9 +491,9 @@ webhook discussion_comment/edited,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,
 webhook fork/fork,n,y,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,y,n,n,n,n,n,n
 webhook gollum/created,n,n,n,y,n,y,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook gollum/edited,n,n,n,y,n,y,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook issues/opened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,n
+webhook issues/opened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,y
 webhook issues/closed,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,y,n,n,n,y,n
-webhook issues/edited,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,n
+webhook issues/edited,y,y,n,y,n,y,n,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,y,y
 webhook issues/reopened,y,y,n,y,n,y,n,n,y,y,y,y,n,n,n,y,y,y,y,n,n,n,y,n
 webhook issues/labeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,y,n
 webhook issues/unlabeled,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,y,n
@@ -546,7 +546,7 @@ webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,
 webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,n
+webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
@@ -625,7 +625,7 @@ webhook sponsorship/pending_cancellation,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook sponsorship/pending_tier_change,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook sponsorship/tier_changed,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook project/closed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook project/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook project/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,y
 webhook project/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook project/edited,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook project/reopened,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/tuleap/artifact-created.json
+++ b/test/fixtures/webhooks/tuleap/artifact-created.json
@@ -1,0 +1,113 @@
+{
+  "id": 182,
+  "action": "create",
+  "user": {
+    "id": 102,
+    "uri": "users/102",
+    "user_url": "/users/alice",
+    "real_name": "Alice Example",
+    "display_name": "Alice Example (alice)",
+    "username": "alice",
+    "ldap_id": "102",
+    "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+    "is_anonymous": false
+  },
+  "submitter_user_groups": [
+    {
+      "id": "102_3",
+      "uri": "user_groups/102_3",
+      "label": "Project members",
+      "users_uri": "user_groups/102_3/users",
+      "short_name": "project_members",
+      "key": "ugroup_project_members_name_key"
+    }
+  ],
+  "current": {
+    "id": 355743,
+    "submitted_by": 102,
+    "submitted_by_details": {
+      "id": 102,
+      "uri": "users/102",
+      "user_url": "/users/alice",
+      "real_name": "Alice Example",
+      "display_name": "Alice Example (alice)",
+      "username": "alice",
+      "ldap_id": "102",
+      "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+      "is_anonymous": false
+    },
+    "submitted_on": "2024-01-15T10:30:00+00:00",
+    "email": null,
+    "last_comment": {
+      "body": "First report from Tuleap.",
+      "post_processed_body": "<p>First report from Tuleap.</p>",
+      "format": "text"
+    },
+    "last_modified_by": {
+      "id": 102,
+      "uri": "users/102",
+      "user_url": "/users/alice",
+      "real_name": "Alice Example",
+      "display_name": "Alice Example (alice)",
+      "username": "alice",
+      "ldap_id": "102",
+      "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+      "is_anonymous": false
+    },
+    "values": [
+      {
+        "field_id": 592,
+        "type": "aid",
+        "label": "Artifact ID",
+        "value": 75291
+      },
+      {
+        "field_id": 580,
+        "type": "string",
+        "label": "Title",
+        "value": "Normalize Tuleap webhook payloads"
+      },
+      {
+        "field_id": 581,
+        "type": "text",
+        "label": "Description",
+        "value": "Tuleap should fan out as a normalized issue event.",
+        "format": "text"
+      },
+      {
+        "field_id": 587,
+        "type": "sb",
+        "label": "Status",
+        "values": [
+          {
+            "id": "371",
+            "label": "Todo",
+            "color": {
+              "r": 204,
+              "g": 0,
+              "b": 204
+            },
+            "tlp_color": "deep-purple"
+          }
+        ],
+        "bind_value_ids": [
+          371
+        ]
+      },
+      {
+        "field_id": 593,
+        "type": "subon",
+        "label": "Submitted On",
+        "value": "2024-01-15T10:30:00+00:00"
+      },
+      {
+        "field_id": 596,
+        "type": "lud",
+        "label": "Last Update On",
+        "value": "2024-01-15T10:30:00+00:00"
+      }
+    ]
+  },
+  "previous": null,
+  "is_custom_code_execution": false
+}

--- a/test/fixtures/webhooks/tuleap/artifact-updated.json
+++ b/test/fixtures/webhooks/tuleap/artifact-updated.json
@@ -1,0 +1,168 @@
+{
+  "id": 182,
+  "action": "update",
+  "user": {
+    "id": 103,
+    "uri": "users/103",
+    "user_url": "/users/bob",
+    "real_name": "Bob Reviewer",
+    "display_name": "Bob Reviewer (bob)",
+    "username": "bob",
+    "ldap_id": "103",
+    "avatar_url": "https://tuleap.example.com/users/bob/avatar.png",
+    "is_anonymous": false
+  },
+  "submitter_user_groups": [
+    {
+      "id": "102_3",
+      "uri": "user_groups/102_3",
+      "label": "Project members",
+      "users_uri": "user_groups/102_3/users",
+      "short_name": "project_members",
+      "key": "ugroup_project_members_name_key"
+    },
+    {
+      "id": "150",
+      "uri": "user_groups/150",
+      "label": "reviewers",
+      "users_uri": "user_groups/150/users",
+      "short_name": "reviewers",
+      "key": "reviewers"
+    }
+  ],
+  "current": {
+    "id": 355744,
+    "submitted_by": 103,
+    "submitted_by_details": {
+      "id": 103,
+      "uri": "users/103",
+      "user_url": "/users/bob",
+      "real_name": "Bob Reviewer",
+      "display_name": "Bob Reviewer (bob)",
+      "username": "bob",
+      "ldap_id": "103",
+      "avatar_url": "https://tuleap.example.com/users/bob/avatar.png",
+      "is_anonymous": false
+    },
+    "submitted_on": "2024-01-15T11:00:00+00:00",
+    "email": null,
+    "last_comment": {
+      "body": "Moved into review.",
+      "post_processed_body": "<p>Moved into review.</p>",
+      "format": "text"
+    },
+    "last_modified_by": {
+      "id": 103,
+      "uri": "users/103",
+      "user_url": "/users/bob",
+      "real_name": "Bob Reviewer",
+      "display_name": "Bob Reviewer (bob)",
+      "username": "bob",
+      "ldap_id": "103",
+      "avatar_url": "https://tuleap.example.com/users/bob/avatar.png",
+      "is_anonymous": false
+    },
+    "values": [
+      {
+        "field_id": 592,
+        "type": "aid",
+        "label": "Artifact ID",
+        "value": 75291
+      },
+      {
+        "field_id": 580,
+        "type": "string",
+        "label": "Title",
+        "value": "Normalize Tuleap webhook payloads"
+      },
+      {
+        "field_id": 587,
+        "type": "sb",
+        "label": "Status",
+        "values": [
+          {
+            "id": "372",
+            "label": "In review",
+            "color": {
+              "r": 0,
+              "g": 128,
+              "b": 255
+            },
+            "tlp_color": "lake-placid-blue"
+          }
+        ],
+        "bind_value_ids": [
+          372
+        ]
+      },
+      {
+        "field_id": 596,
+        "type": "lud",
+        "label": "Last Update On",
+        "value": "2024-01-15T11:00:00+00:00"
+      }
+    ]
+  },
+  "previous": {
+    "id": 355743,
+    "submitted_by": 102,
+    "submitted_on": "2024-01-15T10:30:00+00:00",
+    "last_comment": {
+      "body": "First report from Tuleap.",
+      "post_processed_body": "<p>First report from Tuleap.</p>",
+      "format": "text"
+    },
+    "last_modified_by": {
+      "id": 102,
+      "uri": "users/102",
+      "user_url": "/users/alice",
+      "real_name": "Alice Example",
+      "display_name": "Alice Example (alice)",
+      "username": "alice",
+      "ldap_id": "102",
+      "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+      "is_anonymous": false
+    },
+    "values": [
+      {
+        "field_id": 592,
+        "type": "aid",
+        "label": "Artifact ID",
+        "value": 75291
+      },
+      {
+        "field_id": 580,
+        "type": "string",
+        "label": "Title",
+        "value": "Normalize Tuleap webhook payloads"
+      },
+      {
+        "field_id": 587,
+        "type": "sb",
+        "label": "Status",
+        "values": [
+          {
+            "id": "371",
+            "label": "Todo",
+            "color": {
+              "r": 204,
+              "g": 0,
+              "b": 204
+            },
+            "tlp_color": "deep-purple"
+          }
+        ],
+        "bind_value_ids": [
+          371
+        ]
+      },
+      {
+        "field_id": 596,
+        "type": "lud",
+        "label": "Last Update On",
+        "value": "2024-01-15T10:30:00+00:00"
+      }
+    ]
+  },
+  "is_custom_code_execution": false
+}

--- a/test/fixtures/webhooks/tuleap/create.json
+++ b/test/fixtures/webhooks/tuleap/create.json
@@ -1,0 +1,25 @@
+{
+  "ref": "refs/heads/feature/tuleap-fixtures",
+  "after": "3333333333333333333333333333333333333333",
+  "before": "0000000000000000000000000000000000000000",
+  "repository": {
+    "id": "123",
+    "name": "hello-world",
+    "full_name": "hello-world"
+  },
+  "pusher": {
+    "name": "alice",
+    "email": "alice@example.com"
+  },
+  "sender": {
+    "id": 102,
+    "uri": "users/102",
+    "user_url": "/users/alice",
+    "real_name": "Alice Example",
+    "display_name": "Alice Example (alice)",
+    "username": "alice",
+    "ldap_id": "102",
+    "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+    "is_anonymous": false
+  }
+}

--- a/test/fixtures/webhooks/tuleap/delete.json
+++ b/test/fixtures/webhooks/tuleap/delete.json
@@ -1,0 +1,25 @@
+{
+  "ref": "refs/heads/feature/tuleap-fixtures",
+  "after": "0000000000000000000000000000000000000000",
+  "before": "4444444444444444444444444444444444444444",
+  "repository": {
+    "id": "123",
+    "name": "hello-world",
+    "full_name": "hello-world"
+  },
+  "pusher": {
+    "name": "alice",
+    "email": "alice@example.com"
+  },
+  "sender": {
+    "id": 102,
+    "uri": "users/102",
+    "user_url": "/users/alice",
+    "real_name": "Alice Example",
+    "display_name": "Alice Example (alice)",
+    "username": "alice",
+    "ldap_id": "102",
+    "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+    "is_anonymous": false
+  }
+}

--- a/test/fixtures/webhooks/tuleap/project-created.json
+++ b/test/fixtures/webhooks/tuleap/project-created.json
@@ -1,0 +1,13 @@
+{
+  "created_at": "2024-01-15T10:00:00+00:00",
+  "updated_at": "2024-01-15T10:05:00+00:00",
+  "event_name": "project_create",
+  "name": "Hello World",
+  "owner_id": 102,
+  "owner_email": "alice@example.com",
+  "owner_name": "Alice Example",
+  "path": "hello-world",
+  "path_with_namespace": "octocat/hello-world",
+  "project_id": 126,
+  "project_visibility": "public"
+}

--- a/test/fixtures/webhooks/tuleap/push.json
+++ b/test/fixtures/webhooks/tuleap/push.json
@@ -1,0 +1,25 @@
+{
+  "ref": "refs/heads/main",
+  "after": "2222222222222222222222222222222222222222",
+  "before": "1111111111111111111111111111111111111111",
+  "repository": {
+    "id": "123",
+    "name": "hello-world",
+    "full_name": "hello-world"
+  },
+  "pusher": {
+    "name": "alice",
+    "email": "alice@example.com"
+  },
+  "sender": {
+    "id": 102,
+    "uri": "users/102",
+    "user_url": "/users/alice",
+    "real_name": "Alice Example",
+    "display_name": "Alice Example (alice)",
+    "username": "alice",
+    "ldap_id": "102",
+    "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+    "is_anonymous": false
+  }
+}

--- a/test/fixtures/webhooks/tuleap/tag-create.json
+++ b/test/fixtures/webhooks/tuleap/tag-create.json
@@ -1,0 +1,25 @@
+{
+  "ref": "refs/tags/v1.0.0",
+  "after": "5555555555555555555555555555555555555555",
+  "before": "0000000000000000000000000000000000000000",
+  "repository": {
+    "id": "123",
+    "name": "hello-world",
+    "full_name": "hello-world"
+  },
+  "pusher": {
+    "name": "alice",
+    "email": "alice@example.com"
+  },
+  "sender": {
+    "id": 102,
+    "uri": "users/102",
+    "user_url": "/users/alice",
+    "real_name": "Alice Example",
+    "display_name": "Alice Example (alice)",
+    "username": "alice",
+    "ldap_id": "102",
+    "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+    "is_anonymous": false
+  }
+}

--- a/test/fixtures/webhooks/tuleap/tag-delete.json
+++ b/test/fixtures/webhooks/tuleap/tag-delete.json
@@ -1,0 +1,25 @@
+{
+  "ref": "refs/tags/v1.0.0",
+  "after": "0000000000000000000000000000000000000000",
+  "before": "5555555555555555555555555555555555555555",
+  "repository": {
+    "id": "123",
+    "name": "hello-world",
+    "full_name": "hello-world"
+  },
+  "pusher": {
+    "name": "alice",
+    "email": "alice@example.com"
+  },
+  "sender": {
+    "id": 102,
+    "uri": "users/102",
+    "user_url": "/users/alice",
+    "real_name": "Alice Example",
+    "display_name": "Alice Example (alice)",
+    "username": "alice",
+    "ldap_id": "102",
+    "avatar_url": "https://tuleap.example.com/users/alice/avatar.png",
+    "is_anonymous": false
+  }
+}

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -454,7 +454,18 @@ run_delivery_phase test/webhook-delivery-sourcehut-confusio-shape.hurl \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
   "webhook_target_shape=confusio"
 
-# Phase 48: Startup event synthesis — github shape.
+# Phase 48: Tuleap fixture-based delivery tests — native project, Git, and tracker events.
+run_delivery_phase test/webhook-delivery-tuleap.hurl \
+  -- tuleap "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
+
+# Phase 49: Tuleap delivery with "confusio" shape — normalized hook envelopes.
+run_delivery_phase test/webhook-delivery-tuleap-confusio-shape.hurl \
+  -- tuleap "http://127.0.0.1:$MOCK_PORT" \
+  "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT" \
+  "webhook_target_shape=confusio"
+
+# Phase 50: Startup event synthesis — github shape.
 # Verifies that confusio synthesizes installation.created and
 # installation_repositories.added before accepting connections, and delivers
 # both to the configured outbound target.  No /reset is called — the hurl file
@@ -463,8 +474,8 @@ run_delivery_phase test/webhook-delivery-startup.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \
   "webhook_target=http://127.0.0.1:$DELIVERY_TARGET_PORT"
 
-# Phase 49: Startup event synthesis — confusio shape.
-# Same as Phase 48 but with webhook_target_shape=confusio; verifies
+# Phase 51: Startup event synthesis — confusio shape.
+# Same as Phase 50 but with webhook_target_shape=confusio; verifies
 # X-Confusio-* headers are used and X-GitHub-Event is absent.
 run_delivery_phase test/webhook-delivery-startup-confusio-shape.hurl \
   -- gitea "http://127.0.0.1:$MOCK_PORT" \

--- a/test/test-unit.sh
+++ b/test/test-unit.sh
@@ -151,7 +151,7 @@ openssl pkey -in "$SOURCEHUT_KEY" -pubout -outform DER -out "$SOURCEHUT_PUB_DER"
 SOURCEHUT_PUBLIC_KEY=$(tail -c 32 "$SOURCEHUT_PUB_DER" | openssl base64 -A)
 openssl pkeyutl -sign -rawin -inkey "$SOURCEHUT_KEY" -in "$SOURCEHUT_BODY" -out "$SOURCEHUT_SIG_BIN"
 SOURCEHUT_SIG=$(openssl base64 -A < "$SOURCEHUT_SIG_BIN")
-for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad phabricator pagure gerrit onedev radicle kallithea sourceforge confusio; do
+for wh_backend in gitea codeberg gitlab bitbucket bitbucket_datacenter gitbucket launchpad phabricator pagure gerrit onedev radicle kallithea sourceforge tuleap confusio; do
   printf '%s' "$WH_SECRET" > "$WH_SECRET_DIR/$wh_backend.secret"
   chmod 600 "$WH_SECRET_DIR/$wh_backend.secret"
 done
@@ -159,7 +159,7 @@ printf '%s' "$SOURCEHUT_PUBLIC_KEY" > "$WH_SECRET_DIR/sourcehut.secret"
 chmod 600 "$WH_SECRET_DIR/sourcehut.secret"
 printf '%s' "$AZUREDEVOPS_SECRET" > "$WH_SECRET_DIR/azuredevops.secret"
 chmod 600 "$WH_SECRET_DIR/azuredevops.secret"
-WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_radicle=$WH_SECRET_DIR/radicle.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_sourceforge=$WH_SECRET_DIR/sourceforge.secret webhook_secret_file_sourcehut=$WH_SECRET_DIR/sourcehut.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
+WH_CLI_ARGS="-- webhook_secret_file_gitea=$WH_SECRET_DIR/gitea.secret webhook_secret_file_codeberg=$WH_SECRET_DIR/codeberg.secret webhook_secret_file_gitlab=$WH_SECRET_DIR/gitlab.secret webhook_secret_file_bitbucket=$WH_SECRET_DIR/bitbucket.secret webhook_secret_file_bitbucket_datacenter=$WH_SECRET_DIR/bitbucket_datacenter.secret webhook_secret_file_gitbucket=$WH_SECRET_DIR/gitbucket.secret webhook_secret_file_launchpad=$WH_SECRET_DIR/launchpad.secret webhook_secret_file_phabricator=$WH_SECRET_DIR/phabricator.secret webhook_secret_file_pagure=$WH_SECRET_DIR/pagure.secret webhook_secret_file_azuredevops=$WH_SECRET_DIR/azuredevops.secret webhook_secret_file_gerrit=$WH_SECRET_DIR/gerrit.secret webhook_secret_file_onedev=$WH_SECRET_DIR/onedev.secret webhook_secret_file_radicle=$WH_SECRET_DIR/radicle.secret webhook_secret_file_kallithea=$WH_SECRET_DIR/kallithea.secret webhook_secret_file_sourceforge=$WH_SECRET_DIR/sourceforge.secret webhook_secret_file_tuleap=$WH_SECRET_DIR/tuleap.secret webhook_secret_file_sourcehut=$WH_SECRET_DIR/sourcehut.secret webhook_secret_file_confusio=$WH_SECRET_DIR/confusio.secret"
 wh_dir=$(mktemp -d)
 start_confusio "$wh_dir" "$WH_CLI_ARGS"; WH_PID=$!
 trap "kill $WH_PID 2>/dev/null || true; rm -rf $wh_dir; rm -rf $WH_SECRET_DIR" EXIT
@@ -179,6 +179,7 @@ $HURL --retry 10 --retry-interval 200 --connect-timeout 1 --max-time 5 \
   --variable "onedev_tok=$WH_SECRET" \
   --variable "radicle_tok=$WH_SECRET" \
   --variable "sourceforge_sig=$SOURCEFORGE_SIG" \
+  --variable "tuleap_tok=$WH_SECRET" \
   --variable "sourcehut_sig=$SOURCEHUT_SIG" \
   --variable "confusio_sig=$CONFUSIO_SIG" \
   test/webhooks-sig.hurl

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3482,6 +3482,16 @@ do
     400,
     "webhook_receiver: non-JSON Content-Type → 400"
   )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "text/plain" },
+      body = "",
+    }),
+    400,
+    "webhook_receiver: unsupported Tuleap Content-Type → 400"
+  )
 
   -- 400 for missing Content-Type
   eq(
@@ -3539,7 +3549,69 @@ do
     "webhook_receiver: registered handler succeeds → 200"
   )
 
+  -- Tuleap natively sends application/x-www-form-urlencoded with a payload
+  -- field containing the JSON webhook body.
+  local tuleap_payload_seen = nil
+  app.backend.webhooks = {
+    ["test-event"] = function(payload)
+      tuleap_payload_seen = payload
+      return { event = "repository" }, nil
+    end,
+  }
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = {
+        ["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8",
+      },
+      body = "payload=%7B%22eventType%22%3A%22test-event%22%2C%22message%22%3A%22hello+world+%26+100%25%22%7D&ignored=1",
+    }),
+    200,
+    "webhook_receiver: tuleap form payload succeeds → 200"
+  )
+  eq(
+    tuleap_payload_seen and tuleap_payload_seen.message,
+    "hello world & 100%",
+    "webhook_receiver: tuleap form payload is URL-decoded before JSON parse"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+      body = "not_payload=%7B%7D",
+    }),
+    400,
+    "webhook_receiver: tuleap form without payload → 400"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+      body = "payload=%7B%22eventType%22%3A%22test-event%22%7",
+    }),
+    400,
+    "webhook_receiver: tuleap malformed form encoding → 400"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+      body = "payload=not-json",
+    }),
+    400,
+    "webhook_receiver: tuleap form payload with invalid JSON → 400"
+  )
+
   -- Gogs-family backends use their own event-type header, not X-Gitea-Event.
+  app.backend.webhooks = {
+    push = function(_payload)
+      return { event = "push" }, nil
+    end,
+  }
   eq(
     call_webhook({
       method = "POST",

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3353,6 +3353,99 @@ do
 end
 
 -- ============================================================
+-- Tuleap webhook handlers
+-- ============================================================
+
+do
+  local saved_rest = app.backend.rest
+  local saved_capabilities = app.backend.capabilities
+  local saved_webhooks = app.backend.webhooks
+  local saved_webhook_translators = app.backend.webhook_translators
+  local saved_webhook_github_translators = app.backend.webhook_github_translators
+  local saved_resolvers = graphql_resolvers -- luacheck: globals graphql_resolvers
+  local saved_base_url = config.base_url
+  local saved_backend = config.backend
+
+  app.backend.rest = {}
+  app.backend.capabilities = {}
+  app.backend.webhooks = {}
+  app.backend.webhook_translators = {}
+  app.backend.webhook_github_translators = {}
+  graphql_resolvers = {} -- luacheck: globals graphql_resolvers
+  config.base_url = ""
+  config.backend = "tuleap"
+  _real_dofile("backends/tuleap.lua")
+
+  ok(app.backend.webhooks.project_create ~= nil, "tuleap webhook: project_create registered")
+  ok(app.backend.webhooks.git_push ~= nil, "tuleap webhook: git_push registered")
+
+  local function load_tuleap_fixture(name)
+    local f = assert(io.open("test/fixtures/webhooks/tuleap/" .. name .. ".json", "rb"))
+    local body = f:read("*a")
+    f:close()
+    return DecodeJson(body)
+  end
+
+  local project_event = app.backend.webhooks.project_create(load_tuleap_fixture("project-created"))
+  eq(project_event.event, "project", "tuleap webhook: project_create maps to project")
+  eq(project_event.action, "created", "tuleap webhook: project_create maps to created")
+  eq(project_event.provider, "tuleap", "tuleap webhook: project_create sets provider")
+  eq(
+    project_event.data.project.name,
+    "Hello World",
+    "tuleap webhook: project_create keeps project name"
+  )
+  eq(
+    project_event.data.project.path_with_namespace,
+    "octocat/hello-world",
+    "tuleap webhook: project_create keeps namespace path"
+  )
+  eq(
+    project_event.data.sender.email,
+    "alice@example.com",
+    "tuleap webhook: project_create maps owner email to sender"
+  )
+
+  local push_event = app.backend.webhooks.git_push(load_tuleap_fixture("push"))
+  eq(push_event.event, "push", "tuleap webhook: git_push maps update to push")
+  eq(push_event.action, "push", "tuleap webhook: git_push action set")
+  eq(push_event.provider, "tuleap", "tuleap webhook: git_push sets provider")
+  eq(push_event.data.ref, "refs/heads/main", "tuleap webhook: push keeps full ref")
+  eq(push_event.data.repository.name, "hello-world", "tuleap webhook: push maps repository name")
+  eq(push_event.data.sender.login, "alice", "tuleap webhook: push maps sender")
+  eq(push_event.data.pusher.email, "alice@example.com", "tuleap webhook: push maps pusher")
+
+  local create_event = app.backend.webhooks.git_push(load_tuleap_fixture("create"))
+  eq(create_event.event, "create", "tuleap webhook: zero before maps to create")
+  eq(create_event.data.ref, "feature/tuleap-fixtures", "tuleap webhook: create strips branch ref")
+  eq(create_event.data.ref_type, "branch", "tuleap webhook: create detects branch ref")
+
+  local delete_event = app.backend.webhooks.git_push(load_tuleap_fixture("delete"))
+  eq(delete_event.event, "delete", "tuleap webhook: zero after maps to delete")
+  eq(delete_event.data.ref, "feature/tuleap-fixtures", "tuleap webhook: delete strips branch ref")
+  eq(delete_event.data.ref_type, "branch", "tuleap webhook: delete detects branch ref")
+
+  local tag_create_event = app.backend.webhooks.git_push(load_tuleap_fixture("tag-create"))
+  eq(tag_create_event.event, "create", "tuleap webhook: zero before maps tag to create")
+  eq(tag_create_event.data.ref, "v1.0.0", "tuleap webhook: tag create strips tag ref")
+  eq(tag_create_event.data.ref_type, "tag", "tuleap webhook: tag create detects tag ref")
+
+  local tag_delete_event = app.backend.webhooks.git_push(load_tuleap_fixture("tag-delete"))
+  eq(tag_delete_event.event, "delete", "tuleap webhook: zero after maps tag to delete")
+  eq(tag_delete_event.data.ref, "v1.0.0", "tuleap webhook: tag delete strips tag ref")
+  eq(tag_delete_event.data.ref_type, "tag", "tuleap webhook: tag delete detects tag ref")
+
+  app.backend.rest = saved_rest
+  app.backend.capabilities = saved_capabilities
+  app.backend.webhooks = saved_webhooks
+  app.backend.webhook_translators = saved_webhook_translators
+  app.backend.webhook_github_translators = saved_webhook_github_translators
+  graphql_resolvers = saved_resolvers -- luacheck: globals graphql_resolvers
+  config.base_url = saved_base_url
+  config.backend = saved_backend
+end
+
+-- ============================================================
 -- NotABug webhook handlers
 -- ============================================================
 

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3378,6 +3378,8 @@ do
 
   ok(app.backend.webhooks.project_create ~= nil, "tuleap webhook: project_create registered")
   ok(app.backend.webhooks.git_push ~= nil, "tuleap webhook: git_push registered")
+  ok(app.backend.webhooks.artifact_create ~= nil, "tuleap webhook: artifact_create registered")
+  ok(app.backend.webhooks.artifact_update ~= nil, "tuleap webhook: artifact_update registered")
 
   local function load_tuleap_fixture(name)
     local f = assert(io.open("test/fixtures/webhooks/tuleap/" .. name .. ".json", "rb"))
@@ -3434,6 +3436,48 @@ do
   eq(tag_delete_event.event, "delete", "tuleap webhook: zero after maps tag to delete")
   eq(tag_delete_event.data.ref, "v1.0.0", "tuleap webhook: tag delete strips tag ref")
   eq(tag_delete_event.data.ref_type, "tag", "tuleap webhook: tag delete detects tag ref")
+
+  local artifact_created_event =
+    app.backend.webhooks.artifact_create(load_tuleap_fixture("artifact-created"))
+  eq(artifact_created_event.event, "issues", "tuleap webhook: artifact_create maps to issues")
+  eq(artifact_created_event.action, "opened", "tuleap webhook: artifact_create opens issue")
+  eq(artifact_created_event.provider, "tuleap", "tuleap webhook: artifact_create sets provider")
+  eq(
+    artifact_created_event.data.issue.number,
+    75291,
+    "tuleap webhook: artifact_create maps artifact id to issue number"
+  )
+  eq(
+    artifact_created_event.data.issue.title,
+    "Normalize Tuleap webhook payloads",
+    "tuleap webhook: artifact_create maps title field"
+  )
+  eq(
+    artifact_created_event.data.issue.body,
+    "Tuleap should fan out as a normalized issue event.",
+    "tuleap webhook: artifact_create maps description field"
+  )
+  eq(
+    artifact_created_event.data.sender.login,
+    "alice",
+    "tuleap webhook: artifact_create maps sender"
+  )
+
+  local artifact_updated_event =
+    app.backend.webhooks.artifact_update(load_tuleap_fixture("artifact-updated"))
+  eq(artifact_updated_event.event, "issues", "tuleap webhook: artifact_update maps to issues")
+  eq(artifact_updated_event.action, "edited", "tuleap webhook: artifact_update edits issue")
+  eq(
+    artifact_updated_event.data.issue.number,
+    75291,
+    "tuleap webhook: artifact_update keeps artifact id"
+  )
+  eq(
+    artifact_updated_event.data.issue.state,
+    "open",
+    "tuleap webhook: artifact_update maps non-closed status to open"
+  )
+  eq(artifact_updated_event.data.sender.login, "bob", "tuleap webhook: artifact_update maps sender")
 
   app.backend.rest = saved_rest
   app.backend.capabilities = saved_capabilities

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3380,6 +3380,24 @@ do
   ok(app.backend.webhooks.git_push ~= nil, "tuleap webhook: git_push registered")
   ok(app.backend.webhooks.artifact_create ~= nil, "tuleap webhook: artifact_create registered")
   ok(app.backend.webhooks.artifact_update ~= nil, "tuleap webhook: artifact_update registered")
+  ok(
+    app.backend.webhook_translators.project ~= nil,
+    "tuleap webhook: project translator registered"
+  )
+  ok(app.backend.webhook_translators.push ~= nil, "tuleap webhook: push translator registered")
+  ok(app.backend.webhook_translators.issues ~= nil, "tuleap webhook: issues translator registered")
+  ok(
+    app.backend.webhook_github_translators.project ~= nil,
+    "tuleap webhook: project GitHub translator registered"
+  )
+  ok(
+    app.backend.webhook_github_translators.push ~= nil,
+    "tuleap webhook: push GitHub translator registered"
+  )
+  ok(
+    app.backend.webhook_github_translators.issues ~= nil,
+    "tuleap webhook: issues GitHub translator registered"
+  )
 
   local function load_tuleap_fixture(name)
     local f = assert(io.open("test/fixtures/webhooks/tuleap/" .. name .. ".json", "rb"))
@@ -3407,6 +3425,20 @@ do
     "alice@example.com",
     "tuleap webhook: project_create maps owner email to sender"
   )
+  local project_envelope = app.backend.webhook_translators.project(project_event)
+  eq(project_envelope.type, "project.created", "tuleap webhook: normalized project type")
+  eq(
+    project_envelope.payload.project.name,
+    "Hello World",
+    "tuleap webhook: normalized project payload includes project"
+  )
+  local project_github_payload = app.backend.webhook_github_translators.project(project_event)
+  eq(project_github_payload.action, "created", "tuleap webhook: GitHub project action")
+  eq(
+    project_github_payload.project.name,
+    "Hello World",
+    "tuleap webhook: GitHub project payload includes project"
+  )
 
   local push_event = app.backend.webhooks.git_push(load_tuleap_fixture("push"))
   eq(push_event.event, "push", "tuleap webhook: git_push maps update to push")
@@ -3416,11 +3448,26 @@ do
   eq(push_event.data.repository.name, "hello-world", "tuleap webhook: push maps repository name")
   eq(push_event.data.sender.login, "alice", "tuleap webhook: push maps sender")
   eq(push_event.data.pusher.email, "alice@example.com", "tuleap webhook: push maps pusher")
+  local push_envelope = app.backend.webhook_translators.push(push_event)
+  eq(push_envelope.type, "push", "tuleap webhook: normalized push uses actionless type")
+  local push_github_payload = app.backend.webhook_github_translators.push(push_event)
+  eq(push_github_payload.action, nil, "tuleap webhook: GitHub push has no action")
+  eq(push_github_payload.ref, "refs/heads/main", "tuleap webhook: GitHub push includes ref")
+  eq(
+    push_github_payload.pusher.email,
+    "alice@example.com",
+    "tuleap webhook: GitHub push includes pusher"
+  )
 
   local create_event = app.backend.webhooks.git_push(load_tuleap_fixture("create"))
   eq(create_event.event, "create", "tuleap webhook: zero before maps to create")
   eq(create_event.data.ref, "feature/tuleap-fixtures", "tuleap webhook: create strips branch ref")
   eq(create_event.data.ref_type, "branch", "tuleap webhook: create detects branch ref")
+  local create_envelope = app.backend.webhook_translators.create(create_event)
+  eq(create_envelope.type, "create", "tuleap webhook: normalized create uses actionless type")
+  local create_github_payload = app.backend.webhook_github_translators.create(create_event)
+  eq(create_github_payload.ref, "feature/tuleap-fixtures", "tuleap webhook: GitHub create ref")
+  eq(create_github_payload.ref_type, "branch", "tuleap webhook: GitHub create ref_type")
 
   local delete_event = app.backend.webhooks.git_push(load_tuleap_fixture("delete"))
   eq(delete_event.event, "delete", "tuleap webhook: zero after maps to delete")
@@ -3461,6 +3508,20 @@ do
     artifact_created_event.data.sender.login,
     "alice",
     "tuleap webhook: artifact_create maps sender"
+  )
+  local issue_envelope = app.backend.webhook_translators.issues(artifact_created_event)
+  eq(issue_envelope.type, "issue.opened", "tuleap webhook: normalized issue type")
+  eq(
+    issue_envelope.payload.issue.title,
+    "Normalize Tuleap webhook payloads",
+    "tuleap webhook: normalized issue payload includes issue"
+  )
+  local issue_github_payload = app.backend.webhook_github_translators.issues(artifact_created_event)
+  eq(issue_github_payload.action, "opened", "tuleap webhook: GitHub issue action")
+  eq(
+    issue_github_payload.issue.number,
+    75291,
+    "tuleap webhook: GitHub issue payload includes issue"
   )
 
   local artifact_updated_event =

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -3606,6 +3606,79 @@ do
     "webhook_receiver: tuleap form payload with invalid JSON → 400"
   )
 
+  app.backend.webhooks = {
+    project_create = function(payload)
+      tuleap_payload_seen = payload
+      return { event = "project" }, nil
+    end,
+  }
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+      body = "payload=%7B%22event_name%22%3A%22project_create%22%2C%22project_id%22%3A126%7D",
+    }),
+    200,
+    "webhook_receiver: tuleap event_name project_create handler succeeds → 200"
+  )
+  eq(
+    tuleap_payload_seen and tuleap_payload_seen.project_id,
+    126,
+    "webhook_receiver: tuleap project payload is dispatched intact"
+  )
+
+  app.backend.webhooks = {
+    git_push = function(payload)
+      tuleap_payload_seen = payload
+      return { event = "push" }, nil
+    end,
+  }
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+      body = "payload=%7B%22ref%22%3A%22refs%2Fheads%2Fmain%22%2C%22before%22%3A%221111%22%2C%22after%22%3A%222222%22%2C%22repository%22%3A%7B%22id%22%3A%22123%22%7D%7D",
+    }),
+    200,
+    "webhook_receiver: tuleap git push shape infers git_push → 200"
+  )
+  eq(
+    tuleap_payload_seen and tuleap_payload_seen.ref,
+    "refs/heads/main",
+    "webhook_receiver: tuleap git payload is dispatched intact"
+  )
+
+  app.backend.webhooks = {
+    artifact_create = function(_payload)
+      return { event = "issues", action = "opened" }, nil
+    end,
+    artifact_update = function(_payload)
+      return { event = "issues", action = "edited" }, nil
+    end,
+  }
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+      body = "payload=%7B%22id%22%3A182%2C%22action%22%3A%22create%22%2C%22current%22%3A%7B%22id%22%3A355743%7D%7D",
+    }),
+    200,
+    "webhook_receiver: tuleap tracker create infers artifact_create → 200"
+  )
+  eq(
+    call_webhook({
+      method = "POST",
+      path = "/webhooks/tuleap",
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+      body = "payload=%7B%22id%22%3A182%2C%22action%22%3A%22update%22%2C%22current%22%3A%7B%22id%22%3A355743%7D%2C%22previous%22%3A%7B%22id%22%3A355742%7D%7D",
+    }),
+    200,
+    "webhook_receiver: tuleap tracker update infers artifact_update → 200"
+  )
+
   -- Gogs-family backends use their own event-type header, not X-Gitea-Event.
   app.backend.webhooks = {
     push = function(_payload)

--- a/test/webhook-delivery-tuleap-confusio-shape.hurl
+++ b/test/webhook-delivery-tuleap-confusio-shape.hurl
@@ -1,0 +1,191 @@
+# Tuleap webhook delivery test - "confusio" shape variant.
+#
+# Spot-checks every translated Tuleap fixture family with X-Confusio-* headers
+# and normalized envelope bodies.
+
+# -- project_create -> project.created ---------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/project-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "project"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "project.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T10:00:00+00:00"
+jsonpath "$[0].body_json.payload.project.name" == "Hello World"
+
+# -- git_push ref update -> push ---------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "push"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "push"
+jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.payload.pusher.email" == "alice@example.com"
+
+# -- branch create -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.payload.ref" == "feature/tuleap-fixtures"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# -- branch delete -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.payload.ref" == "feature/tuleap-fixtures"
+jsonpath "$[0].body_json.payload.ref_type" == "branch"
+
+# -- tag create -> create ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/tag-create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.payload.ref" == "v1.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"
+
+# -- tag delete -> delete ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/tag-delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.payload.ref" == "v1.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"
+
+# -- artifact create -> issue.opened -----------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/artifact-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "issues"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].body_json.type" == "issue.opened"
+jsonpath "$[0].body_json.actor.login" == "alice"
+jsonpath "$[0].body_json.payload.issue.number" == 75291
+
+# -- artifact update -> issue.edited -----------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/artifact-updated.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "issues"
+jsonpath "$[0].confusio_source" == "tuleap"
+jsonpath "$[0].body_json.type" == "issue.edited"
+jsonpath "$[0].body_json.actor.login" == "bob"
+jsonpath "$[0].body_json.payload.issue.state" == "open"

--- a/test/webhook-delivery-tuleap.hurl
+++ b/test/webhook-delivery-tuleap.hurl
@@ -1,0 +1,191 @@
+# Tuleap webhook delivery tests.
+#
+# These fixture-based tests cover Tuleap project, Git, and tracker artifact
+# events and verify GitHub-shaped fanout.
+
+# -- project_create -> project: created --------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/project-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "project"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.project.name" == "Hello World"
+jsonpath "$[0].body_json.project.path_with_namespace" == "octocat/hello-world"
+
+# -- git_push ref update -> push ---------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/push.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" not exists
+jsonpath "$[0].body_json.ref" == "refs/heads/main"
+jsonpath "$[0].body_json.before" == "1111111111111111111111111111111111111111"
+jsonpath "$[0].body_json.after" == "2222222222222222222222222222222222222222"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.pusher.email" == "alice@example.com"
+
+# -- branch create -> create -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature/tuleap-fixtures"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+
+# -- branch delete -> delete -------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature/tuleap-fixtures"
+jsonpath "$[0].body_json.ref_type" == "branch"
+
+# -- tag create -> create ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/tag-create.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v1.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"
+
+# -- tag delete -> delete ----------------------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/tag-delete.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v1.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"
+
+# -- artifact create -> issues: opened ---------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/artifact-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "opened"
+jsonpath "$[0].body_json.issue.number" == 75291
+jsonpath "$[0].body_json.issue.title" == "Normalize Tuleap webhook payloads"
+jsonpath "$[0].body_json.issue.user.login" == "alice"
+
+# -- artifact update -> issues: edited ---------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/json
+file,fixtures/webhooks/tuleap/artifact-updated.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "issues"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.issue.number" == 75291
+jsonpath "$[0].body_json.issue.state" == "open"
+jsonpath "$[0].body_json.sender.login" == "bob"

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -16,6 +16,7 @@
 #   radicle_tok — the shared secret verbatim (for Authorization)
 #   kallithea — shared secret is embedded in the request body
 #   sourcehut_sig — Ed25519("{}") as base64 (for X-Payload-Signature)
+#   tuleap_tok — the shared secret verbatim (for X-Tuleap-Webhook-Secret)
 #   confusio_sig — "sha256=<hex>, v=1, ts=<ts>" (for X-Confusio-Signature-256)
 #
 # Convention: valid credential → 422 (verification passed; no handlers registered
@@ -576,6 +577,37 @@ jsonpath "$.message" == "Signature verification failed"
 POST http://{{host}}/webhooks/sourceforge
 Content-Type: application/json
 {}
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# ── tuleap: X-Tuleap-Webhook-Secret, verbatim shared token ──────────────────
+
+# Valid token → passes verification (422)
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/x-www-form-urlencoded
+X-Tuleap-Webhook-Secret: {{tuleap_tok}}
+`payload=%7B%7D`
+
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "No webhook handlers registered"
+
+# Bad token → 401
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/x-www-form-urlencoded
+X-Tuleap-Webhook-Secret: wrongtoken
+`payload=%7B%7D`
+
+HTTP 401
+[Asserts]
+jsonpath "$.message" == "Signature verification failed"
+
+# Missing token header → 401
+POST http://{{host}}/webhooks/tuleap
+Content-Type: application/x-www-form-urlencoded
+`payload=%7B%7D`
 
 HTTP 401
 [Asserts]


### PR DESCRIPTION
Fixes #273.

Adds Tuleap webhook source support with native parsing, verification, event inference, fixtures, normalization, and delivery translation already in place. The remaining work adds delivery test coverage and updates the support matrix and docs so the final Tuleap status is explicit.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (9)</summary>

- [x] Add Tuleap webhook delivery tests <!-- type:spec -->
- [x] Update Tuleap webhook matrix and docs <!-- type:spec -->
- [x] Translate Tuleap webhook delivery shapes <!-- type:spec -->
- [x] Normalize Tuleap tracker artifact webhooks <!-- type:spec -->
- [x] Normalize Tuleap project and git webhooks <!-- type:spec -->
- [x] Add Tuleap webhook fixtures <!-- type:spec -->
- [x] Infer Tuleap native webhook event keys <!-- type:spec -->
- [x] Cover Tuleap webhook secret verification <!-- type:spec -->
- [x] Parse Tuleap form webhook payloads <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->