### PR TITLE
v3: Webhook — codecommit source backend (closes #256)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -136,6 +136,7 @@ globals = {
   "sign_github",
   "sign_for_backend",
   "SourcehutVerifyEd25519",
+  "CodeCommitVerifySnsSignature",
   -- Fan-out dispatcher: internal/fanout.lua
   "fanout_body",
   "fanout_dispatch",

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -157,6 +157,15 @@ local CODECOMMIT_COMMENT_ACTIONS = {
   commentOnPullRequestUpdated = "edited",
 }
 
+local CODECOMMIT_APPROVAL_RULE_ACTIONS = {
+  pullRequestApprovalRuleCreated = "created",
+  pullRequestApprovalRuleUpdated = "edited",
+  pullRequestApprovalRuleDeleted = "deleted",
+  approvalRuleTemplateCreated = "created",
+  approvalRuleTemplateUpdated = "edited",
+  approvalRuleTemplateDeleted = "deleted",
+}
+
 local function codecommit_pull_request_action(detail)
   local raw_action = detail.event or ""
   if raw_action == "pullRequestStatusChanged" then
@@ -175,6 +184,19 @@ local function codecommit_supported_pull_request_event(raw_action)
   return CODECOMMIT_PR_ACTIONS[raw_action] ~= nil
     or raw_action == "pullRequestStatusChanged"
     or raw_action == "pullRequestMergeStatusUpdated"
+end
+
+local function codecommit_is_approval_event(raw_action)
+  return raw_action == "pullRequestApprovalStateChanged"
+    or raw_action == "pullRequestApprovalRuleOverridden"
+    or CODECOMMIT_APPROVAL_RULE_ACTIONS[raw_action] ~= nil
+end
+
+local function codecommit_is_approval_template_association_event(raw_action)
+  return raw_action == "approvalRuleTemplateAssociatedWithRepository"
+    or raw_action == "approvalRuleTemplateDisassociatedFromRepository"
+    or raw_action == "batchAssociateApprovalRuleTemplateWithRepositories"
+    or raw_action == "batchDisassociateApprovalRuleTemplateFromRepositories"
 end
 
 local CODECOMMIT_ACTIONLESS_EVENTS = {
@@ -203,6 +225,22 @@ local function codecommit_normalized_event_type(internal_event, fields)
   return normalized_webhook_event_type(internal_event.event, internal_event.action)
 end
 
+local function codecommit_resource_repository_name(payload, detail)
+  for name in pairs(detail.repositories or {}) do
+    return name
+  end
+  local resource = (payload.resources or {})[1] or ""
+  return resource:match(":([^:]+)$") or ""
+end
+
+local function codecommit_repository_from_detail(payload, detail)
+  local repo_names = detail.repositoryNames or {}
+  local repo_name = repo_names[1]
+    or detail.repositoryName
+    or codecommit_resource_repository_name(payload, detail)
+  return codecommit_repository(repo_name or "", payload.account or "", payload.region or "")
+end
+
 local function codecommit_pr_ref(ref, commit, repository)
   local short = codecommit_ref_name(ref)
   return {
@@ -213,13 +251,22 @@ local function codecommit_pr_ref(ref, commit, repository)
   }
 end
 
-local function codecommit_pr_from_comment_detail(payload, detail, repository, sender)
-  local pull_request_id = tonumber(detail.pullRequestId) or 0
-  local console_base = "https://" .. payload.region .. ".console.aws.amazon.com"
-  local console_path = "/codesuite/codecommit/repositories/"
+local function codecommit_pr_url(payload, repository, pull_request_id)
+  if payload.region == "" or repository.name == "" or not pull_request_id then
+    return ""
+  end
+  return "https://"
+    .. payload.region
+    .. ".console.aws.amazon.com/codesuite/codecommit/repositories/"
     .. repository.name
     .. "/pull-requests/"
     .. pull_request_id
+    .. "?region="
+    .. payload.region
+end
+
+local function codecommit_pr_from_comment_detail(payload, detail, repository, sender)
+  local pull_request_id = tonumber(detail.pullRequestId) or 0
   return {
     id = pull_request_id,
     node_id = detail.revisionId or "",
@@ -233,11 +280,11 @@ local function codecommit_pr_from_comment_detail(payload, detail, repository, se
     created_at = payload.time,
     updated_at = payload.time,
     merged = false,
-    html_url = payload.region ~= ""
-        and repository.name ~= ""
-        and pull_request_id ~= 0
-        and (console_base .. console_path .. "?region=" .. payload.region)
-      or "",
+    html_url = codecommit_pr_url(
+      payload,
+      repository,
+      pull_request_id ~= 0 and pull_request_id or nil
+    ),
     url = "",
   }
 end
@@ -245,11 +292,6 @@ end
 local function codecommit_pr_from_detail(payload, detail, repository, sender)
   local merged = codecommit_bool(detail.isMerged)
   local closed = detail.pullRequestStatus == "Closed"
-  local console_base = "https://" .. payload.region .. ".console.aws.amazon.com"
-  local console_path = "/codesuite/codecommit/repositories/"
-    .. repository.name
-    .. "/pull-requests/"
-    .. detail.pullRequestId
   return {
     id = tonumber(detail.pullRequestId) or 0,
     node_id = detail.revisionId or "",
@@ -268,11 +310,7 @@ local function codecommit_pr_from_detail(payload, detail, repository, sender)
     merged = merged,
     mergeable = detail.mergeOption ~= nil and not merged or nil,
     mergeable_state = detail.mergeOption or "unknown",
-    html_url = payload.region ~= ""
-        and repository.name ~= ""
-        and detail.pullRequestId
-        and (console_base .. console_path .. "?region=" .. payload.region)
-      or "",
+    html_url = codecommit_pr_url(payload, repository, detail.pullRequestId),
     url = "",
   }
 end
@@ -322,6 +360,67 @@ local function codecommit_comment_from_detail(payload, detail, repository, sende
   }
 end
 
+local function codecommit_review_state(approval_status)
+  if approval_status == "APPROVE" then
+    return "submitted", "approved"
+  end
+  if approval_status == "REVOKE" then
+    return "dismissed", "dismissed"
+  end
+  return "unknown", "commented"
+end
+
+local function codecommit_review_from_detail(payload, detail, sender)
+  local action, state = codecommit_review_state(detail.approvalStatus)
+  return {
+    id = 0,
+    node_id = (detail.pullRequestId or "") .. ":" .. (detail.callerUserArn or ""),
+    body = detail.notificationBody,
+    state = state,
+    html_url = codecommit_pr_url(
+      payload,
+      codecommit_repository_from_detail(payload, detail),
+      detail.pullRequestId
+    ),
+    user = sender,
+    submitted_at = payload.time or detail.lastModifiedDate or "",
+    commit_id = detail.destinationCommit or detail.sourceCommit or "",
+  },
+    action
+end
+
+local function codecommit_rule_from_detail(payload, detail, repository)
+  local name = detail.approvalRuleName or detail.approvalRuleTemplateName or ""
+  local id = detail.approvalRuleId or detail.approvalRuleTemplateId or ""
+  local content_sha = detail.approvalRuleContentSha256
+    or detail.approvalRuleTemplateContentSha256
+    or ""
+  return {
+    id = 0,
+    node_id = id,
+    name = name,
+    pattern = codecommit_ref_name(detail.destinationReference or "*"),
+    created_at = detail.creationDate or payload.time or "",
+    updated_at = detail.lastModifiedDate or payload.time or "",
+    required_approving_review_count = 0,
+    required_status_checks = {},
+    admin_enforced = false,
+    allows_deletions = false,
+    allows_force_pushes = false,
+    blocks_creations = false,
+    dismisses_stale_reviews = false,
+    is_admin_enforced = false,
+    repository_id = repository.id or 0,
+    codecommit = {
+      content_sha256 = content_sha,
+      pull_request_id = detail.pullRequestId,
+      repository_names = detail.repositoryNames,
+      template_id = detail.approvalRuleTemplateId,
+      template_name = detail.approvalRuleTemplateName,
+    },
+  }
+end
+
 local function codecommit_pull_request_from_eventbridge(payload)
   local detail = payload.detail or {}
   if not codecommit_supported_pull_request_event(detail.event) then
@@ -347,6 +446,67 @@ local function codecommit_pull_request_from_eventbridge(payload)
     },
     timestamp = payload.time or detail.lastModifiedDate or "",
   })
+end
+
+local function codecommit_approval_from_eventbridge(payload)
+  local detail = payload.detail or {}
+  local raw_action = detail.event or ""
+  if codecommit_is_approval_template_association_event(raw_action) then
+    return nil,
+      "CodeCommit approval rule template association events have no GitHub webhook equivalent"
+  end
+  if raw_action == "pullRequestApprovalRuleOverridden" then
+    return nil, "CodeCommit approval rule override events have no GitHub webhook equivalent"
+  end
+
+  local repository = codecommit_repository_from_detail(payload, detail)
+  local sender = codecommit_user_from_arn(detail.callerUserArn or detail.author)
+  if raw_action == "pullRequestApprovalStateChanged" then
+    local review, action = codecommit_review_from_detail(payload, detail, sender)
+    return make_internal_event({
+      event = "pull_request_review",
+      action = action,
+      raw_action = action == "unknown" and detail.approvalStatus or nil,
+      provider = "codecommit",
+      raw = payload,
+      data = {
+        action = action,
+        review = review,
+        pull_request = codecommit_pr_from_detail(payload, detail, repository, sender),
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.time or detail.lastModifiedDate or "",
+    })
+  end
+
+  local action = CODECOMMIT_APPROVAL_RULE_ACTIONS[raw_action]
+  if action then
+    local data = {
+      action = action,
+      rule = codecommit_rule_from_detail(payload, detail, repository),
+      repository = repository,
+      sender = sender,
+    }
+    if action == "edited" then
+      data.changes = {
+        codecommit_content_sha256 = {
+          from = detail.oldApprovalRuleContentSha256
+            or detail.oldApprovalRuleTemplateContentSha256
+            or "",
+        },
+      }
+    end
+    return make_internal_event({
+      event = "branch_protection_rule",
+      action = action,
+      provider = "codecommit",
+      raw = payload,
+      data = data,
+      timestamp = payload.time or detail.lastModifiedDate or "",
+    })
+  end
+  return nil, "Unsupported CodeCommit approval event"
 end
 
 local function codecommit_comment_from_eventbridge(payload)
@@ -585,7 +745,13 @@ local function codecommit_webhook(payload)
     return codecommit_comment_from_eventbridge(payload)
   end
   if payload["detail-type"] == "CodeCommit Pull Request State Change" then
+    if codecommit_is_approval_event((payload.detail or {}).event) then
+      return codecommit_approval_from_eventbridge(payload)
+    end
     return codecommit_pull_request_from_eventbridge(payload)
+  end
+  if payload["detail-type"] == "CodeCommit Approval Rule Template Change" then
+    return codecommit_approval_from_eventbridge(payload)
   end
   if
     payload.source == "aws.codecommit"
@@ -729,16 +895,20 @@ b:rest("search_repositories", function()
 end)
 
 b:webhook("codecommit", codecommit_webhook)
+b:webhook_translator("branch_protection_rule", translate_codecommit_normalized_webhook)
 b:webhook_translator("commit_comment", translate_codecommit_normalized_webhook)
 b:webhook_translator("create", translate_codecommit_normalized_webhook)
 b:webhook_translator("delete", translate_codecommit_normalized_webhook)
 b:webhook_translator("pull_request", translate_codecommit_normalized_webhook)
+b:webhook_translator("pull_request_review", translate_codecommit_normalized_webhook)
 b:webhook_translator("pull_request_review_comment", translate_codecommit_normalized_webhook)
 b:webhook_translator("push", translate_codecommit_normalized_webhook)
+b:webhook_github_translator("branch_protection_rule", translate_codecommit_github_webhook)
 b:webhook_github_translator("commit_comment", translate_codecommit_github_webhook)
 b:webhook_github_translator("create", translate_codecommit_github_webhook)
 b:webhook_github_translator("delete", translate_codecommit_github_webhook)
 b:webhook_github_translator("pull_request", translate_codecommit_github_webhook)
+b:webhook_github_translator("pull_request_review", translate_codecommit_github_webhook)
 b:webhook_github_translator("pull_request_review_comment", translate_codecommit_github_webhook)
 b:webhook_github_translator("push", translate_codecommit_github_webhook)
 

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -68,6 +68,8 @@ end
 local function codecommit_user_from_arn(arn)
   local login = tostring(arn or ""):match(":user/(.+)$")
     or tostring(arn or ""):match(":role/(.+)$")
+    or tostring(arn or ""):match(":federated%-user/(.+)$")
+    or tostring(arn or ""):match(":assumed%-role/[^/]+/(.+)$")
     or ""
   return {
     login = login,
@@ -148,6 +150,13 @@ local CODECOMMIT_PR_ACTIONS = {
   pullRequestSourceBranchUpdated = "synchronize",
 }
 
+local CODECOMMIT_COMMENT_ACTIONS = {
+  commentOnCommitCreated = "created",
+  commentOnCommitUpdated = "edited",
+  commentOnPullRequestCreated = "created",
+  commentOnPullRequestUpdated = "edited",
+}
+
 local function codecommit_pull_request_action(detail)
   local raw_action = detail.event or ""
   if raw_action == "pullRequestStatusChanged" then
@@ -168,6 +177,12 @@ local function codecommit_supported_pull_request_event(raw_action)
     or raw_action == "pullRequestMergeStatusUpdated"
 end
 
+local CODECOMMIT_ACTIONLESS_EVENTS = {
+  create = true,
+  delete = true,
+  push = true,
+}
+
 local function codecommit_normalized_payload_without_envelope_fields(data)
   local payload = {}
   for k, v in pairs(data or {}) do
@@ -178,6 +193,16 @@ local function codecommit_normalized_payload_without_envelope_fields(data)
   return payload
 end
 
+local function codecommit_normalized_event_type(internal_event, fields)
+  if fields and fields.type then
+    return fields.type
+  end
+  if CODECOMMIT_ACTIONLESS_EVENTS[internal_event.event] then
+    return normalized_webhook_event_type(internal_event.event, "")
+  end
+  return normalized_webhook_event_type(internal_event.event, internal_event.action)
+end
+
 local function codecommit_pr_ref(ref, commit, repository)
   local short = codecommit_ref_name(ref)
   return {
@@ -185,6 +210,35 @@ local function codecommit_pr_ref(ref, commit, repository)
     ref = short,
     sha = commit or "",
     repo = repository,
+  }
+end
+
+local function codecommit_pr_from_comment_detail(payload, detail, repository, sender)
+  local pull_request_id = tonumber(detail.pullRequestId) or 0
+  local console_base = "https://" .. payload.region .. ".console.aws.amazon.com"
+  local console_path = "/codesuite/codecommit/repositories/"
+    .. repository.name
+    .. "/pull-requests/"
+    .. pull_request_id
+  return {
+    id = pull_request_id,
+    node_id = detail.revisionId or "",
+    number = pull_request_id,
+    state = "open",
+    title = "",
+    body = nil,
+    user = sender,
+    head = codecommit_pr_ref("", detail.afterCommitId, repository),
+    base = codecommit_pr_ref("", detail.beforeCommitId, repository),
+    created_at = payload.time,
+    updated_at = payload.time,
+    merged = false,
+    html_url = payload.region ~= ""
+        and repository.name ~= ""
+        and pull_request_id ~= 0
+        and (console_base .. console_path .. "?region=" .. payload.region)
+      or "",
+    url = "",
   }
 end
 
@@ -223,6 +277,51 @@ local function codecommit_pr_from_detail(payload, detail, repository, sender)
   }
 end
 
+local function codecommit_console_comment_url(payload, repository, detail)
+  if payload.region == "" or repository.name == "" then
+    return ""
+  end
+  local console_base = "https://" .. payload.region .. ".console.aws.amazon.com"
+  if detail.pullRequestId and detail.pullRequestId ~= "" then
+    return console_base
+      .. "/codesuite/codecommit/repositories/"
+      .. repository.name
+      .. "/pull-requests/"
+      .. detail.pullRequestId
+      .. "/activity#"
+      .. (detail.commentId or "")
+      .. "?region="
+      .. payload.region
+  end
+  return console_base
+    .. "/codesuite/codecommit/repositories/"
+    .. repository.name
+    .. "/commit/"
+    .. (detail.afterCommitId or detail.beforeCommitId or "")
+    .. "?region="
+    .. payload.region
+end
+
+local function codecommit_comment_from_detail(payload, detail, repository, sender)
+  local html_url = codecommit_console_comment_url(payload, repository, detail)
+  return {
+    id = tonumber(detail.commentId) or 0,
+    node_id = detail.commentId or "",
+    url = "",
+    html_url = html_url,
+    body = detail.content or detail.commentContent or detail.notificationBody or "",
+    path = detail.filePath,
+    position = tonumber(detail.filePosition or ""),
+    line = tonumber(detail.fileLineNumber or ""),
+    commit_id = detail.afterCommitId or detail.commitId or detail.beforeCommitId or "",
+    original_commit_id = detail.beforeCommitId or detail.commitId or "",
+    user = sender,
+    created_at = payload.time,
+    updated_at = payload.time,
+    author_association = "NONE",
+  }
+end
+
 local function codecommit_pull_request_from_eventbridge(payload)
   local detail = payload.detail or {}
   if not codecommit_supported_pull_request_event(detail.event) then
@@ -250,12 +349,50 @@ local function codecommit_pull_request_from_eventbridge(payload)
   })
 end
 
+local function codecommit_comment_from_eventbridge(payload)
+  local detail = payload.detail or {}
+  local action = CODECOMMIT_COMMENT_ACTIONS[detail.event]
+  if not action then
+    if
+      detail.event == "commentReactionCreated"
+      or detail.event == "commentReactionUpdated"
+      or payload["detail-type"] == "CodeCommit Comment Reaction Change"
+    then
+      return nil, "CodeCommit comment reaction events have no GitHub webhook equivalent"
+    end
+    return nil, "Unsupported CodeCommit comment event"
+  end
+
+  local repository =
+    codecommit_repository(detail.repositoryName or "", payload.account or "", payload.region or "")
+  local sender = codecommit_user_from_arn(detail.callerUserArn)
+  local comment = codecommit_comment_from_detail(payload, detail, repository, sender)
+  local event = detail.pullRequestId and "pull_request_review_comment" or "commit_comment"
+  local data = {
+    action = action,
+    comment = comment,
+    repository = repository,
+    sender = sender,
+  }
+  if event == "pull_request_review_comment" then
+    data.pull_request = codecommit_pr_from_comment_detail(payload, detail, repository, sender)
+  end
+  return make_internal_event({
+    event = event,
+    action = action,
+    provider = "codecommit",
+    raw = payload,
+    data = data,
+    timestamp = payload.time or "",
+  })
+end
+
 local function translate_codecommit_normalized_webhook(internal_event, fields)
   local data = internal_event.data or {}
   fields = fields or {}
   return make_normalized_webhook_envelope(internal_event, {
     id = fields.id,
-    type = fields.type or normalized_webhook_event_type(internal_event.event, ""),
+    type = codecommit_normalized_event_type(internal_event, fields),
     occurred_at = fields.occurred_at,
     actor = fields.actor or data.sender,
     repository = fields.repository or data.repository,
@@ -440,6 +577,13 @@ local function codecommit_webhook(payload)
   if type(payload.Records) == "table" and type(payload.Records[1]) == "table" then
     return codecommit_push_from_record(payload, payload.Records[1])
   end
+  if
+    payload["detail-type"] == "CodeCommit Comment on Commit"
+    or payload["detail-type"] == "CodeCommit Comment on Pull Request"
+    or payload["detail-type"] == "CodeCommit Comment Reaction Change"
+  then
+    return codecommit_comment_from_eventbridge(payload)
+  end
   if payload["detail-type"] == "CodeCommit Pull Request State Change" then
     return codecommit_pull_request_from_eventbridge(payload)
   end
@@ -585,13 +729,17 @@ b:rest("search_repositories", function()
 end)
 
 b:webhook("codecommit", codecommit_webhook)
+b:webhook_translator("commit_comment", translate_codecommit_normalized_webhook)
 b:webhook_translator("create", translate_codecommit_normalized_webhook)
 b:webhook_translator("delete", translate_codecommit_normalized_webhook)
 b:webhook_translator("pull_request", translate_codecommit_normalized_webhook)
+b:webhook_translator("pull_request_review_comment", translate_codecommit_normalized_webhook)
 b:webhook_translator("push", translate_codecommit_normalized_webhook)
+b:webhook_github_translator("commit_comment", translate_codecommit_github_webhook)
 b:webhook_github_translator("create", translate_codecommit_github_webhook)
 b:webhook_github_translator("delete", translate_codecommit_github_webhook)
 b:webhook_github_translator("pull_request", translate_codecommit_github_webhook)
+b:webhook_github_translator("pull_request_review_comment", translate_codecommit_github_webhook)
 b:webhook_github_translator("push", translate_codecommit_github_webhook)
 
 b:build()

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -226,7 +226,9 @@ local function codecommit_normalized_event_type(internal_event, fields)
 end
 
 local function codecommit_resource_repository_name(payload, detail)
-  for name in pairs(detail.repositories or {}) do
+  local repositories = type(detail.repositories) == "table" and detail.repositories or {}
+  local name = next(repositories)
+  if name then
     return name
   end
   local resource = (payload.resources or {})[1] or ""

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -119,6 +119,14 @@ local function codecommit_ref_name(ref)
   return tostring(ref or ""):match("^refs/[^/]+/(.+)$") or tostring(ref or "")
 end
 
+local function codecommit_bool(value)
+  if type(value) == "boolean" then
+    return value
+  end
+  value = tostring(value or ""):lower()
+  return value == "true" or value == "yes" or value == "1"
+end
+
 local function codecommit_reference_action(raw_action, before, after)
   if raw_action == "referenceCreated" or before == ZERO_SHA then
     return "create"
@@ -135,6 +143,31 @@ local function codecommit_supported_reference_event(raw_action)
     or raw_action == "referenceDeleted"
 end
 
+local CODECOMMIT_PR_ACTIONS = {
+  pullRequestCreated = "opened",
+  pullRequestSourceBranchUpdated = "synchronize",
+}
+
+local function codecommit_pull_request_action(detail)
+  local raw_action = detail.event or ""
+  if raw_action == "pullRequestStatusChanged" then
+    if detail.pullRequestStatus == "Closed" then
+      return "closed"
+    elseif detail.pullRequestStatus == "Open" then
+      return "reopened"
+    end
+  elseif raw_action == "pullRequestMergeStatusUpdated" then
+    return codecommit_bool(detail.isMerged) and "closed" or "edited"
+  end
+  return CODECOMMIT_PR_ACTIONS[raw_action] or "unknown"
+end
+
+local function codecommit_supported_pull_request_event(raw_action)
+  return CODECOMMIT_PR_ACTIONS[raw_action] ~= nil
+    or raw_action == "pullRequestStatusChanged"
+    or raw_action == "pullRequestMergeStatusUpdated"
+end
+
 local function codecommit_normalized_payload_without_envelope_fields(data)
   local payload = {}
   for k, v in pairs(data or {}) do
@@ -143,6 +176,73 @@ local function codecommit_normalized_payload_without_envelope_fields(data)
     end
   end
   return payload
+end
+
+local function codecommit_pr_ref(ref, commit, repository)
+  local short = codecommit_ref_name(ref)
+  return {
+    label = short,
+    ref = short,
+    sha = commit or "",
+    repo = repository,
+  }
+end
+
+local function codecommit_pr_from_detail(payload, detail, repository, sender)
+  local merged = codecommit_bool(detail.isMerged)
+  local closed = detail.pullRequestStatus == "Closed"
+  return {
+    id = tonumber(detail.pullRequestId) or 0,
+    node_id = detail.revisionId or "",
+    number = tonumber(detail.pullRequestId) or 0,
+    state = closed and "closed" or "open",
+    title = detail.title or "",
+    body = detail.description,
+    user = codecommit_user_from_arn(detail.author) or sender,
+    head = codecommit_pr_ref(detail.sourceReference, detail.sourceCommit, repository),
+    base = codecommit_pr_ref(detail.destinationReference, detail.destinationCommit, repository),
+    created_at = detail.creationDate,
+    updated_at = detail.lastModifiedDate or payload.time,
+    closed_at = closed and (detail.lastModifiedDate or payload.time) or nil,
+    merged_at = merged and (detail.lastModifiedDate or payload.time) or nil,
+    merge_commit_sha = merged and detail.destinationCommit or nil,
+    merged = merged,
+    mergeable = detail.mergeOption ~= nil and not merged or nil,
+    mergeable_state = detail.mergeOption or "unknown",
+    html_url = payload.region ~= ""
+        and repository.name ~= ""
+        and detail.pullRequestId
+        and ("https://" .. payload.region .. ".console.aws.amazon.com/codesuite/codecommit/repositories/" .. repository.name .. "/pull-requests/" .. detail.pullRequestId .. "?region=" .. payload.region)
+      or "",
+    url = "",
+  }
+end
+
+local function codecommit_pull_request_from_eventbridge(payload)
+  local detail = payload.detail or {}
+  if not codecommit_supported_pull_request_event(detail.event) then
+    return nil, "Unsupported CodeCommit pull request event"
+  end
+  local action = codecommit_pull_request_action(detail)
+  local repo_names = detail.repositoryNames or {}
+  local repo_name = repo_names[1] or detail.repositoryName or ""
+  local repository = codecommit_repository(repo_name, payload.account or "", payload.region or "")
+  local sender = codecommit_user_from_arn(detail.callerUserArn or detail.author)
+  return make_internal_event({
+    event = "pull_request",
+    action = action,
+    raw_action = action == "unknown" and detail.event or nil,
+    provider = "codecommit",
+    raw = payload,
+    data = {
+      action = action,
+      number = tonumber(detail.pullRequestId) or 0,
+      pull_request = codecommit_pr_from_detail(payload, detail, repository, sender),
+      repository = repository,
+      sender = sender,
+    },
+    timestamp = payload.time or detail.lastModifiedDate or "",
+  })
 end
 
 local function translate_codecommit_normalized_webhook(internal_event, fields)
@@ -335,6 +435,9 @@ local function codecommit_webhook(payload)
   if type(payload.Records) == "table" and type(payload.Records[1]) == "table" then
     return codecommit_push_from_record(payload, payload.Records[1])
   end
+  if payload["detail-type"] == "CodeCommit Pull Request State Change" then
+    return codecommit_pull_request_from_eventbridge(payload)
+  end
   if
     payload.source == "aws.codecommit"
     or payload["detail-type"] == "CodeCommit Repository State Change"
@@ -479,9 +582,11 @@ end)
 b:webhook("codecommit", codecommit_webhook)
 b:webhook_translator("create", translate_codecommit_normalized_webhook)
 b:webhook_translator("delete", translate_codecommit_normalized_webhook)
+b:webhook_translator("pull_request", translate_codecommit_normalized_webhook)
 b:webhook_translator("push", translate_codecommit_normalized_webhook)
 b:webhook_github_translator("create", translate_codecommit_github_webhook)
 b:webhook_github_translator("delete", translate_codecommit_github_webhook)
+b:webhook_github_translator("pull_request", translate_codecommit_github_webhook)
 b:webhook_github_translator("push", translate_codecommit_github_webhook)
 
 b:build()

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -97,7 +97,7 @@ end
 
 local function codecommit_eventbridge_ref(detail)
   detail = detail or {}
-  local name = detail.referenceName or ""
+  local name = detail.referenceFullName or detail.referenceName or ""
   local ref_type = detail.referenceType or "branch"
   if name:match("^refs/") then
     return name
@@ -106,6 +106,33 @@ local function codecommit_eventbridge_ref(detail)
     return "refs/tags/" .. name
   end
   return "refs/heads/" .. name
+end
+
+local function codecommit_ref_type(ref)
+  if tostring(ref or ""):match("^refs/tags/") then
+    return "tag"
+  end
+  return "branch"
+end
+
+local function codecommit_ref_name(ref)
+  return tostring(ref or ""):match("^refs/[^/]+/(.+)$") or tostring(ref or "")
+end
+
+local function codecommit_reference_action(raw_action, before, after)
+  if raw_action == "referenceCreated" or before == ZERO_SHA then
+    return "create"
+  end
+  if raw_action == "referenceDeleted" or after == ZERO_SHA then
+    return "delete"
+  end
+  return "push"
+end
+
+local function codecommit_supported_reference_event(raw_action)
+  return raw_action == "referenceCreated"
+    or raw_action == "referenceUpdated"
+    or raw_action == "referenceDeleted"
 end
 
 local function codecommit_normalized_payload_without_envelope_fields(data)
@@ -201,6 +228,25 @@ local function codecommit_push_from_record(payload, record)
   local account_id = tostring(record.eventSourceARN or ""):match(":codecommit:[^:]+:(%d+):") or ""
   local sender = codecommit_user_from_arn(record.userIdentityARN)
   local repository = codecommit_repository(repo_name, account_id, region)
+  local action = codecommit_reference_action(reference.event, before, after)
+  if action == "create" or action == "delete" then
+    return make_internal_event({
+      event = action,
+      action = action,
+      provider = "codecommit",
+      raw = payload,
+      data = {
+        ref = codecommit_ref_name(raw_ref),
+        ref_type = codecommit_ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = record.eventTime or "",
+    })
+  end
   return make_internal_event({
     event = "push",
     action = "push",
@@ -226,6 +272,9 @@ end
 
 local function codecommit_push_from_eventbridge(payload)
   local detail = payload.detail or {}
+  if not codecommit_supported_reference_event(detail.event) then
+    return nil, "Unsupported CodeCommit reference event"
+  end
   local raw_ref = codecommit_eventbridge_ref(detail)
   local after = detail.commitId or ""
   local before = detail.oldCommitId or ""
@@ -239,6 +288,25 @@ local function codecommit_push_from_eventbridge(payload)
   local repo_name = detail.repositoryName or ""
   local sender = codecommit_user_from_arn(detail.callerUserArn or detail.userIdentityARN)
   local repository = codecommit_repository(repo_name, account_id, region)
+  local action = codecommit_reference_action(detail.event, before, after)
+  if action == "create" or action == "delete" then
+    return make_internal_event({
+      event = action,
+      action = action,
+      provider = "codecommit",
+      raw = payload,
+      data = {
+        ref = codecommit_ref_name(raw_ref),
+        ref_type = codecommit_ref_type(raw_ref),
+        master_branch = repository.default_branch or "",
+        description = repository.description,
+        pusher_type = "user",
+        repository = repository,
+        sender = sender,
+      },
+      timestamp = payload.time or "",
+    })
+  end
   return make_internal_event({
     event = "push",
     action = "push",
@@ -409,7 +477,11 @@ b:rest("search_repositories", function()
 end)
 
 b:webhook("codecommit", codecommit_webhook)
+b:webhook_translator("create", translate_codecommit_normalized_webhook)
+b:webhook_translator("delete", translate_codecommit_normalized_webhook)
 b:webhook_translator("push", translate_codecommit_normalized_webhook)
+b:webhook_github_translator("create", translate_codecommit_github_webhook)
+b:webhook_github_translator("delete", translate_codecommit_github_webhook)
 b:webhook_github_translator("push", translate_codecommit_github_webhook)
 
 b:build()

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -135,18 +135,52 @@ local function translate_codecommit_github_webhook(internal_event, fields)
   return github_webhook_payload(internal_event, fields)
 end
 
-local function decode_codecommit_message(payload)
-  if
-    type(payload) == "table"
-    and payload.Type == "Notification"
-    and type(payload.Message) == "string"
-  then
-    local ok, nested = pcall(DecodeJson, payload.Message)
-    if ok and type(nested) == "table" then
-      return nested
+local function decode_json_table(value)
+  if type(value) ~= "string" or value == "" then
+    return nil
+  end
+  local ok, decoded = pcall(DecodeJson, value)
+  if ok and type(decoded) == "table" then
+    return decoded
+  end
+  return nil
+end
+
+local function codecommit_record_nested_payload(record)
+  record = record or {}
+  local sns = record.Sns or record.sns
+  if type(sns) == "table" then
+    return decode_json_table(sns.Message or sns.message)
+  end
+  return nil
+end
+
+local function decode_codecommit_message(payload, depth)
+  if type(payload) ~= "table" then
+    return {}
+  end
+  depth = (depth or 0) + 1
+  if depth > 8 then
+    return payload
+  end
+  if payload.Type == "Notification" then
+    local nested = decode_json_table(payload.Message)
+    if nested then
+      return decode_codecommit_message(nested, depth)
     end
   end
-  return payload or {}
+  if type(payload.Records) == "table" then
+    for _, record in ipairs(payload.Records) do
+      if record.eventSource == "aws:codecommit" or type(record.codecommit) == "table" then
+        return payload
+      end
+      local nested = codecommit_record_nested_payload(record)
+      if nested then
+        return decode_codecommit_message(nested, depth)
+      end
+    end
+  end
+  return payload
 end
 
 local function codecommit_push_from_record(payload, record)

--- a/backends/codecommit.lua
+++ b/backends/codecommit.lua
@@ -191,6 +191,11 @@ end
 local function codecommit_pr_from_detail(payload, detail, repository, sender)
   local merged = codecommit_bool(detail.isMerged)
   local closed = detail.pullRequestStatus == "Closed"
+  local console_base = "https://" .. payload.region .. ".console.aws.amazon.com"
+  local console_path = "/codesuite/codecommit/repositories/"
+    .. repository.name
+    .. "/pull-requests/"
+    .. detail.pullRequestId
   return {
     id = tonumber(detail.pullRequestId) or 0,
     node_id = detail.revisionId or "",
@@ -212,7 +217,7 @@ local function codecommit_pr_from_detail(payload, detail, repository, sender)
     html_url = payload.region ~= ""
         and repository.name ~= ""
         and detail.pullRequestId
-        and ("https://" .. payload.region .. ".console.aws.amazon.com/codesuite/codecommit/repositories/" .. repository.name .. "/pull-requests/" .. detail.pullRequestId .. "?region=" .. payload.region)
+        and (console_base .. console_path .. "?region=" .. payload.region)
       or "",
     url = "",
   }

--- a/docs/real-world-testing.md
+++ b/docs/real-world-testing.md
@@ -67,7 +67,7 @@ value is `y` or starts with `~`.  Concretely:
 | radicle | 11 | 73 |
 | gerrit | 10 | 73 |
 | phabricator | 9 | 72 |
-| codecommit | 8 | 74 |
+| codecommit | 24 | 75 |
 | launchpad | 8 | 73 |
 | kallithea | 5 | 73 |
 | rhodecode | 5 | 73 |
@@ -136,7 +136,7 @@ value is marginal given their support level.
 
 | Backend | Why deferred | Path forward |
 |---------|-------------|--------------|
-| `codecommit` | AWS CodeCommit entered maintenance mode in February 2024 and is no longer accepting new users as of July 2024.  Only 8 `y` endpoints. | Keep unit tests.  Remove or archive backend once AWS formally retires the service. |
+| `codecommit` | AWS CodeCommit entered maintenance mode in February 2024 and is no longer accepting new users as of July 2024.  Webhook coverage is fixture-backed because new live accounts are not available. | Keep unit tests and mock webhook deliveries.  Add a live SNS/EventBridge smoke test only if an existing AWS account with CodeCommit access is available. |
 | `radicle` | Peer-to-peer; no central server.  Requires a local Radicle node and a seed server; not suitable for standard GHA runners. | Investigate self-hosted runner with persistent Radicle node. |
 
 ## Account and credential management

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -134,7 +134,7 @@ receiver implementation, and a brief note on the signature scheme used.  The
 | `bitbucket` | `POST /webhooks/bitbucket` | `https://bitbucket.org` | bitbucket | `X-Hub-Signature` HMAC-SHA256 |
 | `bitbucket_datacenter` | `POST /webhooks/bitbucket_datacenter` | _(self-hosted)_ | bitbucket_datacenter | `X-Hub-Signature` HMAC-SHA256 |
 | `codeberg` | `POST /webhooks/codeberg` | `https://codeberg.org` | gitea | `X-Gitea-Signature` HMAC-SHA256 |
-| `codecommit` | `POST /webhooks/codecommit` | `https://aws.amazon.com` | codecommit | Trust-the-network mode only; configured secret rejects until SNS verification is implemented |
+| `codecommit` | `POST /webhooks/codecommit` | `https://aws.amazon.com` | codecommit | SNS `SignatureVersion` 1/2 X.509 RSA verification; direct trigger/EventBridge payloads require trusted network delivery |
 | `confusio` | `POST /webhooks/confusio` | _(another confusio instance)_ | confusio | `X-Confusio-Signature-256` HMAC-SHA256 with timestamp |
 | `forgejo` | `POST /webhooks/forgejo` | `https://forgejo.org` | gitea | `X-Gitea-Signature` HMAC-SHA256 |
 | `gerrit` | `POST /webhooks/gerrit` | _(self-hosted)_ | gerrit | Shared secret in `Authorization` header |
@@ -169,7 +169,7 @@ delivered.  Confusio maps these to its canonical internal event family names.
 | bitbucket | `X-Event-Key` | `repo:push`, `pullrequest:created` |
 | bitbucket_datacenter | `X-Event-Key` | `repo:refs_changed`, `pr:opened` |
 | azuredevops | _(body field)_ | `git.push`, `git.pullrequest.created`, `build.complete`, `ms.vss-alerts.alert-created-event` |
-| codecommit | _(SNS `Message.detail-type`)_ | `CodeCommit Repository State Change` |
+| codecommit | _(SNS `Message.detail-type` or body field)_ | `CodeCommit Pull Request State Change` |
 | confusio | _(body field `type`)_ | `push`, `issue.opened`, `pull_request.synchronize` |
 | kallithea | _(body fields)_ | `push`, `CREATE_REPO_HOOK`, `CREATE_PULLREQUEST_HOOK` |
 | pagure | `X-Pagure-Event` | `issue`, `pull-request`, `git` |
@@ -870,6 +870,21 @@ payloads are rejected in this mode.
 HTTP endpoint.  Leave the CodeCommit inbound secret unset for network-trusted direct
 trigger/EventBridge delivery; set `webhook_secret_file_codecommit` to any non-empty
 value to require SNS signature verification.
+
+**Implemented CodeCommit event families:**
+
+| CodeCommit event family | GitHub event family |
+|-------------------------|---------------------|
+| Repository state changes | `push`, `create`, `delete` |
+| Pull request state and source-branch updates | `pull_request` |
+| Commit comments | `commit_comment` |
+| Pull request comments | `pull_request_review_comment` |
+| Pull request approval state changes | `pull_request_review` |
+| Approval rule and approval rule template lifecycle changes | `branch_protection_rule` |
+
+CodeCommit comment reaction changes, approval-rule override events, and approval rule
+template association/disassociation events have no close GitHub webhook equivalent.
+Confusio rejects those native events instead of claiming a lossy translation.
 
 ---
 
@@ -2407,13 +2422,16 @@ and regenerate this grid with:
 <!-- WEBHOOK_ACTION_SUPPORT_START -->
 | Event | Action | Azure DevOps | Bitbucket | Bitbucket DC | Codeberg | CodeCommit | Forgejo | Gerrit | GitBlit | GitBucket | Gitea | GitLab | Gogs | Harness | Kallithea | Launchpad | NotABug | OneDev | Pagure | Phabricator | Radicle | RhodeCode | SourceForge | Sourcehut | Tuleap |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ |
+| Create | `create` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ |
 | Custom Property | `created` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Custom Property Values | `updated` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ |
+| Commit Comments | `created` | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Delete | `delete` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ |
+| Branch Protection Rule | `created` | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `edited` | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `deleted` | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Discussions | `answered` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `category_changed` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `closed` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -2473,24 +2491,24 @@ and regenerate this grid with:
 |  | `updated` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Page Build | `page_build` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Ping | `ping` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ |
-|  | `closed` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `reopened` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `synchronize` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Pull Requests | `opened` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ |
+|  | `closed` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `reopened` | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `edited` | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `synchronize` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
 |  | `labeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `unlabeled` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `assigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `unassigned` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `review_requested` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `review_request_removed` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| PR Reviews | `submitted` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| PR Reviews | `submitted` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `dismissed` | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-|  | `edited` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `dismissed` | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| PR Review Comments | `created` | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+|  | `edited` | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ |
+| Push | `push` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ |
 | Release | `published` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `edited` | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 |  | `deleted` | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -3103,9 +3121,11 @@ Action support for this event is generated in the [action support matrix](#gener
 - **Tuleap** has a pull-request module with review/approval, but its webhook system
   emits generic `pullrequest:update` notifications rather than discrete review events.
   No handler is registered.
-- **CodeCommit** webhooks are delivered via Amazon EventBridge/SNS; the basic PR events
-  do not include a reviewer-approval payload — code review is surfaced through
-  CodeGuru Reviewer as a separate service.  No handler is registered.
+- **CodeCommit** emits pull request approval state changes through EventBridge/SNS.
+  `approvalState: "APPROVE"` maps to `submitted / APPROVED`; `approvalState: "REVOKE"`
+  maps to `dismissed / DISMISSED`.  `review.id`, `review.user`, and direct review URLs
+  are unavailable in the native payload, so confusio emits stable empty/stub values and
+  links back to the pull request console URL.
 - **Harness** is a CI/CD platform whose webhook system covers pipeline and build events;
   it does not emit pull-request review events.  No handler is registered.
 - **Launchpad** uses Bazaar merge proposals rather than pull requests, and its webhook
@@ -3162,6 +3182,10 @@ Action support for this event is generated in the [action support matrix](#gener
   under a review object, so the field is `null`.
 - Bitbucket Cloud does not provide GitHub-style diff hunks or commit IDs on pull-request
   comment webhooks; those fields are emitted as `null`.
+- CodeCommit emits `commentOnPullRequestCreated` and `commentOnPullRequestUpdated`
+  events.  They map to `created` and `edited` pull request review comments.  CodeCommit
+  does not emit a native delete event for pull request comments, and comment reaction
+  changes have no close GitHub webhook equivalent.
 - Most forges do not expose diff-level review comments in webhooks.  Backends not
   listed always emit `✗` for this event.
 
@@ -3229,6 +3253,10 @@ Triggered when a comment is created directly on a commit (not a PR or review).
 - Bitbucket Cloud emits `repo:commit_comment_created`.  It does not emit commit comment
   update/delete events; `comment.commit_id` is extracted from payload links when the SHA is
   not present as a first-class field.
+- CodeCommit emits `commentOnCommitCreated` and `commentOnCommitUpdated`.  Created
+  comments are listed in the generated action matrix; updated comments are delivered as a
+  best-effort `commit_comment` edit because GitHub's native commit comment webhook matrix
+  only exposes `created`.
 - `comment.updated_at`: Gogs webhook payloads do not always include an update timestamp;
   confusio falls back to `created_at` when `updated_at` is absent.
 - Backends not listed (Azure DevOps, etc.) do not emit commit comment events.
@@ -3956,17 +3984,17 @@ GitHub's security event families are mostly GitHub-specific.  Confusio maps Azur
 DevOps Advanced Security alert service hooks and GitLab Vulnerability Hook payloads into
 the closest GitHub alert families where those providers expose equivalent data.
 
-| GitHub event | Azure DevOps | GitLab |
-|---|---|---|
-| `security_advisory` | ✗ | ✗ |
-| `repository_advisory` | ✗ | ✗ |
-| `code_scanning_alert` | ✓ | ~ |
-| `secret_scanning_alert` | ✓ | ~ |
-| `secret_scanning_alert_location` | ✗ | ✗ |
-| `dependabot_alert` | ✓ | ~ |
-| `repository_vulnerability_alert` | ✗ | ✗ |
-| `branch_protection_rule` | ✗ | ✗ |
-| `branch_protection_configuration` | ✗ | ✗ |
+| GitHub event | Azure DevOps | GitLab | CodeCommit |
+|---|---|---|---|
+| `security_advisory` | ✗ | ✗ | ✗ |
+| `repository_advisory` | ✗ | ✗ | ✗ |
+| `code_scanning_alert` | ✓ | ~ | ✗ |
+| `secret_scanning_alert` | ✓ | ~ | ✗ |
+| `secret_scanning_alert_location` | ✗ | ✗ | ✗ |
+| `dependabot_alert` | ✓ | ~ | ✗ |
+| `repository_vulnerability_alert` | ✗ | ✗ | ✗ |
+| `branch_protection_rule` | ✗ | ✗ | ✓ |
+| `branch_protection_configuration` | ✗ | ✗ | ✗ |
 
 Azure DevOps uses the `ms.vss-alerts.*` service-hook family for Advanced Security.
 Confusio derives the GitHub event family from `resource.alertType`: `code` maps to
@@ -4134,6 +4162,9 @@ Triggered when a branch protection rule is created, edited, or deleted.
   `required_status_checks`, and enforcement levels for various checks.
 - `changes`: present only for `edited` action.  Each key in `changes` has a `from` field
   recording the previous value.  Keys match the corresponding fields in `rule`.
+- CodeCommit approval rule and approval rule template create/update/delete events map to
+  this family.  Native approval-rule override and template association/disassociation
+  events have no close GitHub webhook equivalent and are not emitted.
 
 #### `branch_protection_configuration`
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -336,7 +336,7 @@ Several distinct schemes appear across the supported inbound sources:
 | `bitbucket` | `X-Hub-Signature` | HMAC-SHA256 | `sha256=<hex>` |
 | `bitbucket_datacenter` | `X-Hub-Signature` | HMAC-SHA256 | `sha256=<hex>` |
 | `codeberg` | `X-Gitea-Signature` | HMAC-SHA256 | `<hex>` |
-| `codecommit` | _(none)_ | Trust-the-network only | configured secret rejects |
+| `codecommit` | SNS body fields | SNS X.509 RSA signature | `SignatureVersion` 1 or 2 |
 | `confusio` | `X-Confusio-Signature-256` | HMAC-SHA256 with timestamp | `sha256=<hex>, v=1, ts=<unix>` |
 | `forgejo` | `X-Gitea-Signature` | HMAC-SHA256 | `<hex>` |
 | `gerrit` | `Authorization` | Basic or Bearer | see notes |
@@ -854,17 +854,22 @@ closest GitHub webhook families:
 
 CodeCommit can deliver repository changes through SNS-style, EventBridge-style, or
 trigger-style JSON payloads.  Confusio currently supports event-family inference and
-payload translation for those body shapes, but it does **not** implement AWS SNS X.509
-signature verification yet.
+payload translation for those body shapes.  When CodeCommit is delivered through SNS,
+confusio can verify the SNS `SignatureVersion` 1 or 2 RSA signature against the
+certificate published in `SigningCertURL`.
 
 When no `webhook_secret_file_codecommit` is configured, CodeCommit ingest runs in
-trust-the-network mode.  When a CodeCommit inbound secret is configured, confusio
-rejects the request with `401` rather than pretending to verify a scheme it does not
-support.  Operators should restrict `/webhooks/codecommit` with network policy until
-full SNS certificate verification is implemented.
+trust-the-network mode for direct trigger, EventBridge, and SNS payloads.  When a
+CodeCommit inbound secret is configured, confusio requires a signed SNS HTTP payload,
+validates that `SigningCertURL` points at an SNS `amazonaws.com` certificate endpoint,
+builds the canonical SNS string-to-sign, fetches and caches the certificate, and
+verifies the decoded signature before dispatch.  Unsigned direct trigger/EventBridge
+payloads are rejected in this mode.
 
 **Configuration:** Register the confusio receiver URL as the CodeCommit/SNS/EventBridge
-HTTP endpoint and leave the CodeCommit inbound secret unset.
+HTTP endpoint.  Leave the CodeCommit inbound secret unset for network-trusted direct
+trigger/EventBridge delivery; set `webhook_secret_file_codecommit` to any non-empty
+value to require SNS signature verification.
 
 ---
 

--- a/internal/catalog.lua
+++ b/internal/catalog.lua
@@ -2882,6 +2882,11 @@ local webhook_event_sections = {
       -- delete
       { "webhook delete/delete", "wh_delete_delete" },
 
+      -- branch_protection_rule
+      { "webhook branch_protection_rule/created", "wh_branch_protection_rule_created" },
+      { "webhook branch_protection_rule/edited", "wh_branch_protection_rule_edited" },
+      { "webhook branch_protection_rule/deleted", "wh_branch_protection_rule_deleted" },
+
       -- discussion
       { "webhook discussion/answered", "wh_discussion_answered" },
       { "webhook discussion/category_changed", "wh_discussion_category_changed" },

--- a/internal/webhook_catalog.lua
+++ b/internal/webhook_catalog.lua
@@ -159,7 +159,7 @@ local EVENT_DEFS = {
     supported = { "bitbucket" },
   }),
   event("create", "create", { "" }, {
-    supported = REF_PROVIDERS,
+    supported = provider_list(REF_PROVIDERS, "codecommit"),
   }),
   event("custom_property", "custom_property", { "created", "updated", "deleted" }, {
     partial = { "gitbucket" },
@@ -168,7 +168,7 @@ local EVENT_DEFS = {
     partial = { "gitbucket" },
   }),
   event("delete", "delete", { "" }, {
-    supported = REF_PROVIDERS,
+    supported = provider_list(REF_PROVIDERS, "codecommit"),
   }),
   event(
     "dependabot_alert",

--- a/internal/webhook_catalog.lua
+++ b/internal/webhook_catalog.lua
@@ -157,6 +157,7 @@ local EVENT_DEFS = {
   ),
   event("commit_comment", "commit_comment", { "created" }, {
     supported = { "bitbucket" },
+    partial = { "codecommit" },
   }),
   event("create", "create", { "" }, {
     supported = provider_list(REF_PROVIDERS, "codecommit"),
@@ -384,7 +385,7 @@ local EVENT_DEFS = {
     { "created", "edited", "deleted" },
     {
       supported = provider_list(GITEA_FAMILY, "gitlab", BITBUCKET_FAMILY, CHANGE_REVIEW_PROVIDERS),
-      partial = { "azuredevops", "radicle", "sourcehut" },
+      partial = { "azuredevops", "codecommit", "radicle", "sourcehut" },
     }
   ),
   event("pull_request_review_thread", "pull_request.review_thread", { "resolved", "unresolved" }, {

--- a/internal/webhook_catalog.lua
+++ b/internal/webhook_catalog.lua
@@ -139,6 +139,7 @@ local EVENT_DEFS = {
     }
   ),
   event("branch_protection_rule", "branch_protection_rule", { "created", "edited", "deleted" }, {
+    partial = { "codecommit" },
     unsupported = provider_list(GITEA_FAMILY, "gitlab"),
   }),
   event("check_run", "check_run", { "created", "completed", "rerequested", "requested_action" }, {
@@ -377,7 +378,7 @@ local EVENT_DEFS = {
   }),
   event("pull_request_review", "pull_request.review", { "submitted", "edited", "dismissed" }, {
     supported = provider_list(GITEA_FAMILY, "gitlab", BITBUCKET_FAMILY, CHANGE_REVIEW_PROVIDERS),
-    partial = { "azuredevops", "gitbucket", "radicle", "sourcehut" },
+    partial = { "azuredevops", "codecommit", "gitbucket", "radicle", "sourcehut" },
   }),
   event(
     "pull_request_review_comment",

--- a/internal/webhook_catalog.lua
+++ b/internal/webhook_catalog.lua
@@ -139,7 +139,7 @@ local EVENT_DEFS = {
     }
   ),
   event("branch_protection_rule", "branch_protection_rule", { "created", "edited", "deleted" }, {
-    partial = { "codecommit" },
+    supported = { "codecommit" },
     unsupported = provider_list(GITEA_FAMILY, "gitlab"),
   }),
   event("check_run", "check_run", { "created", "completed", "rerequested", "requested_action" }, {
@@ -157,8 +157,7 @@ local EVENT_DEFS = {
     }
   ),
   event("commit_comment", "commit_comment", { "created" }, {
-    supported = { "bitbucket" },
-    partial = { "codecommit" },
+    supported = { "bitbucket", "codecommit" },
   }),
   event("create", "create", { "" }, {
     supported = provider_list(REF_PROVIDERS, "codecommit"),
@@ -373,28 +372,38 @@ local EVENT_DEFS = {
     "auto_merge_enabled",
     "auto_merge_disabled",
   }, {
-    supported = PULL_REQUEST_PROVIDERS,
-    partial = { "codecommit" },
+    supported = provider_list(PULL_REQUEST_PROVIDERS, "codecommit"),
   }),
   event("pull_request_review", "pull_request.review", { "submitted", "edited", "dismissed" }, {
-    supported = provider_list(GITEA_FAMILY, "gitlab", BITBUCKET_FAMILY, CHANGE_REVIEW_PROVIDERS),
-    partial = { "azuredevops", "codecommit", "gitbucket", "radicle", "sourcehut" },
+    supported = provider_list(
+      GITEA_FAMILY,
+      "gitlab",
+      BITBUCKET_FAMILY,
+      CHANGE_REVIEW_PROVIDERS,
+      "codecommit"
+    ),
+    partial = { "azuredevops", "gitbucket", "radicle", "sourcehut" },
   }),
   event(
     "pull_request_review_comment",
     "pull_request.review_comment",
     { "created", "edited", "deleted" },
     {
-      supported = provider_list(GITEA_FAMILY, "gitlab", BITBUCKET_FAMILY, CHANGE_REVIEW_PROVIDERS),
-      partial = { "azuredevops", "codecommit", "radicle", "sourcehut" },
+      supported = provider_list(
+        GITEA_FAMILY,
+        "gitlab",
+        BITBUCKET_FAMILY,
+        CHANGE_REVIEW_PROVIDERS,
+        "codecommit"
+      ),
+      partial = { "azuredevops", "radicle", "sourcehut" },
     }
   ),
   event("pull_request_review_thread", "pull_request.review_thread", { "resolved", "unresolved" }, {
     partial = provider_list(GITEA_FAMILY, "gitlab", BITBUCKET_FAMILY),
   }),
   event("push", "push", { "" }, {
-    supported = provider_list(REF_PROVIDERS, "launchpad"),
-    partial = { "codecommit" },
+    supported = provider_list(REF_PROVIDERS, "launchpad", "codecommit"),
   }),
   event("registry_package", "registry_package", { "published", "updated" }, {
     unsupported = provider_list(GITEA_FAMILY, "gitlab"),

--- a/internal/webhook_catalog.lua
+++ b/internal/webhook_catalog.lua
@@ -372,6 +372,7 @@ local EVENT_DEFS = {
     "auto_merge_disabled",
   }, {
     supported = PULL_REQUEST_PROVIDERS,
+    partial = { "codecommit" },
   }),
   event("pull_request_review", "pull_request.review", { "submitted", "edited", "dismissed" }, {
     supported = provider_list(GITEA_FAMILY, "gitlab", BITBUCKET_FAMILY, CHANGE_REVIEW_PROVIDERS),

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -248,20 +248,50 @@ local SOURCEHUT_BODY_EVENT_FIELDS = {
   "eventType",
 }
 
-local function codecommit_body_event(payload)
+local function decode_json_table(value)
+  if type(value) ~= "string" or value == "" then
+    return nil
+  end
+  local ok, decoded = pcall(DecodeJson, value)
+  if ok and type(decoded) == "table" then
+    return decoded
+  end
+  return nil
+end
+
+local function codecommit_record_nested_payload(record)
+  record = record or {}
+  local sns = record.Sns or record.sns
+  if type(sns) == "table" then
+    return decode_json_table(sns.Message or sns.message)
+  end
+  return nil
+end
+
+local function codecommit_body_event(payload, depth)
   if type(payload) ~= "table" then
     return nil
   end
-  if payload.Type == "Notification" and type(payload.Message) == "string" then
-    local ok, nested = pcall(DecodeJson, payload.Message)
-    if ok then
-      return codecommit_body_event(nested)
+  depth = (depth or 0) + 1
+  if depth > 8 then
+    return nil
+  end
+  if payload.Type == "Notification" then
+    local nested = decode_json_table(payload.Message)
+    if nested then
+      return codecommit_body_event(nested, depth)
     end
   end
-  if type(payload.Records) == "table" and type(payload.Records[1]) == "table" then
-    local record = payload.Records[1]
-    if record.eventSource == "aws:codecommit" or type(record.codecommit) == "table" then
-      return "codecommit"
+  if type(payload.Records) == "table" then
+    for _, record in ipairs(payload.Records) do
+      if record.eventSource == "aws:codecommit" or type(record.codecommit) == "table" then
+        return "codecommit"
+      end
+      local nested = codecommit_record_nested_payload(record)
+      local nested_event = codecommit_body_event(nested, depth)
+      if nested_event then
+        return nested_event
+      end
     end
   end
   if

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -193,7 +193,7 @@ local function sns_string_to_sign(payload)
     return nil
   end
 
-  local fields = nil
+  local fields
   if payload.Type == "Notification" then
     fields = { "Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type" }
   elseif
@@ -303,7 +303,7 @@ local function verify_codecommit_sns_signature(secret, body)
   end
 
   local version = payload.SignatureVersion
-  local alg = nil
+  local alg
   if version == "1" then
     alg = "sha1"
   elseif version == "2" then

--- a/internal/webhooks.lua
+++ b/internal/webhooks.lua
@@ -22,7 +22,7 @@
 -- Globals exported:
 --   make_webhook_receiver   — builder factory; called once at startup
 
--- luacheck: globals webhook_catalog_event_for_normalized_type
+-- luacheck: globals CodeCommitVerifySnsSignature webhook_catalog_event_for_normalized_type
 
 -- KNOWN_BACKENDS maps path segment to true for all recognised inbound sources.
 -- Requests with an unrecognised segment return 404.
@@ -154,6 +154,178 @@ local function sourcehut_ed25519_verify(public_key, body, signature)
     return SourcehutVerifyEd25519(public_key, body, signature)
   end
   return openssl_ed25519_verify(public_key, body, signature)
+end
+
+local SNS_CERT_CACHE = {}
+
+local function sns_signing_cert_url_valid(url)
+  if type(url) ~= "string" then
+    return false
+  end
+  local host, path = url:match("^https://([^/?#]+)(/[^?#]*)$")
+  if not host or not path then
+    return false
+  end
+  host = host:lower()
+  if not host:match("^sns%.[a-z0-9-]+%.amazonaws%.com$") then
+    return false
+  end
+  return path:match("^/SimpleNotificationService%-[%w%-]+%.pem$") ~= nil
+end
+
+local function sns_fetch_certificate(url)
+  if SNS_CERT_CACHE[url] then
+    return SNS_CERT_CACHE[url]
+  end
+  local ok, status, _, body = pcall(Fetch, url, { method = "GET" })
+  if not ok or status ~= 200 or type(body) ~= "string" then
+    return nil
+  end
+  if not body:find("-----BEGIN CERTIFICATE-----", 1, true) then
+    return nil
+  end
+  SNS_CERT_CACHE[url] = body
+  return body
+end
+
+local function sns_string_to_sign(payload)
+  if type(payload) ~= "table" then
+    return nil
+  end
+
+  local fields = nil
+  if payload.Type == "Notification" then
+    fields = { "Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type" }
+  elseif
+    payload.Type == "SubscriptionConfirmation" or payload.Type == "UnsubscribeConfirmation"
+  then
+    fields = { "Message", "MessageId", "SubscribeURL", "Timestamp", "Token", "TopicArn", "Type" }
+  else
+    return nil
+  end
+
+  local lines = {}
+  for _, field in ipairs(fields) do
+    local value = payload[field]
+    if not (field == "Subject" and value == nil) then
+      if type(value) ~= "string" then
+        return nil
+      end
+      lines[#lines + 1] = field
+      lines[#lines + 1] = value
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
+local function openssl_sns_verify(cert, string_to_sign, signature, alg)
+  local base = os.tmpname()
+  local cert_path = base .. ".cert.pem"
+  local pub_path = base .. ".pub.pem"
+  local body_path = base .. ".body"
+  local sig_path = base .. ".sig"
+
+  local ok = write_file(cert_path, cert)
+    and write_file(body_path, string_to_sign)
+    and write_file(sig_path, signature)
+  if not ok then
+    os.remove(base)
+    os.remove(cert_path)
+    os.remove(pub_path)
+    os.remove(body_path)
+    os.remove(sig_path)
+    return false
+  end
+
+  local extract_cmd = table.concat({
+    "openssl x509 -pubkey -noout",
+    "-in",
+    shell_quote(cert_path),
+    ">",
+    shell_quote(pub_path),
+    "2>/dev/null",
+  }, " ")
+  local ok_extract, _, extract_code = os.execute(extract_cmd)
+  if not (ok_extract == true or extract_code == 0) then
+    os.remove(base)
+    os.remove(cert_path)
+    os.remove(pub_path)
+    os.remove(body_path)
+    os.remove(sig_path)
+    return false
+  end
+
+  local digest = alg == "sha256" and "-sha256" or "-sha1"
+  local verify_cmd = table.concat({
+    "openssl dgst",
+    digest,
+    "-verify",
+    shell_quote(pub_path),
+    "-signature",
+    shell_quote(sig_path),
+    shell_quote(body_path),
+    ">/dev/null 2>&1",
+  }, " ")
+  local ok_verify, _, verify_code = os.execute(verify_cmd)
+  os.remove(base)
+  os.remove(cert_path)
+  os.remove(pub_path)
+  os.remove(body_path)
+  os.remove(sig_path)
+  return ok_verify == true or verify_code == 0
+end
+
+local function sns_verify_signature(cert, string_to_sign, signature, alg)
+  if type(CodeCommitVerifySnsSignature) == "function" then
+    return CodeCommitVerifySnsSignature(cert, string_to_sign, signature, alg)
+  end
+  return openssl_sns_verify(cert, string_to_sign, signature, alg)
+end
+
+local function verify_codecommit_sns_signature(secret, body)
+  if not secret or secret == "" then
+    return true
+  end
+
+  local ok_parse, payload = pcall(DecodeJson, body)
+  if not ok_parse or type(payload) ~= "table" then
+    return false
+  end
+
+  local string_to_sign = sns_string_to_sign(payload)
+  if not string_to_sign then
+    return false
+  end
+
+  local cert_url = payload.SigningCertURL
+  if not sns_signing_cert_url_valid(cert_url) then
+    return false
+  end
+
+  local version = payload.SignatureVersion
+  local alg = nil
+  if version == "1" then
+    alg = "sha1"
+  elseif version == "2" then
+    alg = "sha256"
+  else
+    return false
+  end
+
+  local signature_b64 = payload.Signature
+  if type(signature_b64) ~= "string" then
+    return false
+  end
+  local ok_sig, signature = pcall(DecodeBase64, strip_ascii_space(signature_b64))
+  if not ok_sig or type(signature) ~= "string" then
+    return false
+  end
+
+  local cert = sns_fetch_certificate(cert_url)
+  if not cert then
+    return false
+  end
+  return sns_verify_signature(cert, string_to_sign, signature, alg)
 end
 
 local function verify_sourcehut_signature(public_key_b64, body)
@@ -732,12 +904,12 @@ local function verify_signature(backend, secret, body, now)
   elseif backend == "sourcehut" then
     return verify_sourcehut_signature(secret, body)
 
-  -- CodeCommit (SNS X.509):
-  -- Complex platform-managed scheme not yet implemented. Trust-the-network
-  -- when no secret configured; reject otherwise so operators restrict access
-  -- via network policy until full verification ships.
+  -- CodeCommit via SNS: SignatureVersion 1/2 RSA signature over Amazon SNS's
+  -- canonical message fields, verified with the X.509 certificate from the
+  -- SNS-owned SigningCertURL.  With no secret configured, retain the global
+  -- trust-the-network mode for direct CodeCommit trigger/EventBridge delivery.
   elseif backend == "codecommit" then
-    return not secret or secret == ""
+    return verify_codecommit_sns_signature(secret, body)
   else
     return false
   end

--- a/site/compatibility.csv
+++ b/site/compatibility.csv
@@ -463,13 +463,16 @@ GET /users/{username}/received_events,~empty list,~empty list,~empty list,~empty
 GET /users/{username}/received_events/public,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/starred,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
 GET /users/{username}/subscriptions,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,y,~empty list,~empty list,~empty list,y,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list,~empty list
-webhook create/create,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,y
+webhook create/create,y,y,y,y,y,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,y
 webhook custom_property/created,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/deleted,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook custom_property_values/updated,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook commit_comment/created,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
-webhook delete/delete,y,y,y,y,n,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,y
+webhook commit_comment/created,n,y,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook delete/delete,y,y,y,y,y,y,y,y,y,y,y,y,n,y,n,y,y,y,n,y,n,y,y,y
+webhook branch_protection_rule/created,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook branch_protection_rule/edited,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
+webhook branch_protection_rule/deleted,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/answered,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/category_changed,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook discussion/closed,n,n,n,y,n,y,n,n,y,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n
@@ -529,24 +532,24 @@ webhook package/published,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,y,n,n,n,n,n,n,n
 webhook package/updated,n,n,n,y,n,y,n,n,y,y,n,n,n,n,y,n,n,n,n,n,n,n,n,n
 webhook page_build/page_build,n,n,n,n,n,n,n,n,y,n,n,n,n,n,n,n,n,n,n,n,n,n,n,n
 webhook ping/ping,n,n,n,y,n,y,n,n,y,y,n,y,n,n,y,n,n,n,n,n,n,n,n,n
-webhook pull_request/opened,y,y,y,y,n,y,y,n,y,y,y,y,n,y,y,y,y,y,y,y,n,n,y,n
-webhook pull_request/closed,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
-webhook pull_request/reopened,n,n,n,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
-webhook pull_request/edited,n,n,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
-webhook pull_request/synchronize,y,y,y,y,n,y,y,n,y,y,y,y,n,n,y,y,y,y,y,y,n,n,n,n
+webhook pull_request/opened,y,y,y,y,y,y,y,n,y,y,y,y,n,y,y,y,y,y,y,y,n,n,y,n
+webhook pull_request/closed,y,y,y,y,y,y,y,n,y,y,y,y,n,n,y,y,y,y,y,n,n,n,n,n
+webhook pull_request/reopened,n,n,n,y,y,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
+webhook pull_request/edited,n,n,y,y,y,y,y,n,y,y,y,y,n,n,y,y,y,n,y,n,n,n,n,n
+webhook pull_request/synchronize,y,y,y,y,y,y,y,n,y,y,y,y,n,n,y,y,y,y,y,y,n,n,n,n
 webhook pull_request/labeled,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request/unlabeled,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook pull_request/assigned,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n
 webhook pull_request/unassigned,n,n,n,y,n,y,y,n,y,y,n,y,n,n,n,y,y,n,n,n,n,n,n,n
 webhook pull_request/review_requested,n,n,y,y,n,y,y,n,y,y,y,y,n,n,n,y,y,n,n,n,n,n,n,n
 webhook pull_request/review_request_removed,n,n,y,y,n,y,y,n,y,y,y,y,n,n,n,y,y,n,n,n,n,n,n,n
-webhook pull_request_review/submitted,y,y,y,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
+webhook pull_request_review/submitted,y,y,y,y,y,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
 webhook pull_request_review/edited,n,n,n,y,n,y,n,n,y,y,n,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook pull_request_review/dismissed,y,y,n,y,n,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook pull_request_review_comment/created,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
-webhook pull_request_review_comment/edited,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
+webhook pull_request_review/dismissed,y,y,n,y,y,y,y,n,y,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
+webhook pull_request_review_comment/created,n,y,n,y,y,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
+webhook pull_request_review_comment/edited,n,y,n,y,y,y,n,n,n,y,y,y,n,n,n,n,y,n,n,n,n,n,n,n
 webhook pull_request_review_comment/deleted,n,y,n,y,n,y,n,n,n,y,y,y,n,n,n,n,n,n,n,n,n,n,n,n
-webhook push/push,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y
+webhook push/push,y,y,y,y,y,y,y,y,y,y,y,y,n,y,y,y,y,y,y,y,n,y,y,y
 webhook release/published,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/edited,n,n,n,y,n,y,n,n,n,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n
 webhook release/deleted,y,n,n,y,n,y,n,n,y,y,y,y,n,n,n,y,n,n,n,n,n,n,n,n

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-created.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-created.json
@@ -1,0 +1,33 @@
+{
+  "version": "0",
+  "id": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:10:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalRuleContentSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "approvalRuleId": "rule-created",
+    "approvalRuleName": "two-approvers-needed",
+    "author": "arn:aws:iam::123456789012:user/yvonne",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:10:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestApprovalRuleCreated",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T15:10:00Z",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "approval-rule-created",
+    "sourceCommit": "2222222222222222222222222222222222222222",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-deleted.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-deleted.json
@@ -1,0 +1,33 @@
+{
+  "version": "0",
+  "id": "dddddddd-eeee-ffff-0000-111111111111",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:20:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalRuleContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "approvalRuleId": "rule-deleted",
+    "approvalRuleName": "two-approvers-needed",
+    "author": "arn:aws:iam::123456789012:user/yvonne",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:10:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestApprovalRuleDeleted",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T15:20:00Z",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "approval-rule-deleted",
+    "sourceCommit": "2222222222222222222222222222222222222222",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-edited.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-edited.json
@@ -1,0 +1,34 @@
+{
+  "version": "0",
+  "id": "cccccccc-dddd-eeee-ffff-000000000000",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:15:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalRuleContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "approvalRuleId": "rule-edited",
+    "approvalRuleName": "two-approvers-needed",
+    "author": "arn:aws:iam::123456789012:user/yvonne",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:10:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestApprovalRuleUpdated",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T15:15:00Z",
+    "oldApprovalRuleContentSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "approval-rule-edited",
+    "sourceCommit": "2222222222222222222222222222222222222222",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-override.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-override.json
@@ -1,0 +1,24 @@
+{
+  "version": "0",
+  "id": "11111111-2222-3333-4444-555555555555",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:40:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "author": "arn:aws:iam::123456789012:user/yvonne",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestApprovalRuleOverridden",
+    "overrideStatus": "OVERRIDE",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-template-associated.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-template-associated.json
@@ -1,0 +1,24 @@
+{
+  "version": "0",
+  "id": "22222222-3333-4444-5555-666666666666",
+  "detail-type": "CodeCommit Approval Rule Template Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:45:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalRuleTemplateContentSha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "approvalRuleTemplateId": "template-associated",
+    "approvalRuleTemplateName": "two-approvers-required-for-main",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:45:00Z",
+    "event": "approvalRuleTemplateAssociatedWithRepository",
+    "lastModifiedDate": "2024-01-15T15:45:00Z",
+    "repositories": {
+      "hello-world": "repo-id-hello-world"
+    }
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-template-batch-associated.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-template-batch-associated.json
@@ -1,0 +1,24 @@
+{
+  "version": "0",
+  "id": "44444444-5555-6666-7777-888888888888",
+  "detail-type": "CodeCommit Approval Rule Template Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:55:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalRuleTemplateContentSha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "approvalRuleTemplateId": "template-batch-associated",
+    "approvalRuleTemplateName": "two-approvers-required-for-main",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:55:00Z",
+    "event": "batchAssociateApprovalRuleTemplateWithRepositories",
+    "lastModifiedDate": "2024-01-15T15:55:00Z",
+    "repositories": {
+      "hello-world": "example-service"
+    }
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-template-batch-disassociated.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-template-batch-disassociated.json
@@ -1,0 +1,24 @@
+{
+  "version": "0",
+  "id": "55555555-6666-7777-8888-999999999999",
+  "detail-type": "CodeCommit Approval Rule Template Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T16:00:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalRuleTemplateContentSha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "approvalRuleTemplateId": "template-batch-disassociated",
+    "approvalRuleTemplateName": "two-approvers-required-for-main",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T16:00:00Z",
+    "event": "batchDisassociateApprovalRuleTemplateFromRepositories",
+    "lastModifiedDate": "2024-01-15T16:00:00Z",
+    "repositories": {
+      "hello-world": "example-service"
+    }
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-template-created.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-template-created.json
@@ -1,0 +1,20 @@
+{
+  "version": "0",
+  "id": "eeeeeeee-ffff-0000-1111-222222222222",
+  "detail-type": "CodeCommit Approval Rule Template Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:25:00Z",
+  "region": "us-east-1",
+  "resources": [],
+  "detail": {
+    "approvalRuleTemplateContentSha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "approvalRuleTemplateId": "template-created",
+    "approvalRuleTemplateName": "two-approvers-required-for-main",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:25:00Z",
+    "event": "approvalRuleTemplateCreated",
+    "lastModifiedDate": "2024-01-15T15:25:00Z",
+    "repositories": {}
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-template-deleted.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-template-deleted.json
@@ -1,0 +1,20 @@
+{
+  "version": "0",
+  "id": "00000000-1111-2222-3333-444444444444",
+  "detail-type": "CodeCommit Approval Rule Template Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:35:00Z",
+  "region": "us-east-1",
+  "resources": [],
+  "detail": {
+    "approvalRuleTemplateContentSha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "approvalRuleTemplateId": "template-deleted",
+    "approvalRuleTemplateName": "two-approvers-required-for-main",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:25:00Z",
+    "event": "approvalRuleTemplateDeleted",
+    "lastModifiedDate": "2024-01-15T15:35:00Z",
+    "repositories": {}
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-template-disassociated.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-template-disassociated.json
@@ -1,0 +1,24 @@
+{
+  "version": "0",
+  "id": "33333333-4444-5555-6666-777777777777",
+  "detail-type": "CodeCommit Approval Rule Template Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:50:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalRuleTemplateContentSha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "approvalRuleTemplateId": "template-disassociated",
+    "approvalRuleTemplateName": "two-approvers-required-for-main",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:50:00Z",
+    "event": "approvalRuleTemplateDisassociatedFromRepository",
+    "lastModifiedDate": "2024-01-15T15:50:00Z",
+    "repositories": {
+      "hello-world": "repo-id-hello-world"
+    }
+  }
+}

--- a/test/fixtures/webhooks/codecommit/branch_protection_rule-template-edited.json
+++ b/test/fixtures/webhooks/codecommit/branch_protection_rule-template-edited.json
@@ -1,0 +1,21 @@
+{
+  "version": "0",
+  "id": "ffffffff-0000-1111-2222-333333333333",
+  "detail-type": "CodeCommit Approval Rule Template Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:30:00Z",
+  "region": "us-east-1",
+  "resources": [],
+  "detail": {
+    "approvalRuleTemplateContentSha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "approvalRuleTemplateId": "template-edited",
+    "approvalRuleTemplateName": "two-approvers-required-for-main",
+    "callerUserArn": "arn:aws:iam::123456789012:user/zara",
+    "creationDate": "2024-01-15T15:25:00Z",
+    "event": "approvalRuleTemplateUpdated",
+    "lastModifiedDate": "2024-01-15T15:30:00Z",
+    "oldApprovalRuleTemplateContentSha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "repositories": {}
+  }
+}

--- a/test/fixtures/webhooks/codecommit/commit_comment-created.json
+++ b/test/fixtures/webhooks/codecommit/commit_comment-created.json
@@ -1,0 +1,23 @@
+{
+  "version": "0",
+  "id": "33333333-aaaa-bbbb-cccc-444444444444",
+  "detail-type": "CodeCommit Comment on Commit",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T14:00:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "afterCommitId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "beforeCommitId": "9999999999999999999999999999999999999999",
+    "callerUserArn": "arn:aws:iam::123456789012:user/ruth",
+    "commentId": "commit-comment-created",
+    "content": "This commit comment came from CodeCommit.",
+    "event": "commentOnCommitCreated",
+    "inReplyTo": "root-comment",
+    "repositoryId": "repo-id-hello-world",
+    "repositoryName": "hello-world"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/commit_comment-edited.json
+++ b/test/fixtures/webhooks/codecommit/commit_comment-edited.json
@@ -1,0 +1,23 @@
+{
+  "version": "0",
+  "id": "44444444-aaaa-bbbb-cccc-555555555555",
+  "detail-type": "CodeCommit Comment on Commit",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T14:05:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "afterCommitId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "beforeCommitId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "callerUserArn": "arn:aws:iam::123456789012:user/sybil",
+    "commentId": "commit-comment-edited",
+    "content": "This CodeCommit commit comment was edited.",
+    "event": "commentOnCommitUpdated",
+    "inReplyTo": "root-comment",
+    "repositoryId": "repo-id-hello-world",
+    "repositoryName": "hello-world"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/commit_comment-reaction-created.json
+++ b/test/fixtures/webhooks/codecommit/commit_comment-reaction-created.json
@@ -1,0 +1,22 @@
+{
+  "version": "0",
+  "id": "77777777-aaaa-bbbb-cccc-888888888888",
+  "detail-type": "CodeCommit Comment Reaction Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T14:20:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "callerUserArn": "arn:aws:iam::123456789012:user/victor",
+    "commentId": "pr-comment-created",
+    "event": "commentReactionCreated",
+    "reactionEmojis": [""],
+    "reactionShortcodes": [":thumbsup:"],
+    "reactionUnicodes": ["U+1F44D"],
+    "repositoryId": "repo-id-hello-world",
+    "repositoryName": "hello-world"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/commit_comment-reaction-edited.json
+++ b/test/fixtures/webhooks/codecommit/commit_comment-reaction-edited.json
@@ -1,0 +1,22 @@
+{
+  "version": "0",
+  "id": "88888888-aaaa-bbbb-cccc-999999999999",
+  "detail-type": "CodeCommit Comment Reaction Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T14:25:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "callerUserArn": "arn:aws:iam::123456789012:user/wendy",
+    "commentId": "pr-comment-created",
+    "event": "commentReactionUpdated",
+    "reactionEmojis": [""],
+    "reactionShortcodes": [":smile:"],
+    "reactionUnicodes": ["U+1F604"],
+    "repositoryId": "repo-id-hello-world",
+    "repositoryName": "hello-world"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/create-eventbridge.json
+++ b/test/fixtures/webhooks/codecommit/create-eventbridge.json
@@ -1,0 +1,22 @@
+{
+  "version": "0",
+  "id": "eeeeeeee-ffff-1111-2222-333333333333",
+  "detail-type": "CodeCommit Repository State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T12:06:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "event": "referenceCreated",
+    "repositoryName": "hello-world",
+    "repositoryId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "referenceType": "tag",
+    "referenceName": "v2.0.0",
+    "referenceFullName": "refs/tags/v2.0.0",
+    "commitId": "8888888888888888888888888888888888888888",
+    "callerUserArn": "arn:aws:iam::123456789012:user/grace"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/create-record.json
+++ b/test/fixtures/webhooks/codecommit/create-record.json
@@ -1,0 +1,24 @@
+{
+  "Records": [
+    {
+      "awsRegion": "us-east-1",
+      "codecommit": {
+        "references": [
+          {
+            "commit": "7777777777777777777777777777777777777777",
+            "oldCommit": "0000000000000000000000000000000000000000",
+            "ref": "refs/heads/feature"
+          }
+        ]
+      },
+      "eventId": "77777777-2222-3333-4444-555555555555",
+      "eventName": "ReferenceChanges",
+      "eventSource": "aws:codecommit",
+      "eventSourceARN": "arn:aws:codecommit:us-east-1:123456789012:hello-world",
+      "eventTime": "2024-01-15T12:05:00.000+0000",
+      "eventTriggerName": "confusio",
+      "eventVersion": "1.0",
+      "userIdentityARN": "arn:aws:iam::123456789012:user/frank"
+    }
+  ]
+}

--- a/test/fixtures/webhooks/codecommit/create-sns.json
+++ b/test/fixtures/webhooks/codecommit/create-sns.json
@@ -1,0 +1,6 @@
+{
+  "Type": "Notification",
+  "MessageId": "eeeeeeee-1111-2222-3333-ffffffffffff",
+  "TopicArn": "arn:aws:sns:us-east-1:123456789012:codecommit",
+  "Message": "{\"Records\":[{\"awsRegion\":\"us-east-1\",\"codecommit\":{\"references\":[{\"commit\":\"9999999999999999999999999999999999999999\",\"oldCommit\":\"0000000000000000000000000000000000000000\",\"ref\":\"refs/heads/sns-feature\"}]},\"eventId\":\"99999999-7777-8888-9999-000000000000\",\"eventName\":\"ReferenceChanges\",\"eventSource\":\"aws:codecommit\",\"eventSourceARN\":\"arn:aws:codecommit:us-east-1:123456789012:hello-world\",\"eventTime\":\"2024-01-15T12:07:00.000+0000\",\"eventTriggerName\":\"confusio\",\"eventVersion\":\"1.0\",\"userIdentityARN\":\"arn:aws:iam::123456789012:user/heidi\"}]}"
+}

--- a/test/fixtures/webhooks/codecommit/delete-eventbridge.json
+++ b/test/fixtures/webhooks/codecommit/delete-eventbridge.json
@@ -1,0 +1,22 @@
+{
+  "version": "0",
+  "id": "ffffffff-1111-2222-3333-444444444444",
+  "detail-type": "CodeCommit Repository State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T12:09:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "event": "referenceDeleted",
+    "repositoryName": "hello-world",
+    "repositoryId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "referenceType": "tag",
+    "referenceName": "v2.0.0",
+    "referenceFullName": "refs/tags/v2.0.0",
+    "oldCommitId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "callerUserArn": "arn:aws:iam::123456789012:user/judy"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/delete-record.json
+++ b/test/fixtures/webhooks/codecommit/delete-record.json
@@ -1,0 +1,24 @@
+{
+  "Records": [
+    {
+      "awsRegion": "us-east-1",
+      "codecommit": {
+        "references": [
+          {
+            "commit": "0000000000000000000000000000000000000000",
+            "oldCommit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "ref": "refs/heads/feature"
+          }
+        ]
+      },
+      "eventId": "aaaaaaaa-2222-3333-4444-555555555555",
+      "eventName": "ReferenceChanges",
+      "eventSource": "aws:codecommit",
+      "eventSourceARN": "arn:aws:codecommit:us-east-1:123456789012:hello-world",
+      "eventTime": "2024-01-15T12:08:00.000+0000",
+      "eventTriggerName": "confusio",
+      "eventVersion": "1.0",
+      "userIdentityARN": "arn:aws:iam::123456789012:user/ivan"
+    }
+  ]
+}

--- a/test/fixtures/webhooks/codecommit/delete-sns-eventbridge.json
+++ b/test/fixtures/webhooks/codecommit/delete-sns-eventbridge.json
@@ -1,0 +1,6 @@
+{
+  "Type": "Notification",
+  "MessageId": "ffffffff-1111-2222-3333-aaaaaaaaaaaa",
+  "TopicArn": "arn:aws:sns:us-east-1:123456789012:codecommit",
+  "Message": "{\"version\":\"0\",\"id\":\"ffffffff-2222-3333-4444-555555555555\",\"detail-type\":\"CodeCommit Repository State Change\",\"source\":\"aws.codecommit\",\"account\":\"123456789012\",\"time\":\"2024-01-15T12:10:00Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:codecommit:us-east-1:123456789012:hello-world\"],\"detail\":{\"event\":\"referenceDeleted\",\"repositoryName\":\"hello-world\",\"repositoryId\":\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\"referenceType\":\"branch\",\"referenceName\":\"sns-feature\",\"referenceFullName\":\"refs/heads/sns-feature\",\"oldCommitId\":\"cccccccccccccccccccccccccccccccccccccccc\",\"callerUserArn\":\"arn:aws:iam::123456789012:user/kate\"}}"
+}

--- a/test/fixtures/webhooks/codecommit/pull_request-closed.json
+++ b/test/fixtures/webhooks/codecommit/pull_request-closed.json
@@ -1,0 +1,30 @@
+{
+  "version": "0",
+  "id": "33333333-aaaa-bbbb-cccc-444444444444",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T13:10:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "author": "arn:aws:iam::123456789012:user/mallory",
+    "callerUserArn": "arn:aws:iam::123456789012:user/oscar",
+    "creationDate": "2024-01-15T13:00:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestStatusChanged",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T13:10:00Z",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Closed",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "pr-revision-closed",
+    "sourceCommit": "3333333333333333333333333333333333333333",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/pull_request-merged.json
+++ b/test/fixtures/webhooks/codecommit/pull_request-merged.json
@@ -1,0 +1,31 @@
+{
+  "version": "0",
+  "id": "44444444-aaaa-bbbb-cccc-555555555555",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T13:15:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "author": "arn:aws:iam::123456789012:user/mallory",
+    "callerUserArn": "arn:aws:iam::123456789012:user/peggy",
+    "creationDate": "2024-01-15T13:00:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "4444444444444444444444444444444444444444",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestMergeStatusUpdated",
+    "isMerged": "True",
+    "lastModifiedDate": "2024-01-15T13:15:00Z",
+    "mergeOption": "FAST_FORWARD_MERGE",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Closed",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "pr-revision-merged",
+    "sourceCommit": "3333333333333333333333333333333333333333",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/pull_request-opened.json
+++ b/test/fixtures/webhooks/codecommit/pull_request-opened.json
@@ -1,0 +1,30 @@
+{
+  "version": "0",
+  "id": "11111111-aaaa-bbbb-cccc-222222222222",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T13:00:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "author": "arn:aws:iam::123456789012:user/mallory",
+    "callerUserArn": "arn:aws:iam::123456789012:user/mallory",
+    "creationDate": "2024-01-15T13:00:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestCreated",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T13:00:00Z",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "pr-revision-opened",
+    "sourceCommit": "2222222222222222222222222222222222222222",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/pull_request-sns.json
+++ b/test/fixtures/webhooks/codecommit/pull_request-sns.json
@@ -1,0 +1,6 @@
+{
+  "Type": "Notification",
+  "MessageId": "55555555-aaaa-bbbb-cccc-666666666666",
+  "TopicArn": "arn:aws:sns:us-east-1:123456789012:codecommit",
+  "Message": "{\"version\":\"0\",\"id\":\"55555555-bbbb-cccc-dddd-777777777777\",\"detail-type\":\"CodeCommit Pull Request State Change\",\"source\":\"aws.codecommit\",\"account\":\"123456789012\",\"time\":\"2024-01-15T13:20:00Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:codecommit:us-east-1:123456789012:hello-world\"],\"detail\":{\"author\":\"arn:aws:iam::123456789012:user/mallory\",\"callerUserArn\":\"arn:aws:iam::123456789012:user/quinn\",\"creationDate\":\"2024-01-15T13:00:00Z\",\"description\":\"Add a safer webhook parser.\",\"destinationCommit\":\"1111111111111111111111111111111111111111\",\"destinationReference\":\"refs/heads/main\",\"event\":\"pullRequestSourceBranchUpdated\",\"isMerged\":\"False\",\"lastModifiedDate\":\"2024-01-15T13:20:00Z\",\"pullRequestId\":\"42\",\"pullRequestStatus\":\"Open\",\"repositoryNames\":[\"hello-world\"],\"revisionId\":\"pr-revision-sns\",\"sourceCommit\":\"5555555555555555555555555555555555555555\",\"sourceReference\":\"refs/heads/webhook-parser\",\"title\":\"Add webhook parser\"}}"
+}

--- a/test/fixtures/webhooks/codecommit/pull_request-synchronize.json
+++ b/test/fixtures/webhooks/codecommit/pull_request-synchronize.json
@@ -1,0 +1,30 @@
+{
+  "version": "0",
+  "id": "22222222-aaaa-bbbb-cccc-333333333333",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T13:05:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "author": "arn:aws:iam::123456789012:user/mallory",
+    "callerUserArn": "arn:aws:iam::123456789012:user/nancy",
+    "creationDate": "2024-01-15T13:00:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestSourceBranchUpdated",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T13:05:00Z",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "pr-revision-synchronize",
+    "sourceCommit": "3333333333333333333333333333333333333333",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/pull_request_review-dismissed.json
+++ b/test/fixtures/webhooks/codecommit/pull_request_review-dismissed.json
@@ -1,0 +1,32 @@
+{
+  "version": "0",
+  "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:05:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalStatus": "REVOKE",
+    "author": "arn:aws:iam::123456789012:user/yvonne",
+    "callerUserArn": "arn:aws:iam::123456789012:user/xavier",
+    "creationDate": "2024-01-15T13:00:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestApprovalStateChanged",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T15:05:00Z",
+    "notificationBody": "CodeCommit approval state changed to REVOKE.",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "approval-review-revoked",
+    "sourceCommit": "2222222222222222222222222222222222222222",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/pull_request_review-submitted.json
+++ b/test/fixtures/webhooks/codecommit/pull_request_review-submitted.json
@@ -1,0 +1,32 @@
+{
+  "version": "0",
+  "id": "99999999-aaaa-bbbb-cccc-000000000000",
+  "detail-type": "CodeCommit Pull Request State Change",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T15:00:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "approvalStatus": "APPROVE",
+    "author": "arn:aws:iam::123456789012:user/yvonne",
+    "callerUserArn": "arn:aws:iam::123456789012:user/xavier",
+    "creationDate": "2024-01-15T13:00:00Z",
+    "description": "Add a safer webhook parser.",
+    "destinationCommit": "1111111111111111111111111111111111111111",
+    "destinationReference": "refs/heads/main",
+    "event": "pullRequestApprovalStateChanged",
+    "isMerged": "False",
+    "lastModifiedDate": "2024-01-15T15:00:00Z",
+    "notificationBody": "CodeCommit approval state changed to APPROVE.",
+    "pullRequestId": "42",
+    "pullRequestStatus": "Open",
+    "repositoryNames": ["hello-world"],
+    "revisionId": "approval-review-approved",
+    "sourceCommit": "2222222222222222222222222222222222222222",
+    "sourceReference": "refs/heads/webhook-parser",
+    "title": "Add webhook parser"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/pull_request_review_comment-created.json
+++ b/test/fixtures/webhooks/codecommit/pull_request_review_comment-created.json
@@ -1,0 +1,24 @@
+{
+  "version": "0",
+  "id": "55555555-aaaa-bbbb-cccc-666666666666",
+  "detail-type": "CodeCommit Comment on Pull Request",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T14:10:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "afterCommitId": "cccccccccccccccccccccccccccccccccccccccc",
+    "beforeCommitId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "callerUserArn": "arn:aws:iam::123456789012:user/trent",
+    "commentId": "pr-comment-created",
+    "content": "This pull request comment came from CodeCommit.",
+    "event": "commentOnPullRequestCreated",
+    "inReplyTo": "root-pr-comment",
+    "pullRequestId": "42",
+    "repositoryId": "repo-id-hello-world",
+    "repositoryName": "hello-world"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/pull_request_review_comment-edited.json
+++ b/test/fixtures/webhooks/codecommit/pull_request_review_comment-edited.json
@@ -1,0 +1,24 @@
+{
+  "version": "0",
+  "id": "66666666-aaaa-bbbb-cccc-777777777777",
+  "detail-type": "CodeCommit Comment on Pull Request",
+  "source": "aws.codecommit",
+  "account": "123456789012",
+  "time": "2024-01-15T14:15:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codecommit:us-east-1:123456789012:hello-world"
+  ],
+  "detail": {
+    "afterCommitId": "dddddddddddddddddddddddddddddddddddddddd",
+    "beforeCommitId": "cccccccccccccccccccccccccccccccccccccccc",
+    "callerUserArn": "arn:aws:iam::123456789012:user/ursula",
+    "commentId": "pr-comment-edited",
+    "content": "This CodeCommit pull request comment was edited.",
+    "event": "commentOnPullRequestUpdated",
+    "inReplyTo": "root-pr-comment",
+    "pullRequestId": "42",
+    "repositoryId": "repo-id-hello-world",
+    "repositoryName": "hello-world"
+  }
+}

--- a/test/fixtures/webhooks/codecommit/push-sns-eventbridge.json
+++ b/test/fixtures/webhooks/codecommit/push-sns-eventbridge.json
@@ -1,0 +1,6 @@
+{
+  "Type": "Notification",
+  "MessageId": "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+  "TopicArn": "arn:aws:sns:us-east-1:123456789012:codecommit",
+  "Message": "{\"version\":\"0\",\"id\":\"bbbbbbbb-cccc-dddd-eeee-ffffffffffff\",\"detail-type\":\"CodeCommit Repository State Change\",\"source\":\"aws.codecommit\",\"account\":\"123456789012\",\"time\":\"2024-01-15T12:03:00Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:codecommit:us-east-1:123456789012:hello-world\"],\"detail\":{\"event\":\"referenceUpdated\",\"repositoryName\":\"hello-world\",\"referenceType\":\"branch\",\"referenceName\":\"release\",\"commitId\":\"5555555555555555555555555555555555555555\",\"oldCommitId\":\"4444444444444444444444444444444444444444\",\"callerUserArn\":\"arn:aws:iam::123456789012:user/dana\"}}"
+}

--- a/test/fixtures/webhooks/codecommit/push-sns-record.json
+++ b/test/fixtures/webhooks/codecommit/push-sns-record.json
@@ -1,0 +1,14 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "cccccccc-1111-2222-3333-dddddddddddd",
+        "TopicArn": "arn:aws:sns:us-east-1:123456789012:codecommit",
+        "Message": "{\"version\":\"0\",\"id\":\"dddddddd-eeee-ffff-1111-222222222222\",\"detail-type\":\"CodeCommit Repository State Change\",\"source\":\"aws.codecommit\",\"account\":\"123456789012\",\"time\":\"2024-01-15T12:04:00Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:codecommit:us-east-1:123456789012:hello-world\"],\"detail\":{\"event\":\"referenceUpdated\",\"repositoryName\":\"hello-world\",\"referenceType\":\"tag\",\"referenceName\":\"v1.2.3\",\"commitId\":\"6666666666666666666666666666666666666666\",\"oldCommitId\":\"5555555555555555555555555555555555555555\",\"callerUserArn\":\"arn:aws:iam::123456789012:user/erin\"}}"
+      }
+    }
+  ]
+}

--- a/test/unit-init.lua
+++ b/test/unit-init.lua
@@ -34,7 +34,7 @@ reset_request()
 -- Override Redbean HTTP context built-ins before loading .init.lua.
 -- luacheck: push
 -- luacheck: globals SetStatus SetHeader Write GetHeader GetPath GetParam GetMethod GetBody Route
--- luacheck: globals GetCryptoHash DecodeBase64 SourcehutVerifyEd25519
+-- luacheck: globals GetCryptoHash DecodeBase64 SourcehutVerifyEd25519 CodeCommitVerifySnsSignature
 SetStatus = function(code, _reason)
   _last_status = code
 end
@@ -83,6 +83,7 @@ end
 SourcehutVerifyEd25519 = function(public_key, body, signature)
   return public_key == string.rep("k", 32) and body == "{}" and signature == string.rep("s", 64)
 end
+CodeCommitVerifySnsSignature = nil
 -- Stub Fetch: records outbound calls so startup synthesis (synthesize_startup_events)
 -- and deliver_fire tests do not make real network requests.  Returns a 200 response.
 -- Individual tests that need more control save/restore Fetch locally.
@@ -5875,18 +5876,151 @@ do
     "verify_signature kallithea: invalid JSON body → 401"
   )
 
-  -- ── Trust-the-network-only backend: codecommit
-  -- SNS signature verification is not yet implemented.
-  -- No secret → accepted; any secret configured → always rejected.
+  -- ── CodeCommit: Amazon SNS X.509 signature verification
+  -- No secret → trust-the-network; configured secret enables SNS signature verification.
   ok(
     no_secret("codecommit", {}) ~= 401,
     "verify_signature codecommit: no secret (trust-the-network) → not 401"
   )
-  eq(
-    call_sig("codecommit", {}, nil, { codecommit = SECRET }),
-    401,
-    "verify_signature codecommit: secret configured (unimplemented scheme) → 401"
+
+  local saved_fetch = Fetch
+  local saved_codecommit_sns_verify = CodeCommitVerifySnsSignature
+  local fetched_cert_url = nil
+  local captured_sns = nil
+  local sns_cert = "-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----\n"
+  local sns_cert_url = "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-test.pem"
+  local sns_topic = "arn:aws:sns:us-east-1:123456789012:codecommit"
+  local sns_timestamp = "2024-01-15T12:00:00.000Z"
+  local sns_body = '{"Type":"Notification","MessageId":"mid-1","TopicArn":"'
+    .. sns_topic
+    .. '","Subject":"subject","Message":"hello","Timestamp":"'
+    .. sns_timestamp
+    .. '","SignatureVersion":"1","Signature":"good-signature","SigningCertURL":"'
+    .. sns_cert_url
+    .. '","UnsubscribeURL":"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe"}'
+  local sns_expected_string = table.concat({
+    "Message",
+    "hello",
+    "MessageId",
+    "mid-1",
+    "Subject",
+    "subject",
+    "Timestamp",
+    sns_timestamp,
+    "TopicArn",
+    sns_topic,
+    "Type",
+    "Notification",
+  }, "\n")
+
+  Fetch = function(url, _opts)
+    fetched_cert_url = url
+    return 200, {}, sns_cert
+  end
+  CodeCommitVerifySnsSignature = function(cert, string_to_sign, signature, alg)
+    captured_sns = {
+      cert = cert,
+      string_to_sign = string_to_sign,
+      signature = signature,
+      alg = alg,
+    }
+    return cert == sns_cert
+      and string_to_sign == sns_expected_string
+      and signature == "good-signature"
+      and alg == "sha1"
+  end
+  ok(
+    call_sig("codecommit", {}, sns_body, { codecommit = SECRET }) ~= 401,
+    "verify_signature codecommit: valid SNS notification signature → not 401"
   )
+  eq(
+    fetched_cert_url,
+    sns_cert_url,
+    "verify_signature codecommit: fetches certificate from SigningCertURL"
+  )
+  eq(
+    captured_sns and captured_sns.string_to_sign,
+    sns_expected_string,
+    "verify_signature codecommit: builds canonical SNS notification string"
+  )
+  eq(captured_sns and captured_sns.alg, "sha1", "verify_signature codecommit: version 1 uses SHA1")
+
+  local sns_v2_body = sns_body:gsub('"SignatureVersion":"1"', '"SignatureVersion":"2"')
+  CodeCommitVerifySnsSignature = function(_cert, _string_to_sign, _signature, alg)
+    return alg == "sha256"
+  end
+  ok(
+    call_sig("codecommit", {}, sns_v2_body, { codecommit = SECRET }) ~= 401,
+    "verify_signature codecommit: valid SNS SignatureVersion 2 → not 401"
+  )
+
+  local sub_body = '{"Type":"SubscriptionConfirmation","MessageId":"sub-1","Token":"token-1","TopicArn":"'
+    .. sns_topic
+    .. '","Message":"confirm","SubscribeURL":"https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription","Timestamp":"'
+    .. sns_timestamp
+    .. '","SignatureVersion":"2","Signature":"good-signature","SigningCertURL":"'
+    .. sns_cert_url
+    .. '"}'
+  local sub_expected_string = table.concat({
+    "Message",
+    "confirm",
+    "MessageId",
+    "sub-1",
+    "SubscribeURL",
+    "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription",
+    "Timestamp",
+    sns_timestamp,
+    "Token",
+    "token-1",
+    "TopicArn",
+    sns_topic,
+    "Type",
+    "SubscriptionConfirmation",
+  }, "\n")
+  CodeCommitVerifySnsSignature = function(_cert, string_to_sign, _signature, alg)
+    return string_to_sign == sub_expected_string and alg == "sha256"
+  end
+  ok(
+    call_sig("codecommit", {}, sub_body, { codecommit = SECRET }) ~= 401,
+    "verify_signature codecommit: valid SNS subscription confirmation → not 401"
+  )
+
+  CodeCommitVerifySnsSignature = function()
+    return false
+  end
+  eq(
+    call_sig("codecommit", {}, sns_body, { codecommit = SECRET }),
+    401,
+    "verify_signature codecommit: bad SNS signature → 401"
+  )
+
+  eq(
+    call_sig(
+      "codecommit",
+      {},
+      sns_body:gsub("https://sns.us-east-1.amazonaws.com", "https://example.com"),
+      { codecommit = SECRET }
+    ),
+    401,
+    "verify_signature codecommit: untrusted SigningCertURL → 401"
+  )
+  eq(
+    call_sig(
+      "codecommit",
+      {},
+      sns_body:gsub('"SignatureVersion":"1"', '"SignatureVersion":"3"'),
+      { codecommit = SECRET }
+    ),
+    401,
+    "verify_signature codecommit: unsupported SignatureVersion → 401"
+  )
+  eq(
+    call_sig("codecommit", {}, '{"Records":[]}', { codecommit = SECRET }),
+    401,
+    "verify_signature codecommit: configured verification rejects unsigned direct payloads"
+  )
+  Fetch = saved_fetch
+  CodeCommitVerifySnsSignature = saved_codecommit_sns_verify
 
   -- ── Sourcehut: X-Payload-Signature, Ed25519 over raw body
   -- Unit tests use identity base64 decoding and a stub verifier.  The hurl

--- a/test/webhook-delivery-codecommit-confusio-shape.hurl
+++ b/test/webhook-delivery-codecommit-confusio-shape.hurl
@@ -1,6 +1,32 @@
 # CodeCommit webhook delivery test — "confusio" shape variant.
 #
-# Spot-checks CodeCommit's normalized envelope for body-derived push events.
+# Spot-checks CodeCommit's normalized envelope for body-derived ref events.
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/create-eventbridge.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "create"
+jsonpath "$[0].confusio_source" == "codecommit"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "create"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T12:06:00Z"
+jsonpath "$[0].body_json.actor.login" == "grace"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.payload.ref" == "v2.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"
 
 POST http://{{target}}/reset
 {}
@@ -27,3 +53,29 @@ jsonpath "$[0].body_json.actor.login" == "alice"
 jsonpath "$[0].body_json.repository.full_name" == "hello-world"
 jsonpath "$[0].body_json.payload.ref" == "refs/heads/main"
 jsonpath "$[0].body_json.payload.after" == "2222222222222222222222222222222222222222"
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/delete-eventbridge.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "delete"
+jsonpath "$[0].confusio_source" == "codecommit"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "delete"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T12:09:00Z"
+jsonpath "$[0].body_json.actor.login" == "judy"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.payload.ref" == "v2.0.0"
+jsonpath "$[0].body_json.payload.ref_type" == "tag"

--- a/test/webhook-delivery-codecommit-confusio-shape.hurl
+++ b/test/webhook-delivery-codecommit-confusio-shape.hurl
@@ -34,6 +34,54 @@ HTTP 200
 
 POST http://{{host}}/webhooks/codecommit
 Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request_review-submitted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request_review"
+jsonpath "$[0].confusio_source" == "codecommit"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review.submitted"
+jsonpath "$[0].body_json.actor.login" == "xavier"
+jsonpath "$[0].body_json.payload.review.state" == "approved"
+jsonpath "$[0].body_json.payload.pull_request.number" == 42
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "branch_protection_rule"
+jsonpath "$[0].confusio_source" == "codecommit"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "branch_protection_rule.created"
+jsonpath "$[0].body_json.actor.login" == "zara"
+jsonpath "$[0].body_json.payload.rule.node_id" == "rule-created"
+jsonpath "$[0].body_json.payload.rule.codecommit.pull_request_id" == "42"
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
 file,fixtures/webhooks/codecommit/pull_request_review_comment-created.json;
 HTTP 200
 [Asserts]

--- a/test/webhook-delivery-codecommit-confusio-shape.hurl
+++ b/test/webhook-delivery-codecommit-confusio-shape.hurl
@@ -34,6 +34,33 @@ HTTP 200
 
 POST http://{{host}}/webhooks/codecommit
 Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request_review_comment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request_review_comment"
+jsonpath "$[0].confusio_source" == "codecommit"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.review_comment.created"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T14:10:00Z"
+jsonpath "$[0].body_json.actor.login" == "trent"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.payload.action" == "created"
+jsonpath "$[0].body_json.payload.comment.node_id" == "pr-comment-created"
+jsonpath "$[0].body_json.payload.pull_request.number" == 42
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
 file,fixtures/webhooks/codecommit/pull_request-opened.json;
 HTTP 200
 [Asserts]

--- a/test/webhook-delivery-codecommit-confusio-shape.hurl
+++ b/test/webhook-delivery-codecommit-confusio-shape.hurl
@@ -34,6 +34,33 @@ HTTP 200
 
 POST http://{{host}}/webhooks/codecommit
 Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].confusio_event" == "pull_request"
+jsonpath "$[0].confusio_source" == "codecommit"
+jsonpath "$[0].confusio_delivery" isString
+jsonpath "$[0].github_event" == ""
+jsonpath "$[0].body_json.type" == "pull_request.opened"
+jsonpath "$[0].body_json.occurred_at" == "2024-01-15T13:00:00Z"
+jsonpath "$[0].body_json.actor.login" == "mallory"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.payload.action" == "opened"
+jsonpath "$[0].body_json.payload.pull_request.number" == 42
+jsonpath "$[0].body_json.payload.pull_request.head.ref" == "webhook-parser"
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
 file,fixtures/webhooks/codecommit/push-record.json;
 HTTP 200
 [Asserts]

--- a/test/webhook-delivery-codecommit.hurl
+++ b/test/webhook-delivery-codecommit.hurl
@@ -396,3 +396,141 @@ jsonpath "$[0].github_delivery" isString
 jsonpath "$[0].body_json.action" == "synchronize"
 jsonpath "$[0].body_json.pull_request.head.sha" == "5555555555555555555555555555555555555555"
 jsonpath "$[0].body_json.sender.login" == "quinn"
+
+# -- EventBridge commentOnCommitCreated -> commit_comment created ------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/commit_comment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "commit_comment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.comment.node_id" == "commit-comment-created"
+jsonpath "$[0].body_json.comment.body" == "This commit comment came from CodeCommit."
+jsonpath "$[0].body_json.comment.commit_id" == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.sender.login" == "ruth"
+
+# -- EventBridge commentOnCommitUpdated -> commit_comment edited -------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/commit_comment-edited.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "commit_comment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.comment.node_id" == "commit-comment-edited"
+jsonpath "$[0].body_json.comment.body" == "This CodeCommit commit comment was edited."
+jsonpath "$[0].body_json.comment.commit_id" == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+jsonpath "$[0].body_json.sender.login" == "sybil"
+
+# -- EventBridge commentOnPullRequestCreated -> PR review comment created ----
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request_review_comment-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request_review_comment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.comment.node_id" == "pr-comment-created"
+jsonpath "$[0].body_json.comment.body" == "This pull request comment came from CodeCommit."
+jsonpath "$[0].body_json.pull_request.number" == 42
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.sender.login" == "trent"
+
+# -- EventBridge commentOnPullRequestUpdated -> PR review comment edited -----
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request_review_comment-edited.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request_review_comment"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.comment.node_id" == "pr-comment-edited"
+jsonpath "$[0].body_json.comment.body" == "This CodeCommit pull request comment was edited."
+jsonpath "$[0].body_json.pull_request.number" == 42
+jsonpath "$[0].body_json.sender.login" == "ursula"
+
+# -- EventBridge commentReactionCreated has no GitHub webhook equivalent -----
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/commit_comment-reaction-created.json;
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "CodeCommit comment reaction events have no GitHub webhook equivalent"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 0
+
+# -- EventBridge commentReactionUpdated has no GitHub webhook equivalent -----
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/commit_comment-reaction-edited.json;
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "CodeCommit comment reaction events have no GitHub webhook equivalent"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 0

--- a/test/webhook-delivery-codecommit.hurl
+++ b/test/webhook-delivery-codecommit.hurl
@@ -270,3 +270,129 @@ jsonpath "$[0].github_delivery" isString
 jsonpath "$[0].body_json.ref" == "sns-feature"
 jsonpath "$[0].body_json.ref_type" == "branch"
 jsonpath "$[0].body_json.sender.login" == "kate"
+
+# -- EventBridge pullRequestCreated -> pull_request opened -------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request-opened.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "opened"
+jsonpath "$[0].body_json.number" == 42
+jsonpath "$[0].body_json.pull_request.number" == 42
+jsonpath "$[0].body_json.pull_request.state" == "open"
+jsonpath "$[0].body_json.pull_request.title" == "Add webhook parser"
+jsonpath "$[0].body_json.pull_request.head.ref" == "webhook-parser"
+jsonpath "$[0].body_json.pull_request.head.sha" == "2222222222222222222222222222222222222222"
+jsonpath "$[0].body_json.pull_request.base.ref" == "main"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.sender.login" == "mallory"
+
+# -- EventBridge pullRequestSourceBranchUpdated -> synchronize ---------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request-synchronize.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "synchronize"
+jsonpath "$[0].body_json.number" == 42
+jsonpath "$[0].body_json.pull_request.head.sha" == "3333333333333333333333333333333333333333"
+jsonpath "$[0].body_json.sender.login" == "nancy"
+
+# -- EventBridge pullRequestStatusChanged -> closed --------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request-closed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "closed"
+jsonpath "$[0].body_json.pull_request.state" == "closed"
+jsonpath "$[0].body_json.pull_request.merged" == false
+jsonpath "$[0].body_json.sender.login" == "oscar"
+
+# -- EventBridge pullRequestMergeStatusUpdated -> closed merged --------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request-merged.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "closed"
+jsonpath "$[0].body_json.pull_request.state" == "closed"
+jsonpath "$[0].body_json.pull_request.merged" == true
+jsonpath "$[0].body_json.pull_request.merge_commit_sha" == "4444444444444444444444444444444444444444"
+jsonpath "$[0].body_json.sender.login" == "peggy"
+
+# -- SNS Notification envelope containing pull request update ----------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request-sns.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "synchronize"
+jsonpath "$[0].body_json.pull_request.head.sha" == "5555555555555555555555555555555555555555"
+jsonpath "$[0].body_json.sender.login" == "quinn"

--- a/test/webhook-delivery-codecommit.hurl
+++ b/test/webhook-delivery-codecommit.hurl
@@ -397,6 +397,286 @@ jsonpath "$[0].body_json.action" == "synchronize"
 jsonpath "$[0].body_json.pull_request.head.sha" == "5555555555555555555555555555555555555555"
 jsonpath "$[0].body_json.sender.login" == "quinn"
 
+# -- EventBridge pullRequestApprovalStateChanged -> review submitted ---------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request_review-submitted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request_review"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "submitted"
+jsonpath "$[0].body_json.review.state" == "approved"
+jsonpath "$[0].body_json.review.user.login" == "xavier"
+jsonpath "$[0].body_json.pull_request.number" == 42
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.sender.login" == "xavier"
+
+# -- EventBridge pullRequestApprovalStateChanged -> review dismissed ---------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/pull_request_review-dismissed.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "pull_request_review"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "dismissed"
+jsonpath "$[0].body_json.review.state" == "dismissed"
+jsonpath "$[0].body_json.pull_request.number" == 42
+jsonpath "$[0].body_json.sender.login" == "xavier"
+
+# -- EventBridge pullRequestApprovalRuleCreated -> rule created --------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "branch_protection_rule"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.rule.node_id" == "rule-created"
+jsonpath "$[0].body_json.rule.name" == "two-approvers-needed"
+jsonpath "$[0].body_json.rule.pattern" == "main"
+jsonpath "$[0].body_json.rule.codecommit.pull_request_id" == "42"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.sender.login" == "zara"
+
+# -- EventBridge pullRequestApprovalRuleUpdated -> rule edited ---------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-edited.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "branch_protection_rule"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.rule.node_id" == "rule-edited"
+jsonpath "$[0].body_json.changes.codecommit_content_sha256.from" == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+jsonpath "$[0].body_json.sender.login" == "zara"
+
+# -- EventBridge pullRequestApprovalRuleDeleted -> rule deleted --------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "branch_protection_rule"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "deleted"
+jsonpath "$[0].body_json.rule.node_id" == "rule-deleted"
+jsonpath "$[0].body_json.sender.login" == "zara"
+
+# -- EventBridge approvalRuleTemplateCreated -> rule created -----------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-template-created.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "branch_protection_rule"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "created"
+jsonpath "$[0].body_json.rule.node_id" == "template-created"
+jsonpath "$[0].body_json.rule.name" == "two-approvers-required-for-main"
+jsonpath "$[0].body_json.rule.codecommit.template_id" == "template-created"
+jsonpath "$[0].body_json.sender.login" == "zara"
+
+# -- EventBridge approvalRuleTemplateUpdated -> rule edited ------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-template-edited.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "branch_protection_rule"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "edited"
+jsonpath "$[0].body_json.rule.node_id" == "template-edited"
+jsonpath "$[0].body_json.changes.codecommit_content_sha256.from" == "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+jsonpath "$[0].body_json.sender.login" == "zara"
+
+# -- EventBridge approvalRuleTemplateDeleted -> rule deleted -----------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-template-deleted.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "branch_protection_rule"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.action" == "deleted"
+jsonpath "$[0].body_json.rule.node_id" == "template-deleted"
+jsonpath "$[0].body_json.sender.login" == "zara"
+
+# -- EventBridge pullRequestApprovalRuleOverridden has no GitHub equivalent --
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-override.json;
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "CodeCommit approval rule override events have no GitHub webhook equivalent"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 0
+
+# -- EventBridge approval template association events have no GitHub equivalent
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-template-associated.json;
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "CodeCommit approval rule template association events have no GitHub webhook equivalent"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 0
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-template-disassociated.json;
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "CodeCommit approval rule template association events have no GitHub webhook equivalent"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 0
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-template-batch-associated.json;
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "CodeCommit approval rule template association events have no GitHub webhook equivalent"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 0
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/branch_protection_rule-template-batch-disassociated.json;
+HTTP 422
+[Asserts]
+jsonpath "$.message" == "CodeCommit approval rule template association events have no GitHub webhook equivalent"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 0
+
 # -- EventBridge commentOnCommitCreated -> commit_comment created ------------
 
 POST http://{{target}}/reset

--- a/test/webhook-delivery-codecommit.hurl
+++ b/test/webhook-delivery-codecommit.hurl
@@ -54,6 +54,54 @@ jsonpath "$[0].body_json.before" == "2222222222222222222222222222222222222222"
 jsonpath "$[0].body_json.after" == "3333333333333333333333333333333333333333"
 jsonpath "$[0].body_json.sender.login" == "bob"
 
+# -- SNS Notification envelope containing EventBridge -> push ----------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/push-sns-eventbridge.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "refs/heads/release"
+jsonpath "$[0].body_json.before" == "4444444444444444444444444444444444444444"
+jsonpath "$[0].body_json.after" == "5555555555555555555555555555555555555555"
+jsonpath "$[0].body_json.sender.login" == "dana"
+
+# -- Lambda-style SNS record envelope containing EventBridge -> push ----------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/push-sns-record.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "push"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "refs/tags/v1.2.3"
+jsonpath "$[0].body_json.before" == "5555555555555555555555555555555555555555"
+jsonpath "$[0].body_json.after" == "6666666666666666666666666666666666666666"
+jsonpath "$[0].body_json.sender.login" == "erin"
+
 # -- EventBridge repository state change -> push -----------------------------
 
 POST http://{{target}}/reset

--- a/test/webhook-delivery-codecommit.hurl
+++ b/test/webhook-delivery-codecommit.hurl
@@ -3,6 +3,79 @@
 # CodeCommit payloads are identified from the body. These fixtures cover native
 # repository triggers, SNS notification envelopes, and EventBridge state changes.
 
+# -- CodeCommit trigger record -> create -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/create-record.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].user_agent" contains "confusio"
+jsonpath "$[0].body_json.ref" == "feature"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.master_branch" == "main"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.sender.login" == "frank"
+
+# -- EventBridge referenceCreated -> create ----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/create-eventbridge.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v2.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"
+jsonpath "$[0].body_json.repository.clone_url" == "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/hello-world"
+jsonpath "$[0].body_json.sender.login" == "grace"
+
+# -- SNS Notification envelope -> create -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/create-sns.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "create"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "sns-feature"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.sender.login" == "heidi"
+
 # -- CodeCommit trigger record -> push ---------------------------------------
 
 POST http://{{target}}/reset
@@ -126,3 +199,74 @@ jsonpath "$[0].body_json.before" == "3333333333333333333333333333333333333333"
 jsonpath "$[0].body_json.after" == "4444444444444444444444444444444444444444"
 jsonpath "$[0].body_json.repository.clone_url" == "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/hello-world"
 jsonpath "$[0].body_json.sender.login" == "carol"
+
+# -- CodeCommit trigger record -> delete -------------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/delete-record.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "feature"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.repository.full_name" == "hello-world"
+jsonpath "$[0].body_json.sender.login" == "ivan"
+
+# -- EventBridge referenceDeleted -> delete ----------------------------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/delete-eventbridge.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "v2.0.0"
+jsonpath "$[0].body_json.ref_type" == "tag"
+jsonpath "$[0].body_json.repository.clone_url" == "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/hello-world"
+jsonpath "$[0].body_json.sender.login" == "judy"
+
+# -- SNS Notification envelope containing EventBridge -> delete --------------
+
+POST http://{{target}}/reset
+{}
+HTTP 200
+
+POST http://{{host}}/webhooks/codecommit
+Content-Type: application/json
+file,fixtures/webhooks/codecommit/delete-sns-eventbridge.json;
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "accepted"
+
+GET http://{{target}}/deliveries
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].github_event" == "delete"
+jsonpath "$[0].github_delivery" isString
+jsonpath "$[0].body_json.ref" == "sns-feature"
+jsonpath "$[0].body_json.ref_type" == "branch"
+jsonpath "$[0].body_json.sender.login" == "kate"

--- a/test/webhooks-sig.hurl
+++ b/test/webhooks-sig.hurl
@@ -685,11 +685,9 @@ HTTP 401
 [Asserts]
 jsonpath "$.message" == "Signature verification failed"
 
-# ── codecommit: SNS X.509 signatures are not verified from shared secrets ───
+# ── codecommit: configured verification requires valid signed SNS bodies ────
 
-# CodeCommit's SNS signature model needs certificate-chain validation, not a
-# shared webhook secret. When a local secret is configured, reject instead of
-# pretending an HMAC/token check would be meaningful.
+# Unsigned or malformed SNS bodies reject when CodeCommit verification is enabled.
 POST http://{{host}}/webhooks/codecommit
 Content-Type: application/json
 X-Amz-Sns-Message-Type: Notification


### PR DESCRIPTION
Adds CodeCommit approval status, approval rule, and approval rule template translation into the closest GitHub-shaped and normalized webhook deliveries. It finishes the remaining fixtures, delivery assertions, docs, and matrix entries with honest unsupported notes for no-equivalent gaps.

Fixes #256.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] Translate CodeCommit approval and rule events <!-- type:spec -->
- [x] Finalize CodeCommit webhook matrix and docs <!-- type:spec -->
- [x] Translate CodeCommit comment and reaction events <!-- type:spec -->
- [x] Translate CodeCommit pull request events <!-- type:spec -->
- [x] Translate CodeCommit reference events <!-- type:spec -->
- [x] Verify CodeCommit SNS signatures <!-- type:spec -->
- [x] Broaden CodeCommit webhook envelope parsing <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->