### PR TITLE
Epic: shrink confusio with metatables — translators-as-data, alias chains, default fallthrough, transport stacking (closes #356)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,7 @@ Long-form lessons live in `lessons/*.MD`. Read those files before starting broad
 - `lessons/001-abstraction-costs.MD` — abstractions must pay for themselves in clarity and maintenance cost, not just nominal LOC movement.
 - `lessons/002-explicit-alias-chains.MD` — making an implicit relationship explicit still has to reduce maintenance weight.
 - `lessons/003-default-fallthrough.MD` — replacing explicit fallback logic with lookup indirection must make default behavior easier to reason about.
+- `lessons/004-transport-layers.MD` — composable transport layers must solve real variation before replacing the compact factory.
 
 ### Architectural deduplication baseline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ Long-form lessons live in `lessons/*.MD`. Read those files before starting broad
 - `lessons/002-explicit-alias-chains.MD` — making an implicit relationship explicit still has to reduce maintenance weight.
 - `lessons/003-default-fallthrough.MD` — replacing explicit fallback logic with lookup indirection must make default behavior easier to reason about.
 - `lessons/004-transport-layers.MD` — composable transport layers must solve real variation before replacing the compact factory.
+- `lessons/005-metatable-epic-recap.MD` — broad architectural themes still have to prove the whole branch is simpler.
 
 ### Architectural deduplication baseline
 

--- a/lessons/005-metatable-epic-recap.MD
+++ b/lessons/005-metatable-epic-recap.MD
@@ -1,0 +1,39 @@
+# Lesson 005: The Epic Has To Pay Too
+
+Source: rhencke/confusio#372, from the metatable-shrink epic for issue #356.
+
+## What Happened
+
+The metatable-shrink epic started with a plausible pattern: several parts of
+confusio looked hand-rolled in ways Lua metatables might simplify. Translators
+could become callable data, aliases could inherit through `__index`, defaults
+could fall through through the backend handler table, and transport could stack
+as layers.
+
+Each experiment was tried on its own PR. Each one either grew the branch or made
+the behavior harder to explain, so the production code was backed out and the
+useful result became the lessons in this directory.
+
+## The Lesson
+
+An epic made of individually questionable refactors does not become good because
+the theme is coherent. The whole proposal has to pay rent too.
+
+Metatables are powerful, but power is not the same thing as simplification. Use
+them when they make a real invariant smaller, more local, or easier to verify.
+Do not use them just because several code paths can be described as lookup,
+fallback, wrapping, or inheritance.
+
+## How To Use This
+
+Before committing to a broad architectural theme:
+
+- Land the smallest representative slice first and measure the whole branch.
+- Treat review feedback on one slice as evidence about the whole epic.
+- Stop early when the repeated result is more plumbing, more docs, or worse
+  debuggability.
+- Preserve the lesson when the experiment teaches something useful, even if the
+  code is not worth keeping.
+
+The good outcome is not "the epic shipped." The good outcome is "the codebase
+kept what helped and remembered what did not."


### PR DESCRIPTION
Updates the metatable-shrink epic into a lessons-focused closeout after the attempted refactors proved heavier than the code they replaced. The remaining work keeps the CLAUDE lesson index current and adds an epic recap so future broad refactors start from the measured outcome.

Fixes #356.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add transport lesson to CLAUDE index <!-- type:spec -->
- [x] Add metatable epic recap lesson <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->