### PR TITLE
Dedup #5: gitea + gitlab — 37 lines / 144 tokens (closes #302)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -68,6 +68,9 @@ globals = {
   "cap_rest_paged",
   -- Backend registration helpers: internal/backend_helpers.lua
   "register_repo_rest_handlers",
+  "register_graphql_local_id_node_resolver",
+  "register_graphql_login_query_resolver",
+  "register_graphql_owner_repo_number_node_resolver",
   -- Default stub handlers: populated by internal/defaults.lua, read by the catalog in .init.lua
   "defaults",
   -- Router: populated by internal/router.lua, used by the catalog and OnHttpRequest in .init.lua

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -5601,89 +5601,54 @@ b:graphql("node.Repository", function(local_id, _ctx)
 end)
 
 -- node.User: fetch a user by login.
-b:graphql("node.User", function(local_id, _ctx)
-  local data, _ = users.get(local_id)
-  if not data then
-    return nil
-  end
-  return graphql_translate_user(data)
-end)
+register_graphql_local_id_node_resolver(b, "node.User", users.get, graphql_translate_user)
 
 -- node.Organization: fetch an organization by login.
-b:graphql("node.Organization", function(local_id, _ctx)
-  local data, _ = orgs.get(local_id)
-  if not data then
-    return nil
-  end
-  return graphql_translate_org(data)
-end)
+register_graphql_local_id_node_resolver(b, "node.Organization", orgs.get, graphql_translate_org)
 
 -- node.Issue: fetch an issue by "owner/repo/number" local ID.
-b:graphql("node.Issue", function(local_id, _ctx)
-  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
-  if not owner then
-    return nil
-  end
-  local data, _ = issues_cap.get(owner, repo, number)
-  if not data then
-    return nil
-  end
-  return graphql_translate_issue(data, owner, repo)
-end)
+register_graphql_owner_repo_number_node_resolver(
+  b,
+  "node.Issue",
+  issues_cap.get,
+  graphql_translate_issue
+)
 
 -- node.PullRequest: fetch a pull request by "owner/repo/number" local ID.
-b:graphql("node.PullRequest", function(local_id, _ctx)
-  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
-  if not owner then
-    return nil
-  end
-  local data, _ = pulls_cap.get(owner, repo, number)
-  if not data then
-    return nil
-  end
-  return graphql_translate_pr(data, owner, repo)
-end)
+register_graphql_owner_repo_number_node_resolver(
+  b,
+  "node.PullRequest",
+  pulls_cap.get,
+  graphql_translate_pr
+)
 
 -- node.IssueComment: fetch an issue comment by "owner/repo/comment_id" local ID.
-b:graphql("node.IssueComment", function(local_id, _ctx)
-  local owner, repo, cid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
-  if not owner then
-    return nil
-  end
-  local data, _ = comments_cap.get(owner, repo, cid)
-  if not data then
-    return nil
-  end
-  return graphql_translate_comment(data, owner, repo)
-end)
+register_graphql_owner_repo_number_node_resolver(
+  b,
+  "node.IssueComment",
+  comments_cap.get,
+  graphql_translate_comment
+)
 
 -- Query.user: look up a User by login.
 -- Returns nil (and no error) when the user does not exist.
-b:graphql("Query.user", function(_parent, args, ctx)
-  if not args.login then
-    graphql_error(ctx, "user requires a login argument")
-    return nil
-  end
-  local data, _ = users.get(args.login)
-  if not data then
-    return nil
-  end
-  return graphql_translate_user(data)
-end)
+register_graphql_login_query_resolver(
+  b,
+  "Query.user",
+  "user requires a login argument",
+  users.get,
+  graphql_translate_user
+)
 
 -- Query.organization: look up an Organization by login.
 -- Returns nil (and no error) when the organization does not exist.
-b:graphql("Query.organization", function(_parent, args, ctx)
-  if not args.login then
-    graphql_error(ctx, "organization requires a login argument")
-    return nil
-  end
-  local data, _ = orgs.get(args.login)
-  if not data then
-    return nil
-  end
-  return graphql_translate_org(data)
-end)
+register_graphql_login_query_resolver(
+  b,
+  "Query.organization",
+  "organization requires a login argument",
+  orgs.get,
+  graphql_translate_org
+)
 
 -- Query.repository: look up a Repository by owner login and repo name.
 -- Returns nil (and no error) when the repository does not exist.

--- a/backends/gitlab.lua
+++ b/backends/gitlab.lua
@@ -5310,30 +5310,22 @@ b:graphql("Query.viewer", function(_parent, _args, ctx)
 end)
 
 -- Query.user: look up a User by login.
-b:graphql("Query.user", function(_parent, args, ctx)
-  if not args.login then
-    graphql_error(ctx, "user requires a login argument")
-    return nil
-  end
-  local data, _ = users.by_username(args.login)
-  if not data then
-    return nil
-  end
-  return graphql_translate_user(data)
-end)
+register_graphql_login_query_resolver(
+  b,
+  "Query.user",
+  "user requires a login argument",
+  users.by_username,
+  graphql_translate_user
+)
 
 -- Query.organization: look up a GitLab group by path.
-b:graphql("Query.organization", function(_parent, args, ctx)
-  if not args.login then
-    graphql_error(ctx, "organization requires a login argument")
-    return nil
-  end
-  local data, _ = orgs.get(args.login)
-  if not data then
-    return nil
-  end
-  return graphql_translate_org(data)
-end)
+register_graphql_login_query_resolver(
+  b,
+  "Query.organization",
+  "organization requires a login argument",
+  orgs.get,
+  graphql_translate_org
+)
 
 -- Query.repository: look up a Repository by owner and name.
 b:graphql("Query.repository", function(_parent, args, ctx)
@@ -5362,52 +5354,28 @@ b:graphql("node.Repository", function(local_id, _ctx)
 end)
 
 -- node.User: fetch a user by login.
-b:graphql("node.User", function(local_id, _ctx)
-  local data, _ = users.by_username(local_id)
-  if not data then
-    return nil
-  end
-  return graphql_translate_user(data)
-end)
+register_graphql_local_id_node_resolver(b, "node.User", users.by_username, graphql_translate_user)
 
 -- node.Organization: fetch a group by path.
-b:graphql("node.Organization", function(local_id, _ctx)
-  local data, _ = orgs.get(local_id)
-  if not data then
-    return nil
-  end
-  return graphql_translate_org(data)
-end)
+register_graphql_local_id_node_resolver(b, "node.Organization", orgs.get, graphql_translate_org)
 
 -- node.Issue: fetch an issue by "owner/repo/iid" local ID.
-b:graphql("node.Issue", function(local_id, _ctx)
-  local owner, repo, iid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
-  if not owner then
-    return nil
-  end
-  local data, _ = graphql_fetch(
+register_graphql_owner_repo_number_node_resolver(b, "node.Issue", function(owner, repo, iid)
+  return graphql_fetch(
     fetch_json,
     base() .. "/projects/" .. project_id(owner, repo) .. "/issues/" .. iid
   )
-  if not data then
-    return nil
-  end
+end, function(data, owner, repo)
   return graphql_translate_issue(translate_gl_issue(data), owner, repo)
 end)
 
 -- node.PullRequest: fetch a merge request by "owner/repo/iid" local ID.
-b:graphql("node.PullRequest", function(local_id, _ctx)
-  local owner, repo, iid = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
-  if not owner then
-    return nil
-  end
-  local data, _ = graphql_fetch(
+register_graphql_owner_repo_number_node_resolver(b, "node.PullRequest", function(owner, repo, iid)
+  return graphql_fetch(
     fetch_json,
     base() .. "/projects/" .. project_id(owner, repo) .. "/merge_requests/" .. iid
   )
-  if not data then
-    return nil
-  end
+end, function(data, owner, repo)
   return graphql_translate_pr(translate_gl_mr(data), owner, repo)
 end)
 

--- a/internal/backend_helpers.lua
+++ b/internal/backend_helpers.lua
@@ -1,5 +1,43 @@
 -- Shared backend registration helpers.
 
+function register_graphql_local_id_node_resolver(b, key, fetch, translate) -- luacheck: globals register_graphql_local_id_node_resolver
+  b:graphql(key, function(local_id, _ctx)
+    local data, _ = fetch(local_id)
+    if not data then
+      return nil
+    end
+    return translate(data)
+  end)
+end
+
+function register_graphql_login_query_resolver(b, key, missing_message, fetch, translate) -- luacheck: globals register_graphql_login_query_resolver
+  b:graphql(key, function(_parent, args, ctx)
+    if not args.login then
+      graphql_error(ctx, missing_message)
+      return nil
+    end
+    local data, _ = fetch(args.login)
+    if not data then
+      return nil
+    end
+    return translate(data)
+  end)
+end
+
+function register_graphql_owner_repo_number_node_resolver(b, key, fetch, translate) -- luacheck: globals register_graphql_owner_repo_number_node_resolver
+  b:graphql(key, function(local_id, _ctx)
+    local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+    if not owner then
+      return nil
+    end
+    local data, _ = fetch(owner, repo, number)
+    if not data then
+      return nil
+    end
+    return translate(data, owner, repo)
+  end)
+end
+
 function register_repo_rest_handlers(b, repos, topics, pages) -- luacheck: globals register_repo_rest_handlers
   b:rest("get_repo", function(owner, repo_name)
     local data, err = repos.get(owner, repo_name)


### PR DESCRIPTION
Deduplicates the shared GraphQL node resolver flow used by Gitea and GitLab. The change keeps backend-specific fetch and translation behavior intact while removing the CPD-reported duplicate block.

Fixes #302.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Deduplicate Gitea and GitLab GraphQL resolvers <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->