### PR TITLE
Dedup #10: gitbucket + gitea — 19 lines / 113 tokens (closes #307)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -163,6 +163,7 @@ globals = {
   "graphql_cursor_url",
   "graphql_prefetch_total_from_headers",
   "graphql_inline_connection",
+  "graphql_pull_request_commits_connection",
   "graphql_language_connection",
   "graphql_default_branch_ref",
   "graphql_search_params",

--- a/backends/gitbucket.lua
+++ b/backends/gitbucket.lua
@@ -2082,39 +2082,18 @@ end)
 
 -- PullRequest.commits: paginated commit list for a pull request.
 b:graphql("PullRequest.commits", function(parent, args, ctx)
-  local _, local_id = decode_node_id(parent.id)
-  if not local_id then
-    return nil
-  end
-  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
-  if not owner then
-    return nil
-  end
-  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits"
-  local total
-  if args.last and not args.before then
-    total = graphql_prefetch_total_from_headers(fetch_json, url_base, GQL_PAGES, GB_TOTAL_HEADERS)
-  end
-  local url = graphql_cursor_url(url_base, args, GQL_PAGES, total)
-  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
-  if not data then
-    graphql_error(ctx, err)
-    return nil
-  end
-  total = gb_total(headers) or total
-  -- PullRequest.commits returns PullRequestCommitConnection, whose nodes are
-  -- PullRequestCommit objects wrapping bare Commit objects.
-  local nodes = {}
-  for _, c in ipairs(data) do
-    local sha = c.sha or ""
-    nodes[#nodes + 1] = {
-      __typename = "PullRequestCommit",
-      id = encode_node_id("PullRequestCommit", sha),
-      commit = graphql_translate_commit(c, owner, repo),
-      url = c.html_url,
-    }
-  end
-  return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
+  return graphql_pull_request_commits_connection(parent, args, ctx, {
+    fetch_json = fetch_json,
+    pages = GQL_PAGES,
+    total_headers = GB_TOTAL_HEADERS,
+    total = gb_total,
+    url_base = function(owner, repo, number)
+      return base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits"
+    end,
+    sha = function(c)
+      return c.sha or ""
+    end,
+  })
 end)
 
 -- PullRequest.reviews: paginated review list for a pull request.

--- a/backends/gitea.lua
+++ b/backends/gitea.lua
@@ -5909,41 +5909,18 @@ end)
 -- Decodes the PullRequest node ID (PullRequest:owner/repo/number) for coordinates,
 -- then fetches /api/v1/repos/{owner}/{repo}/pulls/{number}/commits.
 b:graphql("PullRequest.commits", function(parent, args, ctx)
-  local _, local_id = decode_node_id(parent.id)
-  if not local_id then
-    return nil
-  end
-  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
-  if not owner then
-    return nil
-  end
-  local url_base = base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits"
-  local total
-  if args.last and not args.before then
-    total =
-      graphql_prefetch_total_from_headers(fetch_json, url_base, GITEA_PAGES, GITEA_TOTAL_HEADERS)
-  end
-  local url = graphql_cursor_url(url_base, args, GITEA_PAGES, total)
-  local data, headers, err = graphql_fetch_with_headers(fetch_json, url)
-  if not data then
-    graphql_error(ctx, err)
-    return nil
-  end
-  total = gitea_total(headers) or total
-  -- PullRequest.commits returns PullRequestCommitConnection, whose nodes are
-  -- PullRequestCommit objects (not bare Commit objects).  Each PullRequestCommit
-  -- wraps the Commit so clients can query commits { nodes { commit { oid } } }.
-  local nodes = {}
-  for _, c in ipairs(data) do
-    local sha = c.sha or (c.commit and c.commit.id) or ""
-    nodes[#nodes + 1] = {
-      __typename = "PullRequestCommit",
-      id = encode_node_id("PullRequestCommit", sha),
-      commit = graphql_translate_commit(c, owner, repo),
-      url = c.html_url,
-    }
-  end
-  return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
+  return graphql_pull_request_commits_connection(parent, args, ctx, {
+    fetch_json = fetch_json,
+    pages = GITEA_PAGES,
+    total_headers = GITEA_TOTAL_HEADERS,
+    total = gitea_total,
+    url_base = function(owner, repo, number)
+      return base() .. "/repos/" .. owner .. "/" .. repo .. "/pulls/" .. number .. "/commits"
+    end,
+    sha = function(c)
+      return c.sha or (c.commit and c.commit.id) or ""
+    end,
+  })
 end)
 
 -- PullRequest.reviews: paginated review list for a pull request.

--- a/internal/graphql_translators.lua
+++ b/internal/graphql_translators.lua
@@ -15,6 +15,7 @@
 --   graphql_cursor_url(url_base, args, param_names[, total])
 --   graphql_prefetch_total_from_headers(fetch_json, url_base, param_names, header_names)
 --   graphql_inline_connection(typename, nodes)
+--   graphql_pull_request_commits_connection(parent, args, ctx, opts)
 --   graphql_make_connection(typename, nodes, args, total[, ctx])
 --   graphql_issues_connection(nodes, args, total[, ctx])
 --   graphql_prs_connection(nodes, args, total[, ctx])
@@ -318,6 +319,45 @@ function graphql_inline_connection(typename, nodes) -- luacheck: globals graphql
     nodes = nodes,
     edges = edges,
   }
+end
+
+-- graphql_pull_request_commits_connection is global: builds the common
+-- PullRequestCommitConnection shape for GitHub-compatible commit-list endpoints.
+function graphql_pull_request_commits_connection(parent, args, ctx, opts) -- luacheck: globals graphql_pull_request_commits_connection
+  local _, local_id = decode_node_id(parent.id)
+  if not local_id then
+    return nil
+  end
+  local owner, repo, number = local_id:match("^([^/]+)/([^/]+)/(%d+)$")
+  if not owner then
+    return nil
+  end
+
+  local url_base = opts.url_base(owner, repo, number)
+  local total
+  if args.last and not args.before then
+    total =
+      graphql_prefetch_total_from_headers(opts.fetch_json, url_base, opts.pages, opts.total_headers)
+  end
+  local url = graphql_cursor_url(url_base, args, opts.pages, total)
+  local data, headers, err = graphql_fetch_with_headers(opts.fetch_json, url)
+  if not data then
+    graphql_error(ctx, err)
+    return nil
+  end
+  total = opts.total(headers) or total
+
+  local nodes = {}
+  for _, c in ipairs(data) do
+    local sha = opts.sha(c)
+    nodes[#nodes + 1] = {
+      __typename = "PullRequestCommit",
+      id = encode_node_id("PullRequestCommit", sha),
+      commit = graphql_translate_commit(c, owner, repo),
+      url = c.html_url,
+    }
+  end
+  return graphql_make_connection("PullRequestCommit", nodes, args, total, ctx)
 end
 
 -- graphql_language_connection is global: converts a provider language map


### PR DESCRIPTION
## Summary

- Extract the duplicated GraphQL `PullRequest.commits` connection logic shared by GitBucket and Gitea.
- Preserve each backend's pagination headers, total-count handling, REST URL shape, and commit SHA fallback behavior.

## Test plan

- `make -j test`
- Re-run the PMD CPD command from issue #307 and confirm the GitBucket/Gitea duplicate range is gone.

Fixes #307.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Extract shared PullRequest.commits helper <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->